### PR TITLE
fix issue trying to marshall CLO runtime abstraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ clean:
 
 image: imagebuilder
 	@if [ $${USE_IMAGE_STREAM:-false} = false ] && [ $${SKIP_BUILD:-false} = false ] ; \
-	then $(IMAGE_BUILDER) -t $(IMAGE_TAG) . $(IMAGE_BUILDER_OPTS) ; \
+	then $(IMAGE_BUILDER) $(IMAGE_BUILDER_OPTS) -t $(IMAGE_TAG) . ; \
 	fi
 
 fmt:

--- a/README.md
+++ b/README.md
@@ -90,5 +90,5 @@ on which the operator runs or can be pulled from a visible registry.
 **Note:** It is necessary to set the `IMAGE_CLUSTER_LOGGING_OPERATOR` environment variable to a valid pull spec
 in order to run this test against local changes to the `cluster-logging-operator`. For example:
 ```
-$ make deploy-image && IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc/openshift/origin-cluster-logging-operator:latest make test-e2e
+$ make deploy-image && IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc:5000/openshift/origin-cluster-logging-operator:latest make test-e2e
 ```

--- a/hack/deploy-image.sh
+++ b/hack/deploy-image.sh
@@ -55,5 +55,5 @@ if [ $ii = 10 ] ; then
 fi
 
 echo "Pushing image ${tag}..."
-docker login --tls-verify=false 127.0.0.1:${LOCAL_PORT} -u ${ADMIN_USER} -p $(oc whoami -t)
-docker push --tls-verify=false ${tag}
+docker login 127.0.0.1:${LOCAL_PORT} -u ${ADMIN_USER} -p $(oc whoami -t)
+docker push ${tag}

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -4,10 +4,10 @@ set -e
 if [ -n "${IMAGE_CLUSTER_LOGGING_OPERATOR:-}" ] ; then
   source "$(dirname $0)/common"
 fi
-
-STABLE_IMAGE_CLUSTER_LOGGING_OPERATOR=$(echo $IMAGE_FORMAT | sed 's,${component},cluster-logging-operator,')
+if [ -n "${IMAGE_FORMAT:-}" ] ; then
+  IMAGE_CLUSTER_LOGGING_OPERATOR=$(sed -e "s,\${component},cluster-logging-operator," <(echo $IMAGE_FORMAT))
+fi
 IMAGE_CLUSTER_LOGGING_OPERATOR=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift/origin-cluster-logging-operator:latest}
-IMAGE_MANIFEST_CLUSTER_LOGGING_OPERATOR=${STABLE_IMAGE_CLUSTER_LOGGING_OPERATOR:-$IMAGE_CLUSTER_LOGGING_OPERATOR}
 
 repo_dir="$(dirname $0)/.."
 if ! oc get project openshift-logging > /dev/null 2>&1 ; then
@@ -22,7 +22,7 @@ pushd manifests;
   done;
 popd
 # update the manifest with the image built by ci
-sed -i "s,quay.io/openshift/origin-cluster-logging-operator:latest,${IMAGE_MANIFEST_CLUSTER_LOGGING_OPERATOR}," ${manifest}
+sed -i "s,quay.io/openshift/origin-cluster-logging-operator:latest,${IMAGE_CLUSTER_LOGGING_OPERATOR}," ${manifest}
 
 global_manifest=$(mktemp)
 global_files="05-crd.yaml"

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -77,7 +77,7 @@ func (cluster *ClusterLogging) CreateOrUpdateCollection() (err error) {
 						printUpdateMessage = false
 					}
 					cluster.Status.Collection.Logs.FluentdStatus = fluentdStatus
-					return sdk.Update(cluster)
+					return sdk.Update(cluster.ClusterLogging)
 				}
 			}
 			return nil
@@ -116,7 +116,7 @@ func (cluster *ClusterLogging) CreateOrUpdateCollection() (err error) {
 						printUpdateMessage = false
 					}
 					cluster.Status.Collection.Logs.RsyslogStatus = rsyslogStatus
-					return sdk.Update(cluster)
+					return sdk.Update(cluster.ClusterLogging)
 				}
 			}
 			return nil

--- a/pkg/k8shandler/curation.go
+++ b/pkg/k8shandler/curation.go
@@ -58,7 +58,7 @@ func (cluster *ClusterLogging) CreateOrUpdateCuration() (err error) {
 						printUpdateMessage = false
 					}
 					cluster.Status.Curation.CuratorStatus = curatorStatus
-					return sdk.Update(cluster)
+					return sdk.Update(cluster.ClusterLogging)
 				}
 			}
 			return nil

--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -46,7 +46,7 @@ func (cluster *ClusterLogging) CreateOrUpdateLogStore() (err error) {
 						printUpdateMessage = false
 					}
 					cluster.Status.LogStore.ElasticsearchStatus = elasticsearchStatus
-					return sdk.Update(cluster)
+					return sdk.Update(cluster.ClusterLogging)
 				}
 			}
 			return nil

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -67,7 +67,7 @@ func (cluster *ClusterLogging) CreateOrUpdateVisualization() (err error) {
 						printUpdateMessage = false
 					}
 					cluster.Status.Visualization.KibanaStatus = kibanaStatus
-					return sdk.Update(cluster)
+					return sdk.Update(cluster.ClusterLogging)
 				}
 			}
 			return nil

--- a/test/e2e/clusterlogging_test.go
+++ b/test/e2e/clusterlogging_test.go
@@ -140,6 +140,7 @@ func clusterLoggingFullClusterTest(t *testing.T, f *framework.Framework, ctx *fr
 }
 
 func waitForOperatorToBeReady(t *testing.T, ctx *framework.TestCtx) error {
+	t.Log("Initializing cluster resources...")
 	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR fixes an issue updating ClusterLogging.Status where it tries to marshal CLO runtime instance which is a function pointer.

```
time="2019-03-25T19:43:20Z" level=error msg="error syncing key (openshift-logging/instance): Unable to create or update logstore for \"instance\": Failed to update Cluster Logging Elasticsearch status: error running MarshalJSON on runtime object: json: unsupported type: runtime.RetryOnConflict"
```