### PR TITLE
Enhance debug experience for E2E operator registry

### DIFF
--- a/hack/testing-olm/test-020-olm-upgrade.sh
+++ b/hack/testing-olm/test-020-olm-upgrade.sh
@@ -41,10 +41,9 @@ cleanup(){
   oc -n ${NAMESPACE} -o yaml get subscription cluster-logging-operator > $ARTIFACT_DIR/subscription-clo.yml 2>&1 ||:
   oc -n ${NAMESPACE} -o yaml get configmap cluster-logging > $ARTIFACT_DIR/configmap-for-catalogsource-clo.yml 2>&1 ||:
   oc -n ${NAMESPACE} -o yaml get catalogsource cluster-logging > $ARTIFACT_DIR/catalogsource-clo.yml 2>&1 ||:
-  oc  -n openshift-operator-lifecycle-manager logs --since=$runtime deployment/catalog-operator > $ARTIFACT_DIR/catalog-operator.logs 2>&1 ||:
-  oc  -n openshift-operator-lifecycle-manager logs --since=$runtime deployment/olm-operator > $ARTIFACT_DIR/olm-operator.logs 2>&1 ||:
   oc describe -n ${NAMESPACE} deployment/cluster-logging-operator > $ARTIFACT_DIR/cluster-logging-operator.describe.after_update  2>&1 ||:
 
+  get_all_olm_logs $outdir $runtime
 
   if [ "${DO_CLEANUP:-true}" == "true" ] ; then
       ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh

--- a/hack/testing-olm/utils
+++ b/hack/testing-olm/utils
@@ -94,6 +94,7 @@ gather_logging_resources() {
   oc -n ${LOGGING_NS} extract configmap/fluentd --to=$outdir ||:
 
   get_all_logging_pod_logs $outdir
+  get_all_olm_logs $outdir
   set -e
 }
 
@@ -105,7 +106,14 @@ get_all_logging_pod_logs() {
   for p in $(oc get pods -n ${LOGGING_NS} -o jsonpath='{.items[*].metadata.name}') ; do
     oc -n ${LOGGING_NS} describe pod $p > $outdir/$p.describe 2>&1 || :
     oc -n ${LOGGING_NS} get pod $p -o yaml > $outdir/$p.yaml 2>&1 || :
-    for container in $(oc -n ${LOGGING_NS} get po $p -o jsonpath='{.spec.containers[*].name}') ; do
+
+    initContainers=$(oc -n ${LOGGING_NS} get po $p -o jsonpath='{.spec.initContainers[*].name}')
+    for container in $initContainers ; do
+        oc logs -n ${LOGGING_NS} -c $container $p > $outdir/$p.$container.init.log 2>&1
+    done
+
+    containers="$(oc -n ${LOGGING_NS} get po $p -o jsonpath='{.spec.containers[*].name}')"
+    for container in $containers ; do
       oc logs -n ${LOGGING_NS} -c $container $p > $outdir/$p.$container.log 2>&1
       case "$container" in
         fluentd*) oc -n ${LOGGING_NS} exec $p -- logs > $outdir/$p.$container.exec.log 2>&1 ;;
@@ -115,6 +123,15 @@ get_all_logging_pod_logs() {
     done
   done
   set -e
+}
+
+get_all_olm_logs(){
+    set +e
+    local outdir=${1:-$ARTIFACT_DIR}
+    local runtime=${2:-"120s"}
+    oc  -n openshift-operator-lifecycle-manager logs --since=$runtime deployment/catalog-operator > $outdir/catalog-operator.logs 2>&1
+    oc  -n openshift-operator-lifecycle-manager logs --since=$runtime deployment/olm-operator > $outdir/olm-operator.logs 2>&1
+    set -e
 }
 
 wait_for_deployment_to_be_ready(){


### PR DESCRIPTION
This PR enhances the debugging experience of E2E tests by expanding the log exporter in two ways:
- Adds support to export logs from `initContainers`. This enables capturing errors with inconsistencies between the CSV and the provided CRDs on building the operator registry database by `mutate-csv-and-generate-sqlite-db`, e.g. :
```
time="2020-04-15T14:03:11Z" level=warning msg="permissive mode enabled" error="error loading manifests from directory: error checking provided apis in bundle clusterlogging.v4.5.0: couldn't find logging.openshift.io/v1alpha1/LogForwarding (loggggforwardings) in bundle. found: map[logging.openshift.io/v1/ClusterLogging (clusterloggings):{} logging.openshift.io/v1alpha1/Collector (collectors):{} logging.openshift.io/v1alpha1/LogForwarding (logforwardings):{}]"
```
- Adds support to gather logs from the `catalog-operator` and `olm-operator`. This enables capturing errors where CRD validation breaks on processing the subscription, e.g.:
```
time="2020-04-15T09:07:30Z" level=info msg=syncing event=update reconciling="*v1alpha1.Subscription" selflink=/apis/operators.coreos.com/v1alpha1/namespaces/openshift-logging/subscriptions/cluster-logging-operator
E0415 09:07:31.272941       1 queueinformer_operator.go:290] sync "openshift-logging" failed: failed to turn bundle into steps: json: cannot unmarshal object into Go struct field CRDDescription.specDescriptors of type []v1alpha1.SpecDescriptor
```