### PR TITLE
Overwrite pull policy for local olm based E2E tests

### DIFF
--- a/olm_deploy/scripts/registry-init.sh
+++ b/olm_deploy/scripts/registry-init.sh
@@ -24,6 +24,11 @@ sed -i "s,quay.io/openshift/origin-promtail:latest,${IMAGE_PROMTAIL}," /manifest
 sed -i "s,quay.io/openshift/origin-logging-elasticsearch6:latest,${IMAGE_ELASTICSEARCH6}," /manifests/*/*clusterserviceversion.yaml
 sed -i "s,quay.io/openshift/origin-logging-kibana6:latest,${IMAGE_LOGGING_KIBANA6}," /manifests/*/*clusterserviceversion.yaml
 
+# update the manifest to pull always the operator image for non-CI environments
+if [ -z "${IMAGE_FORMAT:-}" ] ; then
+    echo -e "Set operator deployment's imagePullPolicy to 'Always'\n\n"
+    sed -i 's,imagePullPolicy:\ IfNotPresent,imagePullPolicy:\ Always,' /manifests/*/*clusterserviceversion.yaml
+fi
 
 echo -e "substitution complete, dumping new csv\n\n"
 cat /manifests/*/*clusterserviceversion.yaml


### PR DESCRIPTION
This PR addresses an issue on running E2E olm-based tests locally against a devcluster where the operator is already present on the nodes but a newer image was pushed by the development workflow.

This issue is not present on CI, because IMAGE_FORMAT (e.g. egistry.svc.ci.openshift.org/ci-op-3cfm5kx8/stable:${component}) ensures a stable unique name whether local development usually points to your-registry-of-choice/openshift/origin-cluster-logging-operator:latest.

Transfer from: openshift/elasticsearch-operator#304