### PR TITLE
Fix metadata from hack/cr-aws.yaml

### DIFF
--- a/hack/cr-aws.yaml
+++ b/hack/cr-aws.yaml
@@ -1,6 +1,6 @@
 apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
-  metadata:
+metadata:
   name: "instance"
 spec:
   managementState: "Managed"


### PR DESCRIPTION
The metadata had extra indentation, which it shouldn't have. This way
it'll set the name correctly for the instance.