### PR TITLE
Fixed LogForwarding artifacts collection

### DIFF
--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -38,7 +38,7 @@ for dir in $(ls -d $TEST_DIR); do
   log::info "Deploying cluster-logging-operator"
   ${repo_dir}/olm_deploy/scripts/catalog-deploy.sh
   ${repo_dir}/olm_deploy/scripts/operator-install.sh
-  artifact_dir=$ARTIFACT_DIR/$(basename $dir)
+  artifact_dir=$ARTIFACT_DIR/logforwarding/$(basename $dir)
 
   mkdir -p $artifact_dir
   GENERATOR_NS="clo-test-$RANDOM"

--- a/test/e2e/logforwarding/cleanup.sh
+++ b/test/e2e/logforwarding/cleanup.sh
@@ -4,11 +4,11 @@ artifact_dir=$1
 GENERATOR_NS=$2
 runtime=$(date +%s)
 mkdir $artifact_dir/$runtime ||:
-gather_logging_resources "openshift-logging" $artifact_dir $runtime
+gather_logging_resources "openshift-logging" $artifact_dir/$runtime
 
 oc -n $GENERATOR_NS describe deployment/log-generator  > $artifact_dir/$runtime/log-generator.describe||:
 oc -n $GENERATOR_NS logs deployment/log-generator  > $artifact_dir/$runtime/log-generator.logs||:
 oc -n $GENERATOR_NS get deployment/log-generator -o yaml > $artifact_dir/$runtime/log-generator.deployment.yaml||:
 
-oc -n openshift-logging exec $(oc get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- cat /var/log/infra.log > $artifact_dir/$runtime/syslog-receiver.log ||:
-oc -n openshift-logging exec $(oc get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- cat /rsyslog/etc/rsyslog.conf > $artifact_dir/$runtime/syslog-receiver.conf ||:
+oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- cat /var/log/infra.log > $artifact_dir/$runtime/syslog-receiver.log ||:
+oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- cat /rsyslog/etc/rsyslog.conf > $artifact_dir/$runtime/syslog-receiver.conf ||:


### PR DESCRIPTION
Fixed LogForwarding artifacts collection
 - artifacts are captured under the timestamped folder rather than outside
 - LF artifacts are clubbed under `logforwarding` folder