### PR TITLE
bug 1680504. Create collector clusterrole to watch pods/ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,7 @@ This will stand up a cluster logging stack named 'example'.
 
 Running locally outside an OKD cluster:
 ```
- $ ELASTICSEARCH_IMAGE=quay.io/openshift/origin-logging-elasticsearch5:latest \
-   FLUENTD_IMAGE=quay.io/openshift/origin-logging-fluentd:latest \
-   KIBANA_IMAGE=quay.io/openshift/origin-logging-kibana5:latest \
-   CURATOR_IMAGE=quay.io/openshift/origin-logging-curator5:latest \
-   OAUTH_PROXY_IMAGE=quay.io/openshift/origin-oauth-proxy:latest \
-   RSYSLOG_IMAGE=quay.io/viaq/rsyslog:latest \
-   OPERATOR_NAME=cluster-logging-operator \
-   WATCH_NAMESPACE=openshift-logging \
-   KUBERNETES_CONFIG=/etc/origin/master/admin.kubeconfig \
-   go run cmd/cluster-logging-operator/main.go
+ $ make run
 ```
 ### `make` targets
 Various `make` targets are included to simplify building and deploying the operator
@@ -48,9 +39,8 @@ The deployment can be optionally modified using any of the following:
 |`IMAGE_BUILDER`|`imagebuilder`| The command to build the container image|
 |`EXCLUSIONS`|none|The list of manifest files that should will be ignored|
 |`OC`|`oc` in `PATH`| The openshift binary to use to deploy resources|
-|`REMOTE_REGISTRY`|false|`true` if you are running the cluster on a different machine
-    than the one you are developing on|
-  
+|`REMOTE_REGISTRY`|false|`true` if you are running the cluster on a different machine than the one you are developing on|
+
 **Note:** Use `REMOTE_REGISTRY=true`, for example, if you are running a cluster in a
     local libvirt or minishift environment; you may want to build the image on the host
     and push them to the cluster running in the VM. This requires a username with a password (i.e. not the default `system:admin` user).
@@ -100,5 +90,5 @@ on which the operator runs or can be pulled from a visible registry.
 **Note:** It is necessary to set the `IMAGE_CLUSTER_LOGGING_OPERATOR` environment variable to a valid pull spec
 in order to run this test against local changes to the `cluster-logging-operator`. For example:
 ```
-$ make deploy-image && IMAGE_CLUSTER_LOGGING_OPERATOR=openshift/origin-cluster-logging-operator:latest make test-e2e
+$ make deploy-image && IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc/openshift/origin-cluster-logging-operator:latest make test-e2e
 ```

--- a/hack/common
+++ b/hack/common
@@ -8,7 +8,7 @@ alias oc=${OC:-oc}
 repo_dir="$(dirname $0)/.."
 ELASTICSEARCH_OP_REPO=${ELASTICSEARCH_OP_REPO:-${repo_dir}/../elasticsearch-operator}
 
-ADMIN_USER=${ADMIN_USER:-admin}
+ADMIN_USER=${ADMIN_USER:-kubeadmin}
 ADMIN_PSWD=${ADMIN_USER:-admin123}
 REMOTE_REGISTRY=${REMOTE_REGISTRY:-false}
 NAMESPACE=${NAMESPACE:-"openshift-logging"}

--- a/hack/deploy-image.sh
+++ b/hack/deploy-image.sh
@@ -55,5 +55,5 @@ if [ $ii = 10 ] ; then
 fi
 
 echo "Pushing image ${tag}..."
-docker login 127.0.0.1:${LOCAL_PORT} -u ${ADMIN_USER} -p $(oc whoami -t)
-docker push ${tag}
+docker login --tls-verify=false 127.0.0.1:${LOCAL_PORT} -u ${ADMIN_USER} -p $(oc whoami -t)
+docker push --tls-verify=false ${tag}

--- a/manifests/03-role.yaml
+++ b/manifests/03-role.yaml
@@ -81,7 +81,7 @@ rules:
 
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-logging-operator-cluster
 rules:
@@ -100,6 +100,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterroles
   - clusterrolebindings
   verbs:
   - "*"

--- a/manifests/04-role-binding.yaml
+++ b/manifests/04-role-binding.yaml
@@ -27,31 +27,16 @@ roleRef:
   kind: Role
   name: cluster-logging-operator
   apiGroup: rbac.authorization.k8s.io
-
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cluster-logging-operator-cluster-rolebinding
-subjects:
-- kind: ServiceAccount
-  name: cluster-logging-operator
-  namespace: openshift-logging
+  name: cluster-logging-operator-cluster
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-logging-operator-cluster
-  apiGroup: rbac.authorization.k8s.io
-
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cluster-logging-operator-cluster-reader-binding
 subjects:
 - kind: ServiceAccount
   name: cluster-logging-operator
   namespace: openshift-logging
-roleRef:
-  kind: ClusterRole
-  name: cluster-reader
-  apiGroup: rbac.authorization.k8s.io

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -331,7 +331,7 @@ func NewRoleBinding(bindingName, namespace, roleName string, subjects []rbac.Sub
 	}
 }
 
-func NewClusterRoleBinding(bindingName, namespace, roleName string, subjects []rbac.Subject) *rbac.ClusterRoleBinding {
+func NewClusterRoleBinding(bindingName, roleName string, subjects []rbac.Subject) *rbac.ClusterRoleBinding {
 	return &rbac.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRoleBinding",


### PR DESCRIPTION
This PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=1680504 by:

* creates a clusterrole for the logcollector to be able to watch all pods and namespaces