### PR TITLE
Bug 1619479: Remove Kibana oauth-proxy param to allow re-login

### DIFF
--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -393,7 +393,6 @@ func newKibanaPodSpec(cluster *logging.ClusterLogging, kibanaName string, elasti
 		"--tls-cert=/secret/server-cert",
 		"-tls-key=/secret/server-key",
 		"-pass-access-token",
-		"-skip-provider-button",
 	}
 
 	kibanaProxyContainer.Env = []v1.EnvVar{


### PR DESCRIPTION
Remove parameter so Kibana re-login does not redirect more then once.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1619479