### PR TITLE
Updating to generate own signing CA for Cluster Logging

### DIFF
--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -33,15 +33,6 @@ mkdir /tmp/_working_dir
 load_manifest ${repo_dir}
 CREATE_ES_SECRET=false NAMESPACE=openshift-logging make -C ${ELASTICSEARCH_OP_REPO} deploy-setup
 
-tmpdir=$(mktemp -d)
-pushd ${tmpdir}
-  oc adm ca create-signer-cert --cert='ca.crt' --key='ca.key' --serial='ca.serial.txt'
-  oc adm ca create-server-cert --cert='kibana-internal.crt' --key='kibana-internal.key' \
-      --hostnames='kibana,kibana-infra' --signer-cert='ca.crt' --signer-key='ca.key' --signer-serial='ca.serial.txt'
-  oc create -n openshift-logging secret generic logging-master-ca --from-file=masterca=ca.crt --from-file=masterkey=ca.key --from-file=kibanacert=kibana-internal.crt \
-      --from-file=kibanakey=kibana-internal.key
-popd
-
 oc adm policy add-scc-to-user privileged -z rsyslog -n openshift-logging
 oc adm policy add-cluster-role-to-user cluster-reader -z rsyslog -n openshift-logging
 oc adm policy add-scc-to-user privileged -z fluentd -n openshift-logging

--- a/pkg/k8shandler/curation.go
+++ b/pkg/k8shandler/curation.go
@@ -13,7 +13,6 @@ import (
 	sdk "github.com/operator-framework/operator-sdk/pkg/sdk"
 	batchv1 "k8s.io/api/batch/v1"
 	batch "k8s.io/api/batch/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -255,7 +254,7 @@ func updateCuratorIfRequired(desired *batch.CronJob) (err error) {
 	current := desired.DeepCopy()
 
 	if err = sdk.Get(current); err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			// the object doesn't exist -- it was likely culled
 			// recreate it on the next time through if necessary
 			return nil


### PR DESCRIPTION
Updates the CLO to no longer require a secret to be created and mounted by customers. Will create a signing CA if one does not exist and store it in a secret.

Addresses https://jira.coreos.com/browse/LOG-255