### PR TITLE
Bug 1817592: fix Makefile in order to fix ART builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ imagebuilder:
 	then go get -u github.com/openshift/imagebuilder/cmd/imagebuilder ; \
 	fi
 
-build: generate fmt
+build: fmt
 	@mkdir -p $(TARGET_DIR)/src/$(APP_REPO)
 	@cp -ru $(CURDIR)/pkg $(TARGET_DIR)/src/$(APP_REPO)
 	@cp -ru $(CURDIR)/vendor/* $(TARGET_DIR)/src


### PR DESCRIPTION
This PR removes `make` dependency on generate to satisfy the ART building process