### PR TITLE
refix eventrouter bug

### DIFF
--- a/files/fluentd/run.sh
+++ b/files/fluentd/run.sh
@@ -198,11 +198,6 @@ if [[ "${USE_REMOTE_SYSLOG:-}" = "true" ]] ; then
     fi
 fi
 
-# Disable process_kubernetes_events if TRANSFORM_EVENTS is false client.
-if [ "${TRANSFORM_EVENTS:-}" != true ] ; then
-    sed -i 's/\(.*@type viaq_data_model.*\)/\1\n  process_kubernetes_events false/' $CFG_DIR/openshift/filter-viaq-data-model.conf
-fi
-
 if [ "${AUDIT_CONTAINER_ENGINE:-}" = "true" ] ; then
     cp -f $CFG_DIR/input-pre-audit-log.conf $CFG_DIR/openshift
     cp -f $CFG_DIR/filter-pre-a-audit-exclude.conf $CFG_DIR/openshift

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -3,6 +3,7 @@ package fluentd
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1alpha1"
 	test "github.com/openshift/cluster-logging-operator/test"
 )
@@ -273,6 +274,14 @@ var _ = Describe("Generating fluentd config", func() {
 					preserve_json_log "#{ENV['PRESERVE_JSON_LOG'] || 'true'}"
 					json_fields "#{ENV['JSON_FIELDS'] || 'log,MESSAGE'}"
 				</filter>
+
+				<filter kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-**>
+					@type parse_json_field
+					merge_json_log true
+					preserve_json_log true
+					json_fields "#{ENV['JSON_FIELDS'] || 'log,MESSAGE'}"
+				</filter>
+
 				<filter **kibana**>
 					@type record_transformer
 					enable_ruby
@@ -296,6 +305,7 @@ var _ = Describe("Generating fluentd config", func() {
 					undefined_to_string "#{ENV['CDM_UNDEFINED_TO_STRING'] || 'false'}"
 					undefined_dot_replace_char "#{ENV['CDM_UNDEFINED_DOT_REPLACE_CHAR'] || 'UNUSED'}"
 					undefined_max_num_fields "#{ENV['CDM_UNDEFINED_MAX_NUM_FIELDS'] || '-1'}"
+					process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'false'}"
 					<formatter>
 						enabled false
 						tag "audit.log**"
@@ -317,6 +327,12 @@ var _ = Describe("Generating fluentd config", func() {
 						remove_keys "#{ENV['K8S_FILTER_REMOVE_KEYS'] || 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'}"
 					</formatter>
 					<formatter>
+						tag "kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-**"
+						type k8s_json_file
+						remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
+						process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'true'}"
+					</formatter>
+					<formatter>
 						tag "kubernetes.var.log.containers**"
 						type k8s_json_file
 						remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
@@ -336,7 +352,7 @@ var _ = Describe("Generating fluentd config", func() {
 					@type elasticsearch_genid_ext
 					hash_id_key viaq_msg_id
 					alt_key kubernetes.event.metadata.uid
-					alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'}"
+					alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.var.log.containers.eventrouter-*.** kubernetes.var.log.containers.cluster-logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'}"
 				</filter>
 
 				# Relabel specific source tags to specific intermediary labels for copy processing
@@ -652,6 +668,14 @@ var _ = Describe("Generating fluentd config", func() {
 					preserve_json_log "#{ENV['PRESERVE_JSON_LOG'] || 'true'}"
 					json_fields "#{ENV['JSON_FIELDS'] || 'log,MESSAGE'}"
 				</filter>
+
+				<filter kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-**>
+					@type parse_json_field
+					merge_json_log true
+					preserve_json_log true
+					json_fields "#{ENV['JSON_FIELDS'] || 'log,MESSAGE'}"
+				</filter>
+
 				<filter **kibana**>
 					@type record_transformer
 					enable_ruby
@@ -675,6 +699,7 @@ var _ = Describe("Generating fluentd config", func() {
 					undefined_to_string "#{ENV['CDM_UNDEFINED_TO_STRING'] || 'false'}"
 					undefined_dot_replace_char "#{ENV['CDM_UNDEFINED_DOT_REPLACE_CHAR'] || 'UNUSED'}"
 					undefined_max_num_fields "#{ENV['CDM_UNDEFINED_MAX_NUM_FIELDS'] || '-1'}"
+					process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'false'}"
 					<formatter>
 						enabled false
 						tag "audit.log**"
@@ -696,6 +721,12 @@ var _ = Describe("Generating fluentd config", func() {
 						remove_keys "#{ENV['K8S_FILTER_REMOVE_KEYS'] || 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'}"
 					</formatter>
 					<formatter>
+						tag "kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-**"
+						type k8s_json_file
+						remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
+						process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'true'}"
+					</formatter>
+					<formatter>
 						tag "kubernetes.var.log.containers**"
 						type k8s_json_file
 						remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
@@ -715,7 +746,7 @@ var _ = Describe("Generating fluentd config", func() {
 					@type elasticsearch_genid_ext
 					hash_id_key viaq_msg_id
 					alt_key kubernetes.event.metadata.uid
-					alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'}"
+					alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.var.log.containers.eventrouter-*.** kubernetes.var.log.containers.cluster-logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'}"
 				</filter>
 
 				# Relabel specific source tags to specific intermediary labels for copy processing


### PR DESCRIPTION
the recent addition of logforwarding did not take into account
the latest changes to fix
Bug 1756920: fluentd pods do not process kubernetes events
https://bugzilla.redhat.com/show_bug.cgi?id=1756920
This commit adds back those fixes

will need to open (reopen?) a bz for 4.3 and backport