### PR TITLE
LOG-599: Update fluent config to use static index

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -293,6 +293,7 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 				<filter **>
 					@type viaq_data_model
+					elasticsearch_index_prefix_field 'viaq_index_name'
 					default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
 					extra_keep_fields "#{ENV['CDM_EXTRA_KEEP_FIELDS'] || ''}"
 					keep_empty_fields "#{ENV['CDM_KEEP_EMPTY_FIELDS'] || 'message'}"
@@ -336,17 +337,20 @@ var _ = Describe("Generating fluentd config", func() {
 					<elasticsearch_index_name>
 						enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
 						tag "journal.system** system.var.log** **_default_** **_kube-*_** **_openshift-*_** **_openshift_**"
-						name_type operations_full
-					</elasticsearch_index_name>
-					<elasticsearch_index_name>
+						name_type static
+						static_index_name infra-write
+						</elasticsearch_index_name>
+						<elasticsearch_index_name>
 						enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
 						tag "linux-audit.log** k8s-audit.log** openshift-audit.log**"
-						name_type audit_full
-					</elasticsearch_index_name>
-					<elasticsearch_index_name>
+						name_type static
+						static_index_name audit-infra-write
+						</elasticsearch_index_name>
+						<elasticsearch_index_name>
 						enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
 						tag "**"
-						name_type project_full
+						name_type static
+						static_index_name app-write
 					</elasticsearch_index_name>
 				</filter>
 				<filter **>
@@ -710,6 +714,7 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 				<filter **>
 					@type viaq_data_model
+					elasticsearch_index_prefix_field 'viaq_index_name'
 					default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
 					extra_keep_fields "#{ENV['CDM_EXTRA_KEEP_FIELDS'] || ''}"
 					keep_empty_fields "#{ENV['CDM_KEEP_EMPTY_FIELDS'] || 'message'}"
@@ -753,17 +758,20 @@ var _ = Describe("Generating fluentd config", func() {
 					<elasticsearch_index_name>
 						enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
 						tag "journal.system** system.var.log** **_default_** **_kube-*_** **_openshift-*_** **_openshift_**"
-						name_type operations_full
+						name_type static
+						static_index_name infra-write
 					</elasticsearch_index_name>
 					<elasticsearch_index_name>
 						enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
 						tag "linux-audit.log** k8s-audit.log** openshift-audit.log**"
-						name_type audit_full
+						name_type static
+						static_index_name audit-infra-write
 					</elasticsearch_index_name>
 					<elasticsearch_index_name>
 						enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
 						tag "**"
-						name_type project_full
+						name_type static
+						static_index_name app-write
 					</elasticsearch_index_name>
 				</filter>
 				<filter **>
@@ -898,7 +906,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
-						type_name com.redhat.viaq.common
+						type_name _doc
 						write_operation create
 						reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -940,7 +948,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
-						type_name com.redhat.viaq.common
+						type_name _doc
 						retry_tag retry_infra_es
 						write_operation create
 						reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
@@ -985,7 +993,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
-						type_name com.redhat.viaq.common
+						type_name _doc
 						write_operation create
 						reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1027,7 +1035,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
-						type_name com.redhat.viaq.common
+						type_name _doc
 						retry_tag retry_apps_es_1
 						write_operation create
 						reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
@@ -1072,7 +1080,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
-						type_name com.redhat.viaq.common
+						type_name _doc
 						write_operation create
 						reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1114,7 +1122,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
-						type_name com.redhat.viaq.common
+						type_name _doc
 						retry_tag retry_apps_es_2
 						write_operation create
 						reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
@@ -1159,7 +1167,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
-						type_name com.redhat.viaq.common
+						type_name _doc
 						write_operation create
 						reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1201,7 +1209,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
-						type_name com.redhat.viaq.common
+						type_name _doc
 						retry_tag retry_audit_es
 						write_operation create
 						reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
 			client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
 			ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
-			type_name com.redhat.viaq.common
+			type_name _doc
 			write_operation create
 			reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -124,7 +124,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
 			client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
 			ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
-			type_name com.redhat.viaq.common
+			type_name _doc
 			retry_tag retry_oncluster_elasticsearch
 			write_operation create
 			reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
@@ -182,7 +182,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			user fluentd
 			password changeme
 
-			type_name com.redhat.viaq.common
+			type_name _doc
 			write_operation create
 			reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -220,7 +220,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			user fluentd
 			password changeme
 
-			type_name com.redhat.viaq.common
+			type_name _doc
 			retry_tag retry_other_elasticsearch
 			write_operation create
 			reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -193,6 +193,7 @@ const fluentConfTemplate = `{{- define "fluentConf" }}
 	</filter>
 	<filter **>
 		@type viaq_data_model
+		elasticsearch_index_prefix_field 'viaq_index_name'
 		default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
 		extra_keep_fields "#{ENV['CDM_EXTRA_KEEP_FIELDS'] || ''}"
 		keep_empty_fields "#{ENV['CDM_KEEP_EMPTY_FIELDS'] || 'message'}"
@@ -236,17 +237,20 @@ const fluentConfTemplate = `{{- define "fluentConf" }}
 		<elasticsearch_index_name>
 			enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
 			tag "journal.system** system.var.log** **_default_** **_kube-*_** **_openshift-*_** **_openshift_**"
-			name_type operations_full
+			name_type static
+			static_index_name infra-write
 		</elasticsearch_index_name>
 		<elasticsearch_index_name>
 			enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
 			tag "linux-audit.log** k8s-audit.log** openshift-audit.log**"
-			name_type audit_full
+			name_type static
+			static_index_name audit-infra-write
 		</elasticsearch_index_name>
 		<elasticsearch_index_name>
 			enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
 			tag "**"
-			name_type project_full
+			name_type static
+			static_index_name app-write
 		</elasticsearch_index_name>
 	</filter>
 	<filter **>
@@ -542,7 +546,7 @@ const storeElasticsearchTemplate = `{{- define "storeElasticsearch" }}
 	client_cert '{{ .SecretPath "tls.crt"}}'
 	ca_file '{{ .SecretPath "ca-bundle.crt"}}'
 	{{ end -}}
-	type_name com.redhat.viaq.common
+	type_name _doc
 	{{if .Hints.Has "include_retry_tag" -}}
 	retry_tag {{.RetryTag}}
 	{{end -}}

--- a/test/helpers/elasticsearch.go
+++ b/test/helpers/elasticsearch.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	InfraIndexPrefix          = ".operations."
-	ProjectIndexPrefix        = "project."
-	AuditIndexPrefix          = ".audit."
+	InfraIndexPrefix          = "infra-"
+	ProjectIndexPrefix        = "app-"
+	AuditIndexPrefix          = "audit-infra-"
 	elasticsearchesLoggingURI = "apis/logging.openshift.io/v1/namespaces/openshift-logging/elasticsearches"
 )
 


### PR DESCRIPTION
This PR:
* resolves https://issues.redhat.com/browse/LOG-599
* updates the fluent config to write to a static index
* blocked by https://github.com/openshift/origin-aggregated-logging/pull/1797 and equivalent into feature branch