### PR TITLE
Bug 1729316: rsyslog log collector creating operations index with no date in the name

### DIFF
--- a/files/rsyslog/52-rsyslog-internal-logs.conf
+++ b/files/rsyslog/52-rsyslog-internal-logs.conf
@@ -1,0 +1,23 @@
+module(load="omstdout")
+
+template(name="logfmt_rsyslog_json" type="list" option.jsonf="on") {
+    property(outname="@timestamp" name="timereported" dateFormat="rfc3339" format="jsonf")
+    property(outname="host" name="hostname" format="jsonf")
+    property(outname="level" name="syslogseverity-text" caseConversion="lower" format="jsonf")
+    property(outname="facility" name="syslogfacility-text" format="jsonf")
+    property(outname="syslog-tag" name="syslogtag" format="jsonf")
+    property(outname="source" name="app-name" format="jsonf")
+    property(outname="procid" name="procid" format="jsonf")
+    property(outname="msgid" name="msgid" format="jsonf")
+    property(outname="message" name="msg" format="jsonf")
+ }
+
+ if $inputname == "rsyslogd" then {
+    if `echo $LOGGING_FILE_PATH` == "console" then {
+        action(type="omstdout" template="logfmt_rsyslog_json")
+    } else {
+        action(type="omfile" template="logfmt_rsyslog_json" file=`echo $LOGGING_FILE_PATH`)
+    }
+    stop # do not store internal logs in remote log store or forward
+    # otherwise, we will need to format as viaq format
+}

--- a/files/rsyslog/99-logging.conf
+++ b/files/rsyslog/99-logging.conf
@@ -1,6 +1,0 @@
-template(name="FileFormat" type="string" string= "%TIMESTAMP% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n")
-
-if ($inputname == "rsyslogd") and (`echo $LOGGING_FILE_PATH` != "console") then {
-    action(type="omfile" template="FileFormat" file=`echo $LOGGING_FILE_PATH`)
-}
-


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1729316
rsyslog logs were being sent to Elasticsearch.  rsyslog records
are unformatted, so had no @timestamp field, so were causing
indices of the form .operations... to be created.  These logs
should not be sent to Elasticsearch.  The fix is to redirect
these logs to the log file.  This fix also changes rsyslog to
use a JSON format for its logs.  Here is an example:
```json
{"@timestamp":"2019-07-15T21:38:29.966075+00:00", "host":"rsyslog-hp5cm", "level":"info", "facility":"syslog", "syslog-tag":"rsyslogd:", "source":"rsyslogd", "procid":"-", "msgid":"-", "message":" [origin software=\"rsyslogd\" swVersion=\"8.37.0-9.el7\" x-pid=\"13\" x-info=\"http:\/\/www.rsyslog.com\"] start"}
```