### PR TITLE
Updated syslog LF testcase for each syslog rfc

### DIFF
--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -45,7 +45,7 @@ for dir in $(ls -d $TEST_DIR); do
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/logforwarding/cleanup.sh $artifact_dir $GENERATOR_NS" \
     artifact_dir=$artifact_dir \
     GENERATOR_NS=$GENERATOR_NS \
-    go test -count=1 -parallel=1 $dir  | tee -a $artifact_dir/test.log ; then
+    go test -count=1 -parallel=1 -timeout=60m $dir -ginkgo.noColor  | tee -a $artifact_dir/test.log ; then
     log::info "======================================================="
     log::info "Logforwarding $dir passed"
     log::info "======================================================="

--- a/hack/testing/test-367-logforwarding.sh
+++ b/hack/testing/test-367-logforwarding.sh
@@ -62,7 +62,7 @@ for dir in $(ls -d $TEST_DIR); do
     artifact_dir=$artifact_dir \
     GENERATOR_NS=$GENERATOR_NS \
     ELASTICSEARCH_IMAGE="$(format_elasticsearch_image $eo_manifest)" \
-    go test -count=1 -parallel=1 $dir  | tee -a $artifact_dir/test.log ; then
+    go test -count=1 -parallel=1 -timeout=60m $dir -ginkgo.noColor  | tee -a $artifact_dir/test.log ; then
     log::info "======================================================="
     log::info "Logforwarding $dir passed"
     log::info "======================================================="

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -120,6 +120,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       @id syslog_receiver
       host sl.svc.messaging.cluster.local
       port 9654
+      rfc rfc5424
       facility user
       severity debug
       program fluentd
@@ -154,6 +155,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       @id syslog_receiver
       host sl.svc.messaging.cluster.local
       port 9654
+      rfc rfc5424
       facility user
       severity debug
       program fluentd
@@ -182,6 +184,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       @id syslog_receiver
       host sl.svc.messaging.cluster.local
       port 9654
+      rfc rfc5424
       facility user
       severity debug
       program fluentd
@@ -219,6 +222,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       @id syslog_receiver
       host sl.svc.messaging.cluster.local
       port 9654
+      rfc rfc5424
       facility user
       severity debug
       program fluentd

--- a/pkg/generators/forwarding/fluentd/syslog_conf.go
+++ b/pkg/generators/forwarding/fluentd/syslog_conf.go
@@ -6,3 +6,9 @@ func (conf *outputLabelConf) SyslogPlugin() string {
 	}
 	return "syslog_buffered"
 }
+
+func (conf *outputLabelConf) Rfc() string {
+	//return "rfc3164"
+	// TODO update it whem merged with new v1 api
+	return "rfc5424"
+}

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -631,6 +631,7 @@ const storeSyslogTemplate = `{{- define "storeSyslog" -}}
   @id {{.StoreID}}
   host {{.Host}}
   port {{.Port}}
+  rfc {{.Rfc}}
   facility user
   severity debug
   program fluentd

--- a/test/e2e/logforwarding/cleanup.sh
+++ b/test/e2e/logforwarding/cleanup.sh
@@ -9,3 +9,6 @@ gather_logging_resources "openshift-logging" $artifact_dir $runtime
 oc -n $GENERATOR_NS describe deployment/log-generator  > $artifact_dir/$runtime/log-generator.describe||:
 oc -n $GENERATOR_NS logs deployment/log-generator  > $artifact_dir/$runtime/log-generator.logs||:
 oc -n $GENERATOR_NS get deployment/log-generator -o yaml > $artifact_dir/$runtime/log-generator.deployment.yaml||:
+
+oc -n openshift-logging exec $(oc get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- cat /var/log/infra.log > $artifact_dir/$runtime/syslog-receiver.log ||:
+oc -n openshift-logging exec $(oc get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- cat /rsyslog/etc/rsyslog.conf > $artifact_dir/$runtime/syslog-receiver.conf ||:

--- a/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
@@ -37,7 +37,7 @@ var _ = Describe("LogForwarding", func() {
 			Context("and tcp receiver", func() {
 
 				BeforeEach(func() {
-					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, false); err != nil {
+					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, false, helpers.Rfc3164); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
 					const conf = `
@@ -77,7 +77,7 @@ var _ = Describe("LogForwarding", func() {
 			Context("and udp receiver", func() {
 
 				BeforeEach(func() {
-					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolUDP, false); err != nil {
+					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolUDP, false, helpers.Rfc3164); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
 					const conf = `

--- a/test/helpers/elasticsearch.go
+++ b/test/helpers/elasticsearch.go
@@ -137,6 +137,10 @@ func (es *ElasticLogStore) HasAuditLogs(timeToWait time.Duration) (bool, error) 
 	return true, err
 }
 
+func (es *ElasticLogStore) GrepLogs(expr string, timeToWait time.Duration) (string, error) {
+	return "Not Found", fmt.Errorf("Not implemented")
+}
+
 //Indices fetches the list of indices stored by Elasticsearch
 func (es *ElasticLogStore) Indices() (Indices, error) {
 	options := metav1.ListOptions{

--- a/test/helpers/fluentd.go
+++ b/test/helpers/fluentd.go
@@ -166,6 +166,10 @@ func (fluent *fluentReceiverLogStore) HasAuditLogs(timeToWait time.Duration) (bo
 	return fluent.hasLogs("/tmp/audit.logs", timeToWait)
 }
 
+func (es *fluentReceiverLogStore) GrepLogs(expr string, timeToWait time.Duration) (string, error) {
+	return "Not Found", fmt.Errorf("Not implemented")
+}
+
 func (tc *E2ETestFramework) createServiceAccount() (serviceAccount *corev1.ServiceAccount, err error) {
 	serviceAccount = k8shandler.NewServiceAccount("fluent-receiver", OpenshiftLoggingNS)
 	if serviceAccount, err = tc.KubeClient.Core().ServiceAccounts(OpenshiftLoggingNS).Create(serviceAccount); err != nil {

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -63,6 +63,8 @@ type LogStore interface {
 	HasInfraStructureLogs(timeToWait time.Duration) (bool, error)
 
 	HasAuditLogs(timeToWait time.Duration) (bool, error)
+
+	GrepLogs(expr string, timeToWait time.Duration) (string, error)
 }
 
 type E2ETestFramework struct {
@@ -271,6 +273,7 @@ func (tc *E2ETestFramework) CreateLogForwarding(forwarding *logforwarding.LogFor
 
 func (tc *E2ETestFramework) Cleanup() {
 	//allow caller to cleanup if unset (e.g script cleanup())
+	logger.Infof("Running Cleanup....")
 	doCleanup := strings.TrimSpace(os.Getenv("DO_CLEANUP"))
 	if doCleanup == "" || strings.ToLower(doCleanup) == "true" {
 		RunCleanupScript()


### PR DESCRIPTION
Updated syslog LF testcase for each syslog rfc
 - the syslog receiver is created with specific rfc parser (rfc3164, rfc5424)
 - the testcase Expect clause checks for specific fields in the received syslog messages
 - increased timeout for logforwarding testcase completion, and added `-ginkgo.noColor`
 - capturing syslog-receiver logs and configuration in artifacts