### PR TITLE
Addressing error being printed out when we try to create a namespace …

### DIFF
--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -123,7 +123,9 @@ func (tc *E2ETestFramework) CreateTestNamespace() string {
 	}
 	_, err := tc.KubeClient.CoreV1().Namespaces().Create(namespace)
 	if err != nil {
-		logger.Error(err)
+		if !apierrors.IsAlreadyExists(err) {
+			logger.Error(err)
+		}
 	}
 	return name
 }


### PR DESCRIPTION
…that already exists for tests