### PR TITLE
rsyslog - fix impstats file format

### DIFF
--- a/files/rsyslog/10-viaq-modules.conf
+++ b/files/rsyslog/10-viaq-modules.conf
@@ -32,10 +32,7 @@ module(
   ruleset="prometheus_stats"
 )
 
-template(name="impstats_file_template" type="list") {
-    property(name="$!all-json-plain")
-    constant(value="\n")
-}
+template(name="impstats_file_template" type="string" string="%msg%\n")
 
 ruleset(name="prometheus_stats") {
   action(


### PR DESCRIPTION
the msg field is already in JSON format - just print it