### PR TITLE
fix elasticsearch unmanaged test

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -16,6 +16,9 @@ func Debugf(format string, objects ...interface{}) {
 	logrus.Debugf(format, objects...)
 }
 
+func Warn(objects ...interface{}) {
+	logrus.Warn(objects...)
+}
 func Warnf(format string, objects ...interface{}) {
 	logrus.Warnf(format, objects...)
 }

--- a/test/helpers/elasticsearch.go
+++ b/test/helpers/elasticsearch.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	k8shandler "github.com/openshift/cluster-logging-operator/pkg/k8shandler"
+	"github.com/openshift/cluster-logging-operator/pkg/k8shandler/indexmanagement"
 	"github.com/openshift/cluster-logging-operator/pkg/logger"
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
 	elasticsearch "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
@@ -163,6 +164,7 @@ func (tc *E2ETestFramework) DeployAnElasticsearchCluster(pwd string) (cr *elasti
 	if pipelineSecret, err = tc.CreatePipelineSecret(pwd, logStoreName, "test-pipeline-to-elastic", map[string][]byte{}); err != nil {
 		return nil, nil, err
 	}
+	tc.WriteToArchiveDir("test-es-cluster.secret.txt", pipelineSecret)
 
 	esSecret := k8shandler.NewSecret(
 		logStoreName,
@@ -202,6 +204,7 @@ func (tc *E2ETestFramework) DeployAnElasticsearchCluster(pwd string) (cr *elasti
 			Nodes:            []elasticsearch.ElasticsearchNode{node},
 			ManagementState:  elasticsearch.ManagementStateManaged,
 			RedundancyPolicy: elasticsearch.ZeroRedundancy,
+			IndexManagement:  indexmanagement.NewSpec(nil),
 		},
 	}
 	tc.AddCleanup(func() error {

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -81,6 +82,16 @@ func NewE2ETestFramework() *E2ETestFramework {
 
 func (tc *E2ETestFramework) AddCleanup(fn func() error) {
 	tc.CleanupFns = append(tc.CleanupFns, fn)
+}
+
+func (tc *E2ETestFramework) WriteToArchiveDir(file string, object interface{}) {
+	if artifactDir := os.Getenv("artifact_dir"); artifactDir != "" {
+
+		if err := ioutil.WriteFile(fmt.Sprintf("%s/%s", artifactDir, file), []byte(fmt.Sprintf("%v", object)), 444); err != nil {
+			logger.Errorf("Unable to write %s to archive dir: %v", file, err)
+		}
+	}
+	logger.Warn("Trying to write to the artifact_dir but it was not defined")
 }
 
 func (tc *E2ETestFramework) DeployLogGenerator() error {


### PR DESCRIPTION
This PR fixes the elasticsearch unmanaged test:

* Adding indexmanagement for the desired indices that are failing because of https://github.com/uken/fluent-plugin-elasticsearch/issues/734 and blocking autocreate of indices