### PR TITLE
Bug 1780698: Fix disk pressure for fluentd buffer chunks

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -474,7 +474,7 @@ var _ = Describe("Generating fluentd config", func() {
 				<buffer>
 					@type file
 					path '/var/lib/fluentd/secureforward_receiver'
-					queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+					queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 					chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 					flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 					flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
@@ -999,7 +999,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1043,7 +1043,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1088,7 +1088,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1132,7 +1132,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1177,7 +1177,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1221,7 +1221,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1266,7 +1266,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1310,7 +1310,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
@@ -145,7 +145,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
@@ -203,7 +203,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
@@ -243,7 +243,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 	   <buffer>
 	     @type file
 	     path '/var/lib/fluentd/secureforward_receiver'
-	     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+	     queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 	     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 	     flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 	     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
@@ -102,7 +102,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			  <buffer>
 				@type file
 				path '/var/lib/fluentd/secureforward_receiver'
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 				flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
         retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
         retry_forever true
-        queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+        queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
         overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
       </buffer>
@@ -169,7 +169,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
         retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
         retry_forever true
-        queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+        queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
         overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
       </buffer>
@@ -207,7 +207,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
         retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
         retry_forever true
-        queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+        queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
         overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
       </buffer>
@@ -239,7 +239,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
         retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
         retry_forever true
-        queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+        queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
         overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
       </buffer>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -546,7 +546,7 @@ tls_cert_path {{ .SecretPath "ca-bundle.crt"}}
 <buffer>
   @type file
   path '{{.BufferPath}}'
-  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+  queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
   chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
   flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
   flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
@@ -609,7 +609,7 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
     retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
     retry_forever true
-    queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+    queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
     overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
   </buffer>
@@ -662,7 +662,7 @@ const storeSyslogTemplate = `{{- define "storeSyslog" -}}
     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
     retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
     retry_forever true
-    queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+    queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
     overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
   </buffer>

--- a/test/files/secure-forward.conf
+++ b/test/files/secure-forward.conf
@@ -11,7 +11,7 @@
   <buffer>
     @type file
     path '/var/lib/fluentd/secureforwardlegacy'
-    queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+    queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"


### PR DESCRIPTION
This change limits the fluentd queue length to match the number of chunks on the filesystem.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1780698

Needs backport for: release-4.4 and release 4.3.