### PR TITLE
Fix flaky test fluentd-prometheus-metrics

### DIFF
--- a/hack/testing-olm/test-999-fluentd-prometheus-metrics.sh
+++ b/hack/testing-olm/test-999-fluentd-prometheus-metrics.sh
@@ -55,7 +55,10 @@ spec:
 EOL
 fi
 try_until_text "oc -n ${LOGGING_NS} get ds fluentd -o jsonpath={.metadata.name} --ignore-not-found" "fluentd" "$((1 * $minute))"
+expectedcollectors=$( oc get nodes | grep -c " Ready " )
+try_until_text "oc -n ${LOGGING_NS} get ds fluentd -o jsonpath={.status.desiredNumberScheduled}" "${expectedcollectors}"  "$((1 * $minute))"
 desired=$(oc -n ${LOGGING_NS} get ds fluentd  -o jsonpath={.status.desiredNumberScheduled})
+
 log::info "Waiting for ${desired} fluent pods to be available...."
 try_until_text "oc -n ${LOGGING_NS} get ds fluentd -o jsonpath={.status.numberReady}" "$desired" "$((2 * $minute))"
 


### PR DESCRIPTION
Wait for desired number of fluent instances to be populated in daemonset before waiting for all fluentd instances to be running.

error text found in CI
```
 [INFO] Waiting for 0 fluent pods to be available....
```
but it should be 6.