### PR TITLE
Enable logforwarding e2e test and fix fluentd forwarding test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ run:
 
 clean:
 	@rm -rf $(TARGET_DIR) && \
-	go clean -testcache $(TEST_PKGS) $(PKGS)
+	go clean -cache -testcache  $(TEST_PKGS) $(PKGS)
 
 image: imagebuilder
 	@if [ $${USE_IMAGE_STREAM:-false} = false ] && [ $${SKIP_BUILD:-false} = false ] ; \

--- a/pkg/apis/logging/v1alpha1/forwarding_types.go
+++ b/pkg/apis/logging/v1alpha1/forwarding_types.go
@@ -313,7 +313,7 @@ type OutputCondition struct {
 type LogForwardingList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []ForwardingSpec `json:"items"`
+	Items           []LogForwarding `json:"items"`
 }
 
 func init() {

--- a/pkg/apis/logging/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/logging/v1alpha1/zz_generated.deepcopy.go
@@ -210,7 +210,7 @@ func (in *LogForwardingList) DeepCopyInto(out *LogForwardingList) {
 	out.ListMeta = in.ListMeta
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]ForwardingSpec, len(*in))
+		*out = make([]LogForwarding, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	WORKING_DIR = "/tmp/_working_dir"
-	OsNodeLabel = "kubernetes.io/os"
-	LinuxValue  = "linux"
+	DefaultWorkingDir = "/tmp/_working_dir"
+	OsNodeLabel       = "kubernetes.io/os"
+	LinuxValue        = "linux"
 )
 
 // COMPONENT_IMAGES are thee keys are based on the "container name" + "-{image,version}"
@@ -190,7 +190,11 @@ func GetWorkingDirFileContents(filePath string) []byte {
 }
 
 func GetWorkingDirFilePath(toFile string) string {
-	return path.Join(WORKING_DIR, toFile)
+	workingDir := os.Getenv("WORKING_DIR")
+	if workingDir == "" {
+		workingDir = DefaultWorkingDir
+	}
+	return path.Join(workingDir, toFile)
 }
 
 func WriteToWorkingDirFile(toFile string, value []byte) error {

--- a/scripts/cert_generation.sh
+++ b/scripts/cert_generation.sh
@@ -1,9 +1,11 @@
-#! /bin/bash
+#!/bin/bash
 
-WORKING_DIR=${WORKING_DIR:-/tmp/_working_dir}
-NAMESPACE=${NAMESPACE:-openshift-logging}
+set -e
+
+WORKING_DIR=$1
+NAMESPACE=$2
 CA_PATH=${CA_PATH:-$WORKING_DIR/ca.crt}
-LOG_STORE=${LOG_STORE:-elasticsearch}
+LOG_STORE=$3
 REGENERATE_NEEDED=0
 
 function init_cert_files() {

--- a/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go
+++ b/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go
@@ -1,4 +1,4 @@
-package logforwarding
+package elasticsearchmanaged
 
 import (
 	"fmt"

--- a/test/e2e/logforwarding/elasticsearchmanaged/logforwarding_suite_test.go
+++ b/test/e2e/logforwarding/elasticsearchmanaged/logforwarding_suite_test.go
@@ -1,4 +1,4 @@
-package logforwarding
+package elasticsearchmanaged
 
 import (
 	"testing"
@@ -9,5 +9,5 @@ import (
 
 func TestLogForwarding(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "LogForwarding Integration E2E Suite")
+	RunSpecs(t, "LogForwarding Integration E2E Suite - CLO Managed Elasticsearch")
 }

--- a/test/e2e/logforwarding/elasticsearchunmanaged/forward_to_unmanaged_elasticsearch_test.go
+++ b/test/e2e/logforwarding/elasticsearchunmanaged/forward_to_unmanaged_elasticsearch_test.go
@@ -1,4 +1,4 @@
-package logforwarding
+package elasticsearchunmanaged
 
 import (
 	"fmt"
@@ -7,16 +7,17 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	logforward "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1alpha1"
 	"github.com/openshift/cluster-logging-operator/pkg/logger"
 	"github.com/openshift/cluster-logging-operator/test/helpers"
 	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("LogForwarding", func() {
+
 	_, filename, _, _ := runtime.Caller(0)
 	logger.Infof("Running %s", filename)
 	var (
@@ -26,7 +27,7 @@ var _ = Describe("LogForwarding", func() {
 	Describe("when ClusterLogging is configured with 'forwarding' to an administrator managed Elasticsearch", func() {
 
 		BeforeEach(func() {
-			rootDir := filepath.Join(filepath.Dir(filename), "..", "..", "..", "/")
+			rootDir := filepath.Join(filepath.Dir(filename), "..", "..", "..", "..", "/")
 			logger.Debugf("Repo rootdir: %s", rootDir)
 			e2e.DeployLogGenerator()
 			var pipelineSecret *corev1.Secret

--- a/test/e2e/logforwarding/elasticsearchunmanaged/logforwarding_suite_test.go
+++ b/test/e2e/logforwarding/elasticsearchunmanaged/logforwarding_suite_test.go
@@ -1,0 +1,13 @@
+package elasticsearchunmanaged
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogForwarding(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LogForwarding Integration E2E Suite - Unmanaged Elasticsearch")
+}

--- a/test/e2e/logforwarding/fluent/forward_to_fluent_test.go
+++ b/test/e2e/logforwarding/fluent/forward_to_fluent_test.go
@@ -1,4 +1,4 @@
-package logforwarding
+package fluent
 
 import (
 	"fmt"
@@ -27,7 +27,7 @@ var _ = Describe("LogForwarding", func() {
 	)
 	BeforeEach(func() {
 		e2e.DeployLogGenerator()
-		rootDir = filepath.Join(filepath.Dir(filename), "..", "..", "..", "/")
+		rootDir = filepath.Join(filepath.Dir(filename), "..", "..", "..", "..", "/")
 	})
 	Describe("when ClusterLogging is configured with 'forwarding' to an administrator managed fluentd", func() {
 

--- a/test/e2e/logforwarding/fluent/logforwarding_suite_test.go
+++ b/test/e2e/logforwarding/fluent/logforwarding_suite_test.go
@@ -1,0 +1,13 @@
+package fluent
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogForwarding(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LogForwarding Integration E2E Suite - Forward to fluent")
+}

--- a/test/helpers/fluentd.go
+++ b/test/helpers/fluentd.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/cluster-logging-operator/pkg/k8shandler"
-	"github.com/openshift/cluster-logging-operator/pkg/logger"
-	"github.com/openshift/cluster-logging-operator/pkg/utils"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/cluster-logging-operator/pkg/k8shandler"
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	"github.com/openshift/cluster-logging-operator/pkg/utils"
 )
 
 type fluentReceiverLogStore struct {
@@ -283,7 +284,11 @@ func (tc *E2ETestFramework) DeployFluendReceiver(rootDir string, secure bool) (d
 		},
 	)
 	tc.AddCleanup(func() error {
-		return tc.KubeClient.Apps().Deployments(OpenshiftLoggingNS).Delete(fluentDeployment.Name, nil)
+		var zerograce int64
+		deleteopts := metav1.DeleteOptions{
+			GracePeriodSeconds: &zerograce,
+		}
+		return tc.KubeClient.AppsV1().Deployments(OpenshiftLoggingNS).Delete(fluentDeployment.Name, &deleteopts)
 	})
 	service, err = tc.KubeClient.Core().Services(OpenshiftLoggingNS).Create(service)
 	if err != nil {

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -300,16 +300,25 @@ func (tc *E2ETestFramework) PodExec(namespace, name, container string, command [
 }
 
 func (tc *E2ETestFramework) CreatePipelineSecret(pwd, logStoreName, secretName string) (secret *corev1.Secret, err error) {
-	logger.Debugf("Generating Pipeline certificates for %q", logStoreName)
-	if err = k8shandler.GenerateCertificates(OpenshiftLoggingNS, pwd, logStoreName, fmt.Sprintf("/tmp/clo-test-%d", rand.Intn(10000))); err != nil {
+	workingDir := fmt.Sprintf("/tmp/clo-test-%d", rand.Intn(10000))
+	logger.Debugf("Generating Pipeline certificates for %q to %s", logStoreName, workingDir)
+	if _, err := os.Stat(workingDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(workingDir, 0766); err != nil {
+			return nil, err
+		}
+	}
+	if err = os.Setenv("WORKING_DIR", workingDir); err != nil {
+		return nil, err
+	}
+	if err = k8shandler.GenerateCertificates(OpenshiftLoggingNS, pwd, logStoreName, workingDir); err != nil {
 		return nil, err
 	}
 	secret = k8shandler.NewSecret(
 		secretName,
 		OpenshiftLoggingNS,
 		map[string][]byte{
-			"tls.key":       utils.GetWorkingDirFileContents("logging-es.key"),
-			"tls.crt":       utils.GetWorkingDirFileContents("logging-es.crt"),
+			"tls.key":       utils.GetWorkingDirFileContents("system.logging.fluentd.key"),
+			"tls.crt":       utils.GetWorkingDirFileContents("system.logging.fluentd.crt"),
 			"ca-bundle.crt": utils.GetWorkingDirFileContents("ca.crt"),
 			"ca.key":        utils.GetWorkingDirFileContents("ca.key"),
 		},


### PR DESCRIPTION
This whole test suite was being skipped by accident. This re-enables
that.

Currently it seems that the admin managed-elasticsearch logstore e2e
tests are broken. So lets skip that and fix it in a subsequent PR.
This way the other tests stay covered.

The fluentd forwarding test was broken due to a race condition. When one
test ended, the other one started immediately, without waiting for the
resources to finish deleting. This fixes that.