### PR TITLE
Catch errors and fix e2e olm upgrade test

### DIFF
--- a/hack/testing/test-020-olm-upgrade.sh
+++ b/hack/testing/test-020-olm-upgrade.sh
@@ -28,11 +28,11 @@ manifest_dir=${repo_dir}/manifests
 version=$(basename $(find $manifest_dir -type d | sort -r | head -n 1))
 
 cleanup(){
+  local return_code="$?"
+  set +e
   os::log::info "Running cleanup"
   end_seconds=$(date +%s)
   runtime="$(($end_seconds - $start_seconds))s"
-  local return_code="$?"
-  set +e
   oc -n openshift-operators-redhat -o yaml get subscription elasticsearch-operator > $ARTIFACT_DIR/subscription-eo.yml 2>&1 ||:
   oc logs -n ${NAMESPACE} deployment/cluster-logging-operator > $ARTIFACT_DIR/cluster-logging-operator.log 2>&1 ||:
   oc -n ${NAMESPACE} -o yaml get subscription cluster-logging-operator > $ARTIFACT_DIR/subscription-clo.yml 2>&1 ||:

--- a/hack/testing/utils
+++ b/hack/testing/utils
@@ -34,7 +34,7 @@ items:
     name: $name
     namespace: $ns
   spec:
-    channel: preview
+    channel: 4.2
     installPlanApproval: Automatic
     name: $package
     source: redhat-operators
@@ -84,7 +84,7 @@ deploy_config_map_catalog_source() {
   local CSV=$(sed '/^#!.*$/d' $manifest_dir/$version/*version.yaml | sed 's/namespace: placeholder/namespace: '$namespace'/' |grep -v -- "---" |  indent apiVersion)
   local PACKAGE_NAME=$(sed -nr 's,.*packageName: (.*),\1,p' $manifest_dir/*package.yaml)
   if [ -n "${image:-}" ] ; then
-    CSV=$(echo "$CSV" | sed -e "s~containerImage:.*+~containerImage: ${image}~" | indent apiVersion)
+    CSV=$(echo "$CSV" | sed -e "s~containerImage:.*~containerImage: ${image}~" | indent apiVersion)
     CSV=$(echo "$CSV" | sed -e "s~image:.*~image: ${image}\n~" | indent ApiVersion)
   fi
 
@@ -107,7 +107,7 @@ kind: CatalogSource
 metadata:
   name: $PACKAGE_NAME
 spec:
-  sourceType: internal
+  sourceType: configmap 
   configMap: $PACKAGE_NAME
   displayName: $PACKAGE_NAME
   publisher: Operator Framework

--- a/hack/vendor/olm-test-script/e2e-olm.sh
+++ b/hack/vendor/olm-test-script/e2e-olm.sh
@@ -66,7 +66,7 @@ PKG=$(sed '/^#!.*$/d' $MANIFEST_DIR/*package.yaml | indent packageName)
 CSV=$(sed '/^#!.*$/d' $MANIFEST_DIR/$VERSION/*version.yaml | sed 's/namespace: placeholder/namespace: '$TEST_NAMESPACE'/' |grep -v -- "---" |  indent apiVersion)
 
 if [ -n "${OPERATOR_IMAGE:-}" ] ; then
-  CSV=$(echo "$CSV" | sed -e "s~containerImage:.*+~containerImage: ${OPERATOR_IMAGE}~" | indent apiVersion)
+  CSV=$(echo "$CSV" | sed -e "s~containerImage:.*~containerImage: ${OPERATOR_IMAGE}~" | indent apiVersion)
   CSV=$(echo "$CSV" | sed -e "s~image:.*~image: ${OPERATOR_IMAGE}\n~" | indent ApiVersion)
 fi
 


### PR DESCRIPTION
The errors were being ignored because of catching the status of the exit
command too late (having a successful command before it)