### PR TITLE
add cluster-monitoring annotation to namespace def

### DIFF
--- a/manifests/01-namespace.yaml
+++ b/manifests/01-namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-logging: "true"
+    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
This PR preps for cluster-monitoring-operator to scrape cluster-logging to support

https://jira.coreos.com/browse/LOG-176