### PR TITLE
LOG-400 rsyslog - support log rotation for rsyslog log files

### DIFF
--- a/files/logrotate/cron.sh
+++ b/files/logrotate/cron.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Wrapper to start cronjob to invoke logrotate periodically
+
+echo "export LOGGING_FILE_PATH=${LOGGING_FILE_PATH:-}" > /tmp/.logrotate
+echo "export LOGGING_FILE_SIZE=${LOGGING_FILE_SIZE:-}" >> /tmp/.logrotate
+echo "export LOGGING_FILE_AGE=${LOGGING_FILE_AGE:-}" >> /tmp/.logrotate
+echo "export RSYSLOG_WORKDIRECTORY=${RSYSLOG_WORKDIRECTORY:-/var/lib/rsyslog.pod}" >> /tmp/.logrotate
+
+exec /usr/sbin/crond -n $CROND_OPTIONS

--- a/files/logrotate/logrotate
+++ b/files/logrotate/logrotate
@@ -1,0 +1,6 @@
+# crontab
+# login as root
+# run logrotate (/var/log/rsyslog/*.log) at 2am everyday
+# run logrotate_pod (/var/lib/rsyslog.pod) at 3am everyday
+0 2 * * *       root /usr/bin/bash /opt/app-root/bin/logrotate.sh
+0 3 * * *       root /usr/bin/bash /opt/app-root/bin/logrotate_pod.sh

--- a/files/logrotate/logrotate.sh
+++ b/files/logrotate/logrotate.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+. /tmp/.logrotate
+
+dirname=$( dirname ${LOGGING_FILE_PATH:-"/var/log/rsyslog/rsyslog.log"} )
+cat > /tmp/logrotate.conf << EOF
+"$dirname/*.log"
+{
+  create 0644 root
+  dateext
+  dateformat -%Y%m%d-%s
+  missingok
+  notifempty
+  size ${LOGGING_FILE_SIZE:-1024000}
+  rotate ${LOGGING_FILE_AGE:-10}
+  postrotate
+    # rsyslogd is "exec"ed in the first script rsyslog.sh
+    kill -HUP $( cat /var/run/rsyslogd.pid )
+  endscript
+}
+EOF
+
+exec /usr/sbin/logrotate --log $dirname/logrotate.log /tmp/logrotate.conf

--- a/files/logrotate/logrotate_pod.sh
+++ b/files/logrotate/logrotate_pod.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+. /tmp/.logrotate
+
+cat > /tmp/logrotate_pod.conf << EOF
+"${RSYSLOG_WORKDIRECTORY}/*.log"
+"${RSYSLOG_WORKDIRECTORY}/impstats.json"
+{
+  create 0644 root
+  dateext
+  dateformat -%Y%m%d-%s
+  missingok
+  notifempty
+  size ${LOGGING_FILE_SIZE:-1024000}
+  rotate ${LOGGING_FILE_AGE:-10}
+  postrotate
+    # rsyslogd is "exec"ed in the first script rsyslog.sh
+    kill -HUP $( cat /var/run/rsyslogd.pid )
+  endscript
+}
+EOF
+
+exec /usr/sbin/logrotate --log ${RSYSLOG_WORKDIRECTORY}/logrotate.log /tmp/logrotate_pod.conf

--- a/files/rsyslog/00-global.conf
+++ b/files/rsyslog/00-global.conf
@@ -7,4 +7,5 @@ global(
   oversizemsg.report="off"
   oversizemsg.input.mode="accept"
   maxMessageSize="32767"
+  processInternalMessages="on"
 )

--- a/files/rsyslog/99-logging.conf
+++ b/files/rsyslog/99-logging.conf
@@ -1,0 +1,6 @@
+template(name="FileFormat" type="string" string= "%TIMESTAMP% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n")
+
+if ($inputname == "rsyslogd") and (`echo $LOGGING_FILE_PATH` != "console") then {
+    action(type="omfile" template="FileFormat" file=`echo $LOGGING_FILE_PATH`)
+}
+

--- a/manifests/4.1/cluster-logging.v4.1.0.clusterserviceversion.yaml
+++ b/manifests/4.1/cluster-logging.v4.1.0.clusterserviceversion.yaml
@@ -72,7 +72,8 @@ spec:
     ## Prerequisites and Requirements
     ### Cluster Logging Namespace
     Cluster logging and the Cluster Logging Operator is only deployable to the **openshift-logging** namespace. This namespace
-    must be explicitly created by a cluster administrator (e.g. `oc create ns openshift-logging`)
+    must be explicitly created by a cluster administrator (e.g. `oc create ns openshift-logging`). To enable metrics
+    service discovery add namespace label `openshift.io/cluster-monitoring: "true"`.
     ### Elasticsearch Operator
     The Elasticsearch Operator is responsible for orchestrating and managing cluster logging's Elasticsearch cluster.  This
     operator must be deployed to the global operator group namespace

--- a/manifests/4.2/cluster-logging.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/4.2/cluster-logging.v4.2.0.clusterserviceversion.yaml
@@ -74,7 +74,8 @@ spec:
     ## Prerequisites and Requirements
     ### Cluster Logging Namespace
     Cluster logging and the Cluster Logging Operator is only deployable to the **openshift-logging** namespace. This namespace
-    must be explicitly created by a cluster administrator (e.g. `oc create ns openshift-logging`)
+    must be explicitly created by a cluster administrator (e.g. `oc create ns openshift-logging`). To enable metrics
+    service discovery add namespace label `openshift.io/cluster-monitoring: "true"`.
     ### Elasticsearch Operator
     The Elasticsearch Operator is responsible for orchestrating and managing cluster logging's Elasticsearch cluster.  This
     operator must be deployed to the global operator group namespace

--- a/manifests/4.2/image-references
+++ b/manifests/4.2/image-references
@@ -22,6 +22,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-logging-fluentd:latest
+  - name: logging-rsyslog
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-logging-rsyslog:latest
   - name: oauth-proxy
     from:
       kind: DockerImage

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -110,6 +110,10 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 			return
 		}
 
+		if err = clusterRequest.createOrUpdateLogrotateConfigMap(); err != nil {
+			return
+		}
+
 		if err = clusterRequest.createOrUpdateRsyslogDaemonset(); err != nil {
 			return
 		}

--- a/pkg/k8shandler/curation.go
+++ b/pkg/k8shandler/curation.go
@@ -166,7 +166,7 @@ func newCuratorCronJob(cluster *logging.ClusterLogging, curatorName string, elas
 			},
 		}
 	}
-	curatorContainer := NewContainer("curator", v1.PullIfNotPresent, *resources)
+	curatorContainer := NewContainer("curator", "curator", v1.PullIfNotPresent, *resources)
 
 	curatorContainer.Env = []v1.EnvVar{
 		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc.cluster.local"},

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -204,7 +204,7 @@ func newFluentdPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			},
 		}
 	}
-	fluentdContainer := NewContainer("fluentd", v1.PullIfNotPresent, *resources)
+	fluentdContainer := NewContainer("fluentd", "fluentd", v1.PullIfNotPresent, *resources)
 
 	fluentdContainer.Ports = []v1.ContainerPort{
 		v1.ContainerPort{

--- a/pkg/k8shandler/pod.go
+++ b/pkg/k8shandler/pod.go
@@ -18,10 +18,10 @@ func NewPodSpec(serviceAccountName string, containers []core.Container, volumes 
 }
 
 //NewContainer stubs an instance of a Container
-func NewContainer(containerName string, pullPolicy core.PullPolicy, resources core.ResourceRequirements) core.Container {
+func NewContainer(containerName string, imageName string, pullPolicy core.PullPolicy, resources core.ResourceRequirements) core.Container {
 	return core.Container{
 		Name:            containerName,
-		Image:           utils.GetComponentImage(containerName),
+		Image:           utils.GetComponentImage(imageName),
 		ImagePullPolicy: pullPolicy,
 		Resources:       resources,
 	}

--- a/pkg/k8shandler/rsyslog_test.go
+++ b/pkg/k8shandler/rsyslog_test.go
@@ -37,8 +37,8 @@ func TestNewRsyslogPodSpecWhenFieldsAreUndefined(t *testing.T) {
 	cluster := &logging.ClusterLogging{}
 	podSpec := newRsyslogPodSpec(cluster, "test-app-name", "test-infra-name")
 
-	if len(podSpec.Containers) != 1 {
-		t.Error("Exp. there to be 1 fluentd container")
+	if len(podSpec.Containers) != 2 {
+		t.Error("Exp. there to be 2 rsyslog containers")
 	}
 
 	resources := podSpec.Containers[0].Resources
@@ -105,8 +105,8 @@ func TestNewRsyslogPodSpecWhenResourcesAreDefined(t *testing.T) {
 	}
 	podSpec := newRsyslogPodSpec(cluster, "test-app-name", "test-infra-name")
 
-	if len(podSpec.Containers) != 1 {
-		t.Error("Exp. there to be 1 fluentd container")
+	if len(podSpec.Containers) != 2 {
+		t.Error("Exp. there to be 2 rsyslog containers")
 	}
 
 	resources := podSpec.Containers[0].Resources

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -400,6 +400,7 @@ func newKibanaPodSpec(cluster *logging.ClusterLogging, kibanaName string, elasti
 	}
 	kibanaContainer := NewContainer(
 		"kibana",
+		"kibana",
 		v1.PullIfNotPresent,
 		*kibanaResources,
 	)
@@ -448,6 +449,7 @@ func newKibanaPodSpec(cluster *logging.ClusterLogging, kibanaName string, elasti
 		}
 	}
 	kibanaProxyContainer := NewContainer(
+		"kibana-proxy",
 		"kibana-proxy",
 		v1.PullIfNotPresent,
 		*kibanaProxyResources,


### PR DESCRIPTION
Purpose: Adding the logrotation supports to rsyslog to match fluentd.

```
Since rsyslog does not include logrotate capability, use an utility logrotate to do the job.
Logrotate is added as a separate container to the rsyslog pod to share the logging paths.

How to see the rsyslog logs:
  oc logs $RSYSLOG_POD -c rsyslog
  =============================
  Rsyslog logs have been redirected to: /var/log/rsyslog/rsyslog.log
  If you want to print out the logs, use command:
  oc exec <pod_name> -- logs
  =============================

  $ oc exec $RSYSLOG_POD -- logs
  Defaulting container name to rsyslog.
  INFO: Disabling Prometheus endpoint
  <DATE> rsyslog-gvcmt rsyslogd-2207: error during parsing file /etc/rsyslog.d/55-elasticsearch.conf, ...

Logrotate is configurable by editing logrotate configmaps and resetting environment variables.
1) logrotate configmaps
  logrotate-bin
    cron.sh
      It executes /usr/sbin/crond in the foreground.
      Crond option CROND_OPTIONS is configurable by the environment variable
      in the logrotate container.
    logrotate.sh
      It executes logrotate to rotate the rsyslog log file, which is
      /var/log/rsyslog/rsyslog.log by default.  The path is configurable
      via the environment variable LOGGING_FILE_PATH.
      The log file size to trigger rotation, LOGGING_FILE_SIZE as well as
      the file count to keep, LOGGING_FILE_AGE are configurable.
      The shell script is launched by the crond following the crontab.
      The crontab logrotate-crontab is another logrotate configmap.
    logrotate_pod.sh
      It executes logrotate to rotate the log files and impstats.json,
      which is located in /var/lib/rsyslog.pod, by default.
      The path is configurable via the environment variable RSYSLOG_WORKDIRECTORY.
      LOGGING_FILE_SIZE and LOGGING_FILE_AGE are shared with logrotate.sh.
      The shell script is also launched by the crond following the crontab.
      The crontab logrotate-crontab is another logrotate configmap.
  logrotate-crontab
      By default, both logrotate.sh and logrotate_pod.sh are executed once a day
      at 2am and 3am, respectively.  The times and timings are configurable in
      the configmap logrotate-crontab.
      # crontab
      # login as root
      # run logrotate (/var/log/rsyslog/*.log) at 2am everyday
      # run logrotate_pod (/var/lib/rsyslog.pod) at 3am everyday
      0 2 * * *       root /usr/bin/bash /opt/app-root/bin/logrotate.sh
      0 3 * * *       root /usr/bin/bash /opt/app-root/bin/logrotate_pod.sh

2) Logrotate environment variables
  CROND_OPTIONS - crond options which; Default to "".
  LOGGING_FILE_PATH - rsyslog log file path; Default to "/var/log/rsyslog/rsyslog.log"
  LOGGING_FILE_SIZE - max rsyslog log file size.  Once reaches the size, the file is rotated to rsyslog.log
                      Default to 1024000.
  LOGGING_FILE_AGE  - max rsyslog log file count; Default to 10.
  RSYSLOG_WORKDIRECTORY - rsyslog work directory to store impstats.json and the other log files.

Notes: This patch makes the rsyslog container and the logrotate container share an rsyslog pod.
The logrotate container does not have its own image but it starts with a shell to launch a script.
Thus, to rsh into a container, you should do as follows:
 rsyslog: oc rsh $RSYSLOG_POD -c rsyslog
 logrotate: kubectl exec -it $RSYSLOG_POD -c logrotate /bin/sh
to rsh rsyslog

To allow logrotate in the logrotate container to send a signal to rsyslogd, set processInternalMessages to "on".
Adding prometheusrules to apiGroup monitoring.coreos.com.
logrotate log - /var/log/rsyslog/logrotate.log
rotated file format -%Y%m%d-%s

(cherry picked from commit b8150d19e633f40f52c0019088acc170b5c894fb)
```