### PR TITLE
expanding the cert dns entry for the es svcs

### DIFF
--- a/scripts/cert_generation.sh
+++ b/scripts/cert_generation.sh
@@ -262,5 +262,5 @@ generate_certs 'system.admin'
 
 # TODO: get es SAN DNS, IP values from es service names
 generate_certs 'kibana-internal' "$(generate_extensions false false kibana)"
-generate_certs 'elasticsearch' "$(generate_extensions true true elasticsearch)"
-generate_certs 'logging-es' "$(generate_extensions false true elasticsearch{,-cluster}{,.${NAMESPACE}.svc.cluster.local})"
+generate_certs 'elasticsearch' "$(generate_extensions true true elasticsearch{,-cluster}{,.${NAMESPACE}.svc}{,.cluster.local})"
+generate_certs 'logging-es' "$(generate_extensions false true elasticsearch{,.${NAMESPACE}.svc}{,.cluster.local})"


### PR DESCRIPTION
`logging-es` is for the `elasticsearch` svc and `elasticsearch` is for the `elasticsearch-cluster` svc... not sure how we missed this. on my local system it looks like the es pods didn't cluster together this should address that