### PR TITLE
Uniform environment variable to skip cleanup for E2E tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Some `make` targets to facilitate deployment:
 ### E2E Testing
 
 This test assumes:
+* the cluster-logging-catalog image is available
 * the cluster-logging-operator image is available
 * the cluster-logging component images are available (i.e. $docker_registry_ip/openshift/$component)
 
@@ -109,4 +110,6 @@ on which the operator runs or can be pulled from a visible registry.
 in order to run this test against local changes to the `cluster-logging-operator`. For example:
 ```
 $ make deploy-image && IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc:5000/openshift/origin-cluster-logging-operator:latest make test-e2e
-```
+``**
+
+**Note:** To skip cleanup of resources while hacking/debugging an E2E test apply `DO_CLEANUP=false`.

--- a/hack/testing-olm/test-010-deploy-via-olm-minimal.sh
+++ b/hack/testing-olm/test-010-deploy-via-olm-minimal.sh
@@ -26,10 +26,11 @@ cleanup(){
   set +e
   gather_logging_resources ${CLUSTER_LOGGING_OPERATOR_NAMESPACE} $test_artifactdir
 
-  ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh
-  ${repo_dir}/olm_deploy/scripts/catalog-uninstall.sh
-  
-  os::cleanup::all "${return_code}"
+  if [ "${DO_CLEANUP:-true}" == "true" ] ; then
+      ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh
+      ${repo_dir}/olm_deploy/scripts/catalog-uninstall.sh
+      os::cleanup::all "${return_code}"
+  fi
   
   set -e
   exit ${return_code}

--- a/hack/testing-olm/test-020-olm-upgrade.sh
+++ b/hack/testing-olm/test-020-olm-upgrade.sh
@@ -45,9 +45,11 @@ cleanup(){
   oc  -n openshift-operator-lifecycle-manager logs --since=$runtime deployment/olm-operator > $ARTIFACT_DIR/olm-operator.logs 2>&1 ||:
   oc describe -n ${NAMESPACE} deployment/cluster-logging-operator > $ARTIFACT_DIR/cluster-logging-operator.describe.after_update  2>&1 ||:
 
-  ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh
-  ${repo_dir}/olm_deploy/scripts/catalog-uninstall.sh
 
+  if [ "${DO_CLEANUP:-true}" == "true" ] ; then
+      ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh
+      ${repo_dir}/olm_deploy/scripts/catalog-uninstall.sh
+  fi
   set -e
   exit ${return_code}
 }

--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -20,7 +20,7 @@ cleanup(){
   end_seconds=$(date +%s)
   runtime="$(($end_seconds - $start_seconds))s"
   
-  if [ "${SKIP_CLEANUP:-false}" == "false" ] ; then
+  if [ "${DO_CLEANUP:-true}" == "true" ] ; then
     ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh
     ${repo_dir}/olm_deploy/scripts/catalog-uninstall.sh
   fi

--- a/hack/testing-olm/test-999-fluentd-prometheus-metrics.sh
+++ b/hack/testing-olm/test-999-fluentd-prometheus-metrics.sh
@@ -15,12 +15,12 @@ cleanup() {
   set +e
   mkdir -p $ARTIFACT_DIR/$test_name
   oc -n $LOGGING_NS get configmap fluentd -o jsonpath={.data} > $ARTIFACT_DIR/$test_name/fluent-configmap.log
-	get_all_logging_pod_logs $ARTIFACT_DIR/$test_name
+  get_all_logging_pod_logs $ARTIFACT_DIR/$test_name
 
-	if [ "${DO_CLEANUP:-true}" == "true" ] ; then
-    ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh
-    ${repo_dir}/olm_deploy/scripts/catalog-uninstall.sh
-	fi
+  if [ "${DO_CLEANUP:-true}" == "true" ] ; then
+      ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh
+      ${repo_dir}/olm_deploy/scripts/catalog-uninstall.sh
+  fi
 
   set -e
   exit $return_code

--- a/test/e2e/logforwarding/cleanup.sh
+++ b/test/e2e/logforwarding/cleanup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../../../hack/testing/utils"
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../../../hack/testing-olm/utils"
 artifact_dir=$1
 GENERATOR_NS=$2
 runtime=$(date +%s)


### PR DESCRIPTION
This PR uniforms the know to skip clean-up scripts for E2E tests. The environemt variable `DO_CLEANUP` needs to be set explicitly to `false` for this purpose.