### PR TITLE
Bug 1715370: Some orphaned logs sent to .operations.* index by mistake.

### DIFF
--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -44,14 +44,6 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 		if err = clusterRequest.createOrUpdateCollectorServiceAccount(); err != nil {
 			return
 		}
-	} else {
-		if err = clusterRequest.RemoveServiceAccount("logcollector"); err != nil {
-			return
-		}
-
-		if err = clusterRequest.RemovePriorityClass(clusterLoggingPriorityClassName); err != nil {
-			return
-		}
 	}
 
 	if cluster.Spec.Collection.Logs.Type == logging.LogCollectionTypeFluentd {
@@ -159,6 +151,16 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 
 	if cluster.Spec.Collection.Logs.Type != logging.LogCollectionTypeRsyslog {
 		clusterRequest.removeRsyslog()
+	}
+
+	if cluster.Spec.Collection.Logs.Type != logging.LogCollectionTypeFluentd && cluster.Spec.Collection.Logs.Type != logging.LogCollectionTypeRsyslog {
+		if err = clusterRequest.RemoveServiceAccount("logcollector"); err != nil {
+			return
+		}
+
+		if err = clusterRequest.RemovePriorityClass(clusterLoggingPriorityClassName); err != nil {
+			return
+		}
 	}
 
 	return nil

--- a/pkg/k8shandler/curation.go
+++ b/pkg/k8shandler/curation.go
@@ -74,7 +74,11 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCuration() (err error
 
 func (clusterRequest *ClusterLoggingRequest) removeCurator() (err error) {
 	if clusterRequest.isManaged() {
-		if err = clusterRequest.RemoveServiceAccount("curator"); err != nil {
+		if err = clusterRequest.RemoveSecret("curator"); err != nil {
+			return
+		}
+
+		if err = clusterRequest.RemoveCronJob("curator"); err != nil {
 			return
 		}
 
@@ -82,11 +86,7 @@ func (clusterRequest *ClusterLoggingRequest) removeCurator() (err error) {
 			return
 		}
 
-		if err = clusterRequest.RemoveSecret("curator"); err != nil {
-			return
-		}
-
-		if err = clusterRequest.RemoveCronJob("curator"); err != nil {
+		if err = clusterRequest.RemoveServiceAccount("curator"); err != nil {
 			return
 		}
 	}

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -90,15 +90,11 @@ func (clusterRequest *ClusterLoggingRequest) removeKibana() (err error) {
 	if clusterRequest.isManaged() {
 		name := "kibana"
 		proxyName := "kibana-proxy"
-		if err = clusterRequest.RemoveServiceAccount(name); err != nil {
+		if err = clusterRequest.RemoveDeployment(name); err != nil {
 			return
 		}
 
-		if err = clusterRequest.RemoveConfigMap(name); err != nil {
-			return
-		}
-
-		if err = clusterRequest.RemoveConfigMap("sharing-config"); err != nil {
+		if err = clusterRequest.RemoveOAuthClient(proxyName); err != nil {
 			return
 		}
 
@@ -110,19 +106,23 @@ func (clusterRequest *ClusterLoggingRequest) removeKibana() (err error) {
 			return
 		}
 
-		if err = clusterRequest.RemoveService(name); err != nil {
-			return
-		}
-
 		if err = clusterRequest.RemoveRoute(name); err != nil {
 			return
 		}
 
-		if err = clusterRequest.RemoveDeployment(name); err != nil {
+		if err = clusterRequest.RemoveConfigMap(name); err != nil {
 			return
 		}
 
-		if err = clusterRequest.RemoveOAuthClient(proxyName); err != nil {
+		if err = clusterRequest.RemoveConfigMap("sharing-config"); err != nil {
+			return
+		}
+
+		if err = clusterRequest.RemoveService(name); err != nil {
+			return
+		}
+
+		if err = clusterRequest.RemoveServiceAccount(name); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
There was a small window where the daemonset is up and its service account is
missing for the collectors.  Based on the rule "we should try to delete objects
in the reverse order that we created them", reversing the order of removing the
daemonset and the service account.

Applying the rule to curator and kibana, as well.