### PR TITLE
Bug 1737286: The logs collected by rsyslog are not parsed

### DIFF
--- a/files/rsyslog/65-viaq-formatting.conf
+++ b/files/rsyslog/65-viaq-formatting.conf
@@ -16,6 +16,10 @@ if strlen($!MESSAGE) > 0 then {
             unset $!originalmsg;
             unset $!unparsed-data;
         }
+        # NOTE: We don't currently use PRESERVE_JSON_LOG - we unconditionally delete
+        # the original field - this is in accordance with what fluentd does - it
+        # may preserve the original field in the parse_json plugin, but it will
+        # unconditionally remove the field in the viaq filter
     }
     # ensure that $!message is set and $!MESSAGE is unset
     # if rsyslog is case sensitive, then $!MESSAGE == $!message
@@ -23,29 +27,36 @@ if strlen($!MESSAGE) > 0 then {
         set $.save_message = $!message;
         unset $!MESSAGE; # which also unsets $!message
         set $!message = $.save_message;
-        unset $.save_message;
     } else {
         if strlen($!message) == 0 then {
             set $!message = $!MESSAGE;
         }
         unset $!MESSAGE;
     }
-} else {
-    if strlen($!log) > 0 then {
-        set $!pipeline_metadata!collector!original_raw_message = $!log;
-        if (strlen(`echo $MERGE_JSON_LOG`) > 0) and (`echo $MERGE_JSON_LOG` == "true") then {
-            action(name="parse_json_containers" type="mmnormalize" ruleBase="/etc/rsyslog.d/parse_json.rulebase" variable="$!log")
-            if strlen($!originalmsg) > 0 then {
-                # parsing failed - not json - just continue
-                unset $!originalmsg;
-                unset $!unparsed-data;
-            }
+} else if strlen($!log) > 0 then {
+    set $!pipeline_metadata!collector!original_raw_message = $!log;
+    if (strlen(`echo $MERGE_JSON_LOG`) > 0) and (`echo $MERGE_JSON_LOG` == "true") then {
+        action(name="parse_json_containers" type="mmnormalize" ruleBase="/etc/rsyslog.d/parse_json.rulebase" variable="$!log")
+        if strlen($!originalmsg) > 0 then {
+            # parsing failed - not json - just continue
+            unset $!originalmsg;
+            unset $!unparsed-data;
         }
-        if strlen($!message) == 0 then {
-            set $!message = $!log;
-        }
-        unset $!log;
+        # NOTE: We don't currently use PRESERVE_JSON_LOG - we unconditionally delete
+        # the original field - this is in accordance with what fluentd does - it
+        # may preserve the original field in the parse_json plugin, but it will
+        # unconditionally remove the field in the viaq filter
     }
+    if strlen($!message) == 0 then {
+        if strlen($!MESSAGE) > 0 then {
+            set $!message = $!MESSAGE;
+        } else if strlen($!log) > 0 then {
+            set $!message = $!log;
+        } else {
+            set $!message = "";
+        }
+    }
+    unset $!log;
 }
 
 if strlen($!_MACHINE_ID) > 0 then {

--- a/files/rsyslog/67-mmexternal.conf
+++ b/files/rsyslog/67-mmexternal.conf
@@ -1,21 +1,14 @@
 module(load="mmexternal")
 
-if (strlen(`echo $SKIP_EMPTY`) > 0) and (`echo $SKIP_EMPTY` == "true") then {
-    action(name="skip_empty" type="mmnormalize" ruleBase="/etc/rsyslog.d/parse_json_skip_empty.rulebase" path="$!openshift_logging_all")
-    if strlen($!originalmsg) > 0 then {
-        # parsing failed - not json - just continue
-        unset $!originalmsg;
-        unset $!unparsed-data;
-    }
-} else if (strlen(`echo $USE_MMEXTERNAL`) > 0) and (`echo $USE_MMEXTERNAL` == "true") then {
+if (strlen(`echo $USE_MMEXTERNAL`) > 0) and (`echo $USE_MMEXTERNAL` == "true") then {
     action(name="undefined_field" type="mmexternal" binary="/usr/local/bin/undefined_field" interface.input="fulljson")
-}
-if (strlen($!openshift_logging_all) > 0) then {
-    set $.openshift_logging_all = $!openshift_logging_all;
-    unset $!;
-    set $! = $.openshift_logging_all;
-    unset $.openshift_logging_all;
-}
-if (strlen(`echo $UNDEFINED_DEBUG`) > 0) and (`echo $UNDEFINED_DEBUG` == "true") then {
-    action(name="debug_undefined_field" type="omfile" template="RSYSLOG_DebugFormat" file="/var/log/rsyslog/rsyslog_debug.log")
+    if (strlen($!openshift_logging_all) > 0) then {
+        set $.openshift_logging_all = $!openshift_logging_all;
+        unset $!;
+        set $! = $.openshift_logging_all;
+        unset $.openshift_logging_all;
+    }
+    if (strlen(`echo $UNDEFINED_DEBUG`) > 0) and (`echo $UNDEFINED_DEBUG` == "true") then {
+        action(name="debug_undefined_field" type="omfile" template="RSYSLOG_DebugFormat" file="/var/log/rsyslog/rsyslog_debug.log")
+    }
 }

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -212,6 +212,7 @@ func newFluentdPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 
 	fluentdContainer.Env = []v1.EnvVar{
 		{Name: "MERGE_JSON_LOG", Value: "false"},
+		{Name: "PRESERVE_JSON_LOG", Value: "true"},
 		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc"},
 		{Name: "ES_HOST", Value: elasticsearchAppName},
 		{Name: "ES_PORT", Value: "9200"},
@@ -231,6 +232,7 @@ func newFluentdPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 		{Name: "FLUENTD_CPU_LIMIT", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{ContainerName: "fluentd", Resource: "limits.cpu"}}},
 		{Name: "FLUENTD_MEMORY_LIMIT", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{ContainerName: "fluentd", Resource: "limits.memory"}}},
 		{Name: "NODE_IPV4", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.hostIP"}}},
+		{Name: "CDM_KEEP_EMPTY_FIELDS", Value: "message"}, // by default, keep empty messages
 	}
 
 	fluentdContainer.VolumeMounts = []v1.VolumeMount{

--- a/pkg/k8shandler/rsyslog.go
+++ b/pkg/k8shandler/rsyslog.go
@@ -330,6 +330,7 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 
 	rsyslogContainer.Env = []v1.EnvVar{
 		{Name: "MERGE_JSON_LOG", Value: "false"},
+		{Name: "PRESERVE_JSON_LOG", Value: "true"},
 		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc"},
 		{Name: "ES_HOST", Value: elasticsearchAppName},
 		{Name: "ES_PORT", Value: "9200"},
@@ -348,6 +349,7 @@ func newRsyslogPodSpec(logging *logging.ClusterLogging, elasticsearchAppName str
 		{Name: "RSYSLOG_MEMORY_LIMIT", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{ContainerName: "rsyslog", Resource: "limits.memory"}}},
 		{Name: "NODE_IPV4", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.hostIP"}}},
 		{Name: "RSYSLOG_WORKDIRECTORY", Value: "/var/lib/rsyslog.pod"},
+		{Name: "CDM_KEEP_EMPTY_FIELDS", Value: "message"}, // by default, keep empty messages
 	}
 
 	rsyslogContainer.VolumeMounts = []v1.VolumeMount{


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1737286
Get rid of the mmnormalize based SKIP_EMPTY processing.  In order
for it to be useful for our case we need to be able to specify
CDM_KEEP_EMPTY_FIELDS since we preserve the empty `message`
field by default.
Add more fluentd functionality - unconditionally delete the
MESSAGE and log fields, ignoring PRESERVE_JSON_LOG.  Keep the
empty message field in the record.
If we have performance problems with the mmexternal based
undefined_field.go, we can revisit adding skip_empty_fields
support to the mmnormalize json parser, or write
undefined_field.go as an rsyslog C module.