### PR TITLE
Introduce gosec for security checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ OC?=oc
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 #.PHONY: all build clean install uninstall fmt simplify check run
-.PHONY: all operator-sdk imagebuilder build clean fmt simplify gendeepcopy deploy-setup deploy-image deploy deploy-example test-unit test-e2e undeploy run
+.PHONY: all operator-sdk imagebuilder build clean fmt simplify gendeepcopy deploy-setup deploy-image deploy deploy-example test-unit test-e2e test-sec undeploy run
 
 all: build #check install
 
@@ -112,6 +112,9 @@ test-unit:
 	@go test $(TEST_OPTIONS) $(PKGS)
 test-e2e:
 	hack/test-e2e.sh
+test-sec:
+	go get -u github.com/securego/gosec/cmd/gosec
+	gosec -severity medium --confidence medium -quiet ./...
 
 deploy-example-no-build: deploy-no-build
 	oc create -n $(NAMESPACE) -f hack/cr.yaml

--- a/pkg/k8shandler/prometheus_rule.go
+++ b/pkg/k8shandler/prometheus_rule.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -42,7 +43,7 @@ func NewPrometheusRuleSpecFrom(filePath string) (*monitoringv1.PrometheusRuleSpe
 	if err := utils.CheckFileExists(filePath); err != nil {
 		return nil, err
 	}
-	fileContent, err := ioutil.ReadFile(filePath)
+	fileContent, err := ioutil.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return nil, fmt.Errorf("'%s' not readable", filePath)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -148,7 +149,7 @@ func GetFileContents(filePath string) []byte {
 		return nil
 	}
 
-	contents, err := ioutil.ReadFile(filePath)
+	contents, err := ioutil.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		logrus.Errorf("Unable to read file to get contents: %v", err)
 		return nil


### PR DESCRIPTION
gosec does static code analysis and checks for common security issues in golang codebases.

This PR introduces the tool, and sets it up as a test target in the Makefile; it also fixes a couple of warnings that were found (which were probably not very problematic).