### PR TITLE
Bug 1699268 - Fixing not setting Kibana replicas on generated deployment

### DIFF
--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -137,6 +137,8 @@ func (cluster *ClusterLogging) createOrUpdateKibanaDeployment() (err error) {
 		kibanaPodSpec,
 	)
 
+	kibanaDeployment.Spec.Replicas = &cluster.Spec.Visualization.KibanaSpec.Replicas
+
 	cluster.AddOwnerRefTo(kibanaDeployment)
 
 	err = sdk.Create(kibanaDeployment)


### PR DESCRIPTION
Correctly setting the replicas for the generated deployment for Kibana based on the `replicas` field for the `clusterlogging` cr.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1699268