### PR TITLE
Bug 1813209: Adding oauth-openshift route url to noProxy list for kibana proxy

### DIFF
--- a/pkg/k8shandler/route.go
+++ b/pkg/k8shandler/route.go
@@ -72,6 +72,21 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateRoute(newRoute *route
 	return nil
 }
 
+//GetRouterCanonicalHostname retrieves the router hostname from a given route and namespace
+func (clusterRequest *ClusterLoggingRequest) GetRouterCanonicalHostname(routeName string) (string, error) {
+
+	foundRoute := &route.Route{}
+
+	if err := clusterRequest.Get(routeName, foundRoute); err != nil {
+		if !errors.IsNotFound(err) {
+			logrus.Errorf("Failed to check for ClusterLogging object: %v", err)
+		}
+		return "", err
+	}
+
+	return foundRoute.Status.Ingress[0].RouterCanonicalHostname, nil
+}
+
 //GetRouteURL retrieves the route URL from a given route and namespace
 func (clusterRequest *ClusterLoggingRequest) GetRouteURL(routeName string) (string, error) {
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -400,11 +400,12 @@ func EnvVarResourceFieldSelectorEqual(resource1, resource2 v1.ResourceFieldSelec
 	return false
 }
 
-func SetProxyEnvVars(proxyConfig *configv1.Proxy) []v1.EnvVar {
+func SetKibanaProxyEnvVars(proxyConfig *configv1.Proxy, oauthIssuer string) []v1.EnvVar {
 	envVars := []v1.EnvVar{}
 	if proxyConfig == nil {
 		return envVars
 	}
+
 	if len(proxyConfig.Status.HTTPSProxy) != 0 {
 		envVars = append(envVars, v1.EnvVar{
 			Name:  "HTTPS_PROXY",
@@ -426,6 +427,48 @@ func SetProxyEnvVars(proxyConfig *configv1.Proxy) []v1.EnvVar {
 			})
 	}
 	if len(proxyConfig.Status.NoProxy) != 0 {
+
+		envVars = append(envVars, v1.EnvVar{
+			Name:  "NO_PROXY",
+			Value: fmt.Sprintf("%s,%s", oauthIssuer, proxyConfig.Status.NoProxy),
+		},
+			v1.EnvVar{
+				Name:  "no_proxy",
+				Value: fmt.Sprintf("%s,%s", oauthIssuer, proxyConfig.Status.NoProxy),
+			})
+
+	}
+	return envVars
+}
+
+func SetProxyEnvVars(proxyConfig *configv1.Proxy) []v1.EnvVar {
+	envVars := []v1.EnvVar{}
+	if proxyConfig == nil {
+		return envVars
+	}
+
+	if len(proxyConfig.Status.HTTPSProxy) != 0 {
+		envVars = append(envVars, v1.EnvVar{
+			Name:  "HTTPS_PROXY",
+			Value: proxyConfig.Status.HTTPSProxy,
+		},
+			v1.EnvVar{
+				Name:  "https_proxy",
+				Value: proxyConfig.Status.HTTPSProxy,
+			})
+	}
+	if len(proxyConfig.Status.HTTPProxy) != 0 {
+		envVars = append(envVars, v1.EnvVar{
+			Name:  "HTTP_PROXY",
+			Value: proxyConfig.Status.HTTPProxy,
+		},
+			v1.EnvVar{
+				Name:  "http_proxy",
+				Value: proxyConfig.Status.HTTPProxy,
+			})
+	}
+	if len(proxyConfig.Status.NoProxy) != 0 {
+
 		envVars = append(envVars, v1.EnvVar{
 			Name:  "NO_PROXY",
 			Value: proxyConfig.Status.NoProxy,
@@ -434,6 +477,7 @@ func SetProxyEnvVars(proxyConfig *configv1.Proxy) []v1.EnvVar {
 				Name:  "no_proxy",
 				Value: proxyConfig.Status.NoProxy,
 			})
+
 	}
 	return envVars
 }


### PR DESCRIPTION
when using proxy config, we should add the oauth-openshift route url to the `NO_PROXY` and `no_proxy` env vars so that when we get a callback from oauth we can properly not go through the proxy.

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1813209