### PR TITLE
Bug 1694573 - use ZeroRedundancy esCR policy when omitted from CLO

### DIFF
--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -124,6 +124,11 @@ func (cluster *ClusterLogging) newElasticsearchCR(elasticsearchName string) *ela
 		Storage:      cluster.Spec.LogStore.ElasticsearchSpec.Storage,
 	}
 
+	redundancyPolicy := cluster.Spec.LogStore.ElasticsearchSpec.RedundancyPolicy
+	if redundancyPolicy == "" {
+		redundancyPolicy = elasticsearch.ZeroRedundancy
+	}
+
 	// build Nodes
 	esNodes = append(esNodes, esNode)
 
@@ -143,7 +148,7 @@ func (cluster *ClusterLogging) newElasticsearchCR(elasticsearchName string) *ela
 			},
 			Nodes:            esNodes,
 			ManagementState:  elasticsearch.ManagementStateManaged,
-			RedundancyPolicy: cluster.Spec.LogStore.ElasticsearchSpec.RedundancyPolicy,
+			RedundancyPolicy: redundancyPolicy,
 		},
 	}
 

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -460,7 +460,7 @@ func (cluster *ClusterLogging) newKibanaPodSpec(kibanaName string, elasticsearch
 		"-tls-key=/secret/server-key",
 		"-pass-access-token",
 		"-skip-provider-button",
-        // FIX: https://bugzilla.redhat.com/show_bug.cgi?id=1693957 or revert 1666674 completely
+		// FIX: https://bugzilla.redhat.com/show_bug.cgi?id=1693957 or revert 1666674 completely
 		//		"-openshift-sar={\"resource\": \"selfsubjectaccessreviews\", \"verb\": \"create\", \"group\": \"authorization.k8s.io\"}",
 		//		"-openshift-delegate-urls={\"/\": {\"resource\": \"selfsubjectaccessreviews\", \"verb\": \"create\", \"group\": \"authorization.k8s.io\"}}",
 	}


### PR DESCRIPTION
Defaulting CLO redundancy policy to ZeroRedundancy when omitted and adding unit tests

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1694573