### PR TITLE
Allow logforwarding tests to cleanup from go invocation

### DIFF
--- a/test/helpers/elasticsearch.go
+++ b/test/helpers/elasticsearch.go
@@ -89,13 +89,15 @@ type ElasticLogStore struct {
 
 func (es *ElasticLogStore) HasInfraStructureLogs(timeToWait time.Duration) (bool, error) {
 	err := wait.Poll(defaultRetryInterval, timeToWait, func() (done bool, err error) {
+		errorCount := 0
 		indices, err := es.Indices()
 		if err != nil {
 			logger.Errorf("Error retrieving indices from elasticsearch %v", err)
-			if strings.Contains(err.Error(), "failed to get pod") {
-				return false, nil
+			errorCount++
+			if errorCount > 5 { //accept arbitrary errors like 'etcd leader change'
+				return false, err
 			}
-			return false, err
+			return false, nil
 		}
 		return indices.HasInfraStructureLogs(), nil
 	})
@@ -104,13 +106,15 @@ func (es *ElasticLogStore) HasInfraStructureLogs(timeToWait time.Duration) (bool
 
 func (es *ElasticLogStore) HasApplicationLogs(timeToWait time.Duration) (bool, error) {
 	err := wait.Poll(defaultRetryInterval, timeToWait, func() (done bool, err error) {
+		errorCount := 0
 		indices, err := es.Indices()
 		if err != nil {
 			logger.Errorf("Error retrieving indices from elasticsearch %v", err)
-			if strings.Contains(err.Error(), "failed to get pod") {
-				return false, nil
+			errorCount++
+			if errorCount > 5 {
+				return false, err
 			}
-			return false, err
+			return false, nil
 		}
 		return indices.HasApplicationLogs(), nil
 	})


### PR DESCRIPTION
More updates to make LF testing more reliable

Ref 4.4: https://github.com/openshift/cluster-logging-operator/pull/316