### PR TITLE
LOG-400 rsyslog - support log rotation for rsyslog log files

### DIFF
--- a/controller-manifests/cluster-logging.v4.1.0.clusterserviceversion.yaml
+++ b/controller-manifests/cluster-logging.v4.1.0.clusterserviceversion.yaml
@@ -72,7 +72,8 @@ spec:
     ## Prerequisites and Requirements
     ### Cluster Logging Namespace
     Cluster logging and the Cluster Logging Operator is only deployable to the **openshift-logging** namespace. This namespace
-    must be explicitly created by a cluster administrator (e.g. `oc create ns openshift-logging`)
+    must be explicitly created by a cluster administrator (e.g. `oc create ns openshift-logging`). To enable metrics
+    service discovery add namespace label `openshift.io/cluster-monitoring: "true"`.
     ### Elasticsearch Operator
     The Elasticsearch Operator is responsible for orchestrating and managing cluster logging's Elasticsearch cluster.  This
     operator must be deployed to the global operator group namespace
@@ -176,6 +177,7 @@ spec:
           - monitoring.coreos.com
           resources:
           - servicemonitors
+          - prometheusrules
           verbs:
           - "*"
       clusterPermissions:

--- a/files/logrotate/cron.sh
+++ b/files/logrotate/cron.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Wrapper to start cronjob to invoke logrotate periodically
+
+echo "export LOGGING_FILE_PATH=${LOGGING_FILE_PATH:-}" > /tmp/.logrotate
+echo "export LOGGING_FILE_SIZE=${LOGGING_FILE_SIZE:-}" >> /tmp/.logrotate
+echo "export LOGGING_FILE_AGE=${LOGGING_FILE_AGE:-}" >> /tmp/.logrotate
+echo "export RSYSLOG_WORKDIRECTORY=${RSYSLOG_WORKDIRECTORY:-/var/lib/rsyslog.pod}" >> /tmp/.logrotate
+
+exec /usr/sbin/crond -n $CROND_OPTIONS

--- a/files/logrotate/logrotate
+++ b/files/logrotate/logrotate
@@ -1,0 +1,6 @@
+# crontab
+# login as root
+# run logrotate (/var/log/rsyslog/*.log) at 2am everyday
+# run logrotate_pod (/var/lib/rsyslog.pod) at 3am everyday
+0 2 * * *       root /usr/bin/bash /opt/app-root/bin/logrotate.sh
+0 3 * * *       root /usr/bin/bash /opt/app-root/bin/logrotate_pod.sh

--- a/files/logrotate/logrotate.sh
+++ b/files/logrotate/logrotate.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+. /tmp/.logrotate
+
+dirname=$( dirname ${LOGGING_FILE_PATH:-"/var/log/rsyslog/rsyslog.log"} )
+cat > /tmp/logrotate.conf << EOF
+"$dirname/*.log"
+{
+  create 0644 root
+  dateext
+  dateformat -%Y%m%d-%s
+  missingok
+  notifempty
+  size ${LOGGING_FILE_SIZE:-1024000}
+  rotate ${LOGGING_FILE_AGE:-10}
+  postrotate
+    # rsyslogd is "exec"ed in the first script rsyslog.sh
+    kill -HUP $( cat /var/run/rsyslogd.pid )
+  endscript
+}
+EOF
+
+exec /usr/sbin/logrotate --log $dirname/logrotate.log /tmp/logrotate.conf

--- a/files/logrotate/logrotate_pod.sh
+++ b/files/logrotate/logrotate_pod.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+. /tmp/.logrotate
+
+cat > /tmp/logrotate_pod.conf << EOF
+"${RSYSLOG_WORKDIRECTORY}/*.log"
+"${RSYSLOG_WORKDIRECTORY}/impstats.json"
+{
+  create 0644 root
+  dateext
+  dateformat -%Y%m%d-%s
+  missingok
+  notifempty
+  size ${LOGGING_FILE_SIZE:-1024000}
+  rotate ${LOGGING_FILE_AGE:-10}
+  postrotate
+    # rsyslogd is "exec"ed in the first script rsyslog.sh
+    kill -HUP $( cat /var/run/rsyslogd.pid )
+  endscript
+}
+EOF
+
+exec /usr/sbin/logrotate --log ${RSYSLOG_WORKDIRECTORY}/logrotate.log /tmp/logrotate_pod.conf

--- a/files/rsyslog/00-global.conf
+++ b/files/rsyslog/00-global.conf
@@ -7,4 +7,5 @@ global(
   oversizemsg.report="off"
   oversizemsg.input.mode="accept"
   maxMessageSize="32767"
+  processInternalMessages="on"
 )

--- a/files/rsyslog/99-logging.conf
+++ b/files/rsyslog/99-logging.conf
@@ -1,0 +1,6 @@
+template(name="FileFormat" type="string" string= "%TIMESTAMP% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n")
+
+if ($inputname == "rsyslogd") and (`echo $LOGGING_FILE_PATH` != "console") then {
+    action(type="omfile" template="FileFormat" file=`echo $LOGGING_FILE_PATH`)
+}
+

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -106,6 +106,10 @@ func (cluster *ClusterLogging) CreateOrUpdateCollection() (err error) {
 			return
 		}
 
+		if err = createOrUpdateLogrotateConfigMap(cluster); err != nil {
+			return
+		}
+
 		if err = createOrUpdateRsyslogSecret(cluster); err != nil {
 			return
 		}

--- a/pkg/k8shandler/curation.go
+++ b/pkg/k8shandler/curation.go
@@ -166,7 +166,7 @@ func (cluster *ClusterLogging) newCuratorCronJob(curatorName string, elasticsear
 			},
 		}
 	}
-	curatorContainer := utils.NewContainer("curator", v1.PullIfNotPresent, *resources)
+	curatorContainer := utils.NewContainer("curator", "curator", v1.PullIfNotPresent, *resources)
 
 	curatorContainer.Env = []v1.EnvVar{
 		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc.cluster.local"},

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -200,7 +200,7 @@ func newFluentdPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			},
 		}
 	}
-	fluentdContainer := utils.NewContainer("fluentd", v1.PullIfNotPresent, *resources)
+	fluentdContainer := utils.NewContainer("fluentd", "fluentd", v1.PullIfNotPresent, *resources)
 
 	fluentdContainer.Ports = []v1.ContainerPort{
 		v1.ContainerPort{

--- a/pkg/k8shandler/rsyslog.go
+++ b/pkg/k8shandler/rsyslog.go
@@ -28,6 +28,14 @@ func removeRsyslog(cluster *ClusterLogging) (err error) {
 			return
 		}
 
+		if err = utils.RemoveConfigMap(cluster.Namespace, "logrotate-bin"); err != nil {
+			return
+		}
+
+		if err = utils.RemoveConfigMap(cluster.Namespace, "logrotate-crontab"); err != nil {
+			return
+		}
+
 		if err = utils.RemoveSecret(cluster.Namespace, "rsyslog"); err != nil {
 			return
 		}
@@ -100,6 +108,44 @@ func createOrUpdateRsyslogConfigMap(logging *ClusterLogging) error {
 	return nil
 }
 
+func createOrUpdateLogrotateConfigMap(logging *ClusterLogging) error {
+
+	// need two configmaps
+	// - one for logrotate cron.sh, logrotate.sh and logrotate_pod.sh script - bin
+	// - one for logrotate crontab - crontab
+	logrotateConfigMaps := make(map[string]*v1.ConfigMap)
+	logrotateBinConfigMap := utils.NewConfigMap(
+		"logrotate-bin",
+		logging.Namespace,
+		map[string]string{
+			"cron.sh": string(utils.GetFileContents("/usr/share/logging/logrotate/cron.sh")),
+			"logrotate.sh": string(utils.GetFileContents("/usr/share/logging/logrotate/logrotate.sh")),
+			"logrotate_pod.sh": string(utils.GetFileContents("/usr/share/logging/logrotate/logrotate_pod.sh")),
+		},
+	)
+	logrotateConfigMaps["logrotate-bin"] = logrotateBinConfigMap
+
+	logrotateCrontabConfigMap := utils.NewConfigMap(
+		"logrotate-crontab",
+		logging.Namespace,
+		map[string]string{
+			"logrotate": string(utils.GetFileContents("/usr/share/logging/logrotate/logrotate")),
+		},
+	)
+	logrotateConfigMaps["logrotate-crontab"] = logrotateCrontabConfigMap
+
+	for name, cm := range logrotateConfigMaps {
+		logging.AddOwnerRefTo(cm)
+
+		err := sdk.Create(cm)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("Failure constructing Logrotate configmap %v: %v", name, err)
+		}
+	}
+
+	return nil
+}
+
 func createOrUpdateRsyslogSecret(logging *ClusterLogging) error {
 
 	rsyslogSecret := utils.NewSecret(
@@ -161,7 +207,7 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 				v1.ResourceCPU:    defaultRsyslogCpuRequest,
 			}}
 	}
-	rsyslogContainer := utils.NewContainer("rsyslog", v1.PullIfNotPresent, *resources)
+	rsyslogContainer := utils.NewContainer("rsyslog", "rsyslog", v1.PullIfNotPresent, *resources)
 
 	rsyslogContainer.Env = []v1.EnvVar{
 		{Name: "MERGE_JSON_LOG", Value: "false"},
@@ -183,11 +229,13 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 		{Name: "RSYSLOG_CPU_LIMIT", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{ContainerName: "rsyslog", Resource: "limits.cpu"}}},
 		{Name: "RSYSLOG_MEMORY_LIMIT", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{ContainerName: "rsyslog", Resource: "limits.memory"}}},
 		{Name: "NODE_IPV4", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.hostIP"}}},
+		{Name: "RSYSLOG_WORKDIRECTORY", Value: "/var/lib/rsyslog.pod"},
 	}
 
 	rsyslogContainer.VolumeMounts = []v1.VolumeMount{
 		{Name: "runlogjournal", MountPath: "/run/log/journal"},
 		{Name: "varlog", MountPath: "/var/log"},
+		{Name: "varrun", MountPath: "/var/run"},
 		{Name: "varlibdockercontainers", ReadOnly: true, MountPath: "/var/lib/docker"},
 		{Name: "bin", ReadOnly: true, MountPath: "/opt/app-root/bin"},
 		{Name: "main", ReadOnly: true, MountPath: "/etc/rsyslog/conf"},
@@ -211,12 +259,43 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 		"/opt/app-root/bin/rsyslog.sh",
 	}
 
+	logrotateContainer := utils.NewContainer("logrotate", "rsyslog", v1.PullIfNotPresent, *resources)
+
+	logrotateContainer.Env = []v1.EnvVar{
+		{Name: "LOGGING_FILE_PATH", Value: "/var/log/rsyslog/rsyslog.log"},
+		{Name: "LOGGING_FILE_SIZE", Value: "1024000"},
+		{Name: "LOGGING_FILE_AGE", Value: "10"},
+		{Name: "CROND_OPTIONS", Value: ""},
+		{Name: "RSYSLOG_WORKDIRECTORY", Value: "/var/lib/rsyslog.pod"},
+	}
+
+	logrotateContainer.VolumeMounts = []v1.VolumeMount{
+		{Name: "logrotate-bin", ReadOnly: true, MountPath: "/opt/app-root/bin"},
+		{Name: "logrotate-crontab", ReadOnly: true, MountPath: "/etc/cron.d"},
+		{Name: "varlog", MountPath: "/var/log"},
+		{Name: "varrun", MountPath: "/var/run"},
+		{Name: "filebufferstorage", MountPath: "/var/lib/rsyslog.pod"},
+	}
+
+	logrotateContainer.SecurityContext = &v1.SecurityContext{
+		Privileged: utils.GetBool(true),
+	}
+
+	logrotateContainer.Command = []string{
+		"/bin/sh",
+	}
+
+	logrotateContainer.Args = []string{
+		"/opt/app-root/bin/cron.sh",
+	}
+
 	rsyslogPodSpec := utils.NewPodSpec(
 		"logcollector",
-		[]v1.Container{rsyslogContainer},
+		[]v1.Container{rsyslogContainer, logrotateContainer},
 		[]v1.Volume{
 			{Name: "runlogjournal", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/run/log/journal"}}},
 			{Name: "varlog", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/log"}}},
+			{Name: "varrun", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/run"}}},
 			{Name: "varlibdockercontainers", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/docker"}}},
 			{Name: "bin", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "rsyslog-bin"}}}},
 			{Name: "main", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "rsyslog-main"}}}},
@@ -226,6 +305,8 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			{Name: "localtime", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/localtime"}}},
 			{Name: "machineid", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/machine-id"}}},
 			{Name: "filebufferstorage", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/rsyslog.pod"}}},
+			{Name: "logrotate-bin", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "logrotate-bin"}}}},
+			{Name: "logrotate-crontab", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "logrotate-crontab"}}}},
 		},
 		logging.Spec.Collection.Logs.RsyslogSpec.NodeSelector,
 	)
@@ -241,6 +322,9 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			Effect:   v1.TaintEffectNoSchedule,
 		},
 	}
+
+	b := bool(true)
+	rsyslogPodSpec.ShareProcessNamespace = &b
 
 	return rsyslogPodSpec
 }

--- a/pkg/k8shandler/rsyslog_test.go
+++ b/pkg/k8shandler/rsyslog_test.go
@@ -36,8 +36,8 @@ func TestNewRsyslogPodSpecWhenFieldsAreUndefined(t *testing.T) {
 	cluster := &logging.ClusterLogging{}
 	podSpec := newRsyslogPodSpec(cluster, "test-app-name", "test-infra-name")
 
-	if len(podSpec.Containers) != 1 {
-		t.Error("Exp. there to be 1 fluentd container")
+	if len(podSpec.Containers) != 2 {
+		t.Error("Exp. there to be 2 rsyslog containers")
 	}
 
 	resources := podSpec.Containers[0].Resources
@@ -72,8 +72,8 @@ func TestNewRsyslogPodSpecWhenResourcesAreDefined(t *testing.T) {
 	}
 	podSpec := newRsyslogPodSpec(cluster, "test-app-name", "test-infra-name")
 
-	if len(podSpec.Containers) != 1 {
-		t.Error("Exp. there to be 1 fluentd container")
+	if len(podSpec.Containers) != 2 {
+		t.Error("Exp. there to be 2 rsyslog containers")
 	}
 
 	resources := podSpec.Containers[0].Resources

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -368,6 +368,7 @@ func (cluster *ClusterLogging) newKibanaPodSpec(kibanaName string, elasticsearch
 	}
 	kibanaContainer := utils.NewContainer(
 		"kibana",
+		"kibana",
 		v1.PullIfNotPresent,
 		*kibanaResources,
 	)
@@ -416,6 +417,7 @@ func (cluster *ClusterLogging) newKibanaPodSpec(kibanaName string, elasticsearch
 		}
 	}
 	kibanaProxyContainer := utils.NewContainer(
+		"kibana-proxy",
 		"kibana-proxy",
 		v1.PullIfNotPresent,
 		*kibanaProxyResources,

--- a/pkg/utils/pod.go
+++ b/pkg/utils/pod.go
@@ -17,10 +17,10 @@ func NewPodSpec(serviceAccountName string, containers []core.Container, volumes 
 }
 
 //NewContainer stubs an instance of a Container
-func NewContainer(containerName string, pullPolicy core.PullPolicy, resources core.ResourceRequirements) core.Container {
+func NewContainer(containerName string, imageName string, pullPolicy core.PullPolicy, resources core.ResourceRequirements) core.Container {
 	return core.Container{
 		Name:            containerName,
-		Image:           GetComponentImage(containerName),
+		Image:           GetComponentImage(imageName),
 		ImagePullPolicy: pullPolicy,
 		Resources:       resources,
 	}


### PR DESCRIPTION
Purpose: Adding the logrotation supports to rsyslog to match fluentd.

Since rsyslog does not include logrotate capability, use an utility logrotate to do the job.
Logrotate is added as a separate container to the rsyslog pod to share the logging paths.

How to see the rsyslog logs:
```
  oc logs $RSYSLOG_POD -c rsyslog
  =============================
  Rsyslog logs have been redirected to: /var/log/rsyslog/rsyslog.log
  If you want to print out the logs, use command:
  oc exec <pod_name> -- logs
  =============================

  $ oc exec $RSYSLOG_POD -- logs
  Defaulting container name to rsyslog.
  INFO: Disabling Prometheus endpoint
  <DATE> rsyslog-gvcmt rsyslogd-2207: error during parsing file /etc/rsyslog.d/55-elasticsearch.conf, ...
```
Logrotate is configurable by editing logrotate configmaps and resetting environment variables.
1) logrotate configmaps
  logrotate-bin
    cron.sh
      It executes /usr/sbin/crond in the foreground.
      Crond option CROND_OPTIONS is configurable by the environment variable
      in the logrotate container.
    logrotate.sh
      It executes logrotate to rotate the rsyslog log file, which is
      /var/log/rsyslog/rsyslog.log by default.  The path is configurable
      via the environment variable LOGGING_FILE_PATH.
      The log file size to trigger rotation, LOGGING_FILE_SIZE as well as
      the file count to keep, LOGGING_FILE_AGE are configurable.
      The shell script is launched by the crond following the crontab.
      The crontab logrotate-crontab is another logrotate configmap.
    logrotate_pod.sh
      It executes logrotate to rotate the log files and impstats.json,
      which is located in /var/lib/rsyslog.pod, by default.
      The path is configurable via the environment variable RSYSLOG_WORKDIRECTORY.
      LOGGING_FILE_SIZE and LOGGING_FILE_AGE are shared with logrotate.sh.
      The shell script is also launched by the crond following the crontab.
      The crontab logrotate-crontab is another logrotate configmap.
  logrotate-crontab
      By default, both logrotate.sh and logrotate_pod.sh are executed once a day
      at 2am and 3am, respectively.  The times and timings are configurable in
      the configmap logrotate-crontab.
```
      # crontab
      # login as root
      # run logrotate (/var/log/rsyslog/*.log) at 2am everyday
      # run logrotate_pod (/var/lib/rsyslog.pod) at 3am everyday
      0 2 * * *       root /opt/app-root/bin/logrotate.sh
      0 3 * * *       root /opt/app-root/bin/logrotate_pod.sh
```
2) Logrotate environment variables
```
  CROND_OPTIONS - crond options which; Default to "".
  LOGGING_FILE_PATH - rsyslog log file path; Default to "/var/log/rsyslog/rsyslog.log"
  LOGGING_FILE_SIZE - max rsyslog log file size.  Once reaches the size, the file is rotated to rsyslog.log; Default to 1024000.
  LOGGING_FILE_AGE  - max rsyslog log file count; Default to 10.
  RSYSLOG_WORKDIRECTORY - rsyslog work directory to store impstats.json and the other log files.
```
Notes: This patch makes the rsyslog container and the logrotate container share an rsyslog pod.
The logrotate container does not have its own image but it starts with a shell to launch a script.
Thus, to rsh into a container, you should do as follows:
 rsyslog: oc rsh $RSYSLOG_POD -c rsyslog
 logrotate: kubectl exec -it $RSYSLOG_POD -c logrotate /bin/sh
to rsh rsyslog

To allow logrotate in the logrotate container to send a signal to rsyslogd, set processInternalMessages to "on".