### PR TITLE
CLO logs messages "Collector container EnvVar change fo…

### DIFF
--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -271,8 +271,10 @@ func isDaemonsetDifferent(current *apps.DaemonSet, desired *apps.DaemonSet) (*ap
 		logrus.Infof("Collector resource(s) change found, updating %q", current.Name)
 		different = true
 	}
-	if !reflect.DeepEqual(current.Spec.Template.Spec.Containers[0].Env, desired.Spec.Template.Spec.Containers[0].Env) {
+
+	if !utils.EnvValueEqual(current.Spec.Template.Spec.Containers[0].Env, desired.Spec.Template.Spec.Containers[0].Env) {
 		logrus.Infof("Collector container EnvVar change found, updating %q", current.Name)
+
 		current.Spec.Template.Spec.Containers[0].Env = desired.Spec.Template.Spec.Containers[0].Env
 		different = true
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	v1 "k8s.io/api/core/v1"
 	"testing"
 )
 
@@ -44,5 +45,92 @@ func TestAreMapsSameWhenDifferent(t *testing.T) {
 	}
 	if AreMapsSame(one, two) {
 		t.Errorf("Exp maps to evaluate to be different - left: %v, right: %v", one, two)
+	}
+}
+
+func TestEnvVarEqualEqual(t *testing.T) {
+	currentenv := []v1.EnvVar{
+		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+		{Name: "MERGE_JSON_LOG", Value: "false"},
+		{Name: "PRESERVE_JSON_LOG", Value: "true"},
+		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc"},
+	}
+	desiredenv := []v1.EnvVar{
+		{Name: "PRESERVE_JSON_LOG", Value: "true"},
+		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc"},
+		{Name: "MERGE_JSON_LOG", Value: "false"},
+	}
+
+	if !EnvValueEqual(currentenv, desiredenv) {
+		t.Errorf("EnvVarEqual returned false for the equal inputs")
+	}
+}
+
+func TestEnvVarEqualCheckValueFrom(t *testing.T) {
+	currentenv := []v1.EnvVar{
+		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+	}
+	desiredenv := []v1.EnvVar{
+		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+	}
+
+	if !EnvValueEqual(currentenv, desiredenv) {
+		t.Errorf("EnvVarEqual returned false for the equal inputs")
+	}
+}
+
+func TestEnvVarEqualNotEqual(t *testing.T) {
+	currentenv := []v1.EnvVar{
+		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+		{Name: "MERGE_JSON_LOG", Value: "false"},
+		{Name: "PRESERVE_JSON_LOG", Value: "true"},
+		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc"},
+	}
+	desiredenv := []v1.EnvVar{
+		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+		{Name: "MERGE_JSON_LOG", Value: "true"},
+		{Name: "PRESERVE_JSON_LOG", Value: "true"},
+		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc"},
+	}
+
+	if EnvValueEqual(currentenv, desiredenv) {
+		t.Errorf("EnvVarEqual returned true for the not equal inputs")
+	}
+}
+
+func TestEnvVarEqualShorter(t *testing.T) {
+	currentenv := []v1.EnvVar{
+		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+		{Name: "MERGE_JSON_LOG", Value: "false"},
+		{Name: "PRESERVE_JSON_LOG", Value: "true"},
+		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc"},
+	}
+	desiredenv := []v1.EnvVar{
+		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+		{Name: "MERGE_JSON_LOG", Value: "false"},
+	}
+
+	if EnvValueEqual(currentenv, desiredenv) {
+		t.Errorf("EnvVarEqual returned true when the desired is shorter than the current")
+	}
+}
+
+func TestEnvVarEqualNotEqual2(t *testing.T) {
+	currentenv := []v1.EnvVar{
+		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+		{Name: "MERGE_JSON_LOG", Value: "false"},
+		{Name: "PRESERVE_JSON_LOG", Value: "true"},
+		{Name: "K8S_HOST_URL", Value: "https://kubernetes.default.svc"},
+	}
+	desiredenv := []v1.EnvVar{
+		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+		{Name: "ES_PORT", Value: "9200"},
+		{Name: "MERGE_JSON_LOG", Value: "false"},
+		{Name: "PRESERVE_JSON_LOG", Value: "true"},
+	}
+
+	if EnvValueEqual(currentenv, desiredenv) {
+		t.Errorf("EnvVarEqual returned true when the desired is longer than the current")
 	}
 }

--- a/test/e2e/clusterlogging_test.go
+++ b/test/e2e/clusterlogging_test.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	retryInterval        = time.Second * 5
-	timeout              = time.Second * 120
+	timeout              = time.Second * 180
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
 )


### PR DESCRIPTION
…und, updating \"fluentd\"" although there's no obvious fluentd EnvVar change.

Replacing reflect.DeepEqual with envValueEqual to skip the value provided
by the downward api or otherwise provided by kubernetes.