### PR TITLE
Bug 1724833: Cleanup 4.1 manifest content

### DIFF
--- a/manifests/4.1/cluster-logging.v4.1.0.clusterserviceversion.yaml
+++ b/manifests/4.1/cluster-logging.v4.1.0.clusterserviceversion.yaml
@@ -3,7 +3,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: clusterlogging.v4.1.2
+  name: clusterlogging.v4.1.0
   namespace: placeholder
   annotations:
     capabilities: Seamless Upgrades
@@ -15,7 +15,7 @@ metadata:
     containerImage: quay.io/openshift/origin-cluster-logging-operator:latest
     createdAt: 2018-08-01T08:00:00Z
     support: AOS Logging
-    olm.skipRange: ">=4.1.0 <4.1.2"
+    olm.skipRange: ">=4.1.0 <4.1.0"
     alm-examples: |-
         [
             {
@@ -60,6 +60,7 @@ metadata:
             }
         ]
 spec:
+  version: 4.1.0
   displayName: Cluster Logging
 
   description: |
@@ -248,7 +249,6 @@ spec:
                     value: "quay.io/openshift/origin-oauth-proxy:latest"
                   - name: RSYSLOG_IMAGE
                     value: "quay.io/openshift/origin-logging-rsyslog:latest"
-  version: 4.1.2
   customresourcedefinitions:
     owned:
     - name: clusterloggings.logging.openshift.io

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -2,15 +2,15 @@ updates:
   - file: "{MAJOR}.{MINOR}/cluster-logging.v{MAJOR}.{MINOR}.0.clusterserviceversion.yaml" # relative to this file
     update_list:
     # replace metadata.name value
-    - search: "clusterlogging.v{MAJOR}.{MINOR}.2"
+    - search: "clusterlogging.v{MAJOR}.{MINOR}.0"
       replace: "clusterlogging.{FULL_VER}"
-    # replace entire version line, otherwise would replace 4.1.0 anywhere
-    - search: "version: 4.1.2"
+    # replace entire version line, otherwise would replace {MAJOR}.{MINOR}.0 anywhere
+    - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: 'olm.skipRange: ">=4.1.0 <4.1.2"'
+    - search: 'olm.skipRange: ">=4.1.0 <{MAJOR}.{MINOR}.0"'
       replace: 'olm.skipRange: ">=4.1.0 <{FULL_VER}"'
   - file: "cluster-logging.package.yaml"
     update_list:
-    - search: "currentCSV: clusterlogging.v{MAJOR}.{MINOR}.2"
+    - search: "currentCSV: clusterlogging.v{MAJOR}.{MINOR}.0"
       replace: "currentCSV: clusterlogging.{FULL_VER}"
 

--- a/manifests/cluster-logging.package.yaml
+++ b/manifests/cluster-logging.package.yaml
@@ -2,4 +2,4 @@
 packageName: cluster-logging
 channels:
 - name: preview
-  currentCSV: clusterlogging.v4.1.2
+  currentCSV: clusterlogging.v4.1.0


### PR DESCRIPTION
aligning w/ similar changes in master: https://github.com/openshift/cluster-logging-operator/pull/206

patch manager: there is no master BZ associated w/ this change because this is cleaning up issues that were specific to the 4.1 resource files.
