### PR TITLE
Fix for #375: Proxyconfig-controller fails to delete logcollector service account

### DIFF
--- a/pkg/k8shandler/reconciler.go
+++ b/pkg/k8shandler/reconciler.go
@@ -68,6 +68,9 @@ func ReconcileForLogForwarding(forwarding *logforwarding.LogForwarding, requestC
 	}
 
 	clusterLogging := clusterLoggingRequest.getClusterLogging()
+	if clusterLogging == nil {
+		return nil
+	}
 	clusterLoggingRequest.cluster = clusterLogging
 
 	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {
@@ -91,6 +94,10 @@ func ReconcileForGlobalProxy(proxyConfig *configv1.Proxy, requestClient client.C
 	}
 
 	clusterLogging := clusterLoggingRequest.getClusterLogging()
+	if clusterLogging == nil {
+		return nil
+	}
+
 	clusterLoggingRequest.cluster = clusterLogging
 
 	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {
@@ -122,6 +129,10 @@ func ReconcileForTrustedCABundle(requestName string, requestClient client.Client
 	}
 
 	clusterLogging := clusterLoggingRequest.getClusterLogging()
+	if clusterLogging == nil {
+		return nil
+	}
+
 	clusterLoggingRequest.cluster = clusterLogging
 
 	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {
@@ -156,6 +167,10 @@ func ReconcileForKibanaSecret(requestClient client.Client) (err error) {
 	}
 
 	clusterLogging := clusterLoggingRequest.getClusterLogging()
+	if clusterLogging == nil {
+		return nil
+	}
+
 	clusterLoggingRequest.cluster = clusterLogging
 
 	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {
@@ -176,6 +191,7 @@ func (clusterRequest *ClusterLoggingRequest) getClusterLogging() *logging.Cluste
 		if !apierrors.IsNotFound(err) {
 			fmt.Printf("Encountered unexpected error getting %v", clusterLoggingNamespacedName)
 		}
+		return nil
 	}
 
 	return clusterLogging


### PR DESCRIPTION
Fix for #375. 

Preconditions:
```logging.openshift.io/ClusterLogging``` named "instance" is missing
```config.openshift.io/Proxy``` named "cluster" exists

The CLO comes up, finds the cluster-wide Proxy object, triggers a reconcile and the following call chain builds up:

```go
k8shandler.(*ClusterLoggingRequest).RemoveServiceAccount()
k8shandler(*ClusterLoggingRequest).CreateOrUpdateCollection()
k8shandler.ReconcileForGlobalProxy()
proxyconfig.(*ReconcileProxyConfig).Reconcile()
```

There's no logging.openshift.io/ClusterLogging instance, so in ```ReconcileForGlobalProxy()```, ```getClusterLogging()``` returns an empty object, which on the next line is used to populate clusterLoggingRequest.cluster:

```
clusterLoggingRequest.cluster = clusterLogging
```

In ```RemoveServiceAccount()```, the namespace of the sa is taken from clusterRequest.cluster.Namespace, which is empty. Attempts to delete that sa cause errors that trigger further reconciles, with exponential backoff. This keeps happening until the ClusterLogging instance is created.