### PR TITLE
Forwarding to external syslog, based on a new fluentd plugin

### DIFF
--- a/manifests/4.4/logforwardings.crd.yaml
+++ b/manifests/4.4/logforwardings.crd.yaml
@@ -29,6 +29,7 @@ spec:
                     enum:
                       - elasticsearch
                       - forward
+                      - syslog
                       - syslog-legacy
                   name: 
                     description: The name of the output

--- a/manifests/4.4/logforwardings.crd.yaml
+++ b/manifests/4.4/logforwardings.crd.yaml
@@ -29,6 +29,7 @@ spec:
                     enum:
                       - elasticsearch
                       - forward
+                      - syslog-legacy
                   name: 
                     description: The name of the output
                     type: string

--- a/pkg/apis/logging/v1alpha1/forwarding_types.go
+++ b/pkg/apis/logging/v1alpha1/forwarding_types.go
@@ -74,6 +74,9 @@ const (
 
 	//OutputTypeForward configures the pipeline to send messages via Fluent's secure forward
 	OutputTypeForward OutputType = "forward"
+
+	//OutputTypeLegacySyslog configures pipeline to send messages to an external syslog server through docebo/fluent-plugin-remote-syslog
+	OutputTypeLegacySyslog OutputType = "syslog-legacy"
 )
 
 //LogForwardingReason The reason for the current state

--- a/pkg/apis/logging/v1alpha1/forwarding_types.go
+++ b/pkg/apis/logging/v1alpha1/forwarding_types.go
@@ -77,6 +77,9 @@ const (
 
 	//OutputTypeLegacySyslog configures pipeline to send messages to an external syslog server through docebo/fluent-plugin-remote-syslog
 	OutputTypeLegacySyslog OutputType = "syslog-legacy"
+
+	//OutputTypeSyslog configures pipeline to send messages to an external syslog server through dlackty/fluent-plugin-remote_syslog
+	OutputTypeSyslog OutputType = "syslog"
 )
 
 //LogForwardingReason The reason for the current state

--- a/pkg/generators/factory.go
+++ b/pkg/generators/factory.go
@@ -13,13 +13,7 @@ type Generator struct {
 
 //New creates an instance of a template engine for a set of templates
 func New(name string, addFunctions *template.FuncMap, templates ...string) (*Generator, error) {
-	allFunctions := funcMap
-	if addFunctions != nil {
-		for name, f := range *addFunctions {
-			allFunctions[name] = f
-		}
-	}
-	tmpl := template.New(name).Funcs(funcMap)
+	tmpl := template.New(name).Funcs(*addFunctions).Funcs(funcMap)
 	var err error
 	for i, s := range templates {
 		tmpl, err = tmpl.Parse(s)

--- a/pkg/generators/forwarding/fluentd/fluent_conf.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf.go
@@ -11,6 +11,7 @@ import (
 )
 
 var replacer = strings.NewReplacer(" ", "_", "-", "_", ".", "_")
+var protocolSeparator = "://"
 
 type outputLabelConf struct {
 	Name            string
@@ -44,15 +45,32 @@ func (conf *outputLabelConf) Template() *template.Template {
 	return conf.TemplateContext
 }
 func (conf *outputLabelConf) Host() string {
-	return strings.Split(conf.Target.Endpoint, ":")[0]
+	endpoint := stripProtocol(conf.Target.Endpoint)
+	return strings.Split(endpoint, ":")[0]
 }
 
 func (conf *outputLabelConf) Port() string {
-	parts := strings.Split(conf.Target.Endpoint, ":")
+	endpoint := stripProtocol(conf.Target.Endpoint)
+	parts := strings.Split(endpoint, ":")
 	if len(parts) == 1 {
 		return "9200"
 	}
 	return parts[1]
+}
+
+func (conf *outputLabelConf) Protocol() string {
+	endpoint := conf.Target.Endpoint
+	if index := strings.Index(endpoint, protocolSeparator); index != -1 {
+		return endpoint[:index]
+	}
+	return ""
+}
+
+func stripProtocol(endpoint string) string {
+	if index := strings.Index(endpoint, protocolSeparator); index != -1 {
+		endpoint = endpoint[index+len(protocolSeparator):]
+	}
+	return endpoint
 }
 
 func (conf *outputLabelConf) BufferPath() string {

--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -197,6 +197,9 @@ func (engine *ConfigGenerator) generateOutputLabelBlocks(outputs []logforward.Ou
 		case logforward.OutputTypeForward:
 			storeTemplateName = "forward"
 			outputTemplateName = "outputLabelConfNoCopy"
+		case logforward.OutputTypeLegacySyslog:
+			storeTemplateName = "storeLegacySyslog"
+			outputTemplateName = "outputLabelConfNoRetry"
 		default:
 			logger.Warnf("Pipeline targets include an unrecognized type: %q", output.Type)
 			continue

--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -200,6 +200,9 @@ func (engine *ConfigGenerator) generateOutputLabelBlocks(outputs []logforward.Ou
 		case logforward.OutputTypeLegacySyslog:
 			storeTemplateName = "storeLegacySyslog"
 			outputTemplateName = "outputLabelConfNoRetry"
+		case logforward.OutputTypeSyslog:
+			storeTemplateName = "storeSyslog"
+			outputTemplateName = "outputLabelConfNoRetry"
 		default:
 			logger.Warnf("Pipeline targets include an unrecognized type: %q", output.Type)
 			continue

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -105,4 +105,129 @@ var _ = Describe("Generating external syslog server output store config blocks",
 			})
 		})
 	})
+
+	Context("based on the new syslog plugin", func() {
+		secureConf := `<label @SYSLOG_RECEIVER>
+        <match **>
+           @type copy
+           <store>
+             @type remote_syslog
+             @id syslog_receiver
+             host sl.svc.messaging.cluster.local
+             protocol tcp
+             tls true
+             ca_file '/var/run/ocp-collector/secrets/my-syslog-secret/ca.pem'
+             port 9654
+             hostname ${hostname}
+             facility user
+             severity debug
+           </store>
+        </match>
+</label>`
+		udpConf := `<label @SYSLOG_RECEIVER>
+        <match **>
+           @type copy
+           <store>
+             @type remote_syslog
+             @id syslog_receiver
+             host sl.svc.messaging.cluster.local
+             protocol udp
+             port 9654
+             hostname ${hostname}
+             facility user
+             severity debug
+           </store>
+        </match>
+</label>`
+		tcpConf := `<label @SYSLOG_RECEIVER>
+        <match **>
+           @type copy
+           <store>
+             @type remote_syslog
+             @id syslog_receiver
+             host sl.svc.messaging.cluster.local
+             protocol tcp
+             port 9654
+             hostname ${hostname}
+             facility user
+             severity debug
+           </store>
+        </match>
+</label>`
+
+		Context("for an secure endpoint", func() {
+			BeforeEach(func() {
+				outputs = []logging.OutputSpec{
+					{
+						Type:     logging.OutputTypeSyslog,
+						Name:     "syslog-receiver",
+						Endpoint: "sl.svc.messaging.cluster.local:9654",
+						Secret: &logging.OutputSecretSpec{
+							Name: "my-syslog-secret",
+						},
+					},
+				}
+			})
+			It("should produce well formed output label config", func() {
+				results, err := generator.generateOutputLabelBlocks(outputs)
+				Expect(err).To(BeNil())
+				Expect(len(results)).To(Equal(1))
+				test.Expect(results[0]).ToEqual(secureConf)
+			})
+		})
+
+		Context("for a udp endpoint", func() {
+			BeforeEach(func() {
+				outputs = []logging.OutputSpec{
+					{
+						Type:     logging.OutputTypeSyslog,
+						Name:     "syslog-receiver",
+						Endpoint: "udp://sl.svc.messaging.cluster.local:9654",
+					},
+				}
+			})
+			It("should produce well formed output label config", func() {
+				results, err := generator.generateOutputLabelBlocks(outputs)
+				Expect(err).To(BeNil())
+				Expect(len(results)).To(Equal(1))
+				test.Expect(results[0]).ToEqual(udpConf)
+			})
+		})
+
+		Context("for a tcp endpoint", func() {
+			BeforeEach(func() {
+				outputs = []logging.OutputSpec{
+					{
+						Type:     logging.OutputTypeSyslog,
+						Name:     "syslog-receiver",
+						Endpoint: "tcp://sl.svc.messaging.cluster.local:9654",
+					},
+				}
+			})
+			It("should produce well formed output label config", func() {
+				results, err := generator.generateOutputLabelBlocks(outputs)
+				Expect(err).To(BeNil())
+				Expect(len(results)).To(Equal(1))
+				test.Expect(results[0]).ToEqual(tcpConf)
+			})
+		})
+
+		Context("for a protocol-less endpoint", func() {
+			BeforeEach(func() {
+				outputs = []logging.OutputSpec{
+					{
+						Type:     logging.OutputTypeSyslog,
+						Name:     "syslog-receiver",
+						Endpoint: "sl.svc.messaging.cluster.local:9654",
+					},
+				}
+			})
+			It("should produce well formed output label config", func() {
+				results, err := generator.generateOutputLabelBlocks(outputs)
+				Expect(err).To(BeNil())
+				Expect(len(results)).To(Equal(1))
+				test.Expect(results[0]).ToEqual(tcpConf)
+			})
+		})
+	})
 })

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -1,0 +1,108 @@
+package fluentd
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1alpha1"
+	test "github.com/openshift/cluster-logging-operator/test"
+)
+
+var _ = Describe("Generating external syslog server output store config blocks", func() {
+
+	var (
+		err       error
+		outputs   []logging.OutputSpec
+		generator *ConfigGenerator
+	)
+	BeforeEach(func() {
+		generator, err = NewConfigGenerator(false)
+		Expect(err).To(BeNil())
+	})
+
+	Context("based on legacy syslog plugin", func() {
+		tcpConf := `<label @SYSLOG_RECEIVER>
+		<match **>
+		@type copy
+		<store>
+			@type syslog_buffered
+			@id syslog_receiver
+			remote_syslog sl.svc.messaging.cluster.local
+			port 9654
+			hostname ${hostname}
+			facility user
+			severity debug
+		</store>
+		</match>
+	</label>`
+
+		udpConf := `<label @SYSLOG_RECEIVER>
+		<match **>
+		@type copy
+		<store>
+			@type syslog
+			@id syslog_receiver
+			remote_syslog sl.svc.messaging.cluster.local
+			port 9654
+			hostname ${hostname}
+			facility user
+			severity debug
+		</store>
+		</match>
+	</label>`
+
+		Context("for protocol-less endpoint", func() {
+			BeforeEach(func() {
+				outputs = []logging.OutputSpec{
+					{
+						Type:     logging.OutputTypeLegacySyslog,
+						Name:     "syslog-receiver",
+						Endpoint: "sl.svc.messaging.cluster.local:9654",
+					},
+				}
+			})
+			It("should produce well formed output label config", func() {
+				results, err := generator.generateOutputLabelBlocks(outputs)
+				Expect(err).To(BeNil())
+				Expect(len(results)).To(Equal(1))
+				test.Expect(results[0]).ToEqual(tcpConf)
+			})
+		})
+
+		Context("for tcp endpoint", func() {
+			BeforeEach(func() {
+				outputs = []logging.OutputSpec{
+					{
+						Type:     logging.OutputTypeLegacySyslog,
+						Name:     "syslog-receiver",
+						Endpoint: "tcp://sl.svc.messaging.cluster.local:9654",
+					},
+				}
+			})
+			It("should produce well formed output label config", func() {
+				results, err := generator.generateOutputLabelBlocks(outputs)
+				Expect(err).To(BeNil())
+				Expect(len(results)).To(Equal(1))
+				test.Expect(results[0]).ToEqual(tcpConf)
+			})
+		})
+
+		Context("for udp endpoint", func() {
+			BeforeEach(func() {
+				outputs = []logging.OutputSpec{
+					{
+						Type:     logging.OutputTypeLegacySyslog,
+						Name:     "syslog-receiver",
+						Endpoint: "udp://sl.svc.messaging.cluster.local:9654",
+					},
+				}
+			})
+			It("should produce well formed output label config", func() {
+				results, err := generator.generateOutputLabelBlocks(outputs)
+				Expect(err).To(BeNil())
+				Expect(len(results)).To(Equal(1))
+				test.Expect(results[0]).ToEqual(udpConf)
+			})
+		})
+	})
+})

--- a/pkg/generators/forwarding/fluentd/syslog_conf.go
+++ b/pkg/generators/forwarding/fluentd/syslog_conf.go
@@ -1,0 +1,8 @@
+package fluentd
+
+func (conf *outputLabelConf) SyslogLegacyPlugin() string {
+	if protocol := conf.Protocol(); protocol == "udp" {
+		return "syslog"
+	}
+	return "syslog_buffered"
+}

--- a/pkg/generators/forwarding/fluentd/syslog_conf.go
+++ b/pkg/generators/forwarding/fluentd/syslog_conf.go
@@ -6,3 +6,10 @@ func (conf *outputLabelConf) SyslogLegacyPlugin() string {
 	}
 	return "syslog_buffered"
 }
+
+func (conf *outputLabelConf) SyslogProtocol() string {
+	if protocol := conf.Protocol(); protocol != "" {
+		return protocol
+	}
+	return "tcp"
+}

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -16,6 +16,7 @@ var templateRegistry = []string{
 	storeElasticsearchTemplate,
 	forwardTemplate,
 	storeLegacySyslogTemplate,
+	storeSyslogTemplate,
 }
 
 const fluentConfTemplate = `{{- define "fluentConf" }}
@@ -571,6 +572,25 @@ const storeLegacySyslogTemplate = `{{- define "storeLegacySyslog" }}
 	@type {{.SyslogLegacyPlugin}}
 	@id {{.StoreID}}
 	remote_syslog {{.Host}}
+	port {{.Port}}
+	hostname ${hostname}
+	facility user
+	severity debug
+</store>
+{{- end}}`
+
+const storeSyslogTemplate = `{{- define "storeSyslog" }}
+<store>
+	@type remote_syslog
+	@id {{.StoreID}}
+	host {{.Host}}
+{{ if .Target.Secret }}
+	protocol tcp
+	tls true
+	ca_file '{{ .SecretPath "ca.pem" }}'
+{{ else }}
+	protocol {{.SyslogProtocol}}
+{{- end}}
 	port {{.Port}}
 	hostname ${hostname}
 	facility user

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -12,8 +12,10 @@ var templateRegistry = []string{
 	sourceToPipelineCopyTemplate,
 	outputLabelConfTemplate,
 	outputLabelConfNocopyTemplate,
+	outputLabelConfNoretryTemplate,
 	storeElasticsearchTemplate,
 	forwardTemplate,
+	storeLegacySyslogTemplate,
 }
 
 const fluentConfTemplate = `{{- define "fluentConf" }}
@@ -465,6 +467,15 @@ const outputLabelConfNocopyTemplate = `{{- define "outputLabelConfNoCopy" }}
 </label>
 {{- end}}`
 
+const outputLabelConfNoretryTemplate = `{{- define "outputLabelConfNoRetry" }}
+<label {{.LabelName}}>
+	<match **>
+		@type copy
+{{include .StoreTemplate . "" | indent 4}}
+	</match>
+</label>
+{{- end}}`
+
 const forwardTemplate = `{{- define "forward" }}
 	# https://docs.fluentd.org/v1.0/articles/in_forward
 	@type forward
@@ -552,5 +563,17 @@ const storeElasticsearchTemplate = `{{- define "storeElasticsearch" }}
 		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 	</buffer>
+</store>
+{{- end}}`
+
+const storeLegacySyslogTemplate = `{{- define "storeLegacySyslog" }}
+<store>
+	@type {{.SyslogLegacyPlugin}}
+	@id {{.StoreID}}
+	remote_syslog {{.Host}}
+	port {{.Port}}
+	hostname ${hostname}
+	facility user
+	severity debug
 </store>
 {{- end}}`

--- a/pkg/k8shandler/certificates.go
+++ b/pkg/k8shandler/certificates.go
@@ -143,6 +143,10 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCertificates() (err e
 
 func GenerateCertificates(namespace, rootDir, logStoreName, workDir string) (err error) {
 	script := fmt.Sprintf("%s/scripts/cert_generation.sh", rootDir)
+	return RunCertificatesScript(namespace, logStoreName, workDir, script)
+}
+
+func RunCertificatesScript(namespace, logStoreName, workDir, script string) (err error) {
 	logger.Debugf("Running script '%s %s %s %s'", script, workDir, namespace, logStoreName)
 	cmd := exec.Command(script, workDir, namespace, logStoreName)
 	result, err := cmd.Output()

--- a/pkg/k8shandler/forwarding.go
+++ b/pkg/k8shandler/forwarding.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	outputTypes = sets.NewString(string(logforward.OutputTypeElasticsearch), string(logforward.OutputTypeForward))
+	outputTypes = sets.NewString(string(logforward.OutputTypeElasticsearch), string(logforward.OutputTypeForward), string(logforward.OutputTypeLegacySyslog))
 	sourceTypes = sets.NewString(string(logforward.LogSourceTypeApp), string(logforward.LogSourceTypeInfra), string(logforward.LogSourceTypeAudit))
 )
 

--- a/pkg/k8shandler/forwarding.go
+++ b/pkg/k8shandler/forwarding.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	outputTypes = sets.NewString(string(logforward.OutputTypeElasticsearch), string(logforward.OutputTypeForward), string(logforward.OutputTypeLegacySyslog))
+	outputTypes = sets.NewString(string(logforward.OutputTypeElasticsearch), string(logforward.OutputTypeForward), string(logforward.OutputTypeLegacySyslog), string(logforward.OutputTypeSyslog))
 	sourceTypes = sets.NewString(string(logforward.LogSourceTypeApp), string(logforward.LogSourceTypeInfra), string(logforward.LogSourceTypeAudit))
 )
 

--- a/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
@@ -1,0 +1,144 @@
+package fluent
+
+import (
+	"fmt"
+	"runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	logforward "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1alpha1"
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("LogForwarding", func() {
+	_, filename, _, _ := runtime.Caller(0)
+	logger.Infof("Running %s", filename)
+	var (
+		err              error
+		syslogDeployment *apps.Deployment
+		e2e              = helpers.NewE2ETestFramework()
+	)
+	BeforeEach(func() {
+		if err := e2e.DeployLogGenerator(); err != nil {
+			logger.Errorf("unable to deploy log generator. E: %s", err.Error())
+		}
+	})
+	Describe("when ClusterLogging is configured with 'forwarding' to an external syslog server", func() {
+
+		Context("with the legacy syslog plugin", func() {
+
+			Context("and tcp receiver", func() {
+
+				BeforeEach(func() {
+					if syslogDeployment, err = e2e.DeploySyslogReceiver(corev1.ProtocolTCP); err != nil {
+						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
+					}
+					cr := helpers.NewClusterLogging(helpers.ComponentTypeCollector)
+					if err := e2e.CreateClusterLogging(cr); err != nil {
+						Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+					}
+					forwarding := &logforward.LogForwarding{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       logforward.LogForwardingKind,
+							APIVersion: logforward.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "instance",
+						},
+						Spec: logforward.ForwardingSpec{
+							Outputs: []logforward.OutputSpec{
+								logforward.OutputSpec{
+									Name:     syslogDeployment.ObjectMeta.Name,
+									Type:     logforward.OutputTypeLegacySyslog,
+									Endpoint: fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace),
+								},
+							},
+							Pipelines: []logforward.PipelineSpec{
+								logforward.PipelineSpec{
+									Name:       "test-infra",
+									OutputRefs: []string{syslogDeployment.ObjectMeta.Name},
+									SourceType: logforward.LogSourceTypeInfra,
+								},
+							},
+						},
+					}
+					if err := e2e.CreateLogForwarding(forwarding); err != nil {
+						Fail(fmt.Sprintf("Unable to create an instance of logforwarding: %v", err))
+					}
+					components := []helpers.LogComponentType{helpers.ComponentTypeCollector}
+					for _, component := range components {
+						if err := e2e.WaitFor(component); err != nil {
+							Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
+						}
+					}
+				})
+
+				It("should send logs to the forward.Output logstore", func() {
+					Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+				})
+			})
+
+			Context("and udp receiver", func() {
+
+				BeforeEach(func() {
+					if syslogDeployment, err = e2e.DeploySyslogReceiver(corev1.ProtocolUDP); err != nil {
+						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
+					}
+					cr := helpers.NewClusterLogging(helpers.ComponentTypeCollector)
+					if err := e2e.CreateClusterLogging(cr); err != nil {
+						Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+					}
+					forwarding := &logforward.LogForwarding{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       logforward.LogForwardingKind,
+							APIVersion: logforward.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "instance",
+						},
+						Spec: logforward.ForwardingSpec{
+							Outputs: []logforward.OutputSpec{
+								logforward.OutputSpec{
+									Name:     syslogDeployment.ObjectMeta.Name,
+									Type:     logforward.OutputTypeLegacySyslog,
+									Endpoint: fmt.Sprintf("udp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace),
+								},
+							},
+							Pipelines: []logforward.PipelineSpec{
+								logforward.PipelineSpec{
+									Name:       "test-infra",
+									OutputRefs: []string{syslogDeployment.ObjectMeta.Name},
+									SourceType: logforward.LogSourceTypeInfra,
+								},
+							},
+						},
+					}
+					if err := e2e.CreateLogForwarding(forwarding); err != nil {
+						Fail(fmt.Sprintf("Unable to create an instance of logforwarding: %v", err))
+					}
+					components := []helpers.LogComponentType{helpers.ComponentTypeCollector}
+					for _, component := range components {
+						if err := e2e.WaitFor(component); err != nil {
+							Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
+						}
+					}
+				})
+
+				It("should send logs to the forward.Output logstore", func() {
+					Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+				})
+			})
+		})
+
+		AfterEach(func() {
+			e2e.Cleanup()
+		})
+
+	})
+
+})

--- a/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
@@ -2,6 +2,7 @@ package fluent
 
 import (
 	"fmt"
+	"path/filepath"
 	"runtime"
 
 	. "github.com/onsi/ginkgo"
@@ -22,11 +23,13 @@ var _ = Describe("LogForwarding", func() {
 		err              error
 		syslogDeployment *apps.Deployment
 		e2e              = helpers.NewE2ETestFramework()
+		pwd              string
 	)
 	BeforeEach(func() {
 		if err := e2e.DeployLogGenerator(); err != nil {
 			logger.Errorf("unable to deploy log generator. E: %s", err.Error())
 		}
+		pwd = filepath.Dir(filename)
 	})
 	Describe("when ClusterLogging is configured with 'forwarding' to an external syslog server", func() {
 
@@ -35,7 +38,7 @@ var _ = Describe("LogForwarding", func() {
 			Context("and tcp receiver", func() {
 
 				BeforeEach(func() {
-					if syslogDeployment, err = e2e.DeploySyslogReceiver(corev1.ProtocolTCP); err != nil {
+					if syslogDeployment, err = e2e.DeploySyslogReceiver(corev1.ProtocolTCP, pwd, false); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
 					cr := helpers.NewClusterLogging(helpers.ComponentTypeCollector)
@@ -86,7 +89,7 @@ var _ = Describe("LogForwarding", func() {
 			Context("and udp receiver", func() {
 
 				BeforeEach(func() {
-					if syslogDeployment, err = e2e.DeploySyslogReceiver(corev1.ProtocolUDP); err != nil {
+					if syslogDeployment, err = e2e.DeploySyslogReceiver(corev1.ProtocolUDP, pwd, false); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
 					cr := helpers.NewClusterLogging(helpers.ComponentTypeCollector)
@@ -106,6 +109,165 @@ var _ = Describe("LogForwarding", func() {
 								logforward.OutputSpec{
 									Name:     syslogDeployment.ObjectMeta.Name,
 									Type:     logforward.OutputTypeLegacySyslog,
+									Endpoint: fmt.Sprintf("udp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace),
+								},
+							},
+							Pipelines: []logforward.PipelineSpec{
+								logforward.PipelineSpec{
+									Name:       "test-infra",
+									OutputRefs: []string{syslogDeployment.ObjectMeta.Name},
+									SourceType: logforward.LogSourceTypeInfra,
+								},
+							},
+						},
+					}
+					if err := e2e.CreateLogForwarding(forwarding); err != nil {
+						Fail(fmt.Sprintf("Unable to create an instance of logforwarding: %v", err))
+					}
+					components := []helpers.LogComponentType{helpers.ComponentTypeCollector}
+					for _, component := range components {
+						if err := e2e.WaitFor(component); err != nil {
+							Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
+						}
+					}
+				})
+
+				It("should send logs to the forward.Output logstore", func() {
+					Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+				})
+			})
+		})
+
+		Context("with new syslog plugin", func() {
+
+			Context("and an unsecure tcp receiver", func() {
+
+				BeforeEach(func() {
+					if syslogDeployment, err = e2e.DeploySyslogReceiver(corev1.ProtocolTCP, pwd, false); err != nil {
+						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
+					}
+					cr := helpers.NewClusterLogging(helpers.ComponentTypeCollector)
+					if err := e2e.CreateClusterLogging(cr); err != nil {
+						Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+					}
+					forwarding := &logforward.LogForwarding{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       logforward.LogForwardingKind,
+							APIVersion: logforward.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "instance",
+						},
+						Spec: logforward.ForwardingSpec{
+							Outputs: []logforward.OutputSpec{
+								logforward.OutputSpec{
+									Name:     syslogDeployment.ObjectMeta.Name,
+									Type:     logforward.OutputTypeSyslog,
+									Endpoint: fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace),
+								},
+							},
+							Pipelines: []logforward.PipelineSpec{
+								logforward.PipelineSpec{
+									Name:       "test-infra",
+									OutputRefs: []string{syslogDeployment.ObjectMeta.Name},
+									SourceType: logforward.LogSourceTypeInfra,
+								},
+							},
+						},
+					}
+					if err := e2e.CreateLogForwarding(forwarding); err != nil {
+						Fail(fmt.Sprintf("Unable to create an instance of logforwarding: %v", err))
+					}
+					components := []helpers.LogComponentType{helpers.ComponentTypeCollector}
+					for _, component := range components {
+						if err := e2e.WaitFor(component); err != nil {
+							Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
+						}
+					}
+				})
+
+				It("should send logs to the forward.Output logstore", func() {
+					Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+				})
+			})
+
+			Context("and a secure receiver", func() {
+
+				BeforeEach(func() {
+					if syslogDeployment, err = e2e.DeploySyslogReceiver(corev1.ProtocolTCP, pwd, true); err != nil {
+						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
+					}
+					cr := helpers.NewClusterLogging(helpers.ComponentTypeCollector)
+					if err := e2e.CreateClusterLogging(cr); err != nil {
+						Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+					}
+					forwarding := &logforward.LogForwarding{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       logforward.LogForwardingKind,
+							APIVersion: logforward.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "instance",
+						},
+						Spec: logforward.ForwardingSpec{
+							Outputs: []logforward.OutputSpec{
+								logforward.OutputSpec{
+									Name:     syslogDeployment.ObjectMeta.Name,
+									Type:     logforward.OutputTypeSyslog,
+									Endpoint: fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace),
+									Secret: &logforward.OutputSecretSpec{
+										Name: syslogDeployment.ObjectMeta.Name,
+									},
+								},
+							},
+							Pipelines: []logforward.PipelineSpec{
+								logforward.PipelineSpec{
+									Name:       "test-infra",
+									OutputRefs: []string{syslogDeployment.ObjectMeta.Name},
+									SourceType: logforward.LogSourceTypeInfra,
+								},
+							},
+						},
+					}
+					if err := e2e.CreateLogForwarding(forwarding); err != nil {
+						Fail(fmt.Sprintf("Unable to create an instance of logforwarding: %v", err))
+					}
+					components := []helpers.LogComponentType{helpers.ComponentTypeCollector}
+					for _, component := range components {
+						if err := e2e.WaitFor(component); err != nil {
+							Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
+						}
+					}
+				})
+
+				It("should send logs to the forward.Output logstore", func() {
+					Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+				})
+			})
+
+			Context("and a udp receiver", func() {
+
+				BeforeEach(func() {
+					if syslogDeployment, err = e2e.DeploySyslogReceiver(corev1.ProtocolUDP, pwd, false); err != nil {
+						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
+					}
+					cr := helpers.NewClusterLogging(helpers.ComponentTypeCollector)
+					if err := e2e.CreateClusterLogging(cr); err != nil {
+						Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+					}
+					forwarding := &logforward.LogForwarding{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       logforward.LogForwardingKind,
+							APIVersion: logforward.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "instance",
+						},
+						Spec: logforward.ForwardingSpec{
+							Outputs: []logforward.OutputSpec{
+								logforward.OutputSpec{
+									Name:     syslogDeployment.ObjectMeta.Name,
+									Type:     logforward.OutputTypeSyslog,
 									Endpoint: fmt.Sprintf("udp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace),
 								},
 							},

--- a/test/e2e/logforwarding/syslog/logforwarding_suite_test.go
+++ b/test/e2e/logforwarding/syslog/logforwarding_suite_test.go
@@ -1,0 +1,13 @@
+package fluent
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogForwarding(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LogForwarding Integration E2E Suite - Forward to syslog")
+}

--- a/test/e2e/logforwarding/syslog/syslog_cert_generation.sh
+++ b/test/e2e/logforwarding/syslog/syslog_cert_generation.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+set -e
+
+WORKING_DIR=$1
+NAMESPACE=$2
+LOG_STORE=$3
+
+function generate_signing_ca() {
+  openssl req -x509 \
+              -new \
+              -newkey rsa:4096 \
+              -keyout ${WORKING_DIR}/ca-syslog.key \
+              -nodes \
+              -days 1825 \
+              -out ${WORKING_DIR}/ca-syslog.crt \
+              -subj "/CN=openshift-cluster-logging-signer"
+}
+
+function init_cert_files() {
+
+  if [ ! -f ${WORKING_DIR}/ca.db ]; then
+    touch ${WORKING_DIR}/ca.db
+  fi
+
+  if [ ! -f ${WORKING_DIR}/ca.serial.txt ]; then
+    echo 00 > ${WORKING_DIR}/ca.serial.txt
+  fi
+}
+
+function generate_cert_config() {
+  local subject=$1
+  cat <<EOF > "${WORKING_DIR}/syslog-server.conf"
+[ req ]
+default_bits = 4096
+prompt = no
+encrypt_key = yes
+default_md = sha512
+distinguished_name = dn
+[ dn ]
+CN = ${subject}
+OU = OpenShift
+O = Logging
+EOF
+}
+
+function generate_request() {
+  openssl req -new                                        \
+          -out ${WORKING_DIR}/syslog-server.csr           \
+          -newkey rsa:4096                                \
+          -keyout ${WORKING_DIR}/syslog-server.key        \
+          -config ${WORKING_DIR}/syslog-server.conf       \
+          -days 712                                       \
+          -nodes
+}
+
+function sign_cert() {
+  openssl ca \
+          -in ${WORKING_DIR}/syslog-server.csr  \
+          -notext                               \
+          -out ${WORKING_DIR}/syslog-server.crt \
+          -config ${WORKING_DIR}/signing.conf   \
+          -extensions v3_req                    \
+          -batch                                \
+          -extensions server_ext
+}
+
+function generate_certs() {
+  local subject=$1
+
+  generate_cert_config $subject
+  generate_request
+  sign_cert
+}
+
+function create_signing_conf() {
+  cat <<EOF > "${WORKING_DIR}/signing.conf"
+# Simple Signing CA
+
+# The [default] section contains global constants that can be referred to from
+# the entire configuration file. It may also hold settings pertaining to more
+# than one openssl command.
+
+[ default ]
+dir                     = ${WORKING_DIR}               # Top dir
+
+# The next part of the configuration file is used by the openssl req command.
+# It defines the CA's key pair, its DN, and the desired extensions for the CA
+# certificate.
+
+[ req ]
+default_bits            = 4096                  # RSA key size
+encrypt_key             = yes                   # Protect private key
+default_md              = sha512                # MD to use
+utf8                    = yes                   # Input is UTF-8
+string_mask             = utf8only              # Emit UTF-8 strings
+prompt                  = no                    # Don't prompt for DN
+distinguished_name      = ca_dn                 # DN section
+req_extensions          = ca_reqext             # Desired extensions
+
+[ ca_dn ]
+0.domainComponent       = "io"
+1.domainComponent       = "openshift"
+organizationName        = "OpenShift Origin"
+organizationalUnitName  = "Logging Signing CA"
+commonName              = "Logging Signing CA"
+
+[ ca_reqext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true,pathlen:0
+subjectKeyIdentifier    = hash
+
+# The remainder of the configuration file is used by the openssl ca command.
+# The CA section defines the locations of CA assets, as well as the policies
+# applying to the CA.
+
+[ ca ]
+default_ca              = signing_ca            # The default CA section
+
+[ signing_ca ]
+certificate             = \$dir/ca-syslog.crt       # The CA cert
+private_key             = \$dir/ca-syslog.key # CA private key
+new_certs_dir           = \$dir/           # Certificate archive
+serial                  = \$dir/ca.serial.txt # Serial number file
+crlnumber               = \$dir/ca.crl.srl # CRL number file
+database                = \$dir/ca.db # Index file
+unique_subject          = no                    # Require unique subject
+default_days            = 730                   # How long to certify for
+default_md              = sha512                # MD to use
+policy                  = any_pol             # Default naming policy
+email_in_dn             = no                    # Add email to cert DN
+preserve                = no                    # Keep passed DN ordering
+name_opt                = ca_default            # Subject DN display options
+cert_opt                = ca_default            # Certificate display options
+copy_extensions         = copy                  # Copy extensions from CSR
+x509_extensions         = client_ext             # Default cert extensions
+default_crl_days        = 7                     # How long before next CRL
+crl_extensions          = crl_ext               # CRL extensions
+
+# Naming policies control which parts of a DN end up in the certificate and
+# under what circumstances certification should be denied.
+
+[ match_pol ]
+domainComponent         = match                 # Must match 'simple.org'
+organizationName        = match                 # Must match 'Simple Inc'
+organizationalUnitName  = optional              # Included if present
+commonName              = supplied              # Must be present
+
+[ any_pol ]
+domainComponent         = optional
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = optional
+emailAddress            = optional
+
+# Certificate extensions define what types of certificates the CA is able to
+# create.
+
+[ client_ext ]
+keyUsage                = critical,digitalSignature,keyEncipherment
+basicConstraints        = CA:false
+extendedKeyUsage        = clientAuth
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid
+
+[ server_ext ]
+keyUsage                = critical,digitalSignature,keyEncipherment
+basicConstraints        = CA:false
+extendedKeyUsage        = serverAuth,clientAuth
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid
+
+# CRL extensions exist solely to point to the CA certificate that has issued
+# the CRL.
+
+[ crl_ext ]
+authorityKeyIdentifier  = keyid
+EOF
+}
+
+
+generate_signing_ca
+init_cert_files
+create_signing_conf
+
+generate_certs ${LOG_STORE}.${NAMESPACE}.svc

--- a/test/helpers/syslog.go
+++ b/test/helpers/syslog.go
@@ -1,0 +1,248 @@
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/cluster-logging-operator/pkg/k8shandler"
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	"github.com/openshift/cluster-logging-operator/pkg/utils"
+)
+
+type syslogReceiverLogStore struct {
+	deployment *apps.Deployment
+	tc         *E2ETestFramework
+}
+
+const (
+	syslogReceiverName = "syslog-receiver"
+	tcpSyslogConf      = `
+# Provides TCP syslog reception
+# for parameters see http://www.rsyslog.com/doc/imtcp.html
+module(load="imtcp") # needs to be done just once
+input(type="imtcp" port="24224" ruleset="test")
+
+#### RULES ####
+ruleset(name="test"){
+    action(type="omfile" file="/var/log/infra.log")
+}
+	`
+	udpSyslogConf = `
+# Provides UDP syslog reception
+# for parameters see http://www.rsyslog.com/doc/imudp.html
+module(load="imudp") # needs to be done just once
+input(type="imudp" port="24224" ruleset="test")
+#### RULES ####
+ruleset(name="test"){
+    action(type="omfile" file="/var/log/infra.log")
+}
+	`
+)
+
+func (syslog *syslogReceiverLogStore) hasLogs(file string, timeToWait time.Duration) (bool, error) {
+	options := metav1.ListOptions{
+		LabelSelector: "component=syslog-receiver",
+	}
+	pods, err := syslog.tc.KubeClient.CoreV1().Pods(OpenshiftLoggingNS).List(options)
+	if err != nil {
+		return false, err
+	}
+	if len(pods.Items) == 0 {
+		return false, errors.New("No pods found for syslog receiver")
+	}
+	logger.Debugf("Pod %s", pods.Items[0].Name)
+	cmd := fmt.Sprintf("ls %s | wc -l", file)
+
+	err = wait.Poll(defaultRetryInterval, timeToWait, func() (done bool, err error) {
+		output, err := syslog.tc.PodExec(OpenshiftLoggingNS, pods.Items[0].Name, "syslog-receiver", []string{"bash", "-c", cmd})
+		if err != nil {
+			return false, err
+		}
+		value, err := strconv.Atoi(strings.TrimSpace(output))
+		if err != nil {
+			logger.Debugf("Error parsing output: %s", output)
+			return false, nil
+		}
+		return value > 0, nil
+	})
+	if err == wait.ErrWaitTimeout {
+		return false, err
+	}
+	return true, err
+}
+
+func (syslog *syslogReceiverLogStore) HasInfraStructureLogs(timeToWait time.Duration) (bool, error) {
+	return syslog.hasLogs("/var/log/infra.log", timeToWait)
+}
+
+func (syslog *syslogReceiverLogStore) HasApplicationLogs(timeToWait time.Duration) (bool, error) {
+	return false, fmt.Errorf("Not implemented")
+}
+
+func (syslog *syslogReceiverLogStore) HasAuditLogs(timeToWait time.Duration) (bool, error) {
+	return false, fmt.Errorf("Not implemented")
+}
+
+func (tc *E2ETestFramework) createSyslogServiceAccount() (serviceAccount *corev1.ServiceAccount, err error) {
+	serviceAccount = k8shandler.NewServiceAccount("syslog-receiver", OpenshiftLoggingNS)
+	if serviceAccount, err = tc.KubeClient.Core().ServiceAccounts(OpenshiftLoggingNS).Create(serviceAccount); err != nil {
+		return nil, err
+	}
+	tc.AddCleanup(func() error {
+		return tc.KubeClient.Core().ServiceAccounts(OpenshiftLoggingNS).Delete(serviceAccount.Name, nil)
+	})
+	return serviceAccount, nil
+}
+
+func (tc *E2ETestFramework) createSyslogRbac(name string) (err error) {
+	saRole := k8shandler.NewRole(
+		name,
+		OpenshiftLoggingNS,
+		k8shandler.NewPolicyRules(
+			k8shandler.NewPolicyRule(
+				[]string{"security.openshift.io"},
+				[]string{"securitycontextconstraints"},
+				[]string{"privileged"},
+				[]string{"use"},
+			),
+		),
+	)
+	if _, err = tc.KubeClient.Rbac().Roles(OpenshiftLoggingNS).Create(saRole); err != nil {
+		return err
+	}
+	tc.AddCleanup(func() error {
+		return tc.KubeClient.Rbac().Roles(OpenshiftLoggingNS).Delete(name, nil)
+	})
+	subject := k8shandler.NewSubject(
+		"ServiceAccount",
+		name,
+	)
+	subject.APIGroup = ""
+	roleBinding := k8shandler.NewRoleBinding(
+		name,
+		OpenshiftLoggingNS,
+		saRole.Name,
+		k8shandler.NewSubjects(
+			subject,
+		),
+	)
+	if _, err = tc.KubeClient.Rbac().RoleBindings(OpenshiftLoggingNS).Create(roleBinding); err != nil {
+		return err
+	}
+	tc.AddCleanup(func() error {
+		return tc.KubeClient.Rbac().RoleBindings(OpenshiftLoggingNS).Delete(name, nil)
+	})
+	return nil
+}
+
+func (tc *E2ETestFramework) DeploySyslogReceiver(protocol corev1.Protocol) (deployment *apps.Deployment, err error) {
+	logStore := &syslogReceiverLogStore{
+		tc: tc,
+	}
+	serviceAccount, err := tc.createSyslogServiceAccount()
+	if err != nil {
+		return nil, err
+	}
+	if err := tc.createSyslogRbac(syslogReceiverName); err != nil {
+		return nil, err
+	}
+	container := corev1.Container{
+		Name:            syslogReceiverName,
+		Image:           "quay.io/openshift/origin-logging-rsyslog:latest",
+		ImagePullPolicy: corev1.PullAlways,
+		Args:            []string{"rsyslogd", "-n", "-f", "/rsyslog/etc/rsyslog.conf"},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "config",
+				ReadOnly:  true,
+				MountPath: "/rsyslog/etc",
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: utils.GetBool(true),
+		},
+	}
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{container},
+		Volumes: []corev1.Volume{
+			{
+				Name: "config", VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: container.Name,
+						},
+					},
+				},
+			},
+		},
+		ServiceAccountName: serviceAccount.Name,
+	}
+
+	var rsyslogConf string
+	switch {
+	case protocol == corev1.ProtocolUDP:
+		rsyslogConf = udpSyslogConf
+	default:
+		rsyslogConf = tcpSyslogConf
+	}
+
+	config := k8shandler.NewConfigMap(container.Name, OpenshiftLoggingNS, map[string]string{
+		"rsyslog.conf": rsyslogConf,
+	})
+	config, err = tc.KubeClient.Core().ConfigMaps(OpenshiftLoggingNS).Create(config)
+	if err != nil {
+		return nil, err
+	}
+	tc.AddCleanup(func() error {
+		return tc.KubeClient.Core().ConfigMaps(OpenshiftLoggingNS).Delete(config.Name, nil)
+	})
+
+	syslogDeployment := k8shandler.NewDeployment(
+		container.Name,
+		OpenshiftLoggingNS,
+		container.Name,
+		serviceAccount.Name,
+		podSpec,
+	)
+
+	syslogDeployment, err = tc.KubeClient.Apps().Deployments(OpenshiftLoggingNS).Create(syslogDeployment)
+	if err != nil {
+		return nil, err
+	}
+	service := k8shandler.NewService(
+		serviceAccount.Name,
+		OpenshiftLoggingNS,
+		serviceAccount.Name,
+		[]corev1.ServicePort{
+			{
+				Protocol: protocol,
+				Port:     24224,
+			},
+		},
+	)
+	tc.AddCleanup(func() error {
+		var zerograce int64
+		deleteopts := metav1.DeleteOptions{
+			GracePeriodSeconds: &zerograce,
+		}
+		return tc.KubeClient.AppsV1().Deployments(OpenshiftLoggingNS).Delete(syslogDeployment.Name, &deleteopts)
+	})
+	service, err = tc.KubeClient.Core().Services(OpenshiftLoggingNS).Create(service)
+	if err != nil {
+		return nil, err
+	}
+	tc.AddCleanup(func() error {
+		return tc.KubeClient.Core().Services(OpenshiftLoggingNS).Delete(service.Name, nil)
+	})
+	logStore.deployment = syslogDeployment
+	tc.LogStore = logStore
+	return syslogDeployment, tc.waitForDeployment(OpenshiftLoggingNS, syslogDeployment.Name, defaultRetryInterval, defaultTimeout)
+}


### PR DESCRIPTION
This PR continues #341 and introduces an alternative way to specify syslog output within the `LogForwarding` CR that is based on a new plugin for fluentd (see openshift/origin-aggregated-logging#1826).

This PR fixes openshift/origin-aggregated-logging#1547 by enabling to transmit the logs over tcp+tls.

The secure connection can be specified as follow:
```yaml
spec:
  outputs:
  - name: syslog
    type: syslog
    endpoint: "10.46.9.101:515"
    secret:
      name: my-secret
  pipelines:
  - name: logsapp
    inputSource: logs.audit
    outputRefs:
    - syslog
```

Alternatively, the transport protocol can be set to udp (note the `endpoint` property):
```yaml
spec:
  outputs:
  - name: syslog
    type: syslog
    endpoint: "udp://10.46.9.101:515"
  pipelines:
  - name: logsapp
    inputSource: logs.audit
    outputRefs:
    - syslog
```
Or to unsecure tcp (which is also the case when no protocol is specified):
```yaml
spec:
  outputs:
  - name: syslog
    type: syslog
    endpoint: "tcp://10.46.9.101:515"
  pipelines:
  - name: logsapp
    inputSource: logs.audit
    outputRefs:
    - syslog
```

This allows us to deprecate the output type `syslog-legacy` and remove it once we feel the new plugin provides all the necessary things that were provided by the previous plugin.