### PR TITLE
Bug 1812920: Adding nodeSelector to operator deployment

### DIFF
--- a/manifests/4.4/cluster-logging.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/cluster-logging.v4.4.0.clusterserviceversion.yaml
@@ -282,6 +282,8 @@ spec:
               labels:
                 name: cluster-logging-operator
             spec:
+              nodeSelector:
+                kubernetes.io/os: linux
               serviceAccountName: cluster-logging-operator
               containers:
               - name: cluster-logging-operator


### PR DESCRIPTION
Manual cherry-pick of #392
Adds a `"kubernetes.io/os": "linux"` node selector for the ClusterLoggingOperator deployment

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1812920