### PR TITLE
Creating shared-config for console to consume

### DIFF
--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -188,6 +188,7 @@ func createOrUpdateKibanaRoute(logging *logging.ClusterLogging) error {
 			logging.Namespace,
 			"kibana",
 			"kibana",
+			"/tmp/_working_dir/ca.crt",
 		)
 
 		utils.AddOwnerRefToObject(kibanaRoute, utils.AsOwner(logging))
@@ -197,7 +198,7 @@ func createOrUpdateKibanaRoute(logging *logging.ClusterLogging) error {
 			return fmt.Errorf("Failure creating Kibana route: %v", err)
 		}
 
-		sharedConfig := createSharedConfig(logging, "kibana", "kibana")
+		sharedConfig := createSharedConfig(logging, "https://kibana", "https://kibana")
 		utils.AddOwnerRefToObject(sharedConfig, utils.AsOwner(logging))
 
 		err = sdk.Create(sharedConfig)
@@ -210,6 +211,7 @@ func createOrUpdateKibanaRoute(logging *logging.ClusterLogging) error {
 			logging.Namespace,
 			"kibana-app",
 			"kibana-app",
+			"/tmp/_working_dir/ca.crt",
 		)
 
 		utils.AddOwnerRefToObject(kibanaRoute, utils.AsOwner(logging))
@@ -224,6 +226,7 @@ func createOrUpdateKibanaRoute(logging *logging.ClusterLogging) error {
 			logging.Namespace,
 			"kibana-infra",
 			"kibana-infra",
+			"/tmp/_working_dir/ca.crt",
 		)
 
 		utils.AddOwnerRefToObject(kibanaInfraRoute, utils.AsOwner(logging))
@@ -233,7 +236,7 @@ func createOrUpdateKibanaRoute(logging *logging.ClusterLogging) error {
 			return fmt.Errorf("Failure creating Kibana Infra route: %v", err)
 		}
 
-		sharedConfig := createSharedConfig(logging, "kibana-app", "kibana-infra")
+		sharedConfig := createSharedConfig(logging, "https://kibana-app", "https://kibana-infra")
 		utils.AddOwnerRefToObject(sharedConfig, utils.AsOwner(logging))
 
 		err = sdk.Create(sharedConfig)
@@ -505,13 +508,13 @@ func updateCurrentImages(current *apps.Deployment, desired *apps.Deployment) (*a
 	return current
 }
 
-func createSharedConfig(logging *logging.ClusterLogging, kibanaAppHost, kibanaInfraHost string) *v1.ConfigMap {
+func createSharedConfig(logging *logging.ClusterLogging, kibanaAppURL, kibanaInfraURL string) *v1.ConfigMap {
 	return utils.ConfigMap(
 		"sharing-config",
 		logging.Namespace,
 		map[string]string{
-			"kibanaAppHost":   kibanaAppHost,
-			"kibanaInfraHost": kibanaInfraHost,
+			"kibanaAppURL":   kibanaAppURL,
+			"kibanaInfraURL": kibanaInfraURL,
 		},
 	)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -144,7 +144,7 @@ func Service(serviceName string, namespace string, selectorComponent string, ser
 	}
 }
 
-func Route(routeName string, namespace string, hostName string, serviceName string) *route.Route {
+func Route(routeName string, namespace string, hostName string, serviceName string, cafilePath string) *route.Route {
 	return &route.Route{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Route",
@@ -164,6 +164,12 @@ func Route(routeName string, namespace string, hostName string, serviceName stri
 			To: route.RouteTargetReference{
 				Name: serviceName,
 				Kind: "Service",
+			},
+			TLS: &route.TLSConfig{
+				Termination: route.TLSTerminationReencrypt,
+				InsecureEdgeTerminationPolicy: route.InsecureEdgeTerminationPolicyRedirect,
+				CACertificate: string(GetFileContents(cafilePath)),
+				DestinationCACertificate: string(GetFileContents(cafilePath)),
 			},
 		},
 	}


### PR DESCRIPTION
Addresses https://jira.coreos.com/browse/LOG-233

@spadgett PTAL and confirm this would work. There will always be `kibanaAppHost` and `kibanaInfraHost` entries, even if it is an "all-in-one" configuration where we only create a single `route`.

e.g.
```
oc get configmap -o yaml sharing-config
apiVersion: v1
data:
  kibanaAppHost: kibana-app
  kibanaInfraHost: kibana-infra
kind: ConfigMap
metadata:
  creationTimestamp: 2018-11-30T18:21:05Z
  name: sharing-config
  namespace: openshift-logging
  ownerReferences:
  - apiVersion: logging.openshift.io/v1alpha1
    controller: true
    kind: ClusterLogging
    name: example-cluster-logging
    uid: b27ce418-f4cc-11e8-a9ff-0e3a960e086c
  resourceVersion: "7727"
```