### PR TITLE
Update LF GA api for syslog rfc5424 parameters

### DIFF
--- a/deploy/crds/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/deploy/crds/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -70,6 +70,19 @@ spec:
                     description: 'Syslog provides optional extra properties for `type:
                       syslog`'
                     properties:
+                      RFC:
+                        description: "Rfc specifies the rfc to be used for sending
+                          syslog \n Rfc values can be one of:  - RFC3164 (https://tools.ietf.org/html/rfc3164)
+                          \ - RFC5424 (https://tools.ietf.org/html/rfc5424) \n If
+                          unspecified, RFC5424 will be assumed."
+                        enum:
+                        - RFC3164
+                        - RFC5425
+                        type: string
+                      appName:
+                        description: "AppName is APP-NAME part of the syslog-msg header
+                          \n AppName needs to be specified if using rfc5424"
+                        type: string
                       facility:
                         description: "Facility to set on outgoing syslog records.
                           \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
@@ -80,8 +93,16 @@ spec:
                           cron authpriv ftp ntp security console solaris-cron     local0
                           local1 local2 local3 local4 local5 local6 local7"
                         type: string
+                      msgID:
+                        description: "MsgID is MSGID part of the syslog-msg header
+                          \n MsgID needs to be specified if using rfc5424"
+                        type: string
                       payloadKey:
                         description: PayloadKey specifies record field to use as payload.
+                        type: string
+                      procID:
+                        description: "ProcID is PROCID part of the syslog-msg header
+                          \n ProcID needs to be specified if using rfc5424"
                         type: string
                       severity:
                         description: "Severity to set on outgoing syslog records.

--- a/pkg/apis/logging/v1/outputs/syslog.go
+++ b/pkg/apis/logging/v1/outputs/syslog.go
@@ -40,4 +40,37 @@ type Syslog struct {
 	//
 	// +optional
 	PayloadKey string `json:"payloadKey,omitempty"`
+
+	// Rfc specifies the rfc to be used for sending syslog
+	//
+	// Rfc values can be one of:
+	//  - RFC3164 (https://tools.ietf.org/html/rfc3164)
+	//  - RFC5424 (https://tools.ietf.org/html/rfc5424)
+	//
+	// If unspecified, RFC5424 will be assumed.
+	//
+	// +kubebuilder:validation:Enum:=RFC3164;RFC5425
+	// +optional
+	RFC string `json:"RFC,omitempty"`
+
+	// AppName is APP-NAME part of the syslog-msg header
+	//
+	// AppName needs to be specified if using rfc5424
+	//
+	// +optional
+	AppName string `json:"appName,omitempty"`
+
+	// ProcID is PROCID part of the syslog-msg header
+	//
+	// ProcID needs to be specified if using rfc5424
+	//
+	// +optional
+	ProcID string `json:"procID,omitempty"`
+
+	// MsgID is MSGID part of the syslog-msg header
+	//
+	// MsgID needs to be specified if using rfc5424
+	//
+	// +optional
+	MsgID string `json:"msgID,omitempty"`
 }


### PR DESCRIPTION
Added api parameters to specify
 - rfc (rfc3164/rfc5424)
 - app-name (used in rfc5424)
 - procid (used in rfc5424)
 - msgid (used in rfc5424)