### PR TITLE
Bug 1811870: Synced doc version in the CLO description, v 4.4

### DIFF
--- a/manifests/4.4/cluster-logging.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/cluster-logging.v4.4.0.clusterserviceversion.yaml
@@ -111,7 +111,7 @@ spec:
     must be explicitly created by a cluster administrator (e.g. `oc create ns openshift-logging`). To enable metrics
     service discovery add namespace label `openshift.io/cluster-monitoring: "true"`.
 
-    For additional installation documentation see [Deploying cluster logging](https://docs.openshift.com/container-platform/4.1/logging/efk-logging-deploying.html)
+    For additional installation documentation see [Deploying cluster logging](https://docs.openshift.com/container-platform/4.4/logging/cluster-logging-deploying.html)
     in the OpenShift product documentation.
 
     ### Elasticsearch Operator


### PR DESCRIPTION
A fix for the doc URL in the CLO description in the web console