### PR TITLE
Fix make targets for local development environment

### DIFF
--- a/hack/common
+++ b/hack/common
@@ -11,7 +11,7 @@ source "$repo_dir/hack/lib/init.sh"
 source "$repo_dir/hack/testing/utils"
 source "$repo_dir/hack/testing/assertions"
 
-VERSION=${VERSION:-$(basename $(find ${repo_dir}/../manifests -type d | sort -r | head -n 1))}
+VERSION=${VERSION:-$(basename $(find ${repo_dir}/manifests -type d | sort -r | head -n 1))}
 ELASTICSEARCH_OP_REPO=${ELASTICSEARCH_OP_REPO:-${repo_dir}/../elasticsearch-operator}
 
 ADMIN_USER=${ADMIN_USER:-kubeadmin}


### PR DESCRIPTION
This PR provides a small fix for a glitch landed by merging the feature-es6 branch back to master. It enables execution of make targets against a development cluster from a local development environment, where basic environment variables are substituted from the manifests.