### PR TITLE
Bug 1707465: Adding disk-pressure toleration for fluentd

### DIFF
--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -256,6 +256,11 @@ func newFluentdPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,
 		},
+		v1.Toleration{
+			Key:      "node.kubernetes.io/disk-pressure",
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
 	}
 
 	return fluentdPodSpec

--- a/pkg/k8shandler/fluentd_test.go
+++ b/pkg/k8shandler/fluentd_test.go
@@ -68,6 +68,37 @@ func TestNewFluentdPodSpecWhenResourcesAreDefined(t *testing.T) {
 	}
 }
 
+func TestFluentdPodSpecHasTaintTolerations(t *testing.T) {
+
+	expectedTolerations := []v1.Toleration{
+		v1.Toleration{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+		v1.Toleration{
+			Key:      "node.kubernetes.io/disk-pressure",
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+	}
+
+	cluster := &logging.ClusterLogging{
+		Spec: logging.ClusterLoggingSpec{
+			Collection: logging.CollectionSpec{
+				logging.LogCollectionSpec{
+					Type: "fluentd",
+				},
+			},
+		},
+	}
+	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name")
+
+	if !reflect.DeepEqual(podSpec.Tolerations, expectedTolerations) {
+		t.Errorf("Exp. the tolerations to be %q but was %q", expectedTolerations, podSpec.Tolerations)
+	}
+}
+
 func TestNewFluentdPodSpecWhenSelectorIsDefined(t *testing.T) {
 	expSelector := map[string]string{
 		"foo": "bar",

--- a/pkg/k8shandler/rsyslog.go
+++ b/pkg/k8shandler/rsyslog.go
@@ -240,6 +240,11 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,
 		},
+		v1.Toleration{
+			Key:      "node.kubernetes.io/disk-pressure",
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
 	}
 
 	return rsyslogPodSpec

--- a/pkg/k8shandler/rsyslog_test.go
+++ b/pkg/k8shandler/rsyslog_test.go
@@ -31,6 +31,7 @@ func TestNewRsyslogPodSpecWhenSelectorIsDefined(t *testing.T) {
 		t.Errorf("Exp. the nodeSelector to be %q but was %q", expSelector, podSpec.NodeSelector)
 	}
 }
+
 func TestNewRsyslogPodSpecWhenFieldsAreUndefined(t *testing.T) {
 
 	cluster := &logging.ClusterLogging{}
@@ -54,6 +55,38 @@ func TestNewRsyslogPodSpecWhenFieldsAreUndefined(t *testing.T) {
 		t.Errorf("Exp. the nodeSelector to be %T but was %T", map[string]string{}, podSpec.NodeSelector)
 	}
 }
+
+func TestRsyslogPodSpecHasTaintTolerations(t *testing.T) {
+
+	expectedTolerations := []v1.Toleration{
+		v1.Toleration{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+		v1.Toleration{
+			Key:      "node.kubernetes.io/disk-pressure",
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+	}
+
+	cluster := &logging.ClusterLogging{
+		Spec: logging.ClusterLoggingSpec{
+			Collection: logging.CollectionSpec{
+				logging.LogCollectionSpec{
+					Type: "rsyslog",
+				},
+			},
+		},
+	}
+	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name")
+
+	if !reflect.DeepEqual(podSpec.Tolerations, expectedTolerations) {
+		t.Errorf("Exp. the tolerations to be %q but was %q", expectedTolerations, podSpec.Tolerations)
+	}
+}
+
 func TestNewRsyslogPodSpecWhenResourcesAreDefined(t *testing.T) {
 	limitMemory := resource.MustParse("100Gi")
 	requestMemory := resource.MustParse("120Gi")


### PR DESCRIPTION
To address fluentd not being scheduled to nodes where it may have left buffer files causing disk-pressure, allow fluentd to be scheduled on nodes where that taint has been applied so it can attempt to clear its buffer files.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1707465