### PR TITLE
rsyslog - set default queue.size; timing issue switching from fluentd

### DIFF
--- a/files/rsyslog/00-global.conf
+++ b/files/rsyslog/00-global.conf
@@ -9,3 +9,9 @@ global(
   maxMessageSize="32767"
   processInternalMessages="on"
 )
+main_queue(
+  queue.spoolDirectory=`echo $RSYSLOG_WORKDIRECTORY`
+  queue.filename="main-queue"
+  queue.type="linkedlist"
+  queue.size=`echo $RSYSLOG_MAIN_QUEUE_SIZE`
+)

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -100,8 +100,6 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 		if retryErr != nil {
 			return fmt.Errorf("Failed to update Cluster Logging Fluentd status: %v", retryErr)
 		}
-	} else {
-		clusterRequest.removeFluentd()
 	}
 
 	if cluster.Spec.Collection.Logs.Type == logging.LogCollectionTypeRsyslog {
@@ -153,7 +151,13 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 		if retryErr != nil {
 			return fmt.Errorf("Failed to update Cluster Logging Rsyslog status: %v", retryErr)
 		}
-	} else {
+	}
+
+	if cluster.Spec.Collection.Logs.Type != logging.LogCollectionTypeFluentd {
+		clusterRequest.removeFluentd()
+	}
+
+	if cluster.Spec.Collection.Logs.Type != logging.LogCollectionTypeRsyslog {
 		clusterRequest.removeRsyslog()
 	}
 

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -66,7 +66,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateFluentdService() erro
 	)
 
 	service.Annotations = map[string]string{
-		"service.alpha.openshift.io/serving-cert-secret-name": metricsVolumeName,
+		"service.alpha.openshift.io/serving-cert-secret-name": "fluentd-metrics",
 	}
 
 	utils.AddOwnerRefToObject(service, utils.AsOwner(clusterRequest.cluster))
@@ -265,7 +265,7 @@ func newFluentdPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			{Name: "dockercfg", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/sysconfig/docker"}}},
 			{Name: "dockerdaemoncfg", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/docker"}}},
 			{Name: "filebufferstorage", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/fluentd"}}},
-			{Name: metricsVolumeName, VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: metricsVolumeName}}},
+			{Name: metricsVolumeName, VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "fluentd-metrics"}}},
 		},
 		logging.Spec.Collection.Logs.FluentdSpec.NodeSelector,
 	)

--- a/pkg/k8shandler/rsyslog.go
+++ b/pkg/k8shandler/rsyslog.go
@@ -82,7 +82,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateRsyslogService() erro
 	)
 
 	service.Annotations = map[string]string{
-		"service.alpha.openshift.io/serving-cert-secret-name": metricsVolumeName,
+		"service.alpha.openshift.io/serving-cert-secret-name": "rsyslog-metrics",
 	}
 
 	utils.AddOwnerRefToObject(service, utils.AsOwner(clusterRequest.cluster))
@@ -426,7 +426,7 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 			{Name: "filebufferstorage", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/rsyslog.pod"}}},
 			{Name: "logrotate-bin", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "logrotate-bin"}}}},
 			{Name: "logrotate-crontab", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "logrotate-crontab"}}}},
-			{Name: metricsVolumeName, VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: metricsVolumeName}}},
+			{Name: metricsVolumeName, VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "rsyslog-metrics"}}},
 		},
 		logging.Spec.Collection.Logs.RsyslogSpec.NodeSelector,
 	)


### PR DESCRIPTION
The default queue.size for memory queues (50000) is too large
for small deployments.  It needs to be based on the amount of
memory available to the pod.  From trial and error it seems
that a value of `memory / 10240` gives good performance and
leaves enough memory for rsyslog and overhead.  Average
record size in testing was about 10k.  Use the env. var.
`RSYSLOG_MAIN_QUEUE_SIZE` to set the main queue size to a
different value than the default.
There is a race condition when switching between fluentd and
rsyslog.  The new collector should be created first, before
removing the old collector.
When switching between fluentd and rsyslog collector,
the service cert signer gets confused because the secret
is deleted and added too quickly - so just avoid the confusion
and use a separate secret name for fluentd and rsyslog

In some cases when restarting rsyslog in the pod, the old
pid file can exist, so remove it.