### PR TITLE
LOG-682: Remove _output directory, simplify Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 .git/*
-_output/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 pf.log
-_output
 # GoLand
 .idea
 # Temporary Build Files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-logging-operator
 COPY . .
-RUN make
+RUN make build
 
 FROM centos:centos7
 RUN INSTALL_PKGS=" \
@@ -12,7 +12,7 @@ RUN INSTALL_PKGS=" \
     yum clean all && \
     mkdir /tmp/ocp-clo && \
     chmod og+w /tmp/ocp-clo
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/_output/bin/cluster-logging-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/bin/cluster-logging-operator /usr/bin/
 COPY scripts/* /usr/bin/scripts/
 RUN mkdir -p /usr/share/logging/
 COPY files/ /usr/share/logging/

--- a/Makefile
+++ b/Makefile
@@ -1,62 +1,34 @@
-TARGET_DIR=$(CURDIR)/_output
 KUBECONFIG?=$(HOME)/.kube/config
 
-GOBUILD=go build
-BUILD_GOPATH=$(TARGET_DIR):$(TARGET_DIR)/vendor:$(CURDIR)/cmd
+export GOBIN=$(CURDIR)/bin
+export PATH:=$(GOBIN):$(PATH)
 
-IMAGE_BUILDER_OPTS=
-IMAGE_BUILDER?=imagebuilder
-IMAGE_BUILD=$(IMAGE_BUILDER)
 export IMAGE_TAG_CMD?=docker tag
 
 export APP_NAME=cluster-logging-operator
-APP_REPO=github.com/openshift/$(APP_NAME)
-TARGET=$(TARGET_DIR)/bin/$(APP_NAME)
-IMAGE_TAG?=quay.io/openshift/origin-$(APP_NAME):latest
-export IMAGE_TAG
-MAIN_PKG=cmd/manager/main.go
-export OCP_VERSION?=$(shell basename $(shell find manifests/  -maxdepth 1  -not -name manifests -type d))
-export CSV_FILE=$(CURDIR)/manifests/$(OCP_VERSION)/cluster-logging.v$(OCP_VERSION).0.clusterserviceversion.yaml
+export IMAGE_TAG?=quay.io/openshift/origin-$(APP_NAME):latest
+
+export OCP_VERSION?=4.5
 export NAMESPACE?=openshift-logging
-export EO_CSV_FILE=$(CURDIR)/vendor/github.com/openshift/elasticsearch-operator/manifests/$(OCP_VERSION)/elasticsearch-operator.v$(OCP_VERSION).0.clusterserviceversion.yaml
 
 FLUENTD_IMAGE?=quay.io/openshift/origin-logging-fluentd:latest
 
-PKGS=$(shell go list ./... | grep -v -E '/vendor/|/test|/examples')
-TEST_PKGS=$(shell go list ./test)
+.PHONY: all build clean fmt generate regenerate deploy-setup deploy-image image deploy deploy-example test-unit test-e2e test-sec undeploy run operator-sdk imagebuilder golangci-lint
 
-TEST_OPTIONS?=
+# Run all local pre-merge tests. CI runs additional system tests on the image.
+all: generate fmt test-unit lint
 
-# go source files, excluding generated code.
-SRC = $(shell find cmd pkg version -type f -name '*.go' -not -name zz_generated*)
-
-.PHONY: all imagebuilder build clean fmt simplify generate deploy-setup deploy-image deploy deploy-example test-unit test-e2e test-sec undeploy run
-
-all: build #check install
-
-# Download a known released version of operator-sdk.
-OPERATOR_SDK_RELEASE?=v0.15.2
-OPERATOR_SDK=./operator-sdk-$(OPERATOR_SDK_RELEASE)
-$(OPERATOR_SDK):
-	curl -f -L -o $@ https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_RELEASE}/operator-sdk-${OPERATOR_SDK_RELEASE}-$(shell uname -i)-linux-gnu
-	chmod +x $(OPERATOR_SDK)
-
+# Download tools if not available on local PATH.
+operator-sdk:
+	@type -p operator-sdk > /dev/null || bash hack/get-operator-sdk.sh
 imagebuilder:
-	@if [ $${USE_IMAGE_STREAM:-false} = false ] && ! type -p imagebuilder ; \
-	then go get -u github.com/openshift/imagebuilder/cmd/imagebuilder ; \
-	fi
+	@type -p imagebuilder > /dev/null || go get github.com/openshift/imagebuilder/cmd/imagebuilder
+golangci-lint:
+	@type -p golangci-lint > /dev/null || go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
-build: fmt
-	@mkdir -p $(TARGET_DIR)/src/$(APP_REPO)
-	@cp -ru $(CURDIR)/pkg $(TARGET_DIR)/src/$(APP_REPO)
-	@cp -ru $(CURDIR)/vendor/* $(TARGET_DIR)/src
-	GOPATH=$(BUILD_GOPATH) $(GOBUILD) $(LDFLAGS) -o $(TARGET) $(MAIN_PKG)
 
-build-fast:
-	@mkdir -p $(TARGET_DIR)/src/$(APP_REPO)
-	@cp -ru $(CURDIR)/pkg $(TARGET_DIR)/src/$(APP_REPO)
-	@cp -ru $(CURDIR)/vendor/* $(TARGET_DIR)/src
-	GOPATH=$(BUILD_GOPATH) $(GOBUILD) $(LDFLAGS) -o $(TARGET) $(MAIN_PKG)
+build:
+	go build -o bin/cluster-logging-operator ./cmd/manager
 
 run:
 	ELASTICSEARCH_IMAGE=quay.io/openshift/origin-logging-elasticsearch6:latest \
@@ -66,42 +38,44 @@ run:
 	OAUTH_PROXY_IMAGE=quay.io/openshift/origin-oauth-proxy:latest \
 	PROMTAIL_IMAGE=quay.io/openshift/origin-promtail:latest \
 	OPERATOR_NAME=cluster-logging-operator \
-	WATCH_NAMESPACE=openshift-logging \
+	WATCH_NAMESPACE=$(NAMESPACE) \
 	KUBERNETES_CONFIG=$(KUBECONFIG) \
 	WORKING_DIR=$(TARGET_DIR)/ocp-clo \
 	LOGGING_SHARE_DIR=$(CURDIR)/files \
-	go run ${MAIN_PKG}
+	go run cmd/manager/main.go
 
 clean:
-	@rm -rf $(TARGET_DIR) && \
-	go clean -cache -testcache  $(TEST_PKGS) $(PKGS)
+	@rm -f bin/operator-sdk bin/imagebuilder bin/golangci-lint bin/cluster-logging-operator
+	go clean -cache -testcache ./...
 
-image: imagebuilder
+image: build
+	$(MAKE) imagebuilder
 	@if [ $${USE_IMAGE_STREAM:-false} = false ] && [ $${SKIP_BUILD:-false} = false ] ; \
-	then hack/build-image.sh $(IMAGE_TAG) $(IMAGE_BUILDER) $(IMAGE_BUILDER_OPTS) ; \
+	then hack/build-image.sh $(IMAGE_TAG) imagebuilder $(IMAGE_BUILDER_OPTS) ; \
 	fi
 
-lint:
+lint: fmt
+	@$(MAKE) golangci-lint
 	golangci-lint run -c golangci.yaml
 
 fmt:
-	gofmt -l -w cmd/ pkg/ version/
+	@echo gofmt		# Show progress, real gofmt line is too long
+	@gofmt -s -l -w $(shell find pkg cmd -name '*.go')
 
-simplify:
-	gofmt -s -l -w $(SRC)
-
+# Do all code/CRD generation at once, with timestamp file to check out-of-date.
 GEN_TIMESTAMP=.zz_generate_timestamp
 generate: $(GEN_TIMESTAMP)
-$(GEN_TIMESTAMP): $(SRC) $(OPERATOR_SDK)
-	@$(OPERATOR_SDK) generate k8s
-	@$(OPERATOR_SDK) generate crds
+$(GEN_TIMESTAMP): $(shell find pkg/apis -name '*.go')
+	@echo generating code
+	@$(MAKE) operator-sdk
+	@operator-sdk generate k8s
+	@operator-sdk generate crds
+	@$(MAKE) fmt
 	@touch $@
 
-# spotless does make clean and removes generated code. Don't commit without re-generating.
-spotless: clean
-	@find pkg -name 'zz_generated*' -delete -print
-	@rm -vrf deploy/crds/*.yaml
-	@rm -vf $(GEN_TIMESTAMP)
+regenerate:
+	@rm -f $(GEN_TIMESTAMP)
+	@$(MAKE) generate
 
 deploy-image: image
 	hack/deploy-image.sh
@@ -118,8 +92,8 @@ deploy-elasticsearch-operator:
 deploy-example: deploy
 	oc create -n $(NAMESPACE) -f hack/cr.yaml
 
-test-unit: fmt
-	@LOGGING_SHARE_DIR=$(CURDIR)/files go test $(TEST_OPTIONS) $(PKGS)
+test-unit:
+	go test ./pkg/...
 
 test-e2e:
 	hack/test-e2e.sh

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ An operator to support OKD aggregated cluster logging.  Cluster logging configur
 is found in the [configuration](./docs/configuration.md) documentation.
 
 ## Quick Start
+
 To get started with cluster logging and the `cluster-logging-operator`:
-* Ensure Docker is installed on your local system [(**Note** for Fedora 31)](./docs/fedora31.md)
-* Ensure skopeo is installed, e.g. `sudo dnf install -y skopeo`
+* Ensure `docker` is installed on your local system [(**Note** for Fedora 31)](./docs/fedora31.md)
+* Ensure `skopeo` is installed, e.g. `sudo dnf install -y skopeo`
 ```
 $ oc login $CLUSTER -u $ADMIN_USER -p $ADMIN_PASSWD
 $ REMOTE_CLUSTER=true make deploy-example
@@ -39,83 +40,64 @@ to build the logging, elasticsearch-operator, and cluster-logging-operator image
 push the images to the cluster; deploy logging; and launch the logging CI tests.
 
 
-### Running the operator
+### Make targets
 
-Running locally outside an OKD cluster:
-```
- $ make run
-```
-### `make` targets
-Various `make` targets are included to simplify building and deploying the operator
-from the repository root directory, all of which are not listed here.  Hacking and
-deploying the operator assumes:
-* a running OKD cluster
-* `oc` binary in your `$PATH`
-* Logged into a cluster with an admin user who has the cluster role of `cluster-admin`
-* Access to a clone of the `openshift/elasticsearch-operator` repository
-* `make` targets are executed from the `openshift/cluster-logging-operator` root directory
-* various other commands such as `imagebuilder` and `operator-sdk`. The
-   [sdk_setup.sh](https://raw.githubusercontent.com/openshift/origin-aggregated-logging/master/hack/sdk_setup.sh) will setup your environment.
+Make targets use commands such as `oc`, `imagebuilder` and `operator-sdk`.  If a
+suitable command is not found in `./bin:$PATH`, `make` will automatically build
+or download the command in `./bin`.
+
+See also: [sdk_setup.sh](https://raw.githubusercontent.com/openshift/origin-aggregated-logging/master/hack/sdk_setup.sh) to set up your environment.
+
+#### Targets that do not require a cluster
+
+|Target|Description|
+|-----|------------------------------------------|
+|`all`|Run all local tests, lint and format code.|
+|`lint`|Lint and format code.|
+|`test-unit`|Run unit tests.|
+|`image`|Build the image but do not deploy it.|
+
+#### Targets that require a cluster
+
+These targets assume:
+* Logged into an OKD cluster with cluster role `cluster-admin`
+* Clone of `openshift/elasticsearch-operator` repository in `$GOPATH`
 
 The deployment can be optionally modified using any of the following:
 
 | Env Var | Default | Description|
 |---------|---------|------------|
-|`IMAGE_BUILDER`|`imagebuilder`| The command to build the container image|
 |`EXCLUSIONS`|none|The list of manifest files that should will be ignored|
-|`OC`|`oc` in `PATH`| The openshift binary to use to deploy resources|
-|`REMOTE_REGISTRY`|false|`true` if you are running the cluster on a different machine than the one you are developing on|
 |`PUSH_USER`|none|The name of the user e.g. `kubeadmin` used to push images to the remote registry|
 |`PUSH_PASSWORD`|none|The password for `PUSH_USER`|
 |`SKIP_BUILD`|false|`true` if you are pushing an image to a remote registry and want to skip building it again|
 
-**Note:** Use `REMOTE_REGISTRY=true`, for example, if you are running a cluster in a
-    local libvirt or minishift environment; you may want to build the image on the host
-    and push them to the cluster running in the VM. This requires a username with a password (i.e. not the default `system:admin` user).
-    If your cluster was deployed with the `allow_all` identity provider, you can:
-create a user and assign it rights:
-```
-    oc login --username=admin --password=admin
-    oc adm policy add-cluster-role-to-user cluster-admin admin
-```
-
-If you used the new `openshift-installer`, it creates a user named `kubeadmin`
-    with the password in the file `installer/auth/kubeadmin_password`.
-
-To push the image to the remote registry, set `REMOTE_REGISTRY=true`, `PUSH_USER=kubeadmin`,
-`KUBECONFIG=/path/to/installer/auth/kubeconfig`, and
-`PUSH_PASSWORD=$( cat /path/to/installer/auth/kubeadmin_password )`.  You do not have to
-`oc login` to the cluster.  If you already built the image, use `SKIP_BUILD=true` to do
-a push only.
-
-```bash
-REMOTE_REGISTRY=true PUSH_USER=kubeadmin SKIP_BUILD=true \
-KUBECONFIG=/path/to/installer/auth/kubeconfig \
-PUSH_PASSWORD=$( cat /path/to/installer/auth/kubeadmin_password ) \
-make deploy-image
-```
-
-**Note:** If you are using `REMOTE_REGISTRY=true`, ensure you have `docker` package installed and `docker` daemon up and running on the workstation you are running these commands.  Also ensure you have `podman` (`docker` may be deprecated in the future).
-
+**Note:** If you do `make deploy-image`, you need a `docker` daemon running
+where you are running these commands.  Also ensure you have `podman` (`docker`
+may be deprecated in the future). You need to set `PUSH_USER` and
+`PUSH_PASSWORD` If you used the `openshift-installer`, it creates a user named
+`kubeadmin` with the password in the file
+`<install-dir>/auth/kubeadmin_password`.
 
 **Note:**  If while hacking you find your changes are not being applied, use
 `docker images` to see if there is a local version of the `cluster-logging-operator`
 on your machine which may being used by the cluster instead of the one pushed to
 the docker registry.  You may need to delete it (e.g. `docker rmi $IMAGE`)
 
-Following is a list of some of the existing `make` targets to facilitate deployment:
+Some `make` targets to facilitate deployment:
 
 |Target|Description|
 |------|-----------|
+|`run`| Run controller locally, outside the cluster. |
 |`deploy-example`|Deploys all resources and creates an instance of the `cluster-logging-operator`, creates a ClusterLogging custom resource named `example`, starts the Elasticsearch, Kibana, and Fluentd pods running.|
 |`deploy`|Deploys all resources and creates an instance of the `cluster-logging-operator`, but does not create the CR nor start the components running.|
 |`undeploy`|Removes all `cluster-logging` resources and `openshift-logging` project|
-|`deploy-image`|If you already have a remote cluster, and you just want to rebuild and redeploy the image to the remote cluster.  Use `make image` instead if you only want to build the image but not push it.|
-
+|`deploy-image`|If you already have a remote cluster, and you just want to rebuild and redeploy the image to the remote cluster.|
 
 ## Testing
 
 ### E2E Testing
+
 This test assumes:
 * the cluster-logging-operator image is available
 * the cluster-logging component images are available (i.e. $docker_registry_ip/openshift/$component)

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,4 @@
+Directory for external commands that need to be downloaded or built.
+
+You can copy/link commands here if you want to use a particular executable.
+Otherwise `make` will take the command from `$PATH` or build/download it here.

--- a/deploy/crds/logging.openshift.io_clusterloggings_crd.yaml
+++ b/deploy/crds/logging.openshift.io_clusterloggings_crd.yaml
@@ -724,13 +724,12 @@ spec:
               properties:
                 kibanaStatus:
                   items:
+                    description: KibanaStatus defines the observed state of Kibana
                     properties:
                       clusterCondition:
                         additionalProperties:
-                          description: '`operator-sdk generate crds` does not allow
-                            map-of-slice, must use a named type.'
                           items:
-                            description: 'ConditionStatus contains details for the
+                            description: 'ClusterCondition contains details for the
                               current condition of this elasticsearch cluster. Status:
                               the status of the condition. LastTransitionTime: Last
                               time the condition transitioned from one status to another.

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -54,17 +54,17 @@ var _ = Describe("Generating fluentd config", func() {
 				},
 			},
 			Pipelines: []logging.PipelineSpec{
-				logging.PipelineSpec{
+				{
 					Name:       "infra-pipeline",
 					SourceType: logging.LogSourceTypeInfra,
 					OutputRefs: []string{"infra-es"},
 				},
-				logging.PipelineSpec{
+				{
 					Name:       "apps-pipeline",
 					SourceType: logging.LogSourceTypeApp,
 					OutputRefs: []string{"apps-es-1", "apps-es-2"},
 				},
-				logging.PipelineSpec{
+				{
 					Name:       "audit-pipeline",
 					SourceType: logging.LogSourceTypeAudit,
 					OutputRefs: []string{"audit-es"},
@@ -83,7 +83,7 @@ var _ = Describe("Generating fluentd config", func() {
 				},
 			},
 			Pipelines: []logging.PipelineSpec{
-				logging.PipelineSpec{
+				{
 					Name:       "apps-pipeline",
 					SourceType: logging.LogSourceTypeApp,
 					OutputRefs: []string{"secureforward-receiver"},

--- a/pkg/k8shandler/certificates.go
+++ b/pkg/k8shandler/certificates.go
@@ -15,11 +15,11 @@ var deprecatedKeys = sets.NewString("app-ca", "app-key", "app-cert", "infra-ca",
 
 // golang doesn't allow for const maps
 var secretCertificates = map[string]map[string]string{
-	"master-certs": map[string]string{
+	"master-certs": {
 		"masterca":  "ca.crt",
 		"masterkey": "ca.key",
 	},
-	"elasticsearch": map[string]string{
+	"elasticsearch": {
 		"elasticsearch.key": "elasticsearch.key",
 		"elasticsearch.crt": "elasticsearch.crt",
 		"logging-es.key":    "logging-es.key",
@@ -28,17 +28,17 @@ var secretCertificates = map[string]map[string]string{
 		"admin-cert":        "system.admin.crt",
 		"admin-ca":          "ca.crt",
 	},
-	"kibana": map[string]string{
+	"kibana": {
 		"ca":   "ca.crt",
 		"key":  "system.logging.kibana.key",
 		"cert": "system.logging.kibana.crt",
 	},
-	"kibana-proxy": map[string]string{
+	"kibana-proxy": {
 		"server-key":     "kibana-internal.key",
 		"server-cert":    "kibana-internal.crt",
 		"session-secret": "kibana-session-secret",
 	},
-	"curator": map[string]string{
+	"curator": {
 		"ca":       "ca.crt",
 		"key":      "system.logging.curator.key",
 		"cert":     "system.logging.curator.crt",
@@ -46,7 +46,7 @@ var secretCertificates = map[string]map[string]string{
 		"ops-key":  "system.logging.curator.key",
 		"ops-cert": "system.logging.curator.crt",
 	},
-	"fluentd": map[string]string{
+	"fluentd": {
 		"ca-bundle.crt": "ca.crt",
 		"tls.key":       "system.logging.fluentd.key",
 		"tls.crt":       "system.logging.fluentd.crt",

--- a/pkg/k8shandler/curation.go
+++ b/pkg/k8shandler/curation.go
@@ -83,7 +83,7 @@ func compareCuratorStatus(lhs, rhs []logging.CuratorStatus) bool {
 	}
 
 	if len(lhs) > 0 {
-		for index, _ := range lhs {
+		for index := range lhs {
 			if lhs[index].CronJob != rhs[index].CronJob {
 				return false
 			}

--- a/pkg/k8shandler/curation_test.go
+++ b/pkg/k8shandler/curation_test.go
@@ -160,7 +160,7 @@ func TestNewCuratorNoTolerations(t *testing.T) {
 
 func TestNewCuratorWithTolerations(t *testing.T) {
 	expTolerations := []v1.Toleration{
-		v1.Toleration{
+		{
 			Key:      "node-role.kubernetes.io/master",
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -268,7 +268,7 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, elasticsearchAppName str
 	fluentdContainer := NewContainer("fluentd", "fluentd", v1.PullIfNotPresent, *resources)
 
 	fluentdContainer.Ports = []v1.ContainerPort{
-		v1.ContainerPort{
+		{
 			Name:          metricsPortName,
 			ContainerPort: metricsPort,
 			Protocol:      v1.ProtocolTCP,
@@ -337,12 +337,12 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, elasticsearchAppName str
 	tolerations := utils.AppendTolerations(
 		collectionSpec.Logs.FluentdSpec.Tolerations,
 		[]v1.Toleration{
-			v1.Toleration{
+			{
 				Key:      "node-role.kubernetes.io/master",
 				Operator: v1.TolerationOpExists,
 				Effect:   v1.TaintEffectNoSchedule,
 			},
-			v1.Toleration{
+			{
 				Key:      "node.kubernetes.io/disk-pressure",
 				Operator: v1.TolerationOpExists,
 				Effect:   v1.TaintEffectNoSchedule,

--- a/pkg/k8shandler/fluentd_test.go
+++ b/pkg/k8shandler/fluentd_test.go
@@ -75,12 +75,12 @@ func TestNewFluentdPodSpecWhenResourcesAreDefined(t *testing.T) {
 func TestFluentdPodSpecHasTaintTolerations(t *testing.T) {
 
 	expectedTolerations := []v1.Toleration{
-		v1.Toleration{
+		{
 			Key:      "node-role.kubernetes.io/master",
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,
 		},
-		v1.Toleration{
+		{
 			Key:      "node.kubernetes.io/disk-pressure",
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,
@@ -128,12 +128,12 @@ func TestNewFluentdPodSpecWhenSelectorIsDefined(t *testing.T) {
 
 func TestNewFluentdPodNoTolerations(t *testing.T) {
 	expTolerations := []v1.Toleration{
-		v1.Toleration{
+		{
 			Key:      "node-role.kubernetes.io/master",
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,
 		},
-		v1.Toleration{
+		{
 			Key:      "node.kubernetes.io/disk-pressure",
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,
@@ -169,12 +169,12 @@ func TestNewFluentdPodWithTolerations(t *testing.T) {
 
 	expTolerations := []v1.Toleration{
 		providedToleration,
-		v1.Toleration{
+		{
 			Key:      "node-role.kubernetes.io/master",
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,
 		},
-		v1.Toleration{
+		{
 			Key:      "node.kubernetes.io/disk-pressure",
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,

--- a/pkg/k8shandler/forwarding.go
+++ b/pkg/k8shandler/forwarding.go
@@ -61,14 +61,14 @@ func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config s
 			)
 	}
 	// else
-	clusterRequest.UpdateCondition(
+	err = clusterRequest.UpdateCondition(
 		logging.CollectorDeadEnd,
 		"",
 		"",
 		v1.ConditionFalse,
 	)
 
-	return generatedConfig, nil
+	return generatedConfig, err
 }
 
 func (clusterRequest *ClusterLoggingRequest) normalizeLogForwarding(namespace string, cluster *logging.ClusterLogging) logforward.ForwardingSpec {
@@ -100,7 +100,7 @@ func (clusterRequest *ClusterLoggingRequest) normalizeLogForwarding(namespace st
 			}
 			return logforward.ForwardingSpec{
 				Outputs: []logforward.OutputSpec{
-					logforward.OutputSpec{
+					{
 						Name:     internalOutputName,
 						Type:     logforward.OutputTypeElasticsearch,
 						Endpoint: constants.LogStoreService,
@@ -110,12 +110,12 @@ func (clusterRequest *ClusterLoggingRequest) normalizeLogForwarding(namespace st
 					},
 				},
 				Pipelines: []logforward.PipelineSpec{
-					logforward.PipelineSpec{
+					{
 						Name:       defaultAppPipelineName,
 						SourceType: logforward.LogSourceTypeApp,
 						OutputRefs: []string{internalOutputName},
 					},
-					logforward.PipelineSpec{
+					{
 						Name:       defaultInfraPipelineName,
 						SourceType: logforward.LogSourceTypeInfra,
 						OutputRefs: []string{internalOutputName},

--- a/pkg/k8shandler/forwarding_test.go
+++ b/pkg/k8shandler/forwarding_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Normalizing Forwarding", func() {
 					otherOutput,
 				},
 				Pipelines: []logging.PipelineSpec{
-					logging.PipelineSpec{
+					{
 						Name:       "aPipeline",
 						OutputRefs: []string{output.Name, otherOutput.Name},
 						SourceType: logging.LogSourceTypeApp,
@@ -123,7 +123,7 @@ var _ = Describe("Normalizing Forwarding", func() {
 
 			It("should only include logsources if there is atleast one valid pipeline", func() {
 				request.ForwardingSpec.Pipelines = []logging.PipelineSpec{
-					logging.PipelineSpec{
+					{
 						Name:       "aPipeline",
 						OutputRefs: []string{"someotherendpoint"},
 						SourceType: logging.LogSourceTypeApp,
@@ -420,7 +420,7 @@ var _ = Describe("Normalizing Forwarding", func() {
 					BeforeEach(func() {
 						request.ForwardingSpec = logging.ForwardingSpec{
 							Pipelines: []logging.PipelineSpec{
-								logging.PipelineSpec{
+								{
 									Name:       "mypipeline",
 									OutputRefs: []string{output.Name},
 									SourceType: logging.LogSourceTypeApp,
@@ -438,7 +438,7 @@ var _ = Describe("Normalizing Forwarding", func() {
 						request.ForwardingSpec = logging.ForwardingSpec{
 							Outputs: []logging.OutputSpec{output},
 							Pipelines: []logging.PipelineSpec{
-								logging.PipelineSpec{
+								{
 									Name:       "mypipeline",
 									OutputRefs: []string{otherOutput.Name, output.Name},
 									SourceType: logging.LogSourceTypeApp,
@@ -461,7 +461,7 @@ var _ = Describe("Normalizing Forwarding", func() {
 								otherOutput,
 							},
 							Pipelines: []logging.PipelineSpec{
-								logging.PipelineSpec{
+								{
 									Name:       "mypipeline",
 									OutputRefs: []string{output.Name, otherOutput.Name},
 									SourceType: logging.LogSourceTypeApp,

--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -74,7 +74,7 @@ func compareElasticsearchStatus(lhs, rhs []logging.ElasticsearchStatus) bool {
 	}
 
 	if len(lhs) > 0 {
-		for index, _ := range lhs {
+		for index := range lhs {
 			if lhs[index].ClusterName != rhs[index].ClusterName {
 				return false
 			}

--- a/pkg/k8shandler/logstore_test.go
+++ b/pkg/k8shandler/logstore_test.go
@@ -374,7 +374,7 @@ func TestNewESCRNoTolerations(t *testing.T) {
 func TestNewESCRWithTolerations(t *testing.T) {
 
 	expTolerations := []v1.Toleration{
-		v1.Toleration{
+		{
 			Key:      "node-role.kubernetes.io/master",
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,

--- a/pkg/k8shandler/oauthclient.go
+++ b/pkg/k8shandler/oauthclient.go
@@ -30,7 +30,7 @@ func NewOAuthClient(oauthClientName, namespace, oauthSecret string, redirectURIs
 		RedirectURIs: redirectURIs,
 		GrantMethod:  oauth.GrantHandlerPrompt,
 		ScopeRestrictions: []oauth.ScopeRestriction{
-			oauth.ScopeRestriction{
+			{
 				ExactValues: scopeRestrictions,
 			},
 		},

--- a/pkg/k8shandler/promtail.go
+++ b/pkg/k8shandler/promtail.go
@@ -147,7 +147,7 @@ func newPromTailPodSpec(collector *collector.CollectorSpec) (v1.PodSpec, error) 
 	container := NewContainer(promtailName, promtailName, v1.PullIfNotPresent, *resources)
 
 	container.Ports = []v1.ContainerPort{
-		v1.ContainerPort{
+		{
 			Name:          metricsPortName,
 			ContainerPort: metricsPort,
 			Protocol:      v1.ProtocolTCP,
@@ -161,7 +161,7 @@ func newPromTailPodSpec(collector *collector.CollectorSpec) (v1.PodSpec, error) 
 
 	md5hash := hex.EncodeToString(hasher.Sum(nil))
 	container.Env = []v1.EnvVar{
-		v1.EnvVar{Name: "PROMTAIL_YAML_HASH", Value: md5hash},
+		{Name: "PROMTAIL_YAML_HASH", Value: md5hash},
 	}
 	container.Args = []string{
 		"-config.file=/etc/promtail/promtail.yaml",
@@ -183,12 +183,12 @@ func newPromTailPodSpec(collector *collector.CollectorSpec) (v1.PodSpec, error) 
 	tolerations := utils.AppendTolerations(
 		collector.Tolerations,
 		[]v1.Toleration{
-			v1.Toleration{
+			{
 				Key:      "node-role.kubernetes.io/master",
 				Operator: v1.TolerationOpExists,
 				Effect:   v1.TaintEffectNoSchedule,
 			},
-			v1.Toleration{
+			{
 				Key:      "node.kubernetes.io/disk-pressure",
 				Operator: v1.TolerationOpExists,
 				Effect:   v1.TaintEffectNoSchedule,

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -28,17 +28,9 @@ import (
 )
 
 const (
-	kibanaServiceAccountName     = "kibana"
-	kibanaOAuthRedirectReference = "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"kibana\"}}"
 	// The following strings are turned into JavaScript RegExps. Online tool to test them: https://regex101.com/
 	nodesAndContainersNamespaceFilter = "^(openshift-.*|kube-.*|openshift$|kube$|default$)"
 	appsNamespaceFilter               = "^((?!" + nodesAndContainersNamespaceFilter + ").)*$" // ^((?!^(openshift-.*|kube-.*|openshift$|kube$|default$)).)*$
-)
-
-var (
-	kibanaServiceAccountAnnotations = map[string]string{
-		"serviceaccounts.openshift.io/oauth-redirectreference.first": kibanaOAuthRedirectReference,
-	}
 )
 
 // CreateOrUpdateVisualization reconciles visualization component for cluster logging
@@ -102,7 +94,7 @@ func compareKibanaStatus(lhs, rhs []es.KibanaStatus) bool {
 	}
 
 	if len(lhs) > 0 {
-		for index, _ := range lhs {
+		for index := range lhs {
 			if lhs[index].Deployment != rhs[index].Deployment {
 				return false
 			}

--- a/pkg/k8shandler/visualization_test.go
+++ b/pkg/k8shandler/visualization_test.go
@@ -173,7 +173,7 @@ func TestNewKibanaPodNoTolerations(t *testing.T) {
 func TestNewKibanaPodWithTolerations(t *testing.T) {
 
 	expTolerations := []v1.Toleration{
-		v1.Toleration{
+		{
 			Key:      "node-role.kubernetes.io/master",
 			Operator: v1.TolerationOpExists,
 			Effect:   v1.TaintEffectNoSchedule,


### PR DESCRIPTION
Changes:
- trivial source file changes from gofmts and to satisfy the linter.
- drop _output file, not necessary and causes confusion.  
- remove unused variables, simplify targets.  
- add dependencies to make targets self-sufficient.

Signed-off-by: Alan Conway <aconway@redhat.com>