### PR TITLE
Remove default storageclass from example

### DIFF
--- a/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
@@ -40,7 +40,6 @@ metadata:
                   "nodeCount": 3,
                   "redundancyPolicy": "SingleRedundancy",
                   "storage": {
-                    "storageClassName": "gp2",
                     "size": "200G"
                   }
                 },


### PR DESCRIPTION
This removes a specified `storageClassName` from the pre-populated example from the CSV.

From a usability perspective, if you are provisioning a new `ClusterLogging` and you are using OCP on AWS, you can click "Create" right after bringing the example up and it will provision. If you are on a non-AWS cloud, you won't have the `gp2` storage class, and things will stall out provisioning. Recovery from this is a little complex, as you need to manually remove all the PVCs (as they won't get deleted, even if you delete the `ClusterLogging` CR).