### PR TITLE
fix the scheme used to scrape fluent prometheus metrics

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -312,7 +312,7 @@ func DaemonSet(daemonsetName string, namespace string, loggingComponent string, 
 			Annotations: map[string]string{
 				"prometheus.io/scrape": "true",
 				"prometheus.io/port":   "24231",
-				"prometheus.io/scheme": "http",
+				"prometheus.io/scheme": "https",
 			},
 		},
 		Spec: apps.DaemonSetSpec{


### PR DESCRIPTION
This fixes the protocol to scrape fluent metrics to be https to jive with https://github.com/openshift/origin-aggregated-logging/pull/1316