### PR TITLE
Added lint target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,6 @@ imagebuilder:
 	then go get -u github.com/openshift/imagebuilder/cmd/imagebuilder ; \
 	fi
 
-lint:
-	@golangci-lint run -c golangci.yaml
-
 build: fmt
 	@mkdir -p $(TARGET_DIR)/src/$(APP_REPO)
 	@cp -ru $(CURPATH)/pkg $(TARGET_DIR)/src/$(APP_REPO)
@@ -93,10 +90,11 @@ image: imagebuilder
 	then hack/build-image.sh $(IMAGE_TAG) $(IMAGE_BUILDER) $(IMAGE_BUILDER_OPTS) ; \
 	fi
 
+lint:
+	@golangci-lint run -c golangci.yaml
+
 fmt:
-	@gofmt -l -w cmd && \
-	gofmt -l -w pkg && \
-	gofmt -l -w test
+	@gofmt -l -w cmd/ pkg/ version/
 
 simplify:
 	@gofmt -s -l -w $(SRC)

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ imagebuilder:
 	then go get -u github.com/openshift/imagebuilder/cmd/imagebuilder ; \
 	fi
 
+lint:
+	@golangci-lint run -c golangci.yaml
+
 build: fmt
 	@mkdir -p $(TARGET_DIR)/src/$(APP_REPO)
 	@cp -ru $(CURPATH)/pkg $(TARGET_DIR)/src/$(APP_REPO)
@@ -121,7 +124,7 @@ test-unit: fmt
 
 test-e2e:
 	hack/test-e2e.sh
-	
+
 test-sec:
 	go get -u github.com/securego/gosec/cmd/gosec
 	gosec -severity medium --confidence medium -quiet ./...

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -1,0 +1,8 @@
+linters:
+  disable:
+    - megacheck
+  enable:
+    - gosimple
+    - staticcheck
+    - unused
+


### PR DESCRIPTION
Added `lint` target to Makefile (using `golangci-lint`: https://github.com/golangci/golangci-lint). For now it is just a recommendation. But it is highly recommended to use that as a prerequisite for `make build`