### PR TITLE
Fixing skopeo auth issue in deploy-image.sh

### DIFF
--- a/hack/common
+++ b/hack/common
@@ -164,7 +164,7 @@ function login_to_registry() {
             username=kubeadmin
         fi
     fi
-    podman login --tls-verify=false -u "$username" -p "$token" "$1" > /dev/null
+    docker login -u "$username" -p "$token" "$1" > /dev/null
 }
 
 function push_image() {


### PR DESCRIPTION
[ERROR]
+++ dirname hack/deploy-image.sh
+ skopeo copy --dest-tls-verify=false docker-daemon:quay.io/openshift/origin-cluster-logging-operator:latest docker://127.0.0.1:5000/openshift/origin-cluster-logging-operator:latest
time="..." level=fatal msg="Error trying to reuse blob sha256:... at destination: unable to retrieve auth token: invalid username/password"