### PR TITLE
Cleanup status messages as commented in 1770644

### DIFF
--- a/pkg/apis/logging/v1alpha1/forwarding_types.go
+++ b/pkg/apis/logging/v1alpha1/forwarding_types.go
@@ -107,7 +107,7 @@ type ForwardingStatus struct {
 	Message string `json:"message,omitempty"`
 
 	// LastUpdated represents the last time that the status was updated.
-	LastUpdated metav1.Time
+	LastUpdated metav1.Time `json:"lastUpdated,omitempty"`
 
 	//LogSources lists the configured log sources
 	LogSources []LogSourceType `json:"sources,omitempty"`
@@ -147,6 +147,22 @@ type PipelineStatus struct {
 	LastUpdated metav1.Time `json:"lastUpdated,omitempty"`
 }
 
+func NewPipelineStatusNamed(name string) PipelineStatus {
+	return PipelineStatus{
+		Name:        name,
+		LastUpdated: metav1.Now(),
+	}
+}
+func NewPipelineStatus(name string, state PipelineState, reason PipelineStateReason, message string) PipelineStatus {
+	return PipelineStatus{
+		Name:        name,
+		State:       state,
+		Reason:      reason,
+		Message:     message,
+		LastUpdated: metav1.Now(),
+	}
+}
+
 func (pipelineStatus *PipelineStatus) AddCondition(conditionType PipelineConditionType, reason PipelineConditionReason, message string) {
 	pipelineStatus.Conditions = append(pipelineStatus.Conditions, PipelineCondition{
 		Type:    conditionType,
@@ -176,10 +192,10 @@ const (
 )
 
 type PipelineCondition struct {
-	Type    PipelineConditionType
-	Reason  PipelineConditionReason
-	Status  corev1.ConditionStatus
-	Message string
+	Type    PipelineConditionType   `json:"typ,omitempty"`
+	Reason  PipelineConditionReason `json:"reason,omitempty"`
+	Status  corev1.ConditionStatus  `json:"status,omitempty"`
+	Message string                  `json:"message,omitempty"`
 }
 
 type PipelineConditionType string
@@ -233,6 +249,23 @@ type OutputStatus struct {
 
 	// LastUpdated represents the last time that the status was updated.
 	LastUpdated metav1.Time `json:"lastUpdated,omitempty"`
+}
+
+func NewOutputStatusNamed(name string) OutputStatus {
+	return OutputStatus{
+		Name:        name,
+		LastUpdated: metav1.Now(),
+	}
+}
+
+func NewOutputStatus(name string, state OutputState, reason OutputStateReason, message string) OutputStatus {
+	return OutputStatus{
+		Name:        name,
+		State:       state,
+		Reason:      reason,
+		Message:     message,
+		LastUpdated: metav1.Now(),
+	}
 }
 
 func (outputStatus *OutputStatus) AddCondition(conditionType OutputConditionType, reason OutputConditionReason, message string) {
@@ -301,10 +334,10 @@ const (
 )
 
 type OutputCondition struct {
-	Type    OutputConditionType
-	Reason  OutputConditionReason
-	Status  corev1.ConditionStatus
-	Message string
+	Type    OutputConditionType    `json:"type,omitempty"`
+	Reason  OutputConditionReason  `json:"reason,omitempty"`
+	Status  corev1.ConditionStatus `json:"status,omitempty"`
+	Message string                 `json:"message,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/forwarding/forwarding_controller.go
+++ b/pkg/controller/forwarding/forwarding_controller.go
@@ -110,7 +110,7 @@ func (r *ReconcileForwarding) Reconcile(request reconcile.Request) (reconcile.Re
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
-			logger.Debugf("logforwarding-controller error fetching ClusterLogging instance: %v")
+			logger.Debugf("logforwarding-controller error fetching ClusterLogging instance: %v", err)
 			return reconcile.Result{}, err
 		}
 

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -22,9 +22,9 @@ import (
 	cl "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	logforwarding "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1alpha1"
 	k8shandler "github.com/openshift/cluster-logging-operator/pkg/k8shandler"
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
 	e2eutil "github.com/openshift/cluster-logging-operator/test/e2e"
-	"github.com/openshift/cluster-logging-operator/pkg/logger"
 )
 
 const (


### PR DESCRIPTION
Fix up status messages from:
```status:
  LastUpdated: null
  outputs:
  - lastUpdated: null
    name: fluentd-created-by-user
    state: Accepted
  pipelines:
  - conditions:
    - Message: ""
      Reason: ReservedNameConflict
      Status: "False"
      Type: Name
    lastUpdated: null
    name: pipeline[0]
    state: Dropped
  - conditions:
    - Message: ""
      Reason: ReservedNameConflict
      Status: "False"
      Type: Name
    lastUpdated: null
    name: pipeline[1]
    state: Dropped
  - lastUpdated: null
    name: clo-default-audit-pipeline
    state: Accepted
  sources:
  - logs.audit```