### PR TITLE
Add support for rsyslog_exporter and prometheus alerts

### DIFF
--- a/files/rsyslog/10-viaq-modules.conf
+++ b/files/rsyslog/10-viaq-modules.conf
@@ -19,3 +19,21 @@ module(load="mmkubernetes")
 # stats for monitoring
 # cannot enable until there is log rotation for this file
 #module(load="impstats" interval="1" format="cee" log.syslog="off" log.file=`echo $RSYSLOG_IMPSTATS_FILE`)
+
+module(load="omprog")
+
+module(
+  load="impstats"
+  interval="10"
+  format="json"
+  resetCounters="off"
+  ruleset="prometheus_stats"
+)
+
+ruleset(name="prometheus_stats") {
+  action(
+    type="omprog"
+    name="prometheus_stats"
+    binary="/usr/local/bin/rsyslog_exporter --web.listen-address=:24231 --tls.server-crt=/etc/rsyslog/metrics/tls.crt --tls.server-key=/etc/rsyslog/metrics/tls.key"
+  )
+}

--- a/files/rsyslog/rsyslog_prometheus_alerts.yaml
+++ b/files/rsyslog/rsyslog_prometheus_alerts.yaml
@@ -1,0 +1,43 @@
+"groups":
+- "name": "logging_rsyslog.alerts"
+  "rules":
+  - "alert": "RsyslogNodeDown"
+    "annotations":
+      "message": "Prometheus could not scrape rsyslog {{ $labels.instance }} for more than 10m."
+      "summary": "Rsyslog cannot be scraped"
+    "expr": |
+      absent(up{job="rsyslog"} == 1)
+    "for": "10m"
+    "labels":
+      "service": "rsyslog"
+      "severity": "critical"
+  - "alert": "RsyslogQueueLengthBurst"
+    "annotations":
+      "message": "In the last minute, rsyslog {{ $labels.instance }} queue length increased more than 32. Current value is {{ $value }}."
+      "summary": "Rsyslog is overwhelmed"
+    "expr": |
+      delta(rsyslog_queue_size[1m]) > 32
+    "for": "1m"
+    "labels":
+      "service": "rsyslog"
+      "severity": "warning"
+  - "alert": "RsyslogQueueLengthIncreasing"
+    "annotations":
+      "message": "In the last 12h, rsyslog {{ $labels.instance }} queue length constantly increased more than 1. Current value is {{ $value }}."
+      "summary": "Rsyslog queue usage issue"
+    "expr": |
+      delta(rsyslog_queue_size[1m]) > 1
+    "for": "12h"
+    "labels":
+      "service": "rsyslog"
+      "severity": "critical"
+  - "alert": "RsyslogErrorsHigh"
+    "annotations":
+      "message": "In the last minute, {{ $value }} errors reported by rsyslog {{ $labels.instance }}."
+      "summary": "Rsyslog reports high number of errors"
+    "expr": |
+      sum by(instance, job) (rate(rsyslog_action_failed[1m])) > 10
+    "for": "1m"
+    "labels":
+      "service": "rsyslog"
+      "severity": "critical"

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -20,6 +20,10 @@ import (
 
 const (
 	clusterLoggingPriorityClassName = "cluster-logging"
+	metricsPort                     = int32(24231)
+	metricsPortName                 = "metrics"
+	metricsVolumeName               = "collector-metrics"
+	prometheusCAFile                = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
 )
 
 var (
@@ -102,6 +106,18 @@ func (cluster *ClusterLogging) CreateOrUpdateCollection() (err error) {
 	}
 
 	if cluster.Spec.Collection.Logs.Type == logging.LogCollectionTypeRsyslog {
+		if err = createOrUpdateRsyslogService(cluster); err != nil {
+			return
+		}
+
+		if err = createOrUpdateRsyslogServiceMonitor(cluster); err != nil {
+			return
+		}
+
+		if err = createOrUpdateRsyslogPrometheusRule(cluster); err != nil {
+			return
+		}
+
 		if err = createOrUpdateRsyslogConfigMap(cluster); err != nil {
 			return
 		}

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -18,11 +18,7 @@ import (
 )
 
 const (
-	metricsPort       = int32(24231)
-	metricsPortName   = "metrics"
-	prometheusCAFile  = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
-	metricsVolumeName = "fluentd-metrics"
-	alertsFile        = "/usr/share/logging/fluentd/fluentd_prometheus_alerts.yaml"
+	fluentdAlertsFile = "/usr/share/logging/fluentd/fluentd_prometheus_alerts.yaml"
 )
 
 func removeFluentd(cluster *ClusterLogging) (err error) {
@@ -39,7 +35,6 @@ func removeFluentd(cluster *ClusterLogging) (err error) {
 		if err = utils.RemovePrometheusRule(cluster.Namespace, "fluentd"); err != nil {
 			return
 		}
-
 
 		if err = utils.RemoveConfigMap(cluster.Namespace, "fluentd"); err != nil {
 			return
@@ -127,7 +122,7 @@ func createOrUpdateFluentdServiceMonitor(cluster *ClusterLogging) error {
 func createOrUpdateFluentdPrometheusRule(cluster *ClusterLogging) error {
 	promRule := utils.NewPrometheusRule("fluentd", cluster.Namespace)
 
-	promRuleSpec, err := utils.NewPrometheusRuleSpecFrom(alertsFile)
+	promRuleSpec, err := utils.NewPrometheusRuleSpecFrom(fluentdAlertsFile)
 	if err != nil {
 		return fmt.Errorf("Failure creating the fluentd PrometheusRule: %v", err)
 	}

--- a/pkg/k8shandler/rsyslog.go
+++ b/pkg/k8shandler/rsyslog.go
@@ -4,18 +4,38 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/retry"
 
 	sdk "github.com/operator-framework/operator-sdk/pkg/sdk"
 	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	rsyslogAlertsFile = "/usr/share/logging/rsyslog/rsyslog_prometheus_alerts.yaml"
 )
 
 func removeRsyslog(cluster *ClusterLogging) (err error) {
 	if cluster.Spec.ManagementState == logging.ManagementStateManaged {
+
+		if err = utils.RemoveService(cluster.Namespace, "rsyslog"); err != nil {
+			return
+		}
+
+		if err = utils.RemoveServiceMonitor(cluster.Namespace, "rsyslog"); err != nil {
+			return
+		}
+
+		if err = utils.RemovePrometheusRule(cluster.Namespace, "rsyslog"); err != nil {
+			return
+		}
+
 		if err = utils.RemoveConfigMap(cluster.Namespace, "rsyslog-bin"); err != nil {
 			return
 		}
@@ -35,6 +55,93 @@ func removeRsyslog(cluster *ClusterLogging) (err error) {
 		if err = utils.RemoveDaemonset(cluster.Namespace, "rsyslog"); err != nil {
 			return
 		}
+	}
+
+	return nil
+}
+
+func createOrUpdateRsyslogService(cluster *ClusterLogging) error {
+	service := utils.NewService(
+		"rsyslog",
+		cluster.Namespace,
+		"rsyslog",
+		[]v1.ServicePort{
+			{
+				Port:       metricsPort,
+				TargetPort: intstr.FromString(metricsPortName),
+				Name:       metricsPortName,
+			},
+		},
+	)
+
+	service.Annotations = map[string]string{
+		"service.alpha.openshift.io/serving-cert-secret-name": metricsVolumeName,
+	}
+
+	utils.AddOwnerRefToObject(service, utils.AsOwner(cluster))
+
+	err := sdk.Create(service)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("Failure creating the rsyslog service: %v", err)
+	}
+
+	return nil
+}
+
+func createOrUpdateRsyslogServiceMonitor(cluster *ClusterLogging) error {
+	serviceMonitor := utils.NewServiceMonitor("rsyslog", cluster.Namespace)
+
+	endpoint := monitoringv1.Endpoint{
+		Port:   metricsPortName,
+		Path:   "/metrics",
+		Scheme: "https",
+		TLSConfig: &monitoringv1.TLSConfig{
+			CAFile:     prometheusCAFile,
+			ServerName: fmt.Sprintf("%s.%s.svc", "rsyslog", cluster.Namespace),
+			// ServerName can be e.g. rsyslog.openshift-logging.svc
+		},
+	}
+
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"logging-infra": "support",
+		},
+	}
+
+	serviceMonitor.Spec = monitoringv1.ServiceMonitorSpec{
+		JobLabel:  "monitor-rsyslog",
+		Endpoints: []monitoringv1.Endpoint{endpoint},
+		Selector:  labelSelector,
+		NamespaceSelector: monitoringv1.NamespaceSelector{
+			MatchNames: []string{cluster.Namespace},
+		},
+	}
+
+	utils.AddOwnerRefToObject(serviceMonitor, utils.AsOwner(cluster))
+
+	err := sdk.Create(serviceMonitor)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("Failure creating the rsyslog ServiceMonitor: %v", err)
+	}
+
+	return nil
+}
+
+func createOrUpdateRsyslogPrometheusRule(cluster *ClusterLogging) error {
+	promRule := utils.NewPrometheusRule("rsyslog", cluster.Namespace)
+
+	promRuleSpec, err := utils.NewPrometheusRuleSpecFrom(rsyslogAlertsFile)
+	if err != nil {
+		return fmt.Errorf("Failure creating the rsyslog PrometheusRule: %v", err)
+	}
+
+	promRule.Spec = *promRuleSpec
+
+	utils.AddOwnerRefToObject(promRule, utils.AsOwner(cluster))
+
+	err = sdk.Create(promRule)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("Failure creating the rsyslog PrometheusRule: %v", err)
 	}
 
 	return nil
@@ -126,9 +233,7 @@ func createOrUpdateRsyslogSecret(logging *ClusterLogging) error {
 
 func createOrUpdateRsyslogDaemonset(cluster *ClusterLogging) (err error) {
 
-	var rsyslogPodSpec v1.PodSpec
-
-	rsyslogPodSpec = newRsyslogPodSpec(cluster.ClusterLogging, "elasticsearch", "elasticsearch")
+	rsyslogPodSpec := newRsyslogPodSpec(cluster.ClusterLogging, "elasticsearch", "elasticsearch")
 
 	rsyslogDaemonset := utils.NewDaemonSet("rsyslog", cluster.Namespace, "rsyslog", "rsyslog", rsyslogPodSpec)
 
@@ -162,6 +267,14 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			}}
 	}
 	rsyslogContainer := utils.NewContainer("rsyslog", v1.PullIfNotPresent, *resources)
+
+	rsyslogContainer.Ports = []v1.ContainerPort{
+		v1.ContainerPort{
+			Name:          metricsPortName,
+			ContainerPort: metricsPort,
+			Protocol:      v1.ProtocolTCP,
+		},
+	}
 
 	rsyslogContainer.Env = []v1.EnvVar{
 		{Name: "MERGE_JSON_LOG", Value: "false"},
@@ -197,6 +310,7 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 		{Name: "localtime", ReadOnly: true, MountPath: "/etc/localtime"},
 		{Name: "machineid", ReadOnly: true, MountPath: "/etc/machine-id"},
 		{Name: "filebufferstorage", MountPath: "/var/lib/rsyslog.pod"},
+		{Name: metricsVolumeName, MountPath: "/etc/rsyslog/metrics"},
 	}
 
 	rsyslogContainer.SecurityContext = &v1.SecurityContext{
@@ -226,6 +340,7 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			{Name: "localtime", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/localtime"}}},
 			{Name: "machineid", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/machine-id"}}},
 			{Name: "filebufferstorage", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/rsyslog.pod"}}},
+			{Name: metricsVolumeName, VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: metricsVolumeName}}},
 		},
 		logging.Spec.Collection.Logs.RsyslogSpec.NodeSelector,
 	)


### PR DESCRIPTION
This depends on https://github.com/openshift/origin-aggregated-logging/pull/1619
The code is mostly a copy/paste from rsyslog as it needs almost
the exact same functionality - a service, a servicemonitor,
and an alerts file for prometheus.