### PR TITLE
Use centos instead of RHEL to avoid subscription errors.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cluster-logging-operator
 COPY . .
 RUN make
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM centos:centos7
 ARG CSV=4.3
 RUN INSTALL_PKGS=" \
       openssl \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ is found in the [configuration](./docs/configuration.md) documentation.
 
 ## Quick Start
 To get started with cluster logging and the `cluster-logging-operator`:
-* Ensure Docker is installed on your local system
+* Ensure Docker is installed on your local system [(**Note** for Fedora 31)](./docs/fedora31.md)
+* Ensure skopeo is installed, e.g. `sudo dnf install -y skopeo`
 ```
 $ oc login $CLUSTER -u $ADMIN_USER -p $ADMIN_PASSWD
 $ REMOTE_CLUSTER=true make deploy-example

--- a/docs/fedora31.md
+++ b/docs/fedora31.md
@@ -1,0 +1,19 @@
+## Installing docker on Fedora 31 (and maybe later)
+
+In Fedora 31, default kernel settings changed and are incompatible with docker.
+
+Here's how to fix that (steps taken from [here](https://linuxconfig.org/how-to-install-docker-on-fedora-31))
+
+You should `dnf erase` any existing docker, docker-ce or moby packages first.
+
+```
+sudo dnf install -y grubby
+sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
+sudo reboot
+# After reboot
+sudo dnf config-manager --add-repo=https://download.docker.com/linux/fedora/docker-ce.repo
+sudo dnf install -y docker-ce
+sudo systemctl enable --now docker
+sudo groupadd docker
+sudo usermod -aG docker $USER
+```


### PR DESCRIPTION
Backport c43a731b from 4.4 "replace FROM for local builds".
Ref https://github.com/openshift/cluster-logging-operator/pull/332
Use centos instead of RHEL to avoid subscription errors in `make deploy`