### PR TITLE
Don't use the sdk for exposing operator's metrics

### DIFF
--- a/cmd/cluster-logging-operator/main.go
+++ b/cmd/cluster-logging-operator/main.go
@@ -22,8 +22,6 @@ func printVersion() {
 func main() {
 	printVersion()
 
-	sdk.ExposeMetricsPort()
-
 	resource := "logging.openshift.io/v1alpha1"
 	kind := "ClusterLogging"
 	namespace, err := k8sutil.GetWatchNamespace()


### PR DESCRIPTION
sdk.ExposeMetricsPort() leaks Service and is deprecated
in future version of the sdk.

For now, we won't be exposing metrics of the operator, but we plan
to do that later. This change has no impact on exposing metrics
of the elasticsearch cluster as a whole.