### PR TITLE
Bug 1715370: Some orphaned logs sent to .operations.* index by mistake.

### DIFF
--- a/manifests/4.2/cluster-logging.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/4.2/cluster-logging.v4.2.0.clusterserviceversion.yaml
@@ -139,6 +139,7 @@ spec:
           - configmaps
           - secrets
           - serviceaccounts
+          - serviceaccounts/finalizers
           verbs:
           - "*"
         - apiGroups:

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -221,3 +221,22 @@ func CheckFileExists(filePath string) error {
 	}
 	return nil
 }
+
+func ContainsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func RemoveString(slice []string, s string) (result []string) {
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
+}


### PR DESCRIPTION
In the Cluster Logging instance deletion, resources under Cluster Logging
were deleted independently, which could leave a short time period when the
fluentd or rsyslog daemonset was still running but its logcollector service
account was removed.  That made the logs processed in the time miss kubernetes
information including the namespace name.

In this patch, the following changes are made:
- Setting foregroundDeletion finalizer to collector service account
- Making the ownerReference of fluentd and rsyslog daemonset the collector service account
- Setting blockOwnerDeletion to true in the ownerReference
- The foregroundDeletion informs whether the collector service account is being deleted
  or not via reconciler. If it is being deleted, letting the collector service account
  deletion wait until the other objects are all removed, then, delete the finalizer and
  delete the service account.