### PR TITLE
bug 1660778 CA path for the fluent servicemonitor

### DIFF
--- a/manifests/10-service-monitor-fluentd.yaml
+++ b/manifests/10-service-monitor-fluentd.yaml
@@ -8,7 +8,7 @@ spec:
   - port: "24231"
     scheme: https
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
   selector:
     matchLabels:
       logging-infra: fluentd


### PR DESCRIPTION
fix https://bugzilla.redhat.com/show_bug.cgi?id=1660778

This PR modifies the CA path for the fluent servicemonitor