### PR TITLE
Bug 1735548:  pipeline_metadata.collector.ipaddr6 is incorrect when using rsyslog as log collector.

### DIFF
--- a/files/rsyslog/65-viaq-formatting.conf
+++ b/files/rsyslog/65-viaq-formatting.conf
@@ -303,7 +303,10 @@ set $!pipeline_metadata!collector!name = "rsyslog";
 set $!pipeline_metadata!collector!inputname = $inputname;
 set $!pipeline_metadata!collector!received_at = exec_template("timegeneratedrfc3339");
 set $!pipeline_metadata!collector!ipaddr4 = `echo $IPADDR4`;
-set $!pipeline_metadata!collector!ipaddr6 = `echo $IPADDR6`;
+if strlen(`echo $IPADDR6`) > 0 then {
+    set $!pipeline_metadata!collector!ipaddr6 = `echo $IPADDR6`;
+}
+
 set $!pipeline_metadata!collector!version = `echo $PIPELINE_VERSION`;
 if strlen($!metadata) > 0 then {
     if (strlen($!file) == 0) and (strlen($!metadata!filename) > 0) then {

--- a/files/rsyslog/rsyslog.sh
+++ b/files/rsyslog/rsyslog.sh
@@ -174,6 +174,9 @@ else
 fi
 RSYSLOG_VERSION=`/usr/sbin/rsyslogd -v | awk -F'[ ,]+' '/^rsyslogd / {print $2}'`
 PIPELINE_VERSION="${RSYSLOG_VERSION} ${DATA_VERSION}"
+
+IPADDR6="" # So as to omit "ipaddr6" field from logs. See https://github.com/openshift/cluster-logging-operator/pull/225
+
 export IPADDR4 IPADDR6 PIPELINE_VERSION HOSTNAME
 
 BUFFER_SIZE_LIMIT=${BUFFER_SIZE_LIMIT:-16777216}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1735548 .
Part of that Bugzilla is also Fluentd fix for the same incorrect field. However, the fix requires opening a PR in [Origin Aggregate Logging](https://github.com/openshift/origin-aggregated-logging) repository.

This is the Fluentd PR https://github.com/openshift/origin-aggregated-logging/pull/1718