### PR TITLE
Bug 1710404: No longer set CPU Limit for default ES resource requirements

### DIFF
--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -108,7 +108,6 @@ func newElasticsearchCR(cluster *logging.ClusterLogging, elasticsearchName strin
 		resources = &v1.ResourceRequirements{
 			Limits: v1.ResourceList{
 				v1.ResourceMemory: defaultEsMemory,
-				v1.ResourceCPU:    defaultEsCpuRequest,
 			},
 			Requests: v1.ResourceList{
 				v1.ResourceMemory: defaultEsMemory,

--- a/pkg/k8shandler/logstore_test.go
+++ b/pkg/k8shandler/logstore_test.go
@@ -20,8 +20,8 @@ func TestNewElasticsearchCRWhenResourcesAreUndefined(t *testing.T) {
 	if resources.Limits[v1.ResourceMemory] != defaultEsMemory {
 		t.Errorf("Exp. the default memory limit to be %v", defaultEsMemory)
 	}
-	if resources.Limits[v1.ResourceCPU] != defaultEsCpuRequest {
-		t.Errorf("Exp. the default CPU limit to be %v", defaultEsCpuRequest)
+	if cpu, isPresent := resources.Limits[v1.ResourceCPU]; isPresent {
+		t.Errorf("Exp. no default CPU limit, but got %v", cpu.String())
 	}
 	if resources.Requests[v1.ResourceMemory] != defaultEsMemory {
 		t.Errorf("Exp. the default memory request to be %v", defaultEsMemory)


### PR DESCRIPTION
Don't set cpu limit on elasticsearch. Only request at least 1 CPU and 16Gi of RAM

https://bugzilla.redhat.com/show_bug.cgi?id=1710404