### PR TITLE
Bug 1735511: Rsyslog couldn't parse json log which has prefix space before the json string when set MERGE_JSON_LOG=true

### DIFF
--- a/files/rsyslog/parse_json.rulebase
+++ b/files/rsyslog/parse_json.rulebase
@@ -1,2 +1,3 @@
 version=2
 rule=:%.:json%
+rule=:%-:whitespace%%.:json%

--- a/files/rsyslog/parse_json_skip_empty.rulebase
+++ b/files/rsyslog/parse_json_skip_empty.rulebase
@@ -1,2 +1,3 @@
 version=2
 rule=:%.:json:skipempty%
+rule=:%-:whitespace%%.:json:skipempty%


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1735511
Change the json parser to look for leading whitespace

Note: The multiline_json parser doesn't need this because its json
is computer generated by docker, not human generated as in the bz