### PR TITLE
support buildconfigs and no image build deployments

### DIFF
--- a/hack/common
+++ b/hack/common
@@ -8,11 +8,6 @@ alias oc=${OC:-oc}
 repo_dir="$(dirname $0)/.."
 ELASTICSEARCH_OP_REPO=${ELASTICSEARCH_OP_REPO:-${repo_dir}/../elasticsearch-operator}
 
-# probably needs some work for contexts which have '-' in the name and are not IPs
-context=$(oc config current-context)
-API_SERVER=$(python -c \
-    "import re; m=re.match('.*/(.*)/.*',\"${context}\"); print m.group(1).replace('-','.')")
-
 ADMIN_USER=${ADMIN_USER:-admin}
 ADMIN_PSWD=${ADMIN_USER:-admin123}
 REPO_PREFIX=${REPO_PREFIX:-"openshift/"}

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -7,9 +7,19 @@ source "$(dirname $0)/common"
 if [ $REMOTE_REGISTRY = false ] ; then
     oc create -n ${NAMESPACE} -f manifests/05-deployment.yaml
 else
+    if [ "${USE_IMAGE_STREAM_FOR_LOGGING:-false}" = false ] ; then
+        fix_images() { cat ; }
+    else
+        fix_images() { sed -e "s,docker.io/openshift/origin-logging,$registry_host:5000/openshift/logging," ; }
+    fi
     cat manifests/05-deployment.yaml | \
         sed -e "s,${IMAGE_TAG},${registry_host}:5000/${IMAGE_TAG}," | \
+        fix_images | \
 	    oc create -n ${NAMESPACE} -f -
 fi
 
-CREATE_ES_SECRET=false NAMESPACE=openshift-logging make -C ${ELASTICSEARCH_OP_REPO} deploy
+if [ "${NO_BUILD:-false}" = true ] ; then
+    CREATE_ES_SECRET=false NAMESPACE=openshift-logging make -C ${ELASTICSEARCH_OP_REPO} deploy-no-build
+else
+    CREATE_ES_SECRET=false NAMESPACE=openshift-logging make -C ${ELASTICSEARCH_OP_REPO} deploy
+fi

--- a/hack/image-stream-build-config-template.yaml
+++ b/hack/image-stream-build-config-template.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: "Template"
+metadata:
+  name: cluster-logging-dev-build-template
+  annotations:
+    description: "Template for creating local builds of logging components from source."
+    tags: "infrastructure"
+labels:
+  logging-infra: development
+  provider: openshift
+  component: development
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      build: cluster-logging-operator
+    name: cluster-logging-operator
+  spec: {}
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      app: cluster-logging-operator
+    name: cluster-logging-operator
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: cluster-logging-operator:latest
+    resources: {}
+    source:
+      git:
+        uri: ${CL_OP_GITHUB_URL}
+        ref: ${CL_OP_GITHUB_BRANCH}
+      type: Git
+    strategy:
+      dockerStrategy:
+        dockerfilePath: Dockerfile
+      type: Docker
+parameters:
+-
+  description: 'URL for cluster-logging-operator fork'
+  name: CL_OP_GITHUB_URL
+  value: https://github.com/openshift/cluster-logging-operator
+-
+  description: 'branch for cluster-logging-operator fork'
+  name: CL_OP_GITHUB_BRANCH
+  value: master

--- a/hack/undeploy.sh
+++ b/hack/undeploy.sh
@@ -5,3 +5,8 @@ source "$(dirname $0)/common"
 for repo in ${repo_dir} ${ELASTICSEARCH_OP_REPO}; do
   oc delete -f ${repo}/manifests --ignore-not-found
 done
+
+oc delete -n openshift is cluster-logging-operator || :
+oc delete -n openshift bc cluster-logging-operator || :
+
+NAMESPACE=openshift-logging make -C ${ELASTICSEARCH_OP_REPO} undeploy


### PR DESCRIPTION
If USE_IMAGE_STREAM=true, setup a buildconfig and an
image stream in the remote repo, and build the operator image
there from the github source.  This may save a lot of time
as opposed to building the image locally and pushing the image
into the remote registry.
Also allow deploying without first building the image.  This
assumes something like a CI environment where the previous
CI stage builds the images needed to deploy and test.
depends on https://github.com/openshift/elasticsearch-operator/pull/65