### PR TITLE
use make deploy with oal logging CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ export IMAGE_TAG_CMD?=docker tag
 export APP_NAME=cluster-logging-operator
 APP_REPO=github.com/openshift/$(APP_NAME)
 TARGET=$(TARGET_DIR)/bin/$(APP_NAME)
-export IMAGE_TAG=quay.io/openshift/origin-$(APP_NAME):latest
+IMAGE_TAG?=quay.io/openshift/origin-$(APP_NAME):latest
+export IMAGE_TAG
 MAIN_PKG=cmd/manager/main.go
 export CSV_FILE=$(CURPATH)/manifests/latest
 export NAMESPACE?=openshift-logging

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,10 +24,10 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
-	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis"
-	routev1 "github.com/openshift/api/route/v1"
-	oauth "github.com/openshift/api/oauth/v1"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	oauth "github.com/openshift/api/oauth/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -112,14 +112,14 @@ func main() {
 	}
 
 	if err := routev1.AddToScheme(mgr.GetScheme()); err != nil {
-    log.Error(err, "")
-    os.Exit(1)
-  }
+		log.Error(err, "")
+		os.Exit(1)
+	}
 
 	if err := oauth.AddToScheme(mgr.GetScheme()); err != nil {
-    log.Error(err, "")
-    os.Exit(1)
-  }
+		log.Error(err, "")
+		os.Exit(1)
+	}
 
 	if err := monitoringv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -11,7 +11,7 @@ source "$(dirname $0)/common"
 rm -rf /tmp/_working_dir
 mkdir /tmp/_working_dir
 
-sudo ln -s $(pwd)/files /usr/share/logging
+export LOGGING_SHARE_DIR=$(dirname $0)/../files
 
 manifest=$(mktemp)
 if ! oc get project openshift-logging > /dev/null 2>&1 ; then
@@ -19,4 +19,4 @@ if ! oc get project openshift-logging > /dev/null 2>&1 ; then
 fi
 $repo_dir/hack/gen-olm-artifacts.sh ${CSV_FILE} ${NAMESPACE} 'sa,role,clusterrole,crd'  >> $manifest
 oc create -f $manifest
-CREATE_ES_SECRET=false NAMESPACE=openshift-logging make -C ${ELASTICSEARCH_OP_REPO} deploy-setup
+CREATE_ES_SECRET=false NAMESPACE=openshift-logging IMAGE_OVERRIDE=${EO_IMAGE_OVERRIDE:-} make -C ${ELASTICSEARCH_OP_REPO} deploy-setup

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -16,15 +16,24 @@ else
                 -e "s,quay.io/openshift/origin-logging,$registry_host:5000/openshift/logging,"
         }
     fi
+    if [ -n "${IMAGE_OVERRIDE:-}" ] ; then
+        replace_image() {
+            sed -e "s, image:.*\$, image: ${IMAGE_OVERRIDE},"
+        }
+    else
+        replace_image() {
+            sed -e "s,${IMAGE_TAG},${registry_host}:5000/${image_tag},"
+        }
+    fi
     image_tag=$( echo "$IMAGE_TAG" | sed -e 's,quay.io/,,' )
     $repo_dir/hack/gen-olm-artifacts.sh ${CSV_FILE} ${NAMESPACE} 'dep' | \
-        sed -e "s,${IMAGE_TAG},${registry_host}:5000/${image_tag}," | \
+        replace_image | \
         fix_images | \
 	    oc create -f -
 fi
 
 if [ "${NO_BUILD:-false}" = true ] ; then
-    CREATE_ES_SECRET=false NAMESPACE=openshift-logging IMAGE_TAG=${EO_IMAGE_TAG:-} make -C ${ELASTICSEARCH_OP_REPO} deploy-no-build
+    CREATE_ES_SECRET=false NAMESPACE=openshift-logging IMAGE_OVERRIDE=${EO_IMAGE_OVERRIDE:-} make -C ${ELASTICSEARCH_OP_REPO} deploy-no-build
 else
     CREATE_ES_SECRET=false NAMESPACE=openshift-logging make -C ${ELASTICSEARCH_OP_REPO} deploy
 fi

--- a/hack/gen-olm-artifacts.sh
+++ b/hack/gen-olm-artifacts.sh
@@ -13,7 +13,7 @@ if kinds == 'all':
 def loadFile(file):
   with open(file, "r") as stream:
     try:
-      return yaml.load(stream)
+      return yaml.safe_load(stream)
     except yaml.YAMLError as exc:
       print(exc)
 

--- a/pkg/k8shandler/curation.go
+++ b/pkg/k8shandler/curation.go
@@ -113,9 +113,9 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateCuratorConfigMap() er
 		"curator",
 		clusterRequest.cluster.Namespace,
 		map[string]string{
-			"actions.yaml":  string(utils.GetFileContents("/usr/share/logging/curator/curator-actions.yaml")),
-			"curator5.yaml": string(utils.GetFileContents("/usr/share/logging/curator/curator5-config.yaml")),
-			"config.yaml":   string(utils.GetFileContents("/usr/share/logging/curator/curator-config.yaml")),
+			"actions.yaml":  string(utils.GetFileContents(utils.GetShareDir() + "/curator/curator-actions.yaml")),
+			"curator5.yaml": string(utils.GetFileContents(utils.GetShareDir() + "/curator/curator5-config.yaml")),
+			"config.yaml":   string(utils.GetFileContents(utils.GetShareDir() + "/curator/curator-config.yaml")),
 		},
 	)
 

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -21,7 +21,7 @@ const (
 	metricsPortName   = "metrics"
 	prometheusCAFile  = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
 	metricsVolumeName = "fluentd-metrics"
-	alertsFile        = "/usr/share/logging/fluentd/fluentd_prometheus_alerts.yaml"
+	alertsFile        = "fluentd/fluentd_prometheus_alerts.yaml"
 )
 
 func (clusterRequest *ClusterLoggingRequest) removeFluentd() (err error) {
@@ -131,7 +131,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateFluentdPrometheusRule
 
 	promRule := NewPrometheusRule("fluentd", cluster.Namespace)
 
-	promRuleSpec, err := NewPrometheusRuleSpecFrom(alertsFile)
+	promRuleSpec, err := NewPrometheusRuleSpecFrom(utils.GetShareDir() + "/" + alertsFile)
 	if err != nil {
 		return fmt.Errorf("Failure creating the fluentd PrometheusRule: %v", err)
 	}
@@ -154,9 +154,9 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateFluentdConfigMap() er
 		"fluentd",
 		clusterRequest.cluster.Namespace,
 		map[string]string{
-			"fluent.conf":          string(utils.GetFileContents("/usr/share/logging/fluentd/fluent.conf")),
-			"throttle-config.yaml": string(utils.GetFileContents("/usr/share/logging/fluentd/fluentd-throttle-config.yaml")),
-			"secure-forward.conf":  string(utils.GetFileContents("/usr/share/logging/fluentd/secure-forward.conf")),
+			"fluent.conf":          string(utils.GetFileContents(utils.GetShareDir() + "/fluentd/fluent.conf")),
+			"throttle-config.yaml": string(utils.GetFileContents(utils.GetShareDir() + "/fluentd/fluentd-throttle-config.yaml")),
+			"secure-forward.conf":  string(utils.GetFileContents(utils.GetShareDir() + "/fluentd/secure-forward.conf")),
 		},
 	)
 

--- a/pkg/k8shandler/rsyslog.go
+++ b/pkg/k8shandler/rsyslog.go
@@ -58,7 +58,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateRsyslogConfigMap() er
 		"rsyslog-bin",
 		clusterRequest.cluster.Namespace,
 		map[string]string{
-			"rsyslog.sh": string(utils.GetFileContents("/usr/share/logging/rsyslog/rsyslog.sh")),
+			"rsyslog.sh": string(utils.GetFileContents(utils.GetShareDir() + "/rsyslog/rsyslog.sh")),
 		},
 	)
 	rsyslogConfigMaps["rsyslog-bin"] = rsyslogBinConfigMap
@@ -67,15 +67,15 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateRsyslogConfigMap() er
 		"rsyslog-main",
 		clusterRequest.cluster.Namespace,
 		map[string]string{
-			"rsyslog.conf": string(utils.GetFileContents("/usr/share/logging/rsyslog/rsyslog.conf")),
+			"rsyslog.conf": string(utils.GetFileContents(utils.GetShareDir() + "/rsyslog/rsyslog.conf")),
 		},
 	)
 	rsyslogConfigMaps["rsyslog-main"] = rsyslogMainConfigMap
 
 	rsyslogConfigMapFiles := make(map[string]string)
-	readerDir, err := ioutil.ReadDir("/usr/share/logging/rsyslog")
+	readerDir, err := ioutil.ReadDir(utils.GetShareDir() + "/rsyslog")
 	if err != nil {
-		return fmt.Errorf("Failure %v to read files from directory '/usr/share/logging/rsyslog' for Rsyslog configmap", err)
+		return fmt.Errorf("Failure %v to read files from directory '%v/rsyslog' for Rsyslog configmap", err, utils.GetShareDir())
 	}
 	for _, fileInfo := range readerDir {
 		// exclude files provided by other configmaps
@@ -86,7 +86,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateRsyslogConfigMap() er
 			continue
 		}
 		// include all other files
-		fullname := "/usr/share/logging/rsyslog/" + fileInfo.Name()
+		fullname := utils.GetShareDir() + "/rsyslog/" + fileInfo.Name()
 		rsyslogConfigMapFiles[fileInfo.Name()] = string(utils.GetFileContents(fullname))
 	}
 	rsyslogConfigMap := NewConfigMap(
@@ -117,9 +117,9 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateLogrotateConfigMap() 
 		"logrotate-bin",
 		clusterRequest.cluster.Namespace,
 		map[string]string{
-			"cron.sh": string(utils.GetFileContents("/usr/share/logging/logrotate/cron.sh")),
-			"logrotate.sh": string(utils.GetFileContents("/usr/share/logging/logrotate/logrotate.sh")),
-			"logrotate_pod.sh": string(utils.GetFileContents("/usr/share/logging/logrotate/logrotate_pod.sh")),
+			"cron.sh":          string(utils.GetFileContents(utils.GetShareDir() + "/logrotate/cron.sh")),
+			"logrotate.sh":     string(utils.GetFileContents(utils.GetShareDir() + "/logrotate/logrotate.sh")),
+			"logrotate_pod.sh": string(utils.GetFileContents(utils.GetShareDir() + "/logrotate/logrotate_pod.sh")),
 		},
 	)
 	logrotateConfigMaps["logrotate-bin"] = logrotateBinConfigMap
@@ -128,7 +128,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateLogrotateConfigMap() 
 		"logrotate-crontab",
 		clusterRequest.cluster.Namespace,
 		map[string]string{
-			"logrotate": string(utils.GetFileContents("/usr/share/logging/logrotate/logrotate")),
+			"logrotate": string(utils.GetFileContents(utils.GetShareDir() + "/logrotate/logrotate")),
 		},
 	)
 	logrotateConfigMaps["logrotate-crontab"] = logrotateCrontabConfigMap

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -92,6 +92,14 @@ func GetFileContents(filePath string) []byte {
 	return contents
 }
 
+func GetShareDir() string {
+	shareDir := os.Getenv("LOGGING_SHARE_DIR")
+	if shareDir == "" {
+		return "/usr/share/logging"
+	}
+	return shareDir
+}
+
 func GetWorkingDirFileContents(filePath string) []byte {
 	return GetFileContents(GetWorkingDirFilePath(filePath))
 }


### PR DESCRIPTION
Allows the use of `make deploy` with oal logging CI to
deploy logging.  Set `IMAGE_OVERRIDE` and `EO_IMAGE_OVERRIDE`
to specify the operator images to use.

This also gets rid of the need to create a `/usr/share/logging`
on the local machine - instead, for test purposes, the env var
`LOGGING_SHARE_DIR` sets the location to the files to load.
If this is not set, the default `/usr/share/logging` is used
(e.g. inside the container).

Depends on https://github.com/openshift/elasticsearch-operator/pull/146