### PR TITLE
Bug 1724053: Retrieve oauthclient as a cluster resource

### DIFF
--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -250,6 +250,9 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateOauthClient(oauthSecr
 			current.RedirectURIs = oauthClient.RedirectURIs
 			current.Secret = oauthClient.Secret
 			current.ScopeRestrictions = oauthClient.ScopeRestrictions
+			if current.GetObjectMeta().GetAnnotations() == nil {
+				current.GetObjectMeta().SetAnnotations(make(map[string]string))
+			}
 			current.GetObjectMeta().GetAnnotations()[annotationOauthSecretUpdatedAt] = updatedAt
 			if err = clusterRequest.Update(current); err != nil {
 				return err


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1724053
fix crash associated with missing annotation map when
having to retry oauthclient modification.