### PR TITLE
LOG-464 - Consume global proxy configuration (additional)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	oauth "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis"
@@ -133,6 +134,11 @@ func main() {
 	}
 
 	if err := monitoringv1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	if err := configv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}


### PR DESCRIPTION
main.go - adding configv1 to scheme

To get the cluster proxy object, configv1 needs to be added to scheme.  Without it, it fails with the following error:
`Failed to get proxy: no kind is registered for the type v1.Proxy in scheme "k8s.io/client-go/kubernetes/scheme/register.go:61"`