### PR TITLE
Restrict to single instance of CL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,9 @@ defines a complete cluster logging deployment that includes all the subcomponent
 of the logging stack to collect, store and visualize logs.  The `cluster-logging-operator`
 watches the a `ClusterLogging` CustomResources and adjusts the logging deployment accordingly.
 
+**Note:** The cluster-logging-operator **will only** handle a `ClusterLogging` instance named `instance`.  This
+is to enforce a single ClusterLogging deployment for the entire OKD cluster.
+
 ## Management State
 Cluster logging is managed by the `cluster-logging-operator`.  It can be placed
 into an unmanaged state allowing an administrator to assume full control of individual

--- a/hack/cr-aws.yaml
+++ b/hack/cr-aws.yaml
@@ -1,7 +1,7 @@
 apiVersion: "logging.openshift.io/v1alpha1"
 kind: "ClusterLogging"
 metadata:
-  name: "example"
+  name: "instance"
 spec:
   managementState: "Managed"
   logStore:

--- a/hack/cr.yaml
+++ b/hack/cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: "logging.openshift.io/v1alpha1"
 kind: "ClusterLogging"
 metadata:
-  name: "example"
+  name: "instance"
 spec:
   managementState: "Managed"
   logStore:

--- a/pkg/apis/logging/v1alpha1/types.go
+++ b/pkg/apis/logging/v1alpha1/types.go
@@ -106,6 +106,7 @@ type ClusterLoggingStatus struct {
 	LogStore      LogStoreStatus      `json:"logStore"`
 	Collection    CollectionStatus    `json:"collection"`
 	Curation      CurationStatus      `json:"curation"`
+	Message       string              `json:"message"`
 }
 
 type VisualizationStatus struct {

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,0 +1,28 @@
+package runtime
+
+import (
+	"github.com/operator-framework/operator-sdk/pkg/sdk"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+//RetryOnConflict is a place for "k8s.io/client-go/util/retry#RetryOnConflict"
+type RetryOnConflict func(backoff wait.Backoff, fn func() error) error
+
+//SdkUpdate is a place holder for "github.com/operator-framework/operator-sdk/pkg/sdk#Update"
+type SdkUpdate func(object sdk.Object) error
+
+//OperatorRuntime is an adapter to the underlying runtime for the operator to
+//all mocking for testing
+type OperatorRuntime struct {
+	RetryOnConflict RetryOnConflict
+	Update          SdkUpdate
+}
+
+//New returns the default runtime
+func New() *OperatorRuntime {
+	return &OperatorRuntime{
+		RetryOnConflict: retry.RetryOnConflict,
+		Update:          sdk.Update,
+	}
+}

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -1,0 +1,95 @@
+package stub
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1alpha1"
+	"github.com/openshift/cluster-logging-operator/pkg/runtime"
+	"github.com/operator-framework/operator-sdk/pkg/sdk"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestAllowedToReconcileWhenNameIsTheSingletonName(t *testing.T) {
+	spec := newClusterLogging("instance")
+	if !allowedToReconcile(spec) {
+		t.Errorf("Exp. to be allowed to reconcile ClusterLogging named %q", spec.Name)
+	}
+}
+func TestAllowedToReconcileWhenNameIsNotTheSingletonName(t *testing.T) {
+	spec := newClusterLogging("myclusterLogging")
+	if allowedToReconcile(spec) {
+		t.Errorf("Exp. to not be allowed to reconcile ClusterLogging named %q", spec.Name)
+	}
+}
+
+func newClusterLogging(name string) *logging.ClusterLogging {
+	return &logging.ClusterLogging{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+}
+func TestUpdateStatusToIgnoreWhenNoError(t *testing.T) {
+	mockRuntime := &runtime.OperatorRuntime{
+		RetryOnConflict: func(backoff wait.Backoff, fn func() error) error {
+			return fn()
+		},
+		Update: func(object sdk.Object) error {
+			return nil
+		},
+	}
+
+	spec := newClusterLogging("myclusterLogging")
+	if err := updateStatusToIgnore(spec, mockRuntime); err != nil {
+		t.Errorf("Exp. no error when updating the status for %q: %v", spec.Name, err)
+	}
+	if spec.Status.Message != singletonMessage {
+		t.Errorf("Exp. ClusterLogging status message to indicate it is not the singleton instance but was %q", spec.Status.Message)
+	}
+}
+func TestUpdateStatusToIgnoreUpdatingWhenMessageIsAlreadyCorrect(t *testing.T) {
+	mockRuntime := &runtime.OperatorRuntime{
+		RetryOnConflict: func(backoff wait.Backoff, fn func() error) error {
+			return fn()
+		},
+		Update: func(object sdk.Object) error {
+			var spec = object.(*logging.ClusterLogging)
+			if spec.Status.Message == singletonMessage {
+				return fmt.Errorf("Should not be updating the message")
+			}
+			return nil
+		},
+	}
+
+	spec := newClusterLogging("myclusterLogging")
+	spec.Status.Message = singletonMessage
+	if err := updateStatusToIgnore(spec, mockRuntime); err != nil {
+		t.Errorf("Exp. no error when updating the status for %q: %v", spec.Name, err)
+	}
+	if spec.Status.Message != singletonMessage {
+		t.Errorf("Exp. ClusterLogging status message to indicate it is not the singleton instance but was %q", spec.Status.Message)
+	}
+}
+func TestUpdateStatusWhenRetryOnConflictError(t *testing.T) {
+	mockRuntime := &runtime.OperatorRuntime{
+		RetryOnConflict: func(backoff wait.Backoff, fn func() error) error {
+			return fmt.Errorf("RetryOnConflictTestError")
+		},
+		Update: func(object sdk.Object) error {
+			return nil
+		},
+	}
+
+	spec := newClusterLogging("myclusterLogging")
+	err := updateStatusToIgnore(spec, mockRuntime)
+	if err == nil {
+		t.Errorf("Exp. error while testing RetryOnConflict Error for %q: %v", spec.Name, err)
+	}
+	if !strings.Contains(err.Error(), "RetryOnConflictTestError") {
+		t.Errorf("Exp. an error messagge while testing RetryOnConflict Error for %q: %v", spec.Name, err)
+	}
+}

--- a/test/e2e/clusterlogging_test.go
+++ b/test/e2e/clusterlogging_test.go
@@ -85,7 +85,7 @@ func clusterLoggingFullClusterTest(t *testing.T, f *framework.Framework, ctx *fr
 			APIVersion: logging.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-cluster-logging",
+			Name:      "instance",
 			Namespace: namespace,
 		},
 		Spec: logging.ClusterLoggingSpec{


### PR DESCRIPTION
LOG-358. Restrict CL to single instance called "instance"

This PR additionally introduces an abstraction to allow mocking calls to runtime