### PR TITLE
Bug 1745394: Got many `[WARN ][c.f.s.a.BackendRegistry ] Authenticat…

### DIFF
--- a/pkg/k8shandler/secret.go
+++ b/pkg/k8shandler/secret.go
@@ -49,13 +49,12 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateSecret(secret *core.S
 			if reflect.DeepEqual(current.Data, secret.Data) {
 				// identical; no need to update.
 				return nil
-			} else {
-				current.Data = secret.Data
-				if err = clusterRequest.Update(current); err != nil {
-					return err
-				}
-				return nil
 			}
+			current.Data = secret.Data
+			if err = clusterRequest.Update(current); err != nil {
+				return err
+			}
+			return nil
 		})
 		if retryErr != nil {
 			return retryErr

--- a/pkg/k8shandler/secret_test.go
+++ b/pkg/k8shandler/secret_test.go
@@ -1,0 +1,265 @@
+package k8shandler
+
+import (
+	"reflect"
+	"testing"
+
+	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	rbac "k8s.io/api/rbac/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestClusterLoggingRequest_CreateOrUpdateSecretNoop(t *testing.T) {
+	clusterRoleBinding := &rbac.ClusterRoleBinding{}
+
+	clusterLoggingRequest := &ClusterLoggingRequest{
+		client:  fake.NewFakeClient(clusterRoleBinding),
+		cluster: &logging.ClusterLogging{},
+	}
+
+	// mimic ca.crt
+	caCrtStr := `-----BEGIN CERTIFICATE-----
+This is a ca cert.
+-----END CERTIFICATE-----`
+
+	// mimic ca.key
+	caKeyStr := `-----BEGIN PRIVATE KEY-----
+This is a private key.
+-----END PRIVATE KEY-----`
+
+	initSecret := NewSecret(
+		"test-secret",
+		clusterLoggingRequest.cluster.Namespace,
+		map[string][]byte{
+			"testca":  []byte(caCrtStr),
+			"testkey": []byte(caKeyStr),
+		})
+
+	// create
+	if err := clusterLoggingRequest.CreateOrUpdateSecret(initSecret); err != nil {
+		t.Errorf("CreateOrUpdateSecret failed 1 [%v]", err)
+	}
+
+	firstSecret, err := clusterLoggingRequest.GetSecret("test-secret")
+	if err != nil {
+		t.Errorf("GetSecret failed 1 [%v]", err)
+	}
+
+	// update
+	if err := clusterLoggingRequest.CreateOrUpdateSecret(firstSecret); err != nil {
+		t.Errorf("CreateOrUpdateSecret failed 2 [%v]", err)
+	}
+
+	secondSecret, err := clusterLoggingRequest.GetSecret("test-secret")
+	if err != nil {
+		t.Errorf("GetSecret failed 2 [%v]", err)
+	}
+
+	if reflect.DeepEqual(firstSecret, secondSecret) {
+		t.Logf("Initial secret [%p]\n%v", initSecret, initSecret)
+		t.Logf("First secret [%p]\n%v", firstSecret, firstSecret)
+		t.Logf("Second secret [%p]\n%v", secondSecret, secondSecret)
+	} else {
+		t.Errorf("First secret [%v] != Second secret [%v]", firstSecret, secondSecret)
+	}
+}
+
+func TestClusterLoggingRequest_CreateOrUpdateSecretSameKeysNewValues(t *testing.T) {
+	clusterRoleBinding := &rbac.ClusterRoleBinding{}
+
+	clusterLoggingRequest := &ClusterLoggingRequest{
+		client:  fake.NewFakeClient(clusterRoleBinding),
+		cluster: &logging.ClusterLogging{},
+	}
+
+	// mimic ca.crt
+	caCrtStr := `-----BEGIN CERTIFICATE-----
+This is a ca cert.
+-----END CERTIFICATE-----`
+
+	// mimic ca.key
+	caKeyStr := `-----BEGIN PRIVATE KEY-----
+This is a private key.
+-----END PRIVATE KEY-----`
+
+	initSecret := NewSecret(
+		"test-secret",
+		clusterLoggingRequest.cluster.Namespace,
+		map[string][]byte{
+			"testca":  []byte(caCrtStr),
+			"testkey": []byte(caKeyStr),
+		})
+
+	// create
+	if err := clusterLoggingRequest.CreateOrUpdateSecret(initSecret); err != nil {
+		t.Errorf("CreateOrUpdateSecret failed 1 [%v]", err)
+	}
+
+	firstSecret, err := clusterLoggingRequest.GetSecret("test-secret")
+	if err != nil {
+		t.Errorf("GetSecret failed 1 [%v]", err)
+	}
+
+	caCrtStr = `-----BEGIN CERTIFICATE-----
+This is a new ca cert.
+-----END CERTIFICATE-----`
+
+	caKeyStr = `-----BEGIN PRIVATE KEY-----
+This is a new private key.
+-----END PRIVATE KEY-----`
+
+	newSecret := NewSecret(
+		"test-secret",
+		clusterLoggingRequest.cluster.Namespace,
+		map[string][]byte{
+			"testca":  []byte(caCrtStr),
+			"testkey": []byte(caKeyStr),
+		})
+
+	// update
+	if err := clusterLoggingRequest.CreateOrUpdateSecret(newSecret); err != nil {
+		t.Errorf("CreateOrUpdateSecret failed 2 [%v]", err)
+	}
+
+	secondSecret, err := clusterLoggingRequest.GetSecret("test-secret")
+	if err != nil {
+		t.Errorf("GetSecret failed 2 [%v]", err)
+	}
+
+	if reflect.DeepEqual(firstSecret, secondSecret) {
+		t.Errorf("First secret [%v] == Second secret [%v]", firstSecret, secondSecret)
+	} else {
+		t.Logf("Initial secret [%p]\n%v", initSecret, initSecret)
+		t.Logf("Initial secret [%p]\n%v", newSecret, newSecret)
+		t.Logf("First secret [%p]\n%v", firstSecret, firstSecret)
+		t.Logf("Second secret [%p]\n%v", secondSecret, secondSecret)
+	}
+}
+
+func TestClusterLoggingRequest_CreateOrUpdateSecretNewKeysSameValues(t *testing.T) {
+	clusterRoleBinding := &rbac.ClusterRoleBinding{}
+
+	clusterLoggingRequest := &ClusterLoggingRequest{
+		client:  fake.NewFakeClient(clusterRoleBinding),
+		cluster: &logging.ClusterLogging{},
+	}
+
+	// mimic ca.crt
+	caCrtStr := `-----BEGIN CERTIFICATE-----
+This is a ca cert.
+-----END CERTIFICATE-----`
+
+	// mimic ca.key
+	caKeyStr := `-----BEGIN PRIVATE KEY-----
+This is a private key.
+-----END PRIVATE KEY-----`
+
+	initSecret := NewSecret(
+		"test-secret",
+		clusterLoggingRequest.cluster.Namespace,
+		map[string][]byte{
+			"testca":  []byte(caCrtStr),
+			"testkey": []byte(caKeyStr),
+		})
+
+	// create
+	if err := clusterLoggingRequest.CreateOrUpdateSecret(initSecret); err != nil {
+		t.Errorf("CreateOrUpdateSecret failed 1 [%v]", err)
+	}
+
+	firstSecret, err := clusterLoggingRequest.GetSecret("test-secret")
+	if err != nil {
+		t.Errorf("GetSecret failed 1 [%v]", err)
+	}
+
+	newSecret := NewSecret(
+		"test-secret",
+		clusterLoggingRequest.cluster.Namespace,
+		map[string][]byte{
+			"newtestca":  []byte(caCrtStr),
+			"newtestkey": []byte(caKeyStr),
+		})
+
+	// update
+	if err := clusterLoggingRequest.CreateOrUpdateSecret(newSecret); err != nil {
+		t.Errorf("CreateOrUpdateSecret failed 2 [%v]", err)
+	}
+
+	secondSecret, err := clusterLoggingRequest.GetSecret("test-secret")
+	if err != nil {
+		t.Errorf("GetSecret failed 2 [%v]", err)
+	}
+
+	if reflect.DeepEqual(firstSecret, secondSecret) {
+		t.Errorf("First secret [%v] == Second secret [%v]", firstSecret, secondSecret)
+	} else {
+		t.Logf("Initial secret [%p]\n%v", initSecret, initSecret)
+		t.Logf("Initial secret [%p]\n%v", newSecret, newSecret)
+		t.Logf("First secret [%p]\n%v", firstSecret, firstSecret)
+		t.Logf("Second secret [%p]\n%v", secondSecret, secondSecret)
+	}
+}
+
+func TestClusterLoggingRequest_CreateOrUpdateSecretRemovingKey(t *testing.T) {
+	clusterRoleBinding := &rbac.ClusterRoleBinding{}
+
+	clusterLoggingRequest := &ClusterLoggingRequest{
+		client:  fake.NewFakeClient(clusterRoleBinding),
+		cluster: &logging.ClusterLogging{},
+	}
+
+	// mimic ca.crt
+	caCrtStr := `-----BEGIN CERTIFICATE-----
+This is a ca cert.
+-----END CERTIFICATE-----`
+
+	// mimic ca.key
+	caKeyStr := `-----BEGIN PRIVATE KEY-----
+This is a private key.
+-----END PRIVATE KEY-----`
+
+	initSecret := NewSecret(
+		"test-secret",
+		clusterLoggingRequest.cluster.Namespace,
+		map[string][]byte{
+			"testca":  []byte(caCrtStr),
+			"testkey": []byte(caKeyStr),
+		})
+
+	// create
+	if err := clusterLoggingRequest.CreateOrUpdateSecret(initSecret); err != nil {
+		t.Errorf("CreateOrUpdateSecret failed 1 [%v]", err)
+	}
+
+	firstSecret, err := clusterLoggingRequest.GetSecret("test-secret")
+	if err != nil {
+		t.Errorf("GetSecret failed 1 [%v]", err)
+	}
+
+	newSecret := NewSecret(
+		"test-secret",
+		clusterLoggingRequest.cluster.Namespace,
+		map[string][]byte{
+			"testca":  []byte(caCrtStr),
+		})
+
+	// update
+	if err := clusterLoggingRequest.CreateOrUpdateSecret(newSecret); err != nil {
+		t.Errorf("CreateOrUpdateSecret failed 2 [%v]", err)
+	}
+
+	secondSecret, err := clusterLoggingRequest.GetSecret("test-secret")
+	if err != nil {
+		t.Errorf("GetSecret failed 2 [%v]", err)
+	}
+
+	if reflect.DeepEqual(firstSecret, secondSecret) {
+		t.Errorf("First secret [%v] == Second secret [%v]", firstSecret, secondSecret)
+	} else {
+		t.Logf("Initial secret [%p]\n%v", initSecret, initSecret)
+		t.Logf("Initial secret [%p]\n%v", newSecret, newSecret)
+		t.Logf("First secret [%p]\n%v", firstSecret, firstSecret)
+		t.Logf("Second secret [%p]\n%v", secondSecret, secondSecret)
+	}
+}

--- a/pkg/k8shandler/secret_test.go
+++ b/pkg/k8shandler/secret_test.go
@@ -5,19 +5,11 @@ import (
 	"testing"
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	rbac "k8s.io/api/rbac/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestClusterLoggingRequest_CreateOrUpdateSecretNoop(t *testing.T) {
-	clusterRoleBinding := &rbac.ClusterRoleBinding{}
-
-	clusterLoggingRequest := &ClusterLoggingRequest{
-		client:  fake.NewFakeClient(clusterRoleBinding),
-		cluster: &logging.ClusterLogging{},
-	}
-
 	// mimic ca.crt
 	caCrtStr := `-----BEGIN CERTIFICATE-----
 This is a ca cert.
@@ -30,11 +22,16 @@ This is a private key.
 
 	initSecret := NewSecret(
 		"test-secret",
-		clusterLoggingRequest.cluster.Namespace,
+		"test-namespace",
 		map[string][]byte{
 			"testca":  []byte(caCrtStr),
 			"testkey": []byte(caKeyStr),
 		})
+
+	clusterLoggingRequest := &ClusterLoggingRequest{
+		client:  fake.NewFakeClient(initSecret),
+		cluster: &logging.ClusterLogging{},
+	}
 
 	// create
 	if err := clusterLoggingRequest.CreateOrUpdateSecret(initSecret); err != nil {
@@ -66,13 +63,6 @@ This is a private key.
 }
 
 func TestClusterLoggingRequest_CreateOrUpdateSecretSameKeysNewValues(t *testing.T) {
-	clusterRoleBinding := &rbac.ClusterRoleBinding{}
-
-	clusterLoggingRequest := &ClusterLoggingRequest{
-		client:  fake.NewFakeClient(clusterRoleBinding),
-		cluster: &logging.ClusterLogging{},
-	}
-
 	// mimic ca.crt
 	caCrtStr := `-----BEGIN CERTIFICATE-----
 This is a ca cert.
@@ -85,11 +75,16 @@ This is a private key.
 
 	initSecret := NewSecret(
 		"test-secret",
-		clusterLoggingRequest.cluster.Namespace,
+		"test-namespace",
 		map[string][]byte{
 			"testca":  []byte(caCrtStr),
 			"testkey": []byte(caKeyStr),
 		})
+
+	clusterLoggingRequest := &ClusterLoggingRequest{
+		client:  fake.NewFakeClient(initSecret),
+		cluster: &logging.ClusterLogging{},
+	}
 
 	// create
 	if err := clusterLoggingRequest.CreateOrUpdateSecret(initSecret); err != nil {
@@ -111,7 +106,7 @@ This is a new private key.
 
 	newSecret := NewSecret(
 		"test-secret",
-		clusterLoggingRequest.cluster.Namespace,
+		"test-namespace",
 		map[string][]byte{
 			"testca":  []byte(caCrtStr),
 			"testkey": []byte(caKeyStr),
@@ -138,13 +133,6 @@ This is a new private key.
 }
 
 func TestClusterLoggingRequest_CreateOrUpdateSecretNewKeysSameValues(t *testing.T) {
-	clusterRoleBinding := &rbac.ClusterRoleBinding{}
-
-	clusterLoggingRequest := &ClusterLoggingRequest{
-		client:  fake.NewFakeClient(clusterRoleBinding),
-		cluster: &logging.ClusterLogging{},
-	}
-
 	// mimic ca.crt
 	caCrtStr := `-----BEGIN CERTIFICATE-----
 This is a ca cert.
@@ -157,11 +145,16 @@ This is a private key.
 
 	initSecret := NewSecret(
 		"test-secret",
-		clusterLoggingRequest.cluster.Namespace,
+		"test-namespace",
 		map[string][]byte{
 			"testca":  []byte(caCrtStr),
 			"testkey": []byte(caKeyStr),
 		})
+
+	clusterLoggingRequest := &ClusterLoggingRequest{
+		client:  fake.NewFakeClient(initSecret),
+		cluster: &logging.ClusterLogging{},
+	}
 
 	// create
 	if err := clusterLoggingRequest.CreateOrUpdateSecret(initSecret); err != nil {
@@ -175,7 +168,7 @@ This is a private key.
 
 	newSecret := NewSecret(
 		"test-secret",
-		clusterLoggingRequest.cluster.Namespace,
+		"test-namespace",
 		map[string][]byte{
 			"newtestca":  []byte(caCrtStr),
 			"newtestkey": []byte(caKeyStr),
@@ -202,13 +195,6 @@ This is a private key.
 }
 
 func TestClusterLoggingRequest_CreateOrUpdateSecretRemovingKey(t *testing.T) {
-	clusterRoleBinding := &rbac.ClusterRoleBinding{}
-
-	clusterLoggingRequest := &ClusterLoggingRequest{
-		client:  fake.NewFakeClient(clusterRoleBinding),
-		cluster: &logging.ClusterLogging{},
-	}
-
 	// mimic ca.crt
 	caCrtStr := `-----BEGIN CERTIFICATE-----
 This is a ca cert.
@@ -221,11 +207,16 @@ This is a private key.
 
 	initSecret := NewSecret(
 		"test-secret",
-		clusterLoggingRequest.cluster.Namespace,
+		"test-namespace",
 		map[string][]byte{
 			"testca":  []byte(caCrtStr),
 			"testkey": []byte(caKeyStr),
 		})
+
+	clusterLoggingRequest := &ClusterLoggingRequest{
+		client:  fake.NewFakeClient(initSecret),
+		cluster: &logging.ClusterLogging{},
+	}
 
 	// create
 	if err := clusterLoggingRequest.CreateOrUpdateSecret(initSecret); err != nil {
@@ -239,7 +230,7 @@ This is a private key.
 
 	newSecret := NewSecret(
 		"test-secret",
-		clusterLoggingRequest.cluster.Namespace,
+		"test-namespace",
 		map[string][]byte{
 			"testca":  []byte(caCrtStr),
 		})


### PR DESCRIPTION
…ion finally failed for null` in ES pod log after changing log collector from fluentd to rsyslog.

When updating secret is called, if the newly set secret is identical
to the current one, we do not send request to update, but keep using
the existing one.