### PR TITLE
[release-4.4] Bug 1826861: Fix disk pressure for fluentd buffer chunks

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -405,7 +405,7 @@ var _ = Describe("Generating fluentd config", func() {
 				<buffer>
 					@type file
 					path '/var/lib/fluentd/secureforward_receiver'
-					queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+					queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 					chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 					flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 					flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
@@ -916,7 +916,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -959,7 +959,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1003,7 +1003,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1046,7 +1046,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1090,7 +1090,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1133,7 +1133,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1177,7 +1177,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1220,7 +1220,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
@@ -143,7 +143,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
@@ -200,7 +200,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
@@ -239,7 +239,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 	   <buffer>
 	     @type file
 	     path '/var/lib/fluentd/secureforward_receiver'
-	     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+	     queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 	     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 	     flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 	     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
@@ -102,7 +102,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			  <buffer>
 				@type file
 				path '/var/lib/fluentd/secureforward_receiver'
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 				flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -501,7 +501,7 @@ const forwardTemplate = `{{- define "forward" }}
 	<buffer>
 		@type file
 		path '{{.BufferPath}}'
-		queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+		queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 		flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 		flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
@@ -563,7 +563,7 @@ const storeElasticsearchTemplate = `{{- define "storeElasticsearch" }}
 		flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 		retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 		retry_forever true
-		queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+		queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 	</buffer>

--- a/test/files/secure-forward.conf
+++ b/test/files/secure-forward.conf
@@ -11,7 +11,7 @@
   <buffer>
     @type file
     path '/var/lib/fluentd/secureforwardlegacy'
-    queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+    queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"


### PR DESCRIPTION
This PR backports a serious issue we have according to multiple customer cases regarding fluentd buffers taking up all the node filesystem until crashing the node itself.

Manual cherry-pick for: #479 because of [reason](https://github.com/openshift/cluster-logging-operator/pull/479#issuecomment-617887451)

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1826861