### PR TITLE
Add Role and RoleBinding for console-operator to read the sharing-config

### DIFF
--- a/manifests/4.4/0120_roles.yaml
+++ b/manifests/4.4/0120_roles.yaml
@@ -1,0 +1,14 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: logging-configmap-reader
+  namespace: openshift-logging
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - sharing-config
+  verbs:
+  - get

--- a/manifests/4.4/0130_rolebindings.yaml
+++ b/manifests/4.4/0130_rolebindings.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator
+  namespace: openshift-logging
+roleRef:
+  kind: Role
+  name: logging-configmap-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console-operator
+    namespace: openshift-console-operator


### PR DESCRIPTION
Related [PR](https://github.com/openshift/console-operator/pull/379) with some background [background](https://github.com/openshift/console-operator/pull/379#discussion_r378811466). Basically since the `openshift-logging` namaspace is not created by default on the cluster we need to add the required role and rolebinding for the console-operator here.

@benjaminapetersen fyi

/assign @jcantrill 