### PR TITLE
Bug 1802934: Fix incorrect olm.skipRange in 4.3 CSV

### DIFF
--- a/manifests/4.3/cluster-logging.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/4.3/cluster-logging.v4.3.0.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
     createdAt: 2018-08-01T08:00:00Z
     support: AOS Logging
     # The version value is substituted by the ART pipeline
-    olm.skipRange: ">=4.2.0 <4.3.0"
+    olm.skipRange: ">=4.1.0 <4.3.0"
     alm-examples: |-
         [
           {


### PR DESCRIPTION
Fix an issue where the cluster-logging-operator couldn't be upgraded because it doesn't match the update_list defined in art.yaml nor configured in correct range.

Similar issue https://github.com/openshift/elasticsearch-operator/pull/237