### PR TITLE
Fix pretty print of generated fluent.conf

### DIFF
--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -110,7 +110,7 @@ func mapSourceTypesToPipelineNames(pipelines []logforward.PipelineSpec) map[logf
 }
 
 func pretty(in string) string {
-	stack := -1
+	stack := 0
 	out := bytes.NewBufferString("")
 	for _, line := range strings.Split(in, "\n") {
 		stack = prettyLine(out, line, stack)
@@ -119,14 +119,17 @@ func pretty(in string) string {
 }
 func prettyLine(out *bytes.Buffer, in string, levelIn int) int {
 	levelOut := levelIn
+	level := levelIn
 	trimmed := strings.Trim(in, " \t")
 	if strings.HasPrefix(trimmed, "</") {
 		levelOut = levelIn - 1
+		level = levelOut
 	} else if strings.HasPrefix(trimmed, "<") && !strings.HasPrefix(trimmed, "</") {
 		levelOut = levelIn + 1
+		level = levelIn
 	}
 
-	for i := 0; i < levelOut; i++ {
+	for i := 0; i < level; i++ {
 		out.WriteString("\t")
 	}
 	out.WriteString(trimmed)


### PR DESCRIPTION
Fix pretty print of generated fluent.conf. Improve readability.

Example output:

```

<system>
    @log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
</system>

<source>
    @type prometheus
    bind ''
    <ssl>
        enable true
        certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
        private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
    </ssl>
</source>
```
Output before this change:
```
## CLO GENERATED CONFIGURATION ###    
# This file is a copy of the fluentd configuration entrypoint    
# which should normally be supplied in a configmap.    
    
<system>    
@log_level "#{ENV['LOG_LEVEL'] || 'warn'}"    
</system>    
    
# In each section below, pre- and post- includes don't include anything initially;    
# they exist to enable future additions to openshift conf as needed.    
    
## sources    
## ordered so that syslog always runs last...    
<source>    
@type prometheus    
bind ''    
    <ssl>    
    enable true    
    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"    
    private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"    
</ssl>    
</source>    
```

