### PR TITLE
replace FROM for local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-logging-operator
 COPY . .
 RUN make
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM centos:centos7
 ARG CSV=4.4
 RUN INSTALL_PKGS=" \
       openssl \


### PR DESCRIPTION
This PR modifies the base image:
* The ART process replaces FROM with what's required for a release
* The ci pipeline replaces FROM based on what's defined in config: https://github.com/openshift/release/blob/master/ci-operator/config/openshift/cluster-logging-operator/openshift-cluster-logging-operator-master.yaml#L11-L13

This change will allow us to continue to build locally