### PR TITLE
Add a rhel7 dockerfile and make the centos dockerfile consistent

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-logging-operator
 COPY . .
 RUN make
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.0:base
 RUN INSTALL_PKGS=" \
       openssl \
       " && \


### PR DESCRIPTION
Part of standardizing release tooling