### PR TITLE
Bug 1712721 - Fixing checking if nodes are different when scaling from 3 to 4

### DIFF
--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -118,14 +118,6 @@ func newElasticsearchCR(cluster *logging.ClusterLogging, elasticsearchName strin
 
 	if cluster.Spec.LogStore.NodeCount > 3 {
 
-		dataNode := elasticsearch.ElasticsearchNode{
-			Roles:     []elasticsearch.ElasticsearchNodeRole{"client", "data"},
-			NodeCount: cluster.Spec.LogStore.NodeCount - 3,
-			Storage:   cluster.Spec.LogStore.ElasticsearchSpec.Storage,
-		}
-
-		esNodes = append(esNodes, dataNode)
-
 		masterNode := elasticsearch.ElasticsearchNode{
 			Roles:     []elasticsearch.ElasticsearchNodeRole{"client", "data", "master"},
 			NodeCount: 3,
@@ -133,6 +125,14 @@ func newElasticsearchCR(cluster *logging.ClusterLogging, elasticsearchName strin
 		}
 
 		esNodes = append(esNodes, masterNode)
+
+		dataNode := elasticsearch.ElasticsearchNode{
+			Roles:     []elasticsearch.ElasticsearchNodeRole{"client", "data"},
+			NodeCount: cluster.Spec.LogStore.NodeCount - 3,
+			Storage:   cluster.Spec.LogStore.ElasticsearchSpec.Storage,
+		}
+
+		esNodes = append(esNodes, dataNode)
 
 	} else {
 
@@ -273,6 +273,10 @@ func areNodesDifferent(current, desired []elasticsearch.ElasticsearchNode) ([]el
 
 	// nodes were removed
 	if len(current) == 0 {
+		return desired, true
+	}
+
+	if len(current) != len(desired) {
 		return desired, true
 	}
 

--- a/pkg/k8shandler/logstore_test.go
+++ b/pkg/k8shandler/logstore_test.go
@@ -285,3 +285,65 @@ func createAndCheckSingleNodeWithNodeCount(t *testing.T, expectedNodeCount int32
 		}
 	}
 }
+
+func TestDifferenceFoundWhenNodeCountExceeds3(t *testing.T) {
+	cluster := &logging.ClusterLogging{
+		Spec: logging.ClusterLoggingSpec{
+			LogStore: logging.LogStoreSpec{
+				Type: "elasticsearch",
+				ElasticsearchSpec: logging.ElasticsearchSpec{
+					NodeCount: 3,
+				},
+			},
+		},
+	}
+	elasticsearchCR := newElasticsearchCR(cluster, "test-app-name")
+
+	cluster = &logging.ClusterLogging{
+		Spec: logging.ClusterLoggingSpec{
+			LogStore: logging.LogStoreSpec{
+				Type: "elasticsearch",
+				ElasticsearchSpec: logging.ElasticsearchSpec{
+					NodeCount: 4,
+				},
+			},
+		},
+	}
+	elasticsearchCR2 := newElasticsearchCR(cluster, "test-app-name")
+
+	_, different := isElasticsearchCRDifferent(elasticsearchCR, elasticsearchCR2)
+	if !different {
+		t.Errorf("Expected that difference would be found due to node count change")
+	}
+}
+
+func TestDifferenceFoundWhenNodeCountExceeds4(t *testing.T) {
+	cluster := &logging.ClusterLogging{
+		Spec: logging.ClusterLoggingSpec{
+			LogStore: logging.LogStoreSpec{
+				Type: "elasticsearch",
+				ElasticsearchSpec: logging.ElasticsearchSpec{
+					NodeCount: 4,
+				},
+			},
+		},
+	}
+	elasticsearchCR := newElasticsearchCR(cluster, "test-app-name")
+
+	cluster = &logging.ClusterLogging{
+		Spec: logging.ClusterLoggingSpec{
+			LogStore: logging.LogStoreSpec{
+				Type: "elasticsearch",
+				ElasticsearchSpec: logging.ElasticsearchSpec{
+					NodeCount: 5,
+				},
+			},
+		},
+	}
+	elasticsearchCR2 := newElasticsearchCR(cluster, "test-app-name")
+
+	_, different := isElasticsearchCRDifferent(elasticsearchCR, elasticsearchCR2)
+	if !different {
+		t.Errorf("Expected that difference would be found due to node count change")
+	}
+}


### PR DESCRIPTION
Also fixing ordering of nodes defined to prevent prior node recreation

Needs to be cherry picked to `release-4.1` as well for https://bugzilla.redhat.com/show_bug.cgi?id=1712955

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1712721