### PR TITLE
Bug 1816770: Fluentd inserts \'\' into some log messages ingested from container logs

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Generating fluentd config", func() {
 				key log
 				partial_key logtag
 				partial_value P
-				separator \'\'
+				separator ''
 				</filter>
 				<match kubernetes.**>
 				@type relabel
@@ -590,7 +590,7 @@ var _ = Describe("Generating fluentd config", func() {
 				key log
 				partial_key logtag
 				partial_value P
-				separator \'\'
+				separator ''
 				</filter>
 				<match kubernetes.**>
 				@type relabel

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -71,7 +71,7 @@ const fluentConfTemplate = `{{- define "fluentConf" }}
 		key log
 		partial_key logtag
 		partial_value P
-		separator \'\'
+		separator ''
 	</filter>
 	<match kubernetes.**>
 		@type relabel


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1816770