### PR TITLE
Bug 1768762: Persisting proxy config and trustbundle CM info

### DIFF
--- a/pkg/controller/clusterlogging/clusterlogging_controller.go
+++ b/pkg/controller/clusterlogging/clusterlogging_controller.go
@@ -109,9 +109,6 @@ func (r *ReconcileClusterLogging) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
-	if err = k8shandler.Reconcile(instance, forwardinginstance, r.client); err != nil {
-		return reconcileResult, err
-	}
-
-	return reconcileResult, nil
+	err = k8shandler.Reconcile(instance, forwardinginstance, r.client)
+	return reconcileResult, err
 }

--- a/pkg/k8shandler/certificates.go
+++ b/pkg/k8shandler/certificates.go
@@ -49,13 +49,14 @@ var secretCertificates = map[string]map[string]string{
 		"ca-bundle.crt": "ca.crt",
 		"tls.key":       "system.logging.fluentd.key",
 		"tls.crt":       "system.logging.fluentd.crt",
-		//legacy to be removed in future
+		/*legacy to be removed in future
 		"app-ca":     "ca.crt",
 		"app-key":    "system.logging.fluentd.key",
 		"app-cert":   "system.logging.fluentd.crt",
 		"infra-ca":   "ca.crt",
 		"infra-key":  "system.logging.fluentd.key",
 		"infra-cert": "system.logging.fluentd.crt",
+		*/
 	},
 }
 

--- a/pkg/k8shandler/clusterloggingrequest.go
+++ b/pkg/k8shandler/clusterloggingrequest.go
@@ -53,7 +53,9 @@ func (clusterRequest *ClusterLoggingRequest) Update(object runtime.Object) (err 
 func (clusterRequest *ClusterLoggingRequest) UpdateStatus(object runtime.Object) (err error) {
 	logrus.Tracef("Updating Status: %v", object)
 	if err = clusterRequest.client.Status().Update(context.TODO(), object); err != nil {
-		logrus.Errorf("Error updating %v: %v", object.GetObjectKind(), err)
+		// making this debug because we should be throwing the returned error if we are never
+		// able to update the status
+		logrus.Debugf("Error updating status: %v", err)
 	}
 	return err
 }

--- a/pkg/k8shandler/trustedcabundle.go
+++ b/pkg/k8shandler/trustedcabundle.go
@@ -25,7 +25,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateTrustedCABundleConfig
 
 	utils.AddOwnerRefToObject(configMap, utils.AsOwner(clusterRequest.cluster))
 
-	err := clusterRequest.CreateOrUpdateConfigMap(configMap)
+	err := clusterRequest.CreateOrUpdateTrustedCaBundleConfigMap(configMap)
 	return err
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -266,6 +266,56 @@ func RemoveString(slice []string, s string) (result []string) {
 	return
 }
 
+func PodVolumeEquivalent(lhs, rhs []v1.Volume) bool {
+
+	if len(lhs) != len(rhs) {
+		return false
+	}
+
+	lhsMap := make(map[string]v1.Volume)
+	rhsMap := make(map[string]v1.Volume)
+
+	for _, vol := range lhs {
+		lhsMap[vol.Name] = vol
+	}
+
+	for _, vol := range rhs {
+		rhsMap[vol.Name] = vol
+	}
+
+	for name, lhsVol := range lhsMap {
+		if rhsVol, ok := rhsMap[name]; ok {
+			if lhsVol.Secret != nil && rhsVol.Secret != nil {
+				if lhsVol.Secret.SecretName != rhsVol.Secret.SecretName {
+					return false
+				}
+
+				continue
+			}
+			if lhsVol.ConfigMap != nil && rhsVol.ConfigMap != nil {
+				if lhsVol.ConfigMap.LocalObjectReference.Name != rhsVol.ConfigMap.LocalObjectReference.Name {
+					return false
+				}
+
+				continue
+			}
+			if lhsVol.HostPath != nil && rhsVol.HostPath != nil {
+				if lhsVol.HostPath.Path != rhsVol.HostPath.Path {
+					return false
+				}
+				continue
+			}
+
+			return false
+		} else {
+			// if rhsMap doesn't have the same key has lhsMap
+			return false
+		}
+	}
+
+	return true
+}
+
 /**
 EnvValueEqual - check if 2 EnvValues are equal or not
 Notes:
@@ -357,30 +407,30 @@ func SetProxyEnvVars(proxyConfig *configv1.Proxy) []v1.EnvVar {
 			Name:  "HTTPS_PROXY",
 			Value: proxyConfig.Status.HTTPSProxy,
 		},
-		v1.EnvVar{
-			Name:  "https_proxy",
-			Value: proxyConfig.Status.HTTPSProxy,
-		})
+			v1.EnvVar{
+				Name:  "https_proxy",
+				Value: proxyConfig.Status.HTTPSProxy,
+			})
 	}
 	if len(proxyConfig.Status.HTTPProxy) != 0 {
 		envVars = append(envVars, v1.EnvVar{
 			Name:  "HTTP_PROXY",
 			Value: proxyConfig.Status.HTTPProxy,
 		},
-		v1.EnvVar{
-			Name:  "http_proxy",
-			Value: proxyConfig.Status.HTTPProxy,
-		})
+			v1.EnvVar{
+				Name:  "http_proxy",
+				Value: proxyConfig.Status.HTTPProxy,
+			})
 	}
 	if len(proxyConfig.Status.NoProxy) != 0 {
 		envVars = append(envVars, v1.EnvVar{
 			Name:  "NO_PROXY",
 			Value: proxyConfig.Status.NoProxy,
 		},
-		v1.EnvVar{
-			Name:  "no_proxy",
-			Value: proxyConfig.Status.NoProxy,
-		})
+			v1.EnvVar{
+				Name:  "no_proxy",
+				Value: proxyConfig.Status.NoProxy,
+			})
 	}
 	return envVars
 }


### PR DESCRIPTION
Addresses: 
  * https://bugzilla.redhat.com/show_bug.cgi?id=1768762
  * https://bugzilla.redhat.com/show_bug.cgi?id=1766187

TODO: this PR currently just contains clean up for status triggers and unnecessary configmap updates with trustbundle information. Will also add logic to keep the proxy changes in our components.

When we have an event caught by the `proxyconfig_controller` we see that the proxy config info is pushed into the respective components. However, when we do not reconcile an event through there we are using `nil` for the proxy config and trustbundle CA so we then remove it. This is complicated by the fact that status updates can trigger an event being picked up so we were likely removing any proxy changes before the scheduler could process the deployment/daemonset changes.