### PR TITLE
LOG-411 Ensure linux node selector in ElasticsearchCR

### DIFF
--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -162,9 +162,10 @@ func newElasticsearchCR(cluster *logging.ClusterLogging, elasticsearchName strin
 		},
 		Spec: elasticsearch.ElasticsearchSpec{
 			Spec: elasticsearch.ElasticsearchNodeSpec{
-				Image:        utils.GetComponentImage("elasticsearch"),
-				Resources:    *resources,
-				NodeSelector: cluster.Spec.LogStore.NodeSelector,
+				Image:     utils.GetComponentImage("elasticsearch"),
+				Resources: *resources,
+				// We always want to ensure the "linux" node selector is used, see LOG-411
+				NodeSelector: utils.EnsureLinuxNodeSelector(cluster.Spec.LogStore.NodeSelector),
 			},
 			Nodes:            esNodes,
 			ManagementState:  elasticsearch.ManagementStateManaged,

--- a/pkg/k8shandler/logstore_test.go
+++ b/pkg/k8shandler/logstore_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/pkg/utils"
 	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -29,6 +30,13 @@ func TestNewElasticsearchCRWhenResourcesAreUndefined(t *testing.T) {
 	if resources.Requests[v1.ResourceCPU] != defaultEsCpuRequest {
 		t.Errorf("Exp. the default CPU request to be %v", defaultEsCpuRequest)
 	}
+	nodeSelectors := elasticsearchCR.Spec.Spec.NodeSelector
+	if len(nodeSelectors) != 1 {
+		t.Errorf("Exp. the node Selector to contain 1 item but it contains %d items", len(nodeSelectors))
+	}
+	if nodeSelectors[utils.OsNodeLabel] != utils.LinuxValue {
+		t.Errorf("Exp. the nodeSelector to contains %s: %s pair", utils.OsNodeLabel, utils.LinuxValue)
+	}
 }
 
 func TestNewElasticsearchCRWhenNodeSelectorIsDefined(t *testing.T) {
@@ -50,7 +58,12 @@ func TestNewElasticsearchCRWhenNodeSelectorIsDefined(t *testing.T) {
 	if !reflect.DeepEqual(elasticsearchCR.Spec.Spec.NodeSelector, expSelector) {
 		t.Errorf("Exp. the nodeSelector to be %q but was %q", expSelector, elasticsearchCR.Spec.Spec.NodeSelector)
 	}
-
+	if len(expSelector) != 2 {
+		t.Errorf("Exp. the node Selector to contain 2 items but it contains %d items", len(expSelector))
+	}
+	if expSelector[utils.OsNodeLabel] != utils.LinuxValue {
+		t.Errorf("Exp. the nodeSelector to contains %s: %s pair", utils.OsNodeLabel, utils.LinuxValue)
+	}
 }
 
 func TestNewElasticsearchCRWhenResourcesAreDefined(t *testing.T) {


### PR DESCRIPTION
Ensure linux node selector is added to storage/Elasticsearch CR.
The node selector should propagate to elasticsearch-operator transparently,
meaning all pods started by elasticsearch-operator will be allocated
to linux nodes.