### PR TITLE
Bug 1782740: Addressing LF causing cert rotation

### DIFF
--- a/pkg/controller/clusterlogging/clusterlogging_controller.go
+++ b/pkg/controller/clusterlogging/clusterlogging_controller.go
@@ -5,14 +5,12 @@ import (
 	"time"
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	logforwarding "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1alpha1"
 	"github.com/openshift/cluster-logging-operator/pkg/constants"
 	"github.com/openshift/cluster-logging-operator/pkg/k8shandler"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -99,16 +97,6 @@ func (r *ReconcileClusterLogging) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, nil
 	}
 
-	forwardinginstance := &logforwarding.LogForwarding{}
-	fiName := types.NamespacedName{Name: constants.SingletonName, Namespace: constants.OpenshiftNS}
-	err = r.client.Get(context.TODO(), fiName, forwardinginstance)
-	if err != nil && !errors.IsNotFound(err) {
-		// Request object not found, could have been deleted after reconcile request.
-		// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-		// Return and don't requeue
-		return reconcile.Result{}, err
-	}
-
-	err = k8shandler.Reconcile(instance, forwardinginstance, r.client)
+	err = k8shandler.Reconcile(instance, r.client)
 	return reconcileResult, err
 }

--- a/pkg/k8shandler/certificates.go
+++ b/pkg/k8shandler/certificates.go
@@ -34,8 +34,9 @@ var secretCertificates = map[string]map[string]string{
 		"cert": "system.logging.kibana.crt",
 	},
 	"kibana-proxy": map[string]string{
-		"server-key":  "kibana-internal.key",
-		"server-cert": "kibana-internal.crt",
+		"server-key":     "kibana-internal.key",
+		"server-cert":    "kibana-internal.crt",
+		"session-secret": "kibana-session-secret",
 	},
 	"curator": map[string]string{
 		"ca":       "ca.crt",
@@ -49,14 +50,6 @@ var secretCertificates = map[string]map[string]string{
 		"ca-bundle.crt": "ca.crt",
 		"tls.key":       "system.logging.fluentd.key",
 		"tls.crt":       "system.logging.fluentd.crt",
-		/*legacy to be removed in future
-		"app-ca":     "ca.crt",
-		"app-key":    "system.logging.fluentd.key",
-		"app-cert":   "system.logging.fluentd.crt",
-		"infra-ca":   "ca.crt",
-		"infra-key":  "system.logging.fluentd.key",
-		"infra-cert": "system.logging.fluentd.crt",
-		*/
 	},
 }
 

--- a/pkg/k8shandler/reconciler.go
+++ b/pkg/k8shandler/reconciler.go
@@ -15,26 +15,19 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func Reconcile(requestCluster *logging.ClusterLogging, forwarding *logforwarding.LogForwarding, requestClient client.Client) (err error) {
-	logger.Debugf("Reconciling cl: %v, forwarding: %v", requestCluster, forwarding)
+func Reconcile(requestCluster *logging.ClusterLogging, requestClient client.Client) (err error) {
 	clusterLoggingRequest := ClusterLoggingRequest{
-		client:            requestClient,
-		cluster:           requestCluster,
-		ForwardingRequest: forwarding,
+		client:  requestClient,
+		cluster: requestCluster,
 	}
+
+	forwarding := clusterLoggingRequest.getLogForwarding()
 	if forwarding != nil {
+		clusterLoggingRequest.ForwardingRequest = forwarding
 		clusterLoggingRequest.ForwardingSpec = forwarding.Spec
 	}
 
-	// we need to see if we have the proxy available so we
-	// don't blank out any proxy configured changes...
-	proxyNamespacedName := types.NamespacedName{Name: constants.ProxyName}
-	proxyConfig := &configv1.Proxy{}
-	if err := clusterLoggingRequest.client.Get(context.TODO(), proxyNamespacedName, proxyConfig); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("Encountered unexpected error getting %v", proxyNamespacedName)
-		}
-	}
+	proxyConfig := clusterLoggingRequest.getProxyConfig()
 
 	// Reconcile certs
 	if err = clusterLoggingRequest.CreateOrUpdateCertificates(); err != nil {
@@ -64,14 +57,49 @@ func Reconcile(requestCluster *logging.ClusterLogging, forwarding *logforwarding
 	return nil
 }
 
-func ReconcileForGlobalProxy(requestCluster *logging.ClusterLogging, forwarding *logforwarding.LogForwarding, proxyConfig *configv1.Proxy, requestClient client.Client) (err error) {
+func ReconcileForLogForwarding(forwarding *logforwarding.LogForwarding, requestClient client.Client) (err error) {
 
 	clusterLoggingRequest := ClusterLoggingRequest{
-		client:            requestClient,
-		cluster:           requestCluster,
-		ForwardingRequest: forwarding,
+		client: requestClient,
 	}
 	if forwarding != nil {
+		clusterLoggingRequest.ForwardingRequest = forwarding
+		clusterLoggingRequest.ForwardingSpec = forwarding.Spec
+	}
+
+	clusterLogging := clusterLoggingRequest.getClusterLogging()
+	clusterLoggingRequest.cluster = clusterLogging
+
+	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {
+		return nil
+	}
+
+	proxyConfig := clusterLoggingRequest.getProxyConfig()
+
+	// Reconcile Collection
+	if err = clusterLoggingRequest.CreateOrUpdateCollection(proxyConfig); err != nil {
+		return fmt.Errorf("Unable to create or update collection for %q: %v", clusterLoggingRequest.cluster.Name, err)
+	}
+
+	return nil
+}
+
+func ReconcileForGlobalProxy(proxyConfig *configv1.Proxy, requestClient client.Client) (err error) {
+
+	clusterLoggingRequest := ClusterLoggingRequest{
+		client: requestClient,
+	}
+
+	clusterLogging := clusterLoggingRequest.getClusterLogging()
+	clusterLoggingRequest.cluster = clusterLogging
+
+	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {
+		return nil
+	}
+
+	forwarding := clusterLoggingRequest.getLogForwarding()
+	if forwarding != nil {
+		clusterLoggingRequest.ForwardingRequest = forwarding
 		clusterLoggingRequest.ForwardingSpec = forwarding.Spec
 	}
 
@@ -86,4 +114,44 @@ func ReconcileForGlobalProxy(requestCluster *logging.ClusterLogging, forwarding 
 	}
 
 	return nil
+}
+
+func (clusterRequest *ClusterLoggingRequest) getClusterLogging() *logging.ClusterLogging {
+	clusterLoggingNamespacedName := types.NamespacedName{Name: constants.SingletonName, Namespace: constants.OpenshiftNS}
+	clusterLogging := &logging.ClusterLogging{}
+
+	if err := clusterRequest.client.Get(context.TODO(), clusterLoggingNamespacedName, clusterLogging); err != nil {
+		if !apierrors.IsNotFound(err) {
+			fmt.Errorf("Encountered unexpected error getting %v", clusterLoggingNamespacedName)
+		}
+	}
+
+	return clusterLogging
+}
+
+func (clusterRequest *ClusterLoggingRequest) getProxyConfig() *configv1.Proxy {
+	// we need to see if we have the proxy available so we
+	// don't blank out any proxy configured changes...
+	proxyNamespacedName := types.NamespacedName{Name: constants.ProxyName}
+	proxyConfig := &configv1.Proxy{}
+	if err := clusterRequest.client.Get(context.TODO(), proxyNamespacedName, proxyConfig); err != nil {
+		if !apierrors.IsNotFound(err) {
+			fmt.Errorf("Encountered unexpected error getting %v", proxyNamespacedName)
+		}
+	}
+
+	return proxyConfig
+}
+
+func (clusterRequest *ClusterLoggingRequest) getLogForwarding() *logforwarding.LogForwarding {
+	logForwardingNamespacedName := types.NamespacedName{Name: constants.SingletonName, Namespace: constants.OpenshiftNS}
+	logForwarding := &logforwarding.LogForwarding{}
+	logger.Debug("logforwarding-controller fetching LF instance")
+	if err := clusterRequest.client.Get(context.TODO(), logForwardingNamespacedName, logForwarding); err != nil {
+		if !apierrors.IsNotFound(err) {
+			fmt.Errorf("Encountered unexpected error getting %v", logForwardingNamespacedName)
+		}
+	}
+
+	return logForwarding
 }

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -502,11 +502,18 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateKibanaSecret() error 
 		return err
 	}
 
+	sessionSecret := []byte{}
+
+	sessionSecret = utils.GetWorkingDirFileContents("kibana-session-secret")
+	if sessionSecret == nil {
+		sessionSecret = utils.GetRandomWord(32)
+	}
+
 	proxySecret := NewSecret(
 		"kibana-proxy",
 		clusterRequest.cluster.Namespace,
 		map[string][]byte{
-			"session-secret": utils.GetRandomWord(32),
+			"session-secret": sessionSecret,
 			"server-key":     utils.GetWorkingDirFileContents("kibana-internal.key"),
 			"server-cert":    utils.GetWorkingDirFileContents("kibana-internal.crt"),
 		})


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1782740

Able to recreate the master-certs secret and elasticsearch secret being recreated by deploying CLO, creating a log forwarding object, then deleting the CLO pod. No longer observe that with this PR.