### PR TITLE
Formatted cm/fluentd:fluent.conf so it is usable with oc get cm/fluentd -oyaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,11 @@ imagebuilder:
 golangci-lint:
 	@type -p golangci-lint > /dev/null || go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
-
 build:
-	go build -o bin/cluster-logging-operator ./cmd/manager
+	go build $(BUILD_OPTS) -o bin/cluster-logging-operator ./cmd/manager
+
+build-debug:
+	$(MAKE) build BUILD_OPTS='-gcflags=all="-N -l"'
 
 run:
 	ELASTICSEARCH_IMAGE=quay.io/openshift/origin-logging-elasticsearch6:latest \
@@ -42,7 +44,10 @@ run:
 	KUBERNETES_CONFIG=$(KUBECONFIG) \
 	WORKING_DIR=$(TARGET_DIR)/ocp-clo \
 	LOGGING_SHARE_DIR=$(CURDIR)/files \
-	go run cmd/manager/main.go
+	$(RUN_OPTS) bin/cluster-logging-operator
+
+run-debug:
+	$(MAKE) run RUN_OPTS='dlv exec --'
 
 clean:
 	@rm -f bin/operator-sdk bin/imagebuilder bin/golangci-lint bin/cluster-logging-operator

--- a/pkg/generators/forwarding/factory.go
+++ b/pkg/generators/forwarding/factory.go
@@ -13,8 +13,9 @@ func NewConfigGenerator(collector logging.LogCollectionType, includeLegacyForwar
 	switch collector {
 	case logging.LogCollectionTypeFluentd:
 		return fluentd.NewConfigGenerator(includeLegacyForwardConfig, includeLegacySyslogConfig, useOldRemoteSyslogPlugin)
+	default:
+		return nil, fmt.Errorf("Config generation not supported for collectors of type %s", collector)
 	}
-	return nil, fmt.Errorf("Config generation not supported for collects of type %s", collector)
 }
 
 //ConfigGenerator is a config generator for a given ForwardingSpec

--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -1,10 +1,8 @@
 package fluentd
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
-	"strings"
 	"text/template"
 
 	logforward "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1alpha1"
@@ -86,7 +84,7 @@ func (engine *ConfigGenerator) Generate(forwarding *logforward.ForwardingSpec) (
 	if err != nil {
 		return "", fmt.Errorf("Error processing fluentConf template: %v", err)
 	}
-	return pretty(result), nil
+	return result, nil
 }
 
 func gatherLogSourceTypes(pipelines []logforward.PipelineSpec) sets.String {
@@ -108,34 +106,6 @@ func mapSourceTypesToPipelineNames(pipelines []logforward.PipelineSpec) map[logf
 		result[pipeline.SourceType] = names
 	}
 	return result
-}
-
-func pretty(in string) string {
-	stack := 0
-	out := bytes.NewBufferString("")
-	for _, line := range strings.Split(in, "\n") {
-		stack = prettyLine(out, line, stack)
-	}
-	return out.String()
-}
-func prettyLine(out *bytes.Buffer, in string, levelIn int) int {
-	levelOut := levelIn
-	level := levelIn
-	trimmed := strings.Trim(in, " \t")
-	if strings.HasPrefix(trimmed, "</") {
-		levelOut = levelIn - 1
-		level = levelOut
-	} else if strings.HasPrefix(trimmed, "<") && !strings.HasPrefix(trimmed, "</") {
-		levelOut = levelIn + 1
-		level = levelIn
-	}
-
-	for i := 0; i < level; i++ {
-		out.WriteString("\t")
-	}
-	out.WriteString(trimmed)
-	out.WriteString("\n")
-	return levelOut
 }
 
 //generateSourceToPipelineLabels generates fluentd label stanzas to fan source types to multiple pipelines

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -127,9 +127,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
       packet_size 4096
       timeout 60
       timeout_exception true
-      keep_alive       true
-      keep_alive_idle    75
-      keep_alive_cnt      9
+      keep_alive true
+      keep_alive_idle 75
+      keep_alive_cnt 9
       keep_alive_intvl 7200
       <buffer>
         @type file
@@ -192,9 +192,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
       verify_mode true
       timeout 60
       timeout_exception true
-      keep_alive       true
-      keep_alive_idle    75
-      keep_alive_cnt      9
+      keep_alive true
+      keep_alive_idle 75
+      keep_alive_cnt 9
       keep_alive_intvl 7200
       <buffer>
         @type file

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -19,13 +19,13 @@ var templateRegistry = []string{
 	storeSyslogTemplate,
 }
 
-const fluentConfTemplate = `{{- define "fluentConf" }}
-## CLO GENERATED CONFIGURATION ### 
+const fluentConfTemplate = `{{- define "fluentConf" -}}
+## CLO GENERATED CONFIGURATION ###
 # This file is a copy of the fluentd configuration entrypoint
 # which should normally be supplied in a configmap.
 
 <system>
-	@log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
+  @log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
 </system>
 
 # In each section below, pre- and post- includes don't include anything initially;
@@ -67,233 +67,249 @@ const fluentConfTemplate = `{{- define "fluentConf" }}
 {{- end}}
 
 <label @CONCAT>
-	<filter kubernetes.**>
-		@type concat
-		key log
-		partial_key logtag
-		partial_value P
-		separator ''
-	</filter>
-	<match kubernetes.**>
-		@type relabel
-		@label @INGRESS
-	</match>
+  <filter kubernetes.**>
+    @type concat
+    key log
+    partial_key logtag
+    partial_value P
+    separator ''
+  </filter>
+  <match kubernetes.**>
+    @type relabel
+    @label @INGRESS
+  </match>
 </label>
 
 #syslog input config here
 
 <label @INGRESS>
-	## filters
-	<filter **>
-  		@type record_modifier
-  		char_encoding utf-8
-	</filter>
-	<filter journal>
-		@type grep
-		<exclude>
-			key PRIORITY
-			pattern ^7$
-		</exclude>
-	</filter>
-	<match journal>
-		@type rewrite_tag_filter
-		# skip to @INGRESS label section
-		@label @INGRESS
-		# see if this is a kibana container for special log handling
-		# looks like this:
-		# k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2
-		# we filter these logs through the kibana_transform.conf filter
-		<rule>
-			key CONTAINER_NAME
-			pattern ^k8s_kibana\.
-			tag kubernetes.journal.container.kibana
-		</rule>
-		<rule>
-			key CONTAINER_NAME
-			pattern ^k8s_[^_]+_logging-eventrouter-[^_]+_
-			tag kubernetes.journal.container._default_.kubernetes-event
-		</rule>
-		# mark logs from default namespace for processing as k8s logs but stored as system logs
-		<rule>
-			key CONTAINER_NAME
-			pattern ^k8s_[^_]+_[^_]+_default_
-			tag kubernetes.journal.container._default_
-		</rule>
-		# mark logs from kube-* namespaces for processing as k8s logs but stored as system logs
-		<rule>
-			key CONTAINER_NAME
-			pattern ^k8s_[^_]+_[^_]+_kube-(.+)_
-			tag kubernetes.journal.container._kube-$1_
-		</rule>
-		# mark logs from openshift-* namespaces for processing as k8s logs but stored as system logs
-		<rule>
-			key CONTAINER_NAME
-			pattern ^k8s_[^_]+_[^_]+_openshift-(.+)_
-			tag kubernetes.journal.container._openshift-$1_
-		</rule>
-		# mark logs from openshift namespace for processing as k8s logs but stored as system logs
-		<rule>
-			key CONTAINER_NAME
-			pattern ^k8s_[^_]+_[^_]+_openshift_
-			tag kubernetes.journal.container._openshift_
-		</rule>
-		# mark fluentd container logs
-		<rule>
-			key CONTAINER_NAME
-			pattern ^k8s_.*fluentd
-			tag kubernetes.journal.container.fluentd
-		</rule>
-		# this is a kubernetes container
-		<rule>
-			key CONTAINER_NAME
-			pattern ^k8s_
-			tag kubernetes.journal.container
-		</rule>
-		# not kubernetes - assume a system log or system container log
-		<rule>
-			key _TRANSPORT
-			pattern .+
-			tag journal.system
-		</rule>
-	</match>
-	<filter kubernetes.**>
-		@type kubernetes_metadata
-		kubernetes_url "#{ENV['K8S_HOST_URL']}"
-		cache_size "#{ENV['K8S_METADATA_CACHE_SIZE'] || '1000'}"
-		watch "#{ENV['K8S_METADATA_WATCH'] || 'false'}"
-		use_journal "#{ENV['USE_JOURNAL'] || 'nil'}"
-		ssl_partial_chain "#{ENV['SSL_PARTIAL_CHAIN'] || 'true'}"
-	</filter>
-		
-	<filter kubernetes.journal.**>
-		@type parse_json_field
-		merge_json_log "#{ENV['MERGE_JSON_LOG'] || 'false'}"
-		preserve_json_log "#{ENV['PRESERVE_JSON_LOG'] || 'true'}"
-		json_fields "#{ENV['JSON_FIELDS'] || 'MESSAGE,log'}"
-	</filter>
-		
-	<filter kubernetes.var.log.containers.**>
-		@type parse_json_field
-		merge_json_log "#{ENV['MERGE_JSON_LOG'] || 'false'}"
-		preserve_json_log "#{ENV['PRESERVE_JSON_LOG'] || 'true'}"
-		json_fields "#{ENV['JSON_FIELDS'] || 'log,MESSAGE'}"
-	</filter>
 
-	<filter kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-**>
-	    @type parse_json_field
-	    merge_json_log true
-	    preserve_json_log true
-	    json_fields "#{ENV['JSON_FIELDS'] || 'log,MESSAGE'}"
-	</filter>
+  ## filters
+  <filter **>
+    @type record_modifier
+    char_encoding utf-8
+  </filter>
 
-	<filter **kibana**>
-		@type record_transformer
-		enable_ruby
-		<record>
-			log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
-		</record>
-		remove_keys req,res,msg,name,level,v,pid,err
-	</filter>
-	<filter **>
-		@type viaq_data_model
-		elasticsearch_index_prefix_field 'viaq_index_name'
-		default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
-		extra_keep_fields "#{ENV['CDM_EXTRA_KEEP_FIELDS'] || ''}"
-		keep_empty_fields "#{ENV['CDM_KEEP_EMPTY_FIELDS'] || 'message'}"
-		use_undefined "#{ENV['CDM_USE_UNDEFINED'] || false}"
-		undefined_name "#{ENV['CDM_UNDEFINED_NAME'] || 'undefined'}"
-		rename_time "#{ENV['CDM_RENAME_TIME'] || true}"
-		rename_time_if_missing "#{ENV['CDM_RENAME_TIME_IF_MISSING'] || false}"
-		src_time_name "#{ENV['CDM_SRC_TIME_NAME'] || 'time'}"
-		dest_time_name "#{ENV['CDM_DEST_TIME_NAME'] || '@timestamp'}"
-		pipeline_type "#{ENV['PIPELINE_TYPE'] || 'collector'}"
-		undefined_to_string "#{ENV['CDM_UNDEFINED_TO_STRING'] || 'false'}"
-		undefined_dot_replace_char "#{ENV['CDM_UNDEFINED_DOT_REPLACE_CHAR'] || 'UNUSED'}"
-		undefined_max_num_fields "#{ENV['CDM_UNDEFINED_MAX_NUM_FIELDS'] || '-1'}"
-		process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'false'}"
-		<formatter>
-			tag "system.var.log**"
-			type sys_var_log
-			remove_keys host,pid,ident
-		</formatter>
-		<formatter>
-			tag "journal.system**"
-			type sys_journal
-			remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
-		</formatter>
-		<formatter>
-			tag "kubernetes.journal.container**"
-			type k8s_journal
-			remove_keys "#{ENV['K8S_FILTER_REMOVE_KEYS'] || 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'}"
-		</formatter>
-		<formatter>
-		    tag "kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-** k8s-audit.log** openshift-audit.log**"
-		    type k8s_json_file
-		    remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
-		    process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'true'}"
-		</formatter>
-		<formatter>
-			tag "kubernetes.var.log.containers**"
-			type k8s_json_file
-			remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
-		</formatter>
-		<elasticsearch_index_name>
-			enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
-			tag "journal.system** system.var.log** **_default_** **_kube-*_** **_openshift-*_** **_openshift_**"
-			name_type static
-			static_index_name infra-write
-		</elasticsearch_index_name>
-		<elasticsearch_index_name>
-			enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
-			tag "linux-audit.log** k8s-audit.log** openshift-audit.log**"
-			name_type static
-			static_index_name audit-write
-		</elasticsearch_index_name>
-		<elasticsearch_index_name>
-			enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
-			tag "**"
-			name_type static
-			static_index_name app-write
-		</elasticsearch_index_name>
-	</filter>
-	<filter **>
-      @type elasticsearch_genid_ext
-      hash_id_key viaq_msg_id
-      alt_key kubernetes.event.metadata.uid
-      alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.var.log.containers.eventrouter-*.** kubernetes.var.log.containers.cluster-logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'}"
-	</filter>
-	#flatten labels to prevent field explosion in ES
-	<filter ** >
-		@type record_transformer
-		enable_ruby true
-		<record>
-			kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
-		</record>
-		remove_keys $.kubernetes.labels
-	</filter>
-	
-	# Relabel specific source tags to specific intermediary labels for copy processing
+  <filter journal>
+    @type grep
+    <exclude>
+      key PRIORITY
+      pattern ^7$
+    </exclude>
+  </filter>
+
+  <match journal>
+    @type rewrite_tag_filter
+    # skip to @INGRESS label section
+    @label @INGRESS
+
+    # see if this is a kibana container for special log handling
+    # looks like this:
+    # k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2
+    # we filter these logs through the kibana_transform.conf filter
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_kibana\.
+      tag kubernetes.journal.container.kibana
+    </rule>
+
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_logging-eventrouter-[^_]+_
+      tag kubernetes.journal.container._default_.kubernetes-event
+    </rule>
+
+    # mark logs from default namespace for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_default_
+      tag kubernetes.journal.container._default_
+    </rule>
+
+    # mark logs from kube-* namespaces for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_kube-(.+)_
+      tag kubernetes.journal.container._kube-$1_
+    </rule>
+
+    # mark logs from openshift-* namespaces for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_openshift-(.+)_
+      tag kubernetes.journal.container._openshift-$1_
+    </rule>
+
+    # mark logs from openshift namespace for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_openshift_
+      tag kubernetes.journal.container._openshift_
+    </rule>
+
+    # mark fluentd container logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_.*fluentd
+      tag kubernetes.journal.container.fluentd
+    </rule>
+
+    # this is a kubernetes container
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_
+      tag kubernetes.journal.container
+    </rule>
+
+    # not kubernetes - assume a system log or system container log
+    <rule>
+      key _TRANSPORT
+      pattern .+
+      tag journal.system
+    </rule>
+  </match>
+
+  <filter kubernetes.**>
+    @type kubernetes_metadata
+    kubernetes_url "#{ENV['K8S_HOST_URL']}"
+    cache_size "#{ENV['K8S_METADATA_CACHE_SIZE'] || '1000'}"
+    watch "#{ENV['K8S_METADATA_WATCH'] || 'false'}"
+    use_journal "#{ENV['USE_JOURNAL'] || 'nil'}"
+    ssl_partial_chain "#{ENV['SSL_PARTIAL_CHAIN'] || 'true'}"
+  </filter>
+
+  <filter kubernetes.journal.**>
+    @type parse_json_field
+    merge_json_log "#{ENV['MERGE_JSON_LOG'] || 'false'}"
+    preserve_json_log "#{ENV['PRESERVE_JSON_LOG'] || 'true'}"
+    json_fields "#{ENV['JSON_FIELDS'] || 'MESSAGE,log'}"
+  </filter>
+
+  <filter kubernetes.var.log.containers.**>
+    @type parse_json_field
+    merge_json_log "#{ENV['MERGE_JSON_LOG'] || 'false'}"
+    preserve_json_log "#{ENV['PRESERVE_JSON_LOG'] || 'true'}"
+    json_fields "#{ENV['JSON_FIELDS'] || 'log,MESSAGE'}"
+  </filter>
+
+  <filter kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-**>
+    @type parse_json_field
+    merge_json_log true
+    preserve_json_log true
+    json_fields "#{ENV['JSON_FIELDS'] || 'log,MESSAGE'}"
+  </filter>
+
+  <filter **kibana**>
+    @type record_transformer
+    enable_ruby
+    <record>
+      log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
+    </record>
+    remove_keys req,res,msg,name,level,v,pid,err
+  </filter>
+
+  <filter **>
+    @type viaq_data_model
+    elasticsearch_index_prefix_field 'viaq_index_name'
+    default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
+    extra_keep_fields "#{ENV['CDM_EXTRA_KEEP_FIELDS'] || ''}"
+    keep_empty_fields "#{ENV['CDM_KEEP_EMPTY_FIELDS'] || 'message'}"
+    use_undefined "#{ENV['CDM_USE_UNDEFINED'] || false}"
+    undefined_name "#{ENV['CDM_UNDEFINED_NAME'] || 'undefined'}"
+    rename_time "#{ENV['CDM_RENAME_TIME'] || true}"
+    rename_time_if_missing "#{ENV['CDM_RENAME_TIME_IF_MISSING'] || false}"
+    src_time_name "#{ENV['CDM_SRC_TIME_NAME'] || 'time'}"
+    dest_time_name "#{ENV['CDM_DEST_TIME_NAME'] || '@timestamp'}"
+    pipeline_type "#{ENV['PIPELINE_TYPE'] || 'collector'}"
+    undefined_to_string "#{ENV['CDM_UNDEFINED_TO_STRING'] || 'false'}"
+    undefined_dot_replace_char "#{ENV['CDM_UNDEFINED_DOT_REPLACE_CHAR'] || 'UNUSED'}"
+    undefined_max_num_fields "#{ENV['CDM_UNDEFINED_MAX_NUM_FIELDS'] || '-1'}"
+    process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'false'}"
+    <formatter>
+      tag "system.var.log**"
+      type sys_var_log
+      remove_keys host,pid,ident
+    </formatter>
+    <formatter>
+      tag "journal.system**"
+      type sys_journal
+      remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+    </formatter>
+    <formatter>
+      tag "kubernetes.journal.container**"
+      type k8s_journal
+      remove_keys "#{ENV['K8S_FILTER_REMOVE_KEYS'] || 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'}"
+    </formatter>
+    <formatter>
+      tag "kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-** k8s-audit.log** openshift-audit.log**"
+      type k8s_json_file
+      remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
+      process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'true'}"
+    </formatter>
+    <formatter>
+      tag "kubernetes.var.log.containers**"
+      type k8s_json_file
+      remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
+    </formatter>
+    <elasticsearch_index_name>
+      enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
+      tag "journal.system** system.var.log** **_default_** **_kube-*_** **_openshift-*_** **_openshift_**"
+      name_type static
+      static_index_name infra-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
+      tag "linux-audit.log** k8s-audit.log** openshift-audit.log**"
+      name_type static
+      static_index_name audit-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
+      tag "**"
+      name_type static
+      static_index_name app-write
+    </elasticsearch_index_name>
+  </filter>
+
+  <filter **>
+    @type elasticsearch_genid_ext
+    hash_id_key viaq_msg_id
+    alt_key kubernetes.event.metadata.uid
+    alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.var.log.containers.eventrouter-*.** kubernetes.var.log.containers.cluster-logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'}"
+  </filter>
+
+  #flatten labels to prevent field explosion in ES
+  <filter ** >
+    @type record_transformer
+    enable_ruby true
+    <record>
+      kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+    </record>
+    remove_keys $.kubernetes.labels
+  </filter>
+
+  # Relabel specific source tags to specific intermediary labels for copy processing
 {{ if .CollectInfraLogs }}
-	<match **_default_** **_kube-*_** **_openshift-*_** **_openshift_** journal.** system.var.log**>
-		@type relabel
-		@label @_LOGS_INFRA
-	</match>
+  <match **_default_** **_kube-*_** **_openshift-*_** **_openshift_** journal.** system.var.log**>
+    @type relabel
+    @label @_LOGS_INFRA
+  </match>
 {{- end}}
 {{ if .CollectAppLogs}}
-	<match kubernetes.**>
-		@type relabel
-		@label @_LOGS_APP
-	</match>
+  <match kubernetes.**>
+    @type relabel
+    @label @_LOGS_APP
+  </match>
 {{- end}}
 {{ if .CollectAuditLogs}}
-	<match linux-audit.log** k8s-audit.log** openshift-audit.log**>
-		@type relabel
-		@label @_LOGS_AUDIT
-	</match>
+  <match linux-audit.log** k8s-audit.log** openshift-audit.log**>
+    @type relabel
+    @label @_LOGS_AUDIT
+  </match>
 {{- end}}
-	<match **>
-		@type stdout
-	</match>
+  <match **>
+    @type stdout
+  </match>
 
 </label>
 
@@ -313,26 +329,26 @@ const fluentConfTemplate = `{{- define "fluentConf" }}
 {{- end}}
 {{ if .IncludeLegacySecureForward }}
 <label @_LEGACY_SECUREFORWARD>
-	<match **>
-		@type copy
-		#include legacy secure-forward.conf
-		@include /etc/fluent/configs.d/secure-forward/secure-forward.conf
-	</match>
+  <match **>
+    @type copy
+    #include legacy secure-forward.conf
+    @include /etc/fluent/configs.d/secure-forward/secure-forward.conf
+  </match>
 </label>
 {{- end}}
 {{ if .IncludeLegacySyslog }}
 <label @_LEGACY_SYSLOG>
-	<match **>
-		@type copy
-		#include legacy Syslog
-		@include /etc/fluent/configs.d/syslog/syslog.conf
-	</match>
+  <match **>
+    @type copy
+    #include legacy Syslog
+    @include /etc/fluent/configs.d/syslog/syslog.conf
+  </match>
 </label>
 {{- end}}
 
 {{- end}}`
 
-const inputSourceJournalTemplate = `{{- define "inputSourceJournalTemplate" }}
+const inputSourceJournalTemplate = `{{- define "inputSourceJournalTemplate" -}}
 #journal logs to gather node
 <source>
   @type systemd
@@ -352,7 +368,7 @@ const inputSourceJournalTemplate = `{{- define "inputSourceJournalTemplate" }}
 </source>
 {{- end}}`
 
-const inputSourceContainerTemplate = `{{- define "inputSourceContainerTemplate" }}
+const inputSourceContainerTemplate = `{{- define "inputSourceContainerTemplate" -}}
 # container logs
 <source>
   @type tail
@@ -382,7 +398,7 @@ const inputSourceContainerTemplate = `{{- define "inputSourceContainerTemplate" 
 </source>
 {{- end}}`
 
-const inputSourceHostAuditTemplate = `{{- define "inputSourceHostAuditTemplate" }}
+const inputSourceHostAuditTemplate = `{{- define "inputSourceHostAuditTemplate" -}}
 # linux audit logs
 <source>
   @type tail
@@ -397,7 +413,7 @@ const inputSourceHostAuditTemplate = `{{- define "inputSourceHostAuditTemplate" 
 </source>
 {{- end}}`
 
-const inputSourceK8sAuditTemplate = `{{- define "inputSourceK8sAuditTemplate" }}
+const inputSourceK8sAuditTemplate = `{{- define "inputSourceK8sAuditTemplate" -}}
 # k8s audit logs
 <source>
   @type tail
@@ -435,215 +451,215 @@ const inputSourceOpenShiftAuditTemplate = `{{- define "inputSourceOpenShiftAudit
 </source>
 {{- end}}`
 
-const sourceToPipelineCopyTemplate = `{{- define "sourceToPipelineCopyTemplate" }}
+const sourceToPipelineCopyTemplate = `{{- define "sourceToPipelineCopyTemplate" -}}
 <label {{sourceTypelabelName .Source}}>
-	<match **>
-		@type copy
+  <match **>
+    @type copy
 {{ range $index, $pipelineLabel := .PipelineNames }}
-		<store>
-			@type relabel
-			@label {{labelName $pipelineLabel}}
-		</store>
+    <store>
+      @type relabel
+      @label {{labelName $pipelineLabel}}
+    </store>
 {{- end }}
 {{ if .IncludeLegacySecureForward }}
-		<store>
-			@type relabel
-			@label @_LEGACY_SECUREFORWARD
-		</store>
+    <store>
+      @type relabel
+      @label @_LEGACY_SECUREFORWARD
+    </store>
 {{- end }}
 {{ if .IncludeLegacySyslog }}
-		<store>
-			@type relabel
-			@label @_LEGACY_SYSLOG
-		</store>
+    <store>
+      @type relabel
+      @label @_LEGACY_SYSLOG
+    </store>
 {{- end }}
-	</match>
+  </match>
 </label>
 {{- end}}`
 
-const pipelineToOutputCopyTemplate = `{{- define "pipelineToOutputCopyTemplate" }}
+const pipelineToOutputCopyTemplate = `{{- define "pipelineToOutputCopyTemplate" -}}
 <label {{labelName .Name}}>
-	<match **>
-		@type copy
+  <match **>
+    @type copy
 {{ range $index, $target := .Outputs }}
-		<store>
-			@type relabel
-			@label {{labelName $target}}
-		</store>
+    <store>
+      @type relabel
+      @label {{labelName $target}}
+    </store>
 {{- end }}
-	</match>
+  </match>
 </label>
 {{- end}}`
 
-const outputLabelConfTemplate = `{{- define "outputLabelConf" }}
+const outputLabelConfTemplate = `{{- define "outputLabelConf" -}}
 <label {{.LabelName}}>
-	<match {{.RetryTag}}>
-		@type copy
-{{include .StoreTemplate . "prefix_as_retry" | indent 4}}
-	</match>
-	<match **>
-		@type copy
-{{include .StoreTemplate . "include_retry_tag"| indent 4}}
-	</match>
+  <match {{.RetryTag}}>
+    @type copy
+{{ include .StoreTemplate . "prefix_as_retry" | indent 4}}
+  </match>
+  <match **>
+    @type copy
+{{ include .StoreTemplate . "include_retry_tag"| indent 4}}
+  </match>
 </label>
 {{- end}}`
 
-const outputLabelConfNocopyTemplate = `{{- define "outputLabelConfNoCopy" }}
+const outputLabelConfNocopyTemplate = `{{- define "outputLabelConfNoCopy" -}}
 <label {{.LabelName}}>
-	<match **>
+  <match **>
 {{include .StoreTemplate . "" | indent 4}}
-	</match>
+  </match>
 </label>
 {{- end}}`
 
-const outputLabelConfNoretryTemplate = `{{- define "outputLabelConfNoRetry" }}
+const outputLabelConfNoretryTemplate = `{{- define "outputLabelConfNoRetry" -}}
 <label {{.LabelName}}>
-	<match **>
-		@type copy
+  <match **>
+    @type copy
 {{include .StoreTemplate . "" | indent 4}}
-	</match>
+  </match>
 </label>
 {{- end}}`
 
-const forwardTemplate = `{{- define "forward" }}
-	# https://docs.fluentd.org/v1.0/articles/in_forward
-	@type forward
-	{{ if .Target.Secret }}
-	<security>
-		self_hostname "#{ENV['NODE_NAME']}"
-		shared_key "#{File.open('{{ .SecretPath "shared_key" }}') do |f| f.readline end.rstrip}"
-	</security>
+const forwardTemplate = `{{- define "forward" -}}
+# https://docs.fluentd.org/v1.0/articles/in_forward
+@type forward
+{{ if .Target.Secret }}
+<security>
+  self_hostname "#{ENV['NODE_NAME']}"
+  shared_key "#{File.open('{{ .SecretPath "shared_key" }}') do |f| f.readline end.rstrip}"
+</security>
 
-	transport tls
-	tls_verify_hostname false
-	tls_version 'TLSv1_2'
+transport tls
+tls_verify_hostname false
+tls_version 'TLSv1_2'
 
-	#tls_client_private_key_path {{ .SecretPath "tls.key"}}
-	tls_client_cert_path {{ .SecretPath "tls.crt"}}
-	tls_cert_path {{ .SecretPath "ca-bundle.crt"}}
-	{{ end -}}
+#tls_client_private_key_path {{ .SecretPath "tls.key"}}
+tls_client_cert_path {{ .SecretPath "tls.crt"}}
+tls_cert_path {{ .SecretPath "ca-bundle.crt"}}
+{{ end -}}
 
-	<buffer>
-		@type file
-		path '{{.BufferPath}}'
-		queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
-		flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
-		flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-		flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
-		retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
-		retry_forever true
-		# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-		# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-		# buffer to the remote - default is 'exception' because in_tail handles that case
-		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
-	</buffer>
+<buffer>
+  @type file
+  path '{{.BufferPath}}'
+  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+  flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
+  flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
+  flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
+  retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
+  retry_forever true
+  # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+  # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+  # buffer to the remote - default is 'exception' because in_tail handles that case
+  overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
+</buffer>
 
-	<server>
-		host {{.Host}}
-		port {{.Port}}
-	</server>
+<server>
+  host {{.Host}}
+  port {{.Port}}
+</server>
 {{- end}}`
 
-const storeElasticsearchTemplate = `{{- define "storeElasticsearch" }}
+const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
 <store>
-	@type elasticsearch
-	@id {{.StoreID }}
-	host {{.Host}}
-	port {{.Port}}
-    verify_es_version_at_startup false
-	{{- if .Target.Secret }}
-	scheme https
-	ssl_version TLSv1_2
-	{{ else }}
-	scheme http
-	{{ end -}}
-	target_index_key viaq_index_name
-	id_key viaq_msg_id
-	remove_keys viaq_index_name
-	user fluentd
-	password changeme
-	{{ if .Target.Secret }}
-	client_key '{{ .SecretPath "tls.key"}}'
-	client_cert '{{ .SecretPath "tls.crt"}}'
-	ca_file '{{ .SecretPath "ca-bundle.crt"}}'
-	{{ end -}}
-	type_name _doc
-	{{if .Hints.Has "include_retry_tag" -}}
-	retry_tag {{.RetryTag}}
-	{{end -}}
-	write_operation create
-	reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
-	# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
-	reload_after "#{ENV['ES_RELOAD_AFTER'] || '200'}"
-	# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-	sniffer_class_name "#{ENV['ES_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
-	reload_on_failure false
-	# 2 ^ 31
-	request_timeout 2147483648
-	<buffer>
-		@type file
-		path '{{.BufferPath}}'
-		flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
-		flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
-		flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-		retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
-		retry_forever true
-		queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
-		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
-		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
-	</buffer>
+  @type elasticsearch
+  @id {{.StoreID }}
+  host {{.Host}}
+  port {{.Port}}
+  verify_es_version_at_startup false
+{{- if .Target.Secret }}
+  scheme https
+  ssl_version TLSv1_2
+{{- else }}
+  scheme http
+{{- end }}
+  target_index_key viaq_index_name
+  id_key viaq_msg_id
+  remove_keys viaq_index_name
+  user fluentd
+  password changeme
+{{- if .Target.Secret }}
+  client_key '{{ .SecretPath "tls.key"}}'
+  client_cert '{{ .SecretPath "tls.crt"}}'
+  ca_file '{{ .SecretPath "ca-bundle.crt"}}'
+{{- end }}
+  type_name _doc
+{{- if .Hints.Has "include_retry_tag" }}
+  retry_tag {{.RetryTag}}
+{{- end }}
+  write_operation create
+  reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
+  # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+  reload_after "#{ENV['ES_RELOAD_AFTER'] || '200'}"
+  # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+  sniffer_class_name "#{ENV['ES_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
+  reload_on_failure false
+  # 2 ^ 31
+  request_timeout 2147483648
+  <buffer>
+    @type file
+    path '{{.BufferPath}}'
+    flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
+    flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
+    flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
+    retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+    retry_forever true
+    queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+    chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+    overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
+  </buffer>
 </store>
 {{- end}}`
 
-const storeSyslogTemplateOld = `{{- define "storeSyslogOld" }}
+const storeSyslogTemplateOld = `{{- define "storeSyslogOld" -}}
 <store>
-	@type {{.SyslogPlugin}}
-	@id {{.StoreID}}
-	remote_syslog {{.Host}}
-	port {{.Port}}
-	hostname ${hostname}
-	facility user
-	severity debug
+  @type {{.SyslogPlugin}}
+  @id {{.StoreID}}
+  remote_syslog {{.Host}}
+  port {{.Port}}
+  hostname ${hostname}
+  facility user
+  severity debug
 </store>
 {{- end}}`
 
-//	hostname ${hostname}
-const storeSyslogTemplate = `{{- define "storeSyslog" }}
+//      hostname ${hostname}
+const storeSyslogTemplate = `{{- define "storeSyslog" -}}
 <store>
-    @type remote_syslog
-	@id {{.StoreID}}
-	host {{.Host}}
-	port {{.Port}}
-	facility user
-	severity debug
-	program fluentd
-	protocol {{.Protocol}}
-	packet_size 4096
-	{{if .Target.Secret }}
-	tls true
-	ca_file '{{ .SecretPath "ca-bundle.crt"}}'
-	verify_mode true
-	{{ end -}}
-	{{ if (eq .Protocol "tcp")}}
-	timeout 60
-	timeout_exception true
-	keep_alive       true
-	keep_alive_idle    75
-	keep_alive_cnt      9
-	keep_alive_intvl 7200
-	{{ end -}}
-	<buffer>
-		@type file
-		path '{{.BufferPath}}'
-		flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
-		flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
-		flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-		retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
-		retry_forever true
-		queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
-		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
-		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
-	</buffer>
+  @type remote_syslog
+  @id {{.StoreID}}
+  host {{.Host}}
+  port {{.Port}}
+  facility user
+  severity debug
+  program fluentd
+  protocol {{.Protocol}}
+  packet_size 4096
+{{ if .Target.Secret -}}
+  tls true
+  ca_file '{{ .SecretPath "ca-bundle.crt"}}'
+  verify_mode true
+{{ end -}}
+{{ if (eq .Protocol "tcp") -}}
+  timeout 60
+  timeout_exception true
+  keep_alive true
+  keep_alive_idle 75
+  keep_alive_cnt 9
+  keep_alive_intvl 7200
+{{ end -}}
+  <buffer>
+    @type file
+    path '{{.BufferPath}}'
+    flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
+    flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
+    flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
+    retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+    retry_forever true
+    queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+    chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+    overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
+  </buffer>
 </store>
 {{- end}}`

--- a/pkg/k8shandler/forwarding.go
+++ b/pkg/k8shandler/forwarding.go
@@ -56,13 +56,22 @@ func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config s
 		clusterRequest.includeLegacyForwardConfig(),
 		clusterRequest.includeLegacySyslogConfig(),
 		clusterRequest.useOldRemoteSyslogPlugin())
+	if err != nil {
+		return "",
+			clusterRequest.UpdateCondition(
+				logging.CollectorDeadEnd,
+				"Unable to generate collector configuration",
+				"No defined logstore destination",
+				v1.ConditionTrue,
+			)
+	}
 	generatedConfig, err := generator.Generate(&clusterRequest.ForwardingSpec)
 
 	if err != nil {
 		return "",
 			clusterRequest.UpdateCondition(
 				logging.CollectorDeadEnd,
-				"Collectors are defined but there is no defined LogStore of LogForward destinations",
+				"Collectors are defined but there is no defined LogStore or LogForward destinations",
 				"No defined logstore destination",
 				v1.ConditionTrue,
 			)

--- a/pkg/k8shandler/trustedcabundle.go
+++ b/pkg/k8shandler/trustedcabundle.go
@@ -36,11 +36,7 @@ func hasTrustedCABundle(configMap *core.ConfigMap) bool {
 		return false
 	}
 	caBundle, ok := configMap.Data[constants.TrustedCABundleKey]
-	if ok && caBundle != "" {
-		return true
-	} else {
-		return false
-	}
+	return ok && caBundle != ""
 }
 
 func calcTrustedCAHashValue(configMap *core.ConfigMap) (string, error) {

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -141,7 +141,7 @@ func (tc *E2ETestFramework) WaitFor(component LogComponentType) error {
 
 func (tc *E2ETestFramework) waitForElasticsearchPods(retryInterval, timeout time.Duration) error {
 	logger.Debugf("Waiting for %v", "elasticsearch")
-	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		options := metav1.ListOptions{
 			LabelSelector: "component=elasticsearch",
 		}
@@ -169,11 +169,10 @@ func (tc *E2ETestFramework) waitForElasticsearchPods(retryInterval, timeout time
 		}
 		return true, nil
 	})
-	return err
 }
 
 func (tc *E2ETestFramework) waitForDeployment(namespace, name string, retryInterval, timeout time.Duration) error {
-	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		deployment, err := tc.KubeClient.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{IncludeUninitialized: true})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -187,10 +186,6 @@ func (tc *E2ETestFramework) waitForDeployment(namespace, name string, retryInter
 		}
 		return false, nil
 	})
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func (tc *E2ETestFramework) WaitForCleanupCompletion(podlabels []string) {
@@ -206,7 +201,7 @@ func (tc *E2ETestFramework) waitForClusterLoggingPodsCompletion(podlabels []stri
 	options := metav1.ListOptions{
 		LabelSelector: labelSelector,
 	}
-	wait.Poll(defaultRetryInterval, defaultTimeout, func() (bool, error) {
+	return wait.Poll(defaultRetryInterval, defaultTimeout, func() (bool, error) {
 		pods, err := tc.KubeClient.CoreV1().Pods(OpenshiftLoggingNS).List(options)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
@@ -223,7 +218,6 @@ func (tc *E2ETestFramework) waitForClusterLoggingPodsCompletion(podlabels []stri
 		logger.Debug("pods still running...")
 		return false, nil
 	})
-	return nil
 }
 
 func (tc *E2ETestFramework) SetupClusterLogging(componentTypes ...LogComponentType) error {
@@ -278,14 +272,14 @@ func (tc *E2ETestFramework) Cleanup() {
 	//allow caller to cleanup if unset (e.g script cleanup())
 	doCleanup := strings.TrimSpace(os.Getenv("DO_CLEANUP"))
 	if doCleanup == "" || strings.ToLower(doCleanup) == "true" {
-    	RunCleanupScript()
-    	logger.Debugf("Running %v e2e cleanup functions", len(tc.CleanupFns))
-    	for _, cleanup := range tc.CleanupFns {
-    		logger.Debug("Running an e2e cleanup function")
-    		if err := cleanup(); err != nil {
-    			logger.Debugf("Error during cleanup %v", err)
-    		}
-    	}
+		RunCleanupScript()
+		logger.Debugf("Running %v e2e cleanup functions", len(tc.CleanupFns))
+		for _, cleanup := range tc.CleanupFns {
+			logger.Debug("Running an e2e cleanup function")
+			if err := cleanup(); err != nil {
+				logger.Debugf("Error during cleanup %v", err)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
- Formatted cm/fluentd:fluent.conf so it is usable with ```oc get cm/fluentd -oyaml```
- Added build-debug and run-debug targets to the Makefile
- Added error handling during fluent.conf generation
- Made lint happy in test/framework.go

Before:
```
$ oc get cm/fluentd -oyaml
apiVersion: v1
data:
  fluent.conf: "## CLO GENERATED CONFIGURATION ###\n# This file is a copy of the fluentd
    configuration entrypoint\n# which should normally be supplied in a configmap.\n\n<system>\n
    \ @log_level \"#{ENV['LOG_LEVEL'] || 'warn'}\"\n</system>\n\n# In each section
```

After:
```
$ oc get cm/fluentd -oyaml
apiVersion: v1
data:
  fluent.conf: |+
    ## CLO GENERATED CONFIGURATION ###
    # This file is a copy of the fluentd configuration entrypoint
    # which should normally be supplied in a configmap.

    <system>
      @log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
    </system>
...
```