### PR TITLE
UBI support; allow image build and push with oal logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ clean:
 
 image: imagebuilder
 	@if [ $${USE_IMAGE_STREAM:-false} = false ] && [ $${SKIP_BUILD:-false} = false ] ; \
-	then $(IMAGE_BUILDER) $(IMAGE_BUILDER_OPTS) -t $(IMAGE_TAG) . ; \
+	then hack/build-image.sh $(IMAGE_TAG) $(IMAGE_BUILDER) $(IMAGE_BUILDER_OPTS) ; \
 	fi
 
 fmt:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,30 @@ This will stand up a cluster logging stack named 'example'.
 
 ## Hacking
 
+### Building a Universal Base Image (UBI) based image
+
+You must first `oc login api.ci.openshift.org`.  You'll need these credentials in order
+to pull images from the UBI registry.
+
+The image build process for UBI based images uses a private yum repo.
+In order to use the private yum repo, you will need access to
+https://github.com/openshift/release/blob/master/cluster/ci/config/prow/openshift/rpm-mirrors/ocp-4.0-default.repo
+and
+https://github.com/openshift/shared-secrets/blob/master/mirror/ops-mirror.pem
+Note that the latter is private and requires special permission to access.
+
+The best approach is to clone these repos under `$GOPATH/src/github.com/openshift`
+which the build scripts will pick up automatically.  If you do not, the build script
+will attempt to clone them to a temporary directory.
+
+### Running a full integration test with a 4.x cluster
+
+If you have a local clone of [origin-aggregated-logging](https://github.com/openshift/origin-aggregated-logging)
+under `$GOPATH/github.com/openshift/origin-aggregated-logging` you can use its `hack/get-cluster-run-tests.sh`
+to build the logging, elasticsearch-operator, and cluster-logging-operator images; deploy a 4.x cluster;
+push the images to the cluster; deploy logging; and launch the logging CI tests.
+
+
 ### Running the operator
 
 Running locally outside an OKD cluster:
@@ -40,6 +64,9 @@ The deployment can be optionally modified using any of the following:
 |`EXCLUSIONS`|none|The list of manifest files that should will be ignored|
 |`OC`|`oc` in `PATH`| The openshift binary to use to deploy resources|
 |`REMOTE_REGISTRY`|false|`true` if you are running the cluster on a different machine than the one you are developing on|
+|`PUSH_USER`|none|The name of the user e.g. `kubeadmin` used to push images to the remote registry|
+|`PUSH_PASSWORD`|none|The password for `PUSH_USER`|
+|`SKIP_BUILD`|false|`true` if you are pushing an image to a remote registry and want to skip building it again|
 
 **Note:** Use `REMOTE_REGISTRY=true`, for example, if you are running a cluster in a
     local libvirt or minishift environment; you may want to build the image on the host
@@ -54,11 +81,20 @@ create a user and assign it rights:
 If you used the new `openshift-installer`, it creates a user named `kubeadmin`
     with the password in the file `installer/auth/kubeadmin_password`.
 
-```oc login --username=kubeadmin --password=$( cat ../installer/auth/kubeadmin_password )```
+To push the image to the remote registry, set `REMOTE_REGISTRY=true`, `PUSH_USER=kubeadmin`,
+`KUBECONFIG=/path/to/installer/auth/kubeconfig`, and
+`PUSH_PASSWORD=$( cat /path/to/installer/auth/kubeadmin_password )`.  You do not have to
+`oc login` to the cluster.  If you already built the image, use `SKIP_BUILD=true` to do
+a push only.
 
-The user should already have `cluster-admin` rights.
+```bash
+REMOTE_REGISTRY=true PUSH_USER=kubeadmin SKIP_BUILD=true \
+KUBECONFIG=/path/to/installer/auth/kubeconfig \
+PUSH_PASSWORD=$( cat /path/to/installer/auth/kubeadmin_password ) \
+make deploy-image
+```
 
-**Note:** If you are using `REMOTE_REGISTRY=true`, ensure you have `docker` package installed and `docker` daemon up and running on the workstation you are running these commands.
+**Note:** If you are using `REMOTE_REGISTRY=true`, ensure you have `docker` package installed and `docker` daemon up and running on the workstation you are running these commands.  Also ensure you have `podman` (`docker` may be deprecated in the future).
 
 
 **Note:**  If while hacking you find your changes are not being applied, use

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+source "$(dirname $0)/common"
+
+IMAGE_TAG=$1
+IMAGE_BUILDER=${2:-imagebuilder}
+IMAGE_BUILDER_OPTS=${3:-}
+
+workdir=${WORKDIR:-$( mktemp --tmpdir -d cluster-logging-operator-build-XXXXXXXXXX )}
+if [ -z "${WORKDIR:-}" ] ; then
+    trap "rm -rf $workdir" EXIT
+fi
+
+if image_is_ubi Dockerfile ; then
+    pull_ubi_if_needed
+fi
+
+if image_needs_private_repo Dockerfile ; then
+    repodir=$( get_private_repo_dir $workdir )
+    mountarg="-mount $repodir:/etc/yum.repos.d/"
+else
+    mountarg=""
+fi
+
+echo building image $IMAGE_TAG - this may take a few minutes until you see any output . . .
+$IMAGE_BUILDER $IMAGE_BUILDER_OPTS $mountarg -t $IMAGE_TAG .

--- a/hack/common
+++ b/hack/common
@@ -13,6 +13,160 @@ ADMIN_PSWD=${ADMIN_USER:-admin123}
 REMOTE_REGISTRY=${REMOTE_REGISTRY:-false}
 NAMESPACE=${NAMESPACE:-"openshift-logging"}
 
+UBI_IMAGE=${UBI_IMAGE:-registry.svc.ci.openshift.org/ocp/4.0:base}
+
+function image_is_ubi() {
+    # dockerfile is arg $1
+    grep -q "^FROM $UBI_IMAGE" $1
+}
+
+function image_needs_private_repo() {
+    # dockerfile is arg $1
+    image_is_ubi $1 || \
+        grep -q "^FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base" $1
+}
+
+CI_REGISTRY=${CI_REGISTRY:-registry.svc.ci.openshift.org}
+CI_CLUSTER_NAME=${CI_CLUSTER_NAME:-api-ci-openshift-org:443}
+
+function get_context_for_cluster() {
+    set +o pipefail > /dev/null
+    oc config get-contexts | awk -F'[* ]+' -v clname="$1" '$3 == clname {print $2; exit}'
+    set -o pipefail > /dev/null
+}
+
+# get credentials needed to authenticate to $CI_REGISTRY
+# requires `oc` and requires user to have recently `oc login` to the $CI_CLUSTER_NAME cluster
+# NOTE: cluster name != cluster hostname!!
+function login_to_ci_registry() {
+    local savekc=""
+    local savectx=$( oc config current-context )
+    local cictx=$( get_context_for_cluster $CI_CLUSTER_NAME )
+    rc=0
+    if [ -z "$cictx" ] ; then
+        # try again without KUBECONFIG
+        savekc=${KUBECONFIG:-}
+        unset KUBECONFIG
+        savectx=$( oc config current-context )
+        cictx=$( get_context_for_cluster $CI_CLUSTER_NAME )
+    fi
+    if [ -z "$cictx" ] ; then
+        echo ERROR: login_to_ci_registry: you must oc login to the server for cluster $CI_CLUSTER_NAME
+        echo oc config get-contexts does not list cluster $CI_CLUSTER_NAME
+        rc=1
+    else
+        oc config use-context "$cictx"
+        local username=$( oc whoami )
+        local token=$( oc whoami -t 2> /dev/null || : )
+        if [ -z "$token" -o -z "$username" ] ; then
+            echo ERROR: no username or token for context "$cictx"
+            echo your credentials may have expired
+            echo please oc login to the server for cluster $CI_CLUSTER_NAME
+            rc=1
+        else
+            docker login -u "$username" -p "$token" $CI_REGISTRY
+        fi
+    fi
+    if [ -n "$savectx" ] ; then
+        oc config use-context "$savectx"
+    fi
+    if [ -n "$savekc" ] ; then
+        export KUBECONFIG=$savekc
+    fi
+    return $rc
+}
+
+function pull_ubi_if_needed() {
+    if ! docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "^${UBI_IMAGE}\$" ; then
+        login_to_ci_registry
+        docker pull $UBI_IMAGE
+    fi
+}
+
+# to build using internal/private yum repos, specify
+# INTERNAL_REPO_DIR=/path/to/dir/
+# where /path/to/dir/ contains the yum .repo files, and
+# any private key pem files needed - this dir will be
+# mounted into the builder as /etc/yum.repos.d/
+INTERNAL_REPO_DIR=${INTERNAL_REPO_DIR:-}
+function get_private_repo_dir() {
+    if [ -z "${INTERNAL_REPO_DIR:-}" ] ; then
+        pushd $1 > /dev/null
+        if [ ! -d repos ] ; then
+            mkdir repos
+            if [ -f $GOPATH/src/github.com/openshift/shared-secrets/mirror/ops-mirror.pem ] ; then
+                cp $GOPATH/src/github.com/openshift/shared-secrets/mirror/ops-mirror.pem repos
+            else
+                if [ ! -d shared-secrets ] ; then
+                    git clone -q git@github.com:openshift/shared-secrets.git
+                fi
+                cp shared-secrets/mirror/ops-mirror.pem repos
+            fi
+            if [ -f $GOPATH/src/github.com/openshift/release/cluster/ci/config/prow/openshift/rpm-mirrors/ocp-4.0-default.repo ]; then
+                cp $GOPATH/src/github.com/openshift/release/cluster/ci/config/prow/openshift/rpm-mirrors/ocp-4.0-default.repo repos
+            else
+                if [ ! -d release ] ; then
+                    git clone -q https://github.com/openshift/release
+                fi
+                cp release/cluster/ci/config/prow/openshift/rpm-mirrors/ocp-4.0-default.repo repos
+            fi
+            touch repos/redhat.repo
+            chmod 0444 repos/redhat.repo
+            sed -i 's,= ops-mirror.pem,= /etc/yum.repos.d/ops-mirror.pem,' repos/ocp-4.0-default.repo
+        fi
+        INTERNAL_REPO_DIR=$( pwd )/repos
+        popd > /dev/null
+    elif [ ! -f $INTERNAL_REPO_DIR/ops-mirror.pem -o ! -f $INTERNAL_REPO_DIR/ocp-4.0-default.repo ] ; then
+        echo ERROR: $INTERNAL_REPO_DIR missing one of ops-mirror.pem or ocp-4.0-default.repo
+        exit 1
+    fi
+    echo $INTERNAL_REPO_DIR
+}
+
+function login_to_registry() {
+    local savectx=$( oc config current-context )
+    local token=""
+    local username=""
+    if [ -n "${PUSH_USER:-}" -a -n "${PUSH_PASSWORD:-}" ] ; then
+        username=$PUSH_USER
+        if [ "$username" = "kube:admin" ] ; then
+            username=kubeadmin
+        fi
+        oc login -u "$username" -p "$PUSH_PASSWORD" > /dev/null
+        token=$( oc whoami -t 2> /dev/null || : )
+        oc config use-context "$savectx"
+    else
+        # see if current context has a token
+        token=$( oc whoami -t 2> /dev/null || : )
+        if [ -n "$token" ] ; then
+            username=$( oc whoami )
+        else
+            # get the first user with a token
+            token=$( oc config view -o go-template='{{ range .users }}{{ if .user.token }}{{ print .user.token }}{{ end }}{{ end }}' )
+            if [ -n "$token" ] ; then
+                username=$( oc config view -o go-template='{{ range .users }}{{ if .user.token }}{{ print .name }}{{ end }}{{ end }}' )
+                # username is in form username/cluster - strip off the cluster part
+                username=$( echo "$username" | sed 's,/.*$,,' )
+            fi
+        fi
+        if [ -z "$token" ] ; then
+            echo ERROR: could not determine token to use to login to "$1"
+            echo please do `oc login -u username -p password` to create a context with a token
+            echo OR
+            echo set \$PUSH_USER and \$PUSH_PASSWORD and run this script again
+            return 1
+        fi
+        if [ "$username" = "kube:admin" ] ; then
+            username=kubeadmin
+        fi
+    fi
+    podman login --tls-verify=false -u "$username" -p "$token" "$1" > /dev/null
+}
+
+function push_image() {
+    skopeo copy --dest-tls-verify=false docker-daemon:"$1" docker://"$2"
+}
+
 if [ $REMOTE_REGISTRY = false ] ; then
     : # skip
 else
@@ -22,7 +176,7 @@ else
     if ! oc get namespace $registry_namespace ; then
         registry_namespace=default
         registry_svc=docker-registry
-        # use ip instead of host
+        # use ip instead
         registry_host=$(oc get svc $registry_svc -n $registry_namespace -o jsonpath={.spec.clusterIP})
     fi
 

--- a/hack/deploy-image.sh
+++ b/hack/deploy-image.sh
@@ -54,6 +54,19 @@ if [ $ii = 10 ] ; then
     exit 1
 fi
 
-echo "Pushing image ${tag}..."
-docker login 127.0.0.1:${LOCAL_PORT} -u ${ADMIN_USER} -p $(oc whoami -t)
-docker push ${tag}
+login_to_registry "127.0.0.1:${LOCAL_PORT}"
+echo "Pushing image ${IMAGE_TAG} to ${tag} ..."
+rc=0
+for ii in $( seq 1 5 ) ; do
+    if push_image ${IMAGE_TAG} ${tag} ; then
+        rc=0
+        break
+    fi
+    echo push failed - retrying
+    rc=1
+    sleep 1
+done
+if [ $rc = 1 -a $ii = 5 ] ; then
+    echo ERROR: giving up push of ${IMAGE_TAG} to ${tag} after 5 tries
+    exit 1
+fi


### PR DESCRIPTION
Support building UBI based images, and images that need the
private repo for rpms.
Make it easier to build the image and push to a deployed
cluster with the logging images.