### PR TITLE
Bug 1739558: rsyslog underperforming compared to fluentd

### DIFF
--- a/files/rsyslog/60-mmk8s.conf
+++ b/files/rsyslog/60-mmk8s.conf
@@ -3,9 +3,9 @@
 # however, since imfile processing happens _before_ the field parsing, we have to
 # rely on two regular expressions - basically look for the pattern \n"}$ for the
 # string at the end of the message, or \n"," for the string in the middle of
-# a message
+# a message - need escapeLF="off" for endmsg/multiline to work
 input(type="imfile"
-      file="/var/log/containers/*.log"
+      file="/var/log/containers/*.log" escapeLF="off"
       tag="kubernetes" addmetadata="on" reopenOnTruncate="on"
       discardTruncatedMsg="on" msgDiscardingError="off"
       freshStartTail=`echo $RSYSLOG_FILE_READ_FROM_TAIL`


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1739558
CRI-o partial logs were not being joined because the endmsg.regex
and multiline parsing requires `escapeLF="off"` - it is on by
default.
This doesn't fix all of the problems in the bz . . .