### PR TITLE
Ensure LogForwarding works with multiple outputs

### DIFF
--- a/test/e2e/collection/fluentd/flatten_labels_test.go
+++ b/test/e2e/collection/fluentd/flatten_labels_test.go
@@ -77,10 +77,10 @@ var _ = Describe("Fluentd message filtering", func() {
 	}, helpers.DefaultCleanUpTimeout)
 
 	It("should remove 'kubernetes.labels' and create 'kubernetes.flat_labels' with an array of 'kubernetes.labels'", func() {
-		Expect(e2e.LogStore.HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
+		Expect(e2e.LogStores[helpers.FluentdLogStore].HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
 
 		//verify infra namespaces are not stored to their own index
-		logs, err := e2e.LogStore.ApplicationLogs(helpers.DefaultWaitForLogsTimeout)
+		logs, err := e2e.LogStores[helpers.FluentdLogStore].ApplicationLogs(helpers.DefaultWaitForLogsTimeout)
 		Expect(err).To(BeNil(), fmt.Sprintf("Error fetching logs: %v", err))
 		Expect(len(logs)).To(Not(Equal(0)), "There were no documents returned in the logs")
 

--- a/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go
+++ b/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go
@@ -44,8 +44,8 @@ var _ = Describe("CLO Managed ClusterLogForwarder", func() {
 		}, helpers.DefaultCleanUpTimeout)
 
 		It("should default to forwarding logs to the spec'd logstore", func() {
-			Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
-			Expect(e2e.LogStore.HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
+			Expect(e2e.LogStores["elasticsearch"].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+			Expect(e2e.LogStores["elasticsearch"].HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
 
 			//verify infra namespaces are not stored to their own index
 			elasticSearch := helpers.ElasticLogStore{Framework: e2e}

--- a/test/e2e/logforwarding/elasticsearchunmanaged/forward_to_unmanaged_elasticsearch_test.go
+++ b/test/e2e/logforwarding/elasticsearchunmanaged/forward_to_unmanaged_elasticsearch_test.go
@@ -21,8 +21,10 @@ var _ = Describe("ClusterLogForwarder", func() {
 	_, filename, _, _ := runtime.Caller(0)
 	logger.Infof("Running %s", filename)
 	var (
-		err error
-		e2e = helpers.NewE2ETestFramework()
+		err            error
+		e2e            = helpers.NewE2ETestFramework()
+		pipelineSecret *corev1.Secret
+		elasticsearch  *elasticsearch.Elasticsearch
 	)
 	Describe("when ClusterLogging is configured with 'forwarder' to an administrator managed Elasticsearch", func() {
 
@@ -33,8 +35,7 @@ var _ = Describe("ClusterLogForwarder", func() {
 			if err != nil {
 				Fail(fmt.Sprintf("Unable to deploy log generator. E: %s", err.Error()))
 			}
-			var pipelineSecret *corev1.Secret
-			var elasticsearch *elasticsearch.Elasticsearch
+
 			if elasticsearch, pipelineSecret, err = e2e.DeployAnElasticsearchCluster(rootDir); err != nil {
 				Fail(fmt.Sprintf("Unable to deploy an elastic instance: %v", err))
 			}
@@ -99,9 +100,10 @@ var _ = Describe("ClusterLogForwarder", func() {
 		})
 
 		It("should send logs to the forward.Output logstore", func() {
-			Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
-			Expect(e2e.LogStore.HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
-			Expect(e2e.LogStore.HasAuditLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored audit logs")
+			name := elasticsearch.GetName()
+			Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+			Expect(e2e.LogStores[name].HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
+			Expect(e2e.LogStores[name].HasAuditLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored audit logs")
 		})
 
 	})

--- a/test/e2e/logforwarding/fluent/forward_to_fluent_test.go
+++ b/test/e2e/logforwarding/fluent/forward_to_fluent_test.go
@@ -36,7 +36,7 @@ var _ = Describe("ClusterLogForwarder", func() {
 		Context("and the receiver is unsecured", func() {
 
 			BeforeEach(func() {
-				fluentDeployment, err := e2e.DeployFluentdReceiver(rootDir, false)
+				fluentDeployment, err = e2e.DeployFluentdReceiver(rootDir, false)
 				Expect(err).To(Succeed(), "DeployFluentdReceiver")
 
 				cr := helpers.NewClusterLogging(helpers.ComponentTypeCollector)

--- a/test/e2e/logforwarding/fluent/forward_to_fluent_test.go
+++ b/test/e2e/logforwarding/fluent/forward_to_fluent_test.go
@@ -91,9 +91,10 @@ var _ = Describe("ClusterLogForwarder", func() {
 			})
 
 			It("should send logs to the forward.Output logstore", func() {
-				Expect(e2e.LogStore.HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
-				Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
-				Expect(e2e.LogStore.HasAuditLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored audit logs")
+				name := fluentDeployment.GetName()
+				Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+				Expect(e2e.LogStores[name].HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
+				Expect(e2e.LogStores[name].HasAuditLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored audit logs")
 			})
 		})
 
@@ -105,10 +106,11 @@ var _ = Describe("ClusterLogForwarder", func() {
 				}
 				//sanity check
 				initialWaitForLogsTimeout, _ := time.ParseDuration("30s")
-				if exist, _ := e2e.LogStore.HasInfraStructureLogs(initialWaitForLogsTimeout); exist {
+				name := fluentDeployment.GetName()
+				if exist, _ := e2e.LogStores[name].HasInfraStructureLogs(initialWaitForLogsTimeout); exist {
 					Fail("Found logs when we didnt expect them")
 				}
-				if exist, _ := e2e.LogStore.HasApplicationLogs(initialWaitForLogsTimeout); exist {
+				if exist, _ := e2e.LogStores[name].HasApplicationLogs(initialWaitForLogsTimeout); exist {
 					Fail("Found logs when we didnt expect them")
 				}
 
@@ -167,9 +169,10 @@ var _ = Describe("ClusterLogForwarder", func() {
 			})
 
 			It("should send logs to the forward.Output logstore", func() {
-				Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
-				Expect(e2e.LogStore.HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
-				Expect(e2e.LogStore.HasAuditLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored audit logs")
+				name := fluentDeployment.GetName()
+				Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+				Expect(e2e.LogStores[name].HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
+				Expect(e2e.LogStores[name].HasAuditLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored audit logs")
 			})
 		})
 

--- a/test/e2e/logforwarding/fluentlegacy/forward_to_fluent_test.go
+++ b/test/e2e/logforwarding/fluentlegacy/forward_to_fluent_test.go
@@ -43,10 +43,11 @@ var _ = Describe("Backwards compatibility prior to ClusterLogForwarder", func() 
 				}
 				//sanity check
 				initialWaitForLogsTimeout, _ := time.ParseDuration("30s")
-				if exist, _ := e2e.LogStore.HasInfraStructureLogs(initialWaitForLogsTimeout); exist {
+				name := fluentDeployment.GetName()
+				if exist, _ := e2e.LogStores[name].HasInfraStructureLogs(initialWaitForLogsTimeout); exist {
 					Fail("Found logs when we didnt expect them")
 				}
-				if exist, _ := e2e.LogStore.HasApplicationLogs(initialWaitForLogsTimeout); exist {
+				if exist, _ := e2e.LogStores[name].HasApplicationLogs(initialWaitForLogsTimeout); exist {
 					Fail("Found logs when we didnt expect them")
 				}
 
@@ -90,8 +91,9 @@ var _ = Describe("Backwards compatibility prior to ClusterLogForwarder", func() 
 
 			})
 			It("should send logs to the forward.Output logstore", func() {
-				Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
-				Expect(e2e.LogStore.HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
+				name := fluentDeployment.GetName()
+				Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+				Expect(e2e.LogStores[name].HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
 			})
 		})
 

--- a/test/e2e/logforwarding/multiple_outputs/forward_to_multiple_outputs_test.go
+++ b/test/e2e/logforwarding/multiple_outputs/forward_to_multiple_outputs_test.go
@@ -1,0 +1,203 @@
+package multiple_outputs
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/pkg/constants"
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	. "github.com/openshift/cluster-logging-operator/test/helpers"
+	eologgingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("LogForwarding", func() {
+	_, filename, _, _ := runtime.Caller(0)
+	logger.Infof("Running %s", filename)
+
+	e2e := NewE2ETestFramework()
+
+	var (
+		err            error
+		rootDir        string
+		fluentRcv      *apps.Deployment
+		elasticsearch  *eologgingv1.Elasticsearch
+		pipelineSecret *corev1.Secret
+		selectors      = []string{"elasticsearch", "fluent-receiver", "fluentd"}
+	)
+
+	BeforeEach(func() {
+		if err := e2e.DeployLogGenerator(); err != nil {
+			logger.Errorf("unable to deploy log generator. E: %s", err.Error())
+		}
+		rootDir = filepath.Join(filepath.Dir(filename), "..", "..", "..", "..", "/")
+	})
+
+	Describe("when ClusterLogging is configured with 'forwarding' to multiple outputs", func() {
+
+		Describe("and both are accepting logs", func() {
+
+			BeforeEach(func() {
+				fluentRcv, err = e2e.DeployFluentdReceiver(rootDir, false)
+				if err != nil {
+					Fail(fmt.Sprintf("Unable to deploy fluent receiver: %v", err))
+				}
+
+				elasticsearch, pipelineSecret, err = e2e.DeployAnElasticsearchCluster(rootDir)
+				if err != nil {
+					Fail(fmt.Sprintf("Unable to deploy an elasticsearch instance: %v", err))
+				}
+
+				cr := NewClusterLogging(ComponentTypeCollector)
+				if err := e2e.CreateClusterLogging(cr); err != nil {
+					Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+				}
+
+				forwarder := newClusterLogForwarder(fluentRcv, elasticsearch, pipelineSecret)
+				if err := e2e.CreateClusterLogForwarder(forwarder); err != nil {
+					Fail(fmt.Sprintf("Unable to create an instance of logforwarding: %v", err))
+				}
+
+				components := []LogComponentType{ComponentTypeCollector, ComponentTypeStore}
+				for _, component := range components {
+					if err := e2e.WaitFor(component); err != nil {
+						Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
+					}
+				}
+
+			})
+
+			It("should send logs to the fluentd receiver and elasticsearch", func() {
+				stores := []string{fluentRcv.GetName(), elasticsearch.GetName()}
+				for _, name := range stores {
+					Expect(e2e.LogStores[name].HasInfraStructureLogs(DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs in store %q", name)
+					Expect(e2e.LogStores[name].HasApplicationLogs(DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs in store %q", name)
+					Expect(e2e.LogStores[name].HasAuditLogs(DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored audit logs in store %q", name)
+				}
+			})
+		})
+
+		Describe("and one store is not available", func() {
+
+			BeforeEach(func() {
+				fluentRcv, err = e2e.DeployFluentdReceiver(rootDir, false)
+				if err != nil {
+					Fail(fmt.Sprintf("Unable to deploy fluent receiver: %v", err))
+				}
+
+				elasticsearch := &eologgingv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "err-elasticsearch",
+						Namespace: constants.OpenshiftNS,
+					},
+				}
+				e2e.LogStores[elasticsearch.GetClusterName()] = &ElasticLogStore{Framework: e2e}
+
+				cr := NewClusterLogging(ComponentTypeCollector)
+				if err := e2e.CreateClusterLogging(cr); err != nil {
+					Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+				}
+
+				forwarder := newClusterLogForwarder(fluentRcv, elasticsearch, nil)
+				if err := e2e.CreateClusterLogForwarder(forwarder); err != nil {
+					Fail(fmt.Sprintf("Unable to create an instance of logforwarding: %v", err))
+				}
+
+				components := []LogComponentType{ComponentTypeCollector}
+				for _, component := range components {
+					if err := e2e.WaitFor(component); err != nil {
+						Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
+					}
+				}
+
+			})
+
+			It("should send logs to the fluentd receiver only", func() {
+				fluentd := fluentRcv.GetName()
+				Expect(e2e.LogStores[fluentd].HasInfraStructureLogs(DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs in store %q", fluentd)
+				Expect(e2e.LogStores[fluentd].HasApplicationLogs(DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs in store %q", fluentd)
+				Expect(e2e.LogStores[fluentd].HasAuditLogs(DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored audit logs in store %q", fluentd)
+			})
+		})
+
+		AfterEach(func() {
+			e2e.Cleanup()
+			e2e.WaitForCleanupCompletion(selectors)
+		})
+	})
+})
+
+func newClusterLogForwarder(fluentRcv *apps.Deployment, elasticsearch *eologgingv1.Elasticsearch, pipelineSecret *corev1.Secret) *loggingv1.ClusterLogForwarder {
+	fluentdOutput := loggingv1.OutputSpec{
+		Name: fluentRcv.GetName(),
+		Type: loggingv1.OutputTypeFluentdForward,
+		URL:  fmt.Sprintf("%s.%s.svc:24224", fluentRcv.GetName(), fluentRcv.GetNamespace()),
+	}
+
+	elasticOutput := loggingv1.OutputSpec{
+		Name: elasticsearch.GetName(),
+		Type: loggingv1.OutputTypeElasticsearch,
+		URL:  fmt.Sprintf("%s.%s.svc:9200", elasticsearch.GetName(), elasticsearch.GetNamespace()),
+	}
+
+	if pipelineSecret != nil {
+		elasticOutput.Secret = &loggingv1.OutputSecretSpec{
+			Name: pipelineSecret.GetName(),
+		}
+	}
+
+	return &loggingv1.ClusterLogForwarder{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       loggingv1.ClusterLogForwarderKind,
+			APIVersion: loggingv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "instance",
+		},
+		Spec: loggingv1.ClusterLogForwarderSpec{
+			Outputs: []loggingv1.OutputSpec{
+				fluentdOutput,
+				elasticOutput,
+			},
+			Pipelines: []loggingv1.PipelineSpec{
+				{
+					Name:       "fluent-app-logs",
+					InputRefs:  []string{loggingv1.InputNameApplication},
+					OutputRefs: []string{fluentdOutput.Name},
+				},
+				{
+					Name:       "fluent-audit-logs",
+					InputRefs:  []string{loggingv1.InputNameAudit},
+					OutputRefs: []string{fluentdOutput.Name},
+				},
+				{
+					Name:       "fluent-infra-logs",
+					InputRefs:  []string{loggingv1.InputNameInfrastructure},
+					OutputRefs: []string{fluentdOutput.Name},
+				},
+				{
+					Name:       "elasticsearch-app-logs",
+					InputRefs:  []string{loggingv1.InputNameApplication},
+					OutputRefs: []string{elasticOutput.Name},
+				},
+				{
+					Name:       "elasticsearch-audit-logs",
+					InputRefs:  []string{loggingv1.InputNameAudit},
+					OutputRefs: []string{elasticOutput.Name},
+				},
+				{
+					Name:       "elasticsearch-infra-logs",
+					InputRefs:  []string{loggingv1.InputNameInfrastructure},
+					OutputRefs: []string{elasticOutput.Name},
+				},
+			},
+		},
+	}
+}

--- a/test/e2e/logforwarding/multiple_outputs/logforwarding_suite_test.go
+++ b/test/e2e/logforwarding/multiple_outputs/logforwarding_suite_test.go
@@ -1,0 +1,13 @@
+package multiple_outputs
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogForwarding(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LogForwarding Integration E2E Suite - Ensure Forward to Multiple Outputs")
+}

--- a/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
@@ -97,9 +97,11 @@ var _ = PDescribe("LogForwarder", func() {
 								Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
 							}
 						}
-						Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
-						Expect(e2e.LogStore.GrepLogs(grepprogname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected syslogtag to be \"fluentd\"")
-						Expect(e2e.LogStore.GrepLogs(grepappname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected APP-NAME to be \"fluentd\"")
+
+						name := syslogDeployment.GetName()
+						Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+						Expect(e2e.LogStores[name].GrepLogs(grepprogname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected syslogtag to be \"fluentd\"")
+						Expect(e2e.LogStores[name].GrepLogs(grepappname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected APP-NAME to be \"fluentd\"")
 					},
 						//Entry("with rfc 3164", helpers.Rfc3164))
 						Entry("with rfc 5424", helpers.Rfc5424))
@@ -124,9 +126,11 @@ var _ = PDescribe("LogForwarder", func() {
 								Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
 							}
 						}
-						Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
-						Expect(e2e.LogStore.GrepLogs(grepprogname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected syslogtag to be \"fluentd\"")
-						Expect(e2e.LogStore.GrepLogs(grepappname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected APP-NAME to be \"fluentd\"")
+
+						name := syslogDeployment.GetName()
+						Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+						Expect(e2e.LogStores[name].GrepLogs(grepprogname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected syslogtag to be \"fluentd\"")
+						Expect(e2e.LogStores[name].GrepLogs(grepappname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected APP-NAME to be \"fluentd\"")
 					},
 						//Entry("with rfc 3164", helpers.Rfc3164))
 						Entry("with rfc 5424", helpers.Rfc5424))
@@ -155,9 +159,11 @@ var _ = PDescribe("LogForwarder", func() {
 								Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
 							}
 						}
-						Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
-						Expect(e2e.LogStore.GrepLogs(grepprogname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected syslogtag to be \"fluentd\"")
-						Expect(e2e.LogStore.GrepLogs(grepappname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected APP-NAME to be \"fluentd\"")
+
+						name := syslogDeployment.GetName()
+						Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+						Expect(e2e.LogStores[name].GrepLogs(grepprogname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected syslogtag to be \"fluentd\"")
+						Expect(e2e.LogStores[name].GrepLogs(grepappname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected APP-NAME to be \"fluentd\"")
 					},
 						//Entry("with rfc 3164", helpers.Rfc3164))
 						Entry("with rfc 5424", helpers.Rfc5424))
@@ -186,9 +192,11 @@ var _ = PDescribe("LogForwarder", func() {
 								Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
 							}
 						}
-						Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
-						Expect(e2e.LogStore.GrepLogs(grepprogname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected syslogtag to be \"fluentd\"")
-						Expect(e2e.LogStore.GrepLogs(grepappname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected APP-NAME to be \"fluentd\"")
+
+						name := syslogDeployment.GetName()
+						Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+						Expect(e2e.LogStores[name].GrepLogs(grepprogname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected syslogtag to be \"fluentd\"")
+						Expect(e2e.LogStores[name].GrepLogs(grepappname, helpers.DefaultWaitForLogsTimeout)).To(Equal("fluentd"), "Expected APP-NAME to be \"fluentd\"")
 					},
 						//Entry("with rfc 3164", helpers.Rfc3164))
 						Entry("with rfc 5424", helpers.Rfc5424))
@@ -221,7 +229,9 @@ var _ = PDescribe("LogForwarder", func() {
 							Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
 						}
 					}
-					Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+
+					name := syslogDeployment.GetName()
+					Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
 				},
 					Entry("with rfc 3164", helpers.Rfc3164))
 			})
@@ -249,7 +259,9 @@ var _ = PDescribe("LogForwarder", func() {
 							Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
 						}
 					}
-					Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+
+					name := syslogDeployment.GetName()
+					Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
 				},
 					Entry("with rfc 3164", helpers.Rfc3164))
 			})

--- a/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
@@ -68,7 +68,8 @@ var _ = Describe("ClusterLogForwarder", func() {
 				})
 
 				It("should send logs to the forward.Output logstore", func() {
-					Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+					name := syslogDeployment.GetName()
+					Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
 				})
 			})
 
@@ -107,7 +108,8 @@ var _ = Describe("ClusterLogForwarder", func() {
 				})
 
 				It("should send logs to the forward.Output logstore", func() {
-					Expect(e2e.LogStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+					name := syslogDeployment.GetName()
+					Expect(e2e.LogStores[name].HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
 				})
 			})
 

--- a/test/helpers/elasticsearch.go
+++ b/test/helpers/elasticsearch.go
@@ -244,7 +244,9 @@ func (tc *E2ETestFramework) DeployAnElasticsearchCluster(pwd string) (cr *elasti
 		SetHeader("Content-Type", "application/json").
 		Body(body).
 		Do()
-	tc.LogStore = &ElasticLogStore{
+
+	name := cr.GetName()
+	tc.LogStores[name] = &ElasticLogStore{
 		Framework: tc,
 	}
 	return cr, pipelineSecret, result.Error()

--- a/test/helpers/fluentd.go
+++ b/test/helpers/fluentd.go
@@ -352,6 +352,7 @@ func (tc *E2ETestFramework) DeployFluentdReceiver(rootDir string, secure bool) (
 		return tc.KubeClient.Core().Services(OpenshiftLoggingNS).Delete(service.Name, nil)
 	})
 	logStore.deployment = fluentDeployment
-	tc.LogStore = logStore
+	name := fluentDeployment.GetName()
+	tc.LogStores[name] = logStore
 	return fluentDeployment, tc.waitForDeployment(OpenshiftLoggingNS, fluentDeployment.Name, defaultRetryInterval, defaultTimeout)
 }

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -72,7 +72,7 @@ type E2ETestFramework struct {
 	KubeClient     *kubernetes.Clientset
 	ClusterLogging *cl.ClusterLogging
 	CleanupFns     []func() error
-	LogStore       LogStore
+	LogStores      map[string]LogStore
 }
 
 func NewE2ETestFramework() *E2ETestFramework {
@@ -80,6 +80,7 @@ func NewE2ETestFramework() *E2ETestFramework {
 	framework := &E2ETestFramework{
 		RestConfig: config,
 		KubeClient: client,
+		LogStores:  make(map[string]LogStore, 4),
 	}
 	return framework
 }
@@ -246,7 +247,7 @@ func (tc *E2ETestFramework) waitForStatefulSet(namespace, name string, retryInte
 
 func (tc *E2ETestFramework) SetupClusterLogging(componentTypes ...LogComponentType) error {
 	tc.ClusterLogging = NewClusterLogging(componentTypes...)
-	tc.LogStore = &ElasticLogStore{
+	tc.LogStores["elasticsearch"] = &ElasticLogStore{
 		Framework: tc,
 	}
 	return tc.CreateClusterLogging(tc.ClusterLogging)

--- a/test/helpers/kafka.go
+++ b/test/helpers/kafka.go
@@ -17,11 +17,12 @@ import (
 
 type kafkaReceiver struct {
 	tc     *E2ETestFramework
+	app    *apps.StatefulSet
 	topics []string
 }
 
 func (kr *kafkaReceiver) ApplicationLogs(timeToWait time.Duration) (logs, error) {
-	logs, err := kr.tc.consumedLogs(loggingv1.InputNameApplication)
+	logs, err := kr.tc.consumedLogs(kr.app.Name, loggingv1.InputNameApplication)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read consumed application logs: %s", err)
 	}
@@ -30,7 +31,7 @@ func (kr *kafkaReceiver) ApplicationLogs(timeToWait time.Duration) (logs, error)
 
 func (kr *kafkaReceiver) HasInfraStructureLogs(timeout time.Duration) (bool, error) {
 	err := wait.Poll(defaultRetryInterval, timeout, func() (done bool, err error) {
-		logs, err := kr.tc.consumedLogs(loggingv1.InputNameInfrastructure)
+		logs, err := kr.tc.consumedLogs(kr.app.Name, loggingv1.InputNameInfrastructure)
 		if err != nil {
 			return false, err
 		}
@@ -41,7 +42,7 @@ func (kr *kafkaReceiver) HasInfraStructureLogs(timeout time.Duration) (bool, err
 
 func (kr *kafkaReceiver) HasApplicationLogs(timeout time.Duration) (bool, error) {
 	err := wait.Poll(defaultRetryInterval, timeout, func() (done bool, err error) {
-		logs, err := kr.tc.consumedLogs(loggingv1.InputNameApplication)
+		logs, err := kr.tc.consumedLogs(kr.app.Name, loggingv1.InputNameApplication)
 		if err != nil {
 			return false, err
 		}
@@ -52,7 +53,7 @@ func (kr *kafkaReceiver) HasApplicationLogs(timeout time.Duration) (bool, error)
 
 func (kr *kafkaReceiver) HasAuditLogs(timeout time.Duration) (bool, error) {
 	err := wait.Poll(defaultRetryInterval, timeout, func() (done bool, err error) {
-		logs, err := kr.tc.consumedLogs(loggingv1.InputNameAudit)
+		logs, err := kr.tc.consumedLogs(kr.app.Name, loggingv1.InputNameAudit)
 		if err != nil {
 			return false, err
 		}
@@ -69,30 +70,32 @@ func (kr *kafkaReceiver) ClusterLocalEndpoint() string {
 	return kafka.ClusterLocalEndpoint(OpenshiftLoggingNS)
 }
 
-func (tc *E2ETestFramework) DeployKafkaReceiver(topics []string) error {
+func (tc *E2ETestFramework) DeployKafkaReceiver(topics []string) (*apps.StatefulSet, error) {
+	if err := tc.createZookeeper(); err != nil {
+		return nil, err
+	}
+
+	app, err := tc.createKafkaBroker()
+	if err != nil {
+		return nil, err
+	}
+
 	receiver := &kafkaReceiver{
 		tc:     tc,
+		app:    app,
 		topics: topics,
 	}
-	tc.LogStore = receiver
+	tc.LogStores[app.Name] = receiver
 
-	if err := tc.createZookeeper(); err != nil {
-		return err
+	if err := tc.createKafkaConsumers(receiver); err != nil {
+		return nil, err
 	}
 
-	if err := tc.createKafkaBroker(); err != nil {
-		return err
-	}
-
-	if err := tc.createKafkaConsumers(); err != nil {
-		return err
-	}
-
-	return nil
+	return app, nil
 }
 
-func (tc *E2ETestFramework) consumedLogs(inputName string) (logs, error) {
-	rcv := tc.LogStore.(*kafkaReceiver)
+func (tc *E2ETestFramework) consumedLogs(rcvName, inputName string) (logs, error) {
+	rcv := tc.LogStores[rcvName].(*kafkaReceiver)
 	topic := kafka.TopicForInputName(rcv.topics, inputName)
 	name := kafka.ConsumerNameForTopic(topic)
 
@@ -124,25 +127,25 @@ func (tc *E2ETestFramework) consumedLogs(inputName string) (logs, error) {
 	return logs, nil
 }
 
-func (tc *E2ETestFramework) createKafkaBroker() error {
+func (tc *E2ETestFramework) createKafkaBroker() (*apps.StatefulSet, error) {
 	if err := tc.createKafkaBrokerRBAC(); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := tc.createKafkaBrokerConfigMap(); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := tc.createKafkaBrokerService(); err != nil {
-		return err
+		return nil, err
 	}
 
-	err := tc.createKafkaBrokerStatefulSet()
+	app, err := tc.createKafkaBrokerStatefulSet()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return app, nil
 }
 
 func (tc *E2ETestFramework) createZookeeper() error {
@@ -161,8 +164,7 @@ func (tc *E2ETestFramework) createZookeeper() error {
 	return nil
 }
 
-func (tc *E2ETestFramework) createKafkaConsumers() error {
-	rcv := tc.LogStore.(*kafkaReceiver)
+func (tc *E2ETestFramework) createKafkaConsumers(rcv *kafkaReceiver) error {
 	for _, topic := range rcv.topics {
 		app := kafka.NewKafkaConsumerDeployment(OpenshiftLoggingNS, topic)
 
@@ -184,7 +186,7 @@ func (tc *E2ETestFramework) createKafkaConsumers() error {
 	return err
 }
 
-func (tc *E2ETestFramework) createKafkaBrokerStatefulSet() error {
+func (tc *E2ETestFramework) createKafkaBrokerStatefulSet() (*apps.StatefulSet, error) {
 	app := kafka.NewBrokerStatefuleSet(OpenshiftLoggingNS)
 
 	tc.AddCleanup(func() error {
@@ -194,10 +196,10 @@ func (tc *E2ETestFramework) createKafkaBrokerStatefulSet() error {
 
 	_, err := tc.KubeClient.Apps().StatefulSets(OpenshiftLoggingNS).Create(app)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return tc.waitForStatefulSet(OpenshiftLoggingNS, app.GetName(), defaultRetryInterval, defaultTimeout)
+	return app, tc.waitForStatefulSet(OpenshiftLoggingNS, app.GetName(), defaultRetryInterval, defaultTimeout)
 }
 
 func (tc *E2ETestFramework) createZookeeperStatefulSet() (*apps.StatefulSet, error) {

--- a/test/helpers/syslog.go
+++ b/test/helpers/syslog.go
@@ -429,7 +429,9 @@ func (tc *E2ETestFramework) DeploySyslogReceiver(testDir string, protocol corev1
 		return tc.KubeClient.Core().Services(OpenshiftLoggingNS).Delete(service.Name, nil)
 	})
 	logStore.deployment = syslogDeployment
-	tc.LogStore = logStore
+
+	name := syslogDeployment.GetName()
+	tc.LogStores[name] = logStore
 	return syslogDeployment, tc.waitForDeployment(OpenshiftLoggingNS, syslogDeployment.Name, defaultRetryInterval, defaultTimeout)
 }
 


### PR DESCRIPTION
This PR addresses the case of a LogForwarding CR with multiple outputs. It ensures that all available outputs receive the requests logs according to the defined pipeline.

Depends on: #427 