### PR TITLE
Disable MERGE_JSON_LOG by default

### DIFF
--- a/docs/unmanaged_configuration.md
+++ b/docs/unmanaged_configuration.md
@@ -1,0 +1,27 @@
+# Unmanaged Configurations for Cluster Logging
+This document describes the various settings that can be tuned in cluster logging but are not
+managed by the `cluster-logging-operator`.  Administrators assume responsibility of managing and
+maintaining the deployment by modifying the cluster logging CRD to be unmanaged.
+
+```
+  spec:
+    managementState: "UnManaged"
+```
+**NOTE:** Many of the configurations described in the following sections could previously be modified by
+updating the ansible inventory file.  These changes are no longer supported in a managed capacity and are
+subject to change in the future.
+
+## Fluentd
+### MERGE_JSON_LOG
+This setting configures Fluentd to inspect each log message to determine if it's format is 'JSON' and to merge
+it into the JSON payload document posted to Elasticsearch.  This setting is `false` by default and is a change
+from 3.11 and earlier deployments where it was `true`.  
+
+Enable the feature by:
+```
+oc set env dc/fluentd MERGE_JSON_LOG=true
+```
+**NOTE:** Enabling this feature comes with [risks](https://github.com/openshift/origin-aggregated-logging/issues/1492) summarized here:
+* Possible log loss due to Elasticsearch rejecting documents due to inconsistent type mappings
+* Potential buffer storage leak caused by rejected message cycling
+* Overwrite of data for field with same names

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -353,7 +353,7 @@ func getFluentdPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 	fluentdContainer := utils.Container("fluentd", v1.PullIfNotPresent, logging.Spec.Collection.LogCollection.FluentdSpec.Resources)
 
 	fluentdContainer.Env = []v1.EnvVar{
-		{Name: "MERGE_JSON_LOG", Value: "true"},
+		{Name: "MERGE_JSON_LOG", Value: "false"},
 		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc"},
 		{Name: "ES_HOST", Value: elasticsearchAppName},
 		{Name: "ES_PORT", Value: "9200"},
@@ -421,7 +421,7 @@ func getRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 	rsyslogContainer := utils.Container("rsyslog", v1.PullIfNotPresent, logging.Spec.Collection.LogCollection.RsyslogSpec.Resources)
 
 	rsyslogContainer.Env = []v1.EnvVar{
-		{Name: "MERGE_JSON_LOG", Value: "true"},
+		{Name: "MERGE_JSON_LOG", Value: "false"},
 		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc"},
 		{Name: "ES_HOST", Value: elasticsearchAppName},
 		{Name: "ES_PORT", Value: "9200"},


### PR DESCRIPTION
This PR disables MERGE_JSON_LOG and provides instructions and documentation describing why and how to re-enable it