### PR TITLE
Overriding node selectors causing drop of linux selector for fluentd and rsyslog

### DIFF
--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -272,8 +272,6 @@ func newFluentdPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 
 	fluentdPodSpec.PriorityClassName = clusterLoggingPriorityClassName
 
-	fluentdPodSpec.NodeSelector = logging.Spec.Collection.Logs.FluentdSpec.NodeSelector
-
 	fluentdPodSpec.Tolerations = []v1.Toleration{
 		v1.Toleration{
 			Key:      "node-role.kubernetes.io/master",

--- a/pkg/k8shandler/fluentd_test.go
+++ b/pkg/k8shandler/fluentd_test.go
@@ -29,9 +29,7 @@ func TestNewFluentdPodSpecWhenFieldsAreUndefined(t *testing.T) {
 		t.Errorf("Exp. the default CPU request to be %v", defaultFluentdCpuRequest)
 	}
 
-	if podSpec.NodeSelector != nil {
-		t.Errorf("Exp. the nodeSelector to be %T but was %T", map[string]string{}, podSpec.NodeSelector)
-	}
+	CheckIfThereIsOnlyTheLinuxSelector(podSpec, t)
 }
 
 func TestNewFluentdPodSpecWhenResourcesAreDefined(t *testing.T) {

--- a/pkg/k8shandler/pod_test.go
+++ b/pkg/k8shandler/pod_test.go
@@ -4,8 +4,23 @@ import (
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
+	core "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 )
+
+// Call this method if you want to test that podSpec's node selectors contain only the linux one.
+// Note: This method gets called from other tests. That is why we made it public to other packages.
+func CheckIfThereIsOnlyTheLinuxSelector(podSpec core.PodSpec, t *testing.T) {
+	if podSpec.NodeSelector == nil {
+		t.Errorf("Exp. the nodeSelector to contains the linux allocation selector but was %T", podSpec.NodeSelector)
+	}
+	if len(podSpec.NodeSelector) != 1 {
+		t.Errorf("Exp. single nodeSelector but %d were found", len(podSpec.NodeSelector))
+	}
+	if podSpec.NodeSelector[utils.OsNodeLabel] != utils.LinuxValue {
+		t.Errorf("Exp. the nodeSelector to contains %s: %s pair", utils.OsNodeLabel, utils.LinuxValue)
+	}
+}
 
 func TestNodeAllocationLabelsForPod(t *testing.T) {
 
@@ -18,15 +33,7 @@ func TestNodeAllocationLabelsForPod(t *testing.T) {
 		nil,
 	)
 
-	if podSpec.NodeSelector == nil {
-		t.Errorf("Exp. the nodeSelector to contains the linux allocation selector but was %T", podSpec.NodeSelector)
-	}
-	if len(podSpec.NodeSelector) != 1 {
-		t.Errorf("Exp. single nodeSelector but %d were found", len(podSpec.NodeSelector))
-	}
-	if podSpec.NodeSelector[utils.OsNodeLabel] != utils.LinuxValue {
-		t.Errorf("Exp. the nodeSelector to contains %s: %s pair", utils.OsNodeLabel, utils.LinuxValue)
-	}
+	CheckIfThereIsOnlyTheLinuxSelector(podSpec, t)
 
 	// Create pod with some "foo" selector, we expect a new linux box selector will be added
 	// while existing selectors will be left intact.

--- a/pkg/k8shandler/rsyslog.go
+++ b/pkg/k8shandler/rsyslog.go
@@ -433,8 +433,6 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 
 	rsyslogPodSpec.PriorityClassName = clusterLoggingPriorityClassName
 
-	rsyslogPodSpec.NodeSelector = logging.Spec.Collection.Logs.RsyslogSpec.NodeSelector
-
 	rsyslogPodSpec.Tolerations = []v1.Toleration{
 		v1.Toleration{
 			Key:      "node-role.kubernetes.io/master",

--- a/pkg/k8shandler/rsyslog_test.go
+++ b/pkg/k8shandler/rsyslog_test.go
@@ -51,9 +51,7 @@ func TestNewRsyslogPodSpecWhenFieldsAreUndefined(t *testing.T) {
 	if resources.Requests[v1.ResourceCPU] != defaultFluentdCpuRequest {
 		t.Errorf("Exp. the default CPU request to be %v", defaultRsyslogCpuRequest)
 	}
-	if podSpec.NodeSelector != nil {
-		t.Errorf("Exp. the nodeSelector to be %T but was %T", map[string]string{}, podSpec.NodeSelector)
-	}
+	CheckIfThereIsOnlyTheLinuxSelector(podSpec, t)
 }
 
 func TestRsyslogPodSpecHasTaintTolerations(t *testing.T) {


### PR DESCRIPTION
We made a change in LOG-411 to allocate logging components to linux
nodes only. However we were wrongly overriding node selectors for
fluentd and rsyslog components after the linux selector was set.
Hence the linux selector was missing for these two components.

This commit also makes relevant testing method reusable across
several testing files.