### PR TITLE
do not output env var with empty values

### DIFF
--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -199,8 +199,6 @@ func newFluentdPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 		{Name: "OPS_CLIENT_CERT", Value: "/etc/fluent/keys/infra-cert"},
 		{Name: "OPS_CLIENT_KEY", Value: "/etc/fluent/keys/infra-key"},
 		{Name: "OPS_CA", Value: "/etc/fluent/keys/infra-ca"},
-		{Name: "JOURNAL_SOURCE", Value: ""},
-		{Name: "JOURNAL_READ_FROM_HEAD", Value: ""},
 		{Name: "BUFFER_QUEUE_LIMIT", Value: "32"},
 		{Name: "BUFFER_SIZE_LIMIT", Value: "8m"},
 		{Name: "FILE_BUFFER_LIMIT", Value: "256Mi"},

--- a/pkg/k8shandler/rsyslog.go
+++ b/pkg/k8shandler/rsyslog.go
@@ -176,7 +176,6 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 		{Name: "OPS_CLIENT_CERT", Value: "/etc/rsyslog/keys/infra-cert"},
 		{Name: "OPS_CLIENT_KEY", Value: "/etc/rsyslog/keys/infra-key"},
 		{Name: "OPS_CA", Value: "/etc/rsyslog/keys/infra-ca"},
-		{Name: "JOURNAL_READ_FROM_HEAD", Value: ""},
 		{Name: "BUFFER_QUEUE_LIMIT", Value: "32"},
 		{Name: "BUFFER_SIZE_LIMIT", Value: "8m"},
 		{Name: "FILE_BUFFER_LIMIT", Value: "256Mi"},


### PR DESCRIPTION
This is causing problems with the fluentd image.  Fluentd
has this code:
https://github.com/openshift/origin-aggregated-logging/blob/6820bed406ec080014becc611f95825d98410955/fluentd/configs.d/openshift/input-pre-systemd.conf#L15
```
read_from_head "#{ENV['JOURNAL_READ_FROM_HEAD'] || 'false'}"
```
The intention is to use the value if set to an actual value.
However, the ruby implemenation of `ENV` will return an
empty string, which does not evaulate to `nil`, which means
`read_from_head` will be expanded into the Fluentd configuration
like this
```
  read_from_head
```
In Fluentd, a boolean config parameter with an empty value means
to *set* the value to `true`.
There is a PR to correctly handle an `ENV` var with an empty
value: https://github.com/openshift/origin-aggregated-logging/pull/1630
but we need to fix this in the CLO as well.