### PR TITLE
use ZeroRedundancy for tests - add cr for aws deploys

### DIFF
--- a/hack/cr-aws.yaml
+++ b/hack/cr-aws.yaml
@@ -10,6 +10,10 @@ spec:
       nodeCount: 1
       storage: {}
       redundancyPolicy: "ZeroRedundancy"
+      resources:
+        limits:
+          cpu: 500m
+          memory: 4Gi
   visualization:
     type: "kibana"
     kibana:


### PR DESCRIPTION
tests use single es instance so use ZeroRedundancy
create a cr.yaml for use with OCP 4.0 installer on aws