### PR TITLE
[release-4.1] Bug 1712955: Fixing checking if nodes are different when scaling from 3 to 4

### DIFF
--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -121,14 +121,6 @@ func (cluster *ClusterLogging) newElasticsearchCR(elasticsearchName string) *ela
 
 	if cluster.Spec.LogStore.NodeCount > 3 {
 
-		dataNode := elasticsearch.ElasticsearchNode{
-			Roles:     []elasticsearch.ElasticsearchNodeRole{"client", "data"},
-			NodeCount: cluster.Spec.LogStore.NodeCount - 3,
-			Storage:   cluster.Spec.LogStore.ElasticsearchSpec.Storage,
-		}
-
-		esNodes = append(esNodes, dataNode)
-
 		masterNode := elasticsearch.ElasticsearchNode{
 			Roles:     []elasticsearch.ElasticsearchNodeRole{"client", "data", "master"},
 			NodeCount: 3,
@@ -136,6 +128,14 @@ func (cluster *ClusterLogging) newElasticsearchCR(elasticsearchName string) *ela
 		}
 
 		esNodes = append(esNodes, masterNode)
+
+		dataNode := elasticsearch.ElasticsearchNode{
+			Roles:     []elasticsearch.ElasticsearchNodeRole{"client", "data"},
+			NodeCount: cluster.Spec.LogStore.NodeCount - 3,
+			Storage:   cluster.Spec.LogStore.ElasticsearchSpec.Storage,
+		}
+
+		esNodes = append(esNodes, dataNode)
 
 	} else {
 
@@ -280,6 +280,10 @@ func areNodesDifferent(current, desired []elasticsearch.ElasticsearchNode) ([]el
 
 	// nodes were removed
 	if len(current) == 0 {
+		return desired, true
+	}
+
+	if len(current) != len(desired) {
 		return desired, true
 	}
 

--- a/pkg/k8shandler/logstore_test.go
+++ b/pkg/k8shandler/logstore_test.go
@@ -303,3 +303,73 @@ func createAndCheckSingleNodeWithNodeCount(t *testing.T, expectedNodeCount int32
 		}
 	}
 }
+
+func TestDifferenceFoundWhenNodeCountExceeds3(t *testing.T) {
+	cluster := NewClusterLogging(
+		&logging.ClusterLogging{
+			Spec: logging.ClusterLoggingSpec{
+				LogStore: logging.LogStoreSpec{
+					Type: "elasticsearch",
+					ElasticsearchSpec: logging.ElasticsearchSpec{
+						NodeCount: 3,
+					},
+				},
+			},
+		},
+	)
+	elasticsearchCR := cluster.newElasticsearchCR("test-app-name")
+
+	cluster = NewClusterLogging(
+		&logging.ClusterLogging{
+			Spec: logging.ClusterLoggingSpec{
+				LogStore: logging.LogStoreSpec{
+					Type: "elasticsearch",
+					ElasticsearchSpec: logging.ElasticsearchSpec{
+						NodeCount: 4,
+					},
+				},
+			},
+		},
+	)
+	elasticsearchCR2 := cluster.newElasticsearchCR("test-app-name")
+
+	_, different := isElasticsearchCRDifferent(elasticsearchCR, elasticsearchCR2)
+	if !different {
+		t.Errorf("Expected that difference would be found due to node count change")
+	}
+}
+
+func TestDifferenceFoundWhenNodeCountExceeds4(t *testing.T) {
+	cluster := NewClusterLogging(
+		&logging.ClusterLogging{
+			Spec: logging.ClusterLoggingSpec{
+				LogStore: logging.LogStoreSpec{
+					Type: "elasticsearch",
+					ElasticsearchSpec: logging.ElasticsearchSpec{
+						NodeCount: 4,
+					},
+				},
+			},
+		},
+	)
+	elasticsearchCR := cluster.newElasticsearchCR("test-app-name")
+
+	cluster = NewClusterLogging(
+		&logging.ClusterLogging{
+			Spec: logging.ClusterLoggingSpec{
+				LogStore: logging.LogStoreSpec{
+					Type: "elasticsearch",
+					ElasticsearchSpec: logging.ElasticsearchSpec{
+						NodeCount: 5,
+					},
+				},
+			},
+		},
+	)
+	elasticsearchCR2 := cluster.newElasticsearchCR("test-app-name")
+
+	_, different := isElasticsearchCRDifferent(elasticsearchCR, elasticsearchCR2)
+	if !different {
+		t.Errorf("Expected that difference would be found due to node count change")
+	}
+}


### PR DESCRIPTION
Cherry pick of https://github.com/openshift/cluster-logging-operator/pull/185

Also fixing ordering of nodes defined to prevent prior node recreation

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1712955