### PR TITLE
rsyslog - disable impstats until logrotation available

### DIFF
--- a/files/rsyslog/10-viaq-modules.conf
+++ b/files/rsyslog/10-viaq-modules.conf
@@ -17,4 +17,5 @@ module(load="omelasticsearch")
 module(load="mmkubernetes")
 
 # stats for monitoring
-module(load="impstats" interval="1" format="cee" log.syslog="off" log.file=`echo $RSYSLOG_IMPSTATS_FILE`)
+# cannot enable until there is log rotation for this file
+#module(load="impstats" interval="1" format="cee" log.syslog="off" log.file=`echo $RSYSLOG_IMPSTATS_FILE`)


### PR DESCRIPTION
cannot enable impstats until we have log rotation