### PR TITLE
Bug 1746695: Add scope user:list-projects back to proxy

### DIFF
--- a/pkg/k8shandler/secret_test.go
+++ b/pkg/k8shandler/secret_test.go
@@ -232,7 +232,7 @@ This is a private key.
 		"test-secret",
 		"test-namespace",
 		map[string][]byte{
-			"testca":  []byte(caCrtStr),
+			"testca": []byte(caCrtStr),
 		})
 
 	// update

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -384,7 +384,7 @@ func newKibanaPodSpec(cluster *logging.ClusterLogging, kibanaName string, elasti
 		"-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token",
 		"-cookie-secret-file=/secret/session-secret",
 		"-upstream=http://localhost:5601",
-		"-scope=user:info user:check-access",
+		"-scope=user:info user:check-access user:list-projects",
 		"--tls-cert=/secret/server-cert",
 		"-tls-key=/secret/server-key",
 		"-pass-access-token",

--- a/pkg/k8shandler/visualization_test.go
+++ b/pkg/k8shandler/visualization_test.go
@@ -15,15 +15,18 @@ import (
 func TestNewKibanaPodSpecSetsProxyToUseServiceAccountAsOAuthClient(t *testing.T) {
 	clusterlogging := &logging.ClusterLogging{}
 	spec := newKibanaPodSpec(clusterlogging, "kibana", "elasticsearch")
-	valueIsCorrect := false
 	for _, arg := range spec.Containers[1].Args {
 		keyValue := strings.Split(arg, "=")
 		if len(keyValue) >= 2 && keyValue[0] == "-client-id" {
-			valueIsCorrect = keyValue[1] == "system:serviceaccount:openshift-logging:kibana"
+			if keyValue[1] != "system:serviceaccount:openshift-logging:kibana" {
+				t.Error("Exp. the proxy container arg 'client-id=system:serviceaccount:openshift-logging:kibana'")
+			}
 		}
-	}
-	if !valueIsCorrect {
-		t.Error("Exp. the proxy container arg 'client-id=system:serviceaccount:openshift-logging:kibana'")
+		if len(keyValue) >= 2 && keyValue[0] == "-scope" {
+			if keyValue[1] != "user:info user:check-access user:list-projects" {
+				t.Error("Exp. the proxy container arg 'scope=user:info user:check-access user:list-projects'")
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746695 by reverting the scope removed in https://github.com/openshift/cluster-logging-operator/pull/234/files#diff-5ff1cbe659b99e0e73d8ba484249c27cL480