### PR TITLE
Bug 1725517: Setting ENABLE_PROMETHEUS_ENDPOINT=false in rsyslog env doesn't take effect.

### DIFF
--- a/files/rsyslog/10-viaq-modules.conf
+++ b/files/rsyslog/10-viaq-modules.conf
@@ -38,11 +38,13 @@ template(name="impstats_file_template" type="string" string="%msg%\n")
 # anything, and discard messages if too heavily loaded
 ruleset(name="prometheus_stats" queue.type="FixedArray" queue.size="1000" queue.timeoutEnqueue="100"
         queue.discardSeverity="4" queue.timeoutshutdown="10") {
-  action(
-    type="omprog"
-    name="prometheus_stats"
-    binary="/usr/local/bin/rsyslog_exporter --web.listen-address=:24231 --tls.server-crt=/etc/rsyslog/metrics/tls.crt --tls.server-key=/etc/rsyslog/metrics/tls.key"
-  )
+  if `echo $ENABLE_PROMETHEUS_ENDPOINT` == "true" then {
+    action(
+      type="omprog"
+      name="prometheus_stats"
+      binary="/usr/local/bin/rsyslog_exporter --web.listen-address=:24231 --tls.server-crt=/etc/rsyslog/metrics/tls.crt --tls.server-key=/etc/rsyslog/metrics/tls.key"
+    )
+  }
   if `echo $RSYSLOG_USE_IMPSTATS_FILE` == "true" then {
     action(name="impstats_json" type="omfile" file=`echo $RSYSLOG_IMPSTATS_FILE` template="impstats_file_template")
   }

--- a/files/rsyslog/rsyslog.sh
+++ b/files/rsyslog/rsyslog.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CFG_DIR=/etc/rsyslog.d
-ENABLE_PROMETHEUS_ENDPOINT=${ENABLE_PROMETHEUS_ENDPOINT:-"false"}
+export ENABLE_PROMETHEUS_ENDPOINT=${ENABLE_PROMETHEUS_ENDPOINT:-"true"}
 export LOGGING_FILE_PATH=${LOGGING_FILE_PATH:-"/var/log/rsyslog/rsyslog.log"}
 export RSYSLOG_WORKDIRECTORY=${RSYSLOG_WORKDIRECTORY:-/var/lib/rsyslog.pod}
 export MERGE_JSON_LOG=${MERGE_JSON_LOG:-false}
@@ -337,11 +337,6 @@ if [[ "${USE_REMOTE_SYSLOG:-}" = "true" ]] ; then
     if [[ $REMOTE_SYSLOG_HOST ]] ; then
         ruby generate_syslog_config.rb
     fi
-fi
-
-if [ "${ENABLE_PROMETHEUS_ENDPOINT}" != "true" ] ; then
-  echo "INFO: Disabling Prometheus endpoint"
-  rm -f ${CFG_DIR}/openshift/input-pre-prometheus-metrics.conf
 fi
 
 # Create a directory for log files


### PR DESCRIPTION
The default value of the env variable was false, but we want it to be
true.
Additionally, the env variable did not alter anything, since the only
time it was checked, was when deleting a non existing file.
Therefore, I have deleted this unused control block in rsyslog.sh,
and moved the logic to block Prometheus endpoint to the Rsyslog
configuration.