### PR TITLE
Bug 1793551: Intentional promtail image-reference mismatch

### DIFF
--- a/manifests/4.5/image-references
+++ b/manifests/4.5/image-references
@@ -29,4 +29,4 @@ spec:
   - name: promtail
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-promtail:latest
+      name: quay.io/openshift/origin-promtail:refBz1793551


### PR DESCRIPTION
This PR intentionally introduces a mismatch in image-references so that ART will not point to productized image: 

https://bugzilla.redhat.com/show_bug.cgi?id=1793551