### PR TITLE
Fix for LOG-676, prevent a hotlooping reconcile for a terminated curator job

### DIFF
--- a/pkg/k8shandler/status.go
+++ b/pkg/k8shandler/status.go
@@ -291,7 +291,7 @@ func (clusterRequest *ClusterLoggingRequest) getPodConditions(component string) 
 						Status:             v1.ConditionTrue,
 						Reason:             containerStatus.State.Terminated.Reason,
 						Message:            containerStatus.State.Terminated.Message,
-						LastTransitionTime: metav1.Now(),
+						LastTransitionTime: containerStatus.State.Terminated.FinishedAt,
 					})
 				}
 			}


### PR DESCRIPTION
This fix replaces the changing lastTransitionTime for Terminated container statuses with the actual termination time (FinishedAt), thus preventing a hotloop reconcile over status that is known to not change.