### PR TITLE
Bug 1808986: Adding nodeSelector to operator deployment

### DIFF
--- a/manifests/4.5/cluster-logging.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/cluster-logging.v4.5.0.clusterserviceversion.yaml
@@ -287,6 +287,8 @@ spec:
               labels:
                 name: cluster-logging-operator
             spec:
+              nodeSelector:
+                kubernetes.io/os: linux
               serviceAccountName: cluster-logging-operator
               containers:
               - name: cluster-logging-operator


### PR DESCRIPTION
Adds a `"kubernetes.io/os": "linux"` node selector for the ClusterLoggingOperator deployment

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1808986