### PR TITLE
add rsyslog_exporter for prometheus

### DIFF
--- a/files/rsyslog/10-viaq-modules.conf
+++ b/files/rsyslog/10-viaq-modules.conf
@@ -19,3 +19,21 @@ module(load="mmkubernetes")
 # stats for monitoring
 # cannot enable until there is log rotation for this file
 #module(load="impstats" interval="1" format="cee" log.syslog="off" log.file=`echo $RSYSLOG_IMPSTATS_FILE`)
+
+module(load="omprog")
+
+module(
+  load="impstats"
+  interval="10"
+  format="json"
+  resetCounters="off"
+  ruleset="prometheus_stats"
+)
+
+ruleset(name="prometheus_stats") {
+  action(
+    type="omprog"
+    name="prometheus_stats"
+    binary="/usr/local/bin/rsyslog_exporter --web.listen-address=:24231 --tls.server-crt=/etc/rsyslog/metrics/tls.crt --tls.server-key=/etc/rsyslog/metrics/tls.key"
+  )
+}

--- a/files/rsyslog/rsyslog_prometheus_alerts.yaml
+++ b/files/rsyslog/rsyslog_prometheus_alerts.yaml
@@ -1,0 +1,43 @@
+"groups":
+- "name": "logging_rsyslog.alerts"
+  "rules":
+  - "alert": "RsyslogNodeDown"
+    "annotations":
+      "message": "Prometheus could not scrape rsyslog {{ $labels.instance }} for more than 10m."
+      "summary": "Rsyslog cannot be scraped"
+    "expr": |
+      absent(up{job="rsyslog"} == 1)
+    "for": "10m"
+    "labels":
+      "service": "rsyslog"
+      "severity": "critical"
+  - "alert": "RsyslogQueueLengthBurst"
+    "annotations":
+      "message": "In the last minute, rsyslog {{ $labels.instance }} queue length increased more than 32. Current value is {{ $value }}."
+      "summary": "Rsyslog is overwhelmed"
+    "expr": |
+      delta(rsyslog_queue_size[1m]) > 32
+    "for": "1m"
+    "labels":
+      "service": "rsyslog"
+      "severity": "warning"
+  - "alert": "RsyslogQueueLengthIncreasing"
+    "annotations":
+      "message": "In the last 12h, rsyslog {{ $labels.instance }} queue length constantly increased more than 1. Current value is {{ $value }}."
+      "summary": "Rsyslog queue usage issue"
+    "expr": |
+      delta(rsyslog_queue_size[1m]) > 1
+    "for": "12h"
+    "labels":
+      "service": "rsyslog"
+      "severity": "critical"
+  - "alert": "RsyslogErrorsHigh"
+    "annotations":
+      "message": "In the last minute, {{ $value }} errors reported by rsyslog {{ $labels.instance }}."
+      "summary": "Rsyslog reports high number of errors"
+    "expr": |
+      sum by(instance, job) (rate(rsyslog_action_failed[1m])) > 10
+    "for": "1m"
+    "labels":
+      "service": "rsyslog"
+      "severity": "critical"

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -18,6 +18,10 @@ import (
 
 const (
 	clusterLoggingPriorityClassName = "cluster-logging"
+	metricsPort                     = int32(24231)
+	metricsPortName                 = "metrics"
+	metricsVolumeName               = "collector-metrics"
+	prometheusCAFile                = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
 )
 
 var (
@@ -101,6 +105,17 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 	}
 
 	if cluster.Spec.Collection.Logs.Type == logging.LogCollectionTypeRsyslog {
+		if err = clusterRequest.createOrUpdateRsyslogService(); err != nil {
+			return
+		}
+
+		if err = clusterRequest.createOrUpdateRsyslogServiceMonitor(); err != nil {
+			return
+		}
+
+		if err = clusterRequest.createOrUpdateRsyslogPrometheusRule(); err != nil {
+			return
+		}
 
 		if err = clusterRequest.createOrUpdateRsyslogConfigMap(); err != nil {
 			return

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -17,11 +17,7 @@ import (
 )
 
 const (
-	metricsPort       = int32(24231)
-	metricsPortName   = "metrics"
-	prometheusCAFile  = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
-	metricsVolumeName = "fluentd-metrics"
-	alertsFile        = "fluentd/fluentd_prometheus_alerts.yaml"
+	fluentdAlertsFile = "fluentd/fluentd_prometheus_alerts.yaml"
 )
 
 func (clusterRequest *ClusterLoggingRequest) removeFluentd() (err error) {
@@ -131,7 +127,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateFluentdPrometheusRule
 
 	promRule := NewPrometheusRule("fluentd", cluster.Namespace)
 
-	promRuleSpec, err := NewPrometheusRuleSpecFrom(utils.GetShareDir() + "/" + alertsFile)
+	promRuleSpec, err := NewPrometheusRuleSpecFrom(utils.GetShareDir() + "/" + fluentdAlertsFile)
 	if err != nil {
 		return fmt.Errorf("Failure creating the fluentd PrometheusRule: %v", err)
 	}

--- a/pkg/k8shandler/rsyslog.go
+++ b/pkg/k8shandler/rsyslog.go
@@ -4,17 +4,37 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/util/retry"
 
 	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	rsyslogAlertsFile = "rsyslog/rsyslog_prometheus_alerts.yaml"
 )
 
 func (clusterRequest *ClusterLoggingRequest) removeRsyslog() (err error) {
 	if clusterRequest.isManaged() {
+
+		if err = clusterRequest.RemoveService("rsyslog"); err != nil {
+			return
+		}
+
+		if err = clusterRequest.RemoveServiceMonitor("rsyslog"); err != nil {
+			return
+		}
+
+		if err = clusterRequest.RemovePrometheusRule("rsyslog"); err != nil {
+			return
+		}
+
 		if err = clusterRequest.RemoveConfigMap("rsyslog-bin"); err != nil {
 			return
 		}
@@ -47,8 +67,100 @@ func (clusterRequest *ClusterLoggingRequest) removeRsyslog() (err error) {
 	return nil
 }
 
-func (clusterRequest *ClusterLoggingRequest) createOrUpdateRsyslogConfigMap() error {
+func (clusterRequest *ClusterLoggingRequest) createOrUpdateRsyslogService() error {
+	service := NewService(
+		"rsyslog",
+		clusterRequest.cluster.Namespace,
+		"rsyslog",
+		[]v1.ServicePort{
+			{
+				Port:       metricsPort,
+				TargetPort: intstr.FromString(metricsPortName),
+				Name:       metricsPortName,
+			},
+		},
+	)
 
+	service.Annotations = map[string]string{
+		"service.alpha.openshift.io/serving-cert-secret-name": metricsVolumeName,
+	}
+
+	utils.AddOwnerRefToObject(service, utils.AsOwner(clusterRequest.cluster))
+
+	err := clusterRequest.Create(service)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("Failure creating the rsyslog service: %v", err)
+	}
+
+	return nil
+}
+
+func (clusterRequest *ClusterLoggingRequest) createOrUpdateRsyslogServiceMonitor() error {
+
+	cluster := clusterRequest.cluster
+
+	serviceMonitor := NewServiceMonitor("rsyslog", cluster.Namespace)
+
+	endpoint := monitoringv1.Endpoint{
+		Port:   metricsPortName,
+		Path:   "/metrics",
+		Scheme: "https",
+		TLSConfig: &monitoringv1.TLSConfig{
+			CAFile:     prometheusCAFile,
+			ServerName: fmt.Sprintf("%s.%s.svc", "rsyslog", cluster.Namespace),
+			// ServerName can be e.g. rsyslog.openshift-logging.svc
+		},
+	}
+
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"logging-infra": "support",
+		},
+	}
+
+	serviceMonitor.Spec = monitoringv1.ServiceMonitorSpec{
+		JobLabel:  "monitor-rsyslog",
+		Endpoints: []monitoringv1.Endpoint{endpoint},
+		Selector:  labelSelector,
+		NamespaceSelector: monitoringv1.NamespaceSelector{
+			MatchNames: []string{cluster.Namespace},
+		},
+	}
+
+	utils.AddOwnerRefToObject(serviceMonitor, utils.AsOwner(cluster))
+
+	err := clusterRequest.Create(serviceMonitor)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("Failure creating the rsyslog ServiceMonitor: %v", err)
+	}
+
+	return nil
+}
+
+func (clusterRequest *ClusterLoggingRequest) createOrUpdateRsyslogPrometheusRule() error {
+
+	cluster := clusterRequest.cluster
+
+	promRule := NewPrometheusRule("rsyslog", cluster.Namespace)
+
+	promRuleSpec, err := NewPrometheusRuleSpecFrom(utils.GetShareDir() + "/" + rsyslogAlertsFile)
+	if err != nil {
+		return fmt.Errorf("Failure creating the rsyslog PrometheusRule: %v", err)
+	}
+
+	promRule.Spec = *promRuleSpec
+
+	utils.AddOwnerRefToObject(promRule, utils.AsOwner(cluster))
+
+	err = clusterRequest.Create(promRule)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("Failure creating the rsyslog PrometheusRule: %v", err)
+	}
+
+	return nil
+}
+
+func (clusterRequest *ClusterLoggingRequest) createOrUpdateRsyslogConfigMap() error {
 	// need three configmaps
 	// - one for rsyslog run.sh script - rsyslog-bin
 	// - one for main rsyslog.conf file - rsyslog-main
@@ -173,9 +285,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateRsyslogDaemonset() (e
 
 	cluster := clusterRequest.cluster
 
-	var rsyslogPodSpec v1.PodSpec
-
-	rsyslogPodSpec = newRsyslogPodSpec(cluster, "elasticsearch", "elasticsearch")
+	rsyslogPodSpec := newRsyslogPodSpec(clusterRequest.cluster, "elasticsearch", "elasticsearch")
 
 	rsyslogDaemonset := NewDaemonSet("rsyslog", cluster.Namespace, "rsyslog", "rsyslog", rsyslogPodSpec)
 
@@ -209,6 +319,14 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			}}
 	}
 	rsyslogContainer := NewContainer("rsyslog", "rsyslog", v1.PullIfNotPresent, *resources)
+
+	rsyslogContainer.Ports = []v1.ContainerPort{
+		v1.ContainerPort{
+			Name:          metricsPortName,
+			ContainerPort: metricsPort,
+			Protocol:      v1.ProtocolTCP,
+		},
+	}
 
 	rsyslogContainer.Env = []v1.EnvVar{
 		{Name: "MERGE_JSON_LOG", Value: "false"},
@@ -245,6 +363,7 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 		{Name: "localtime", ReadOnly: true, MountPath: "/etc/localtime"},
 		{Name: "machineid", ReadOnly: true, MountPath: "/etc/machine-id"},
 		{Name: "filebufferstorage", MountPath: "/var/lib/rsyslog.pod"},
+		{Name: metricsVolumeName, MountPath: "/etc/rsyslog/metrics"},
 	}
 
 	rsyslogContainer.SecurityContext = &v1.SecurityContext{
@@ -307,6 +426,7 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			{Name: "filebufferstorage", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/rsyslog.pod"}}},
 			{Name: "logrotate-bin", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "logrotate-bin"}}}},
 			{Name: "logrotate-crontab", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "logrotate-crontab"}}}},
+			{Name: metricsVolumeName, VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: metricsVolumeName}}},
 		},
 		logging.Spec.Collection.Logs.RsyslogSpec.NodeSelector,
 	)

--- a/test/e2e/clusterlogging_test.go
+++ b/test/e2e/clusterlogging_test.go
@@ -15,6 +15,7 @@ import (
 	loggingapi "github.com/openshift/cluster-logging-operator/pkg/apis"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -98,6 +99,14 @@ func clusterLoggingInitialDeploymentTest(t *testing.T, f *framework.Framework, c
 		}
 	}
 
+	// good default values for aws testing environment
+	esResources := &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("4Gi"),
+			v1.ResourceCPU:    resource.MustParse("500m"),
+		},
+	}
+
 	// create clusterlogging custom resource
 	exampleClusterLogging := &logging.ClusterLogging{
 		TypeMeta: metav1.TypeMeta{
@@ -113,6 +122,7 @@ func clusterLoggingInitialDeploymentTest(t *testing.T, f *framework.Framework, c
 				Type: logging.LogStoreTypeElasticsearch,
 				ElasticsearchSpec: logging.ElasticsearchSpec{
 					NodeCount: 1,
+					Resources: esResources,
 				},
 			},
 			Visualization: logging.VisualizationSpec{


### PR DESCRIPTION
This configures the rsyslog pod to export prometheus
metrics using the soundcloud rsyslog_exporter via an
omprog output of the impstats.
This requires https://github.com/openshift/origin-aggregated-logging/pull/1643
for full prometheus support.

This replaces https://github.com/openshift/cluster-logging-operator/pull/164