### PR TITLE
add namespace for manifest

### DIFF
--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -18,5 +18,5 @@ if ! oc get project openshift-logging > /dev/null 2>&1 ; then
   $repo_dir/hack/gen-olm-artifacts.sh ${CSV_FILE} ${NAMESPACE} 'ns' >> $manifest
 fi
 $repo_dir/hack/gen-olm-artifacts.sh ${CSV_FILE} ${NAMESPACE} 'sa,role,clusterrole,crd'  >> $manifest
-oc create -f $manifest
+oc -n $NAMESPACE create -f $manifest
 CREATE_ES_SECRET=false NAMESPACE=openshift-logging IMAGE_OVERRIDE=${EO_IMAGE_OVERRIDE:-} make -C ${ELASTICSEARCH_OP_REPO} deploy-setup

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -29,7 +29,7 @@ else
     $repo_dir/hack/gen-olm-artifacts.sh ${CSV_FILE} ${NAMESPACE} 'dep' | \
         replace_image | \
         fix_images | \
-	    oc create -f -
+	    oc -n $NAMESPACE create -f -
 fi
 
 if [ "${NO_BUILD:-false}" = true ] ; then


### PR DESCRIPTION
Have to specify `-n $NAMESPACE` when creating manifest objects
during CI testing.