### PR TITLE
Bug 1817097: Grant perm to set owner ref to metrics Service resource

### DIFF
--- a/manifests/4.5/cluster-logging.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/cluster-logging.v4.5.0.clusterserviceversion.yaml
@@ -228,6 +228,14 @@ spec:
           - prometheusrules
           verbs:
           - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          resourceNames:
+          - "cluster-logging-operator"
+          verbs:
+          - "update"
       clusterPermissions:
       - serviceAccountName: cluster-logging-operator
         rules:


### PR DESCRIPTION
This PR adds missing permissions to allow the operator to set the owner reference to the metrics service resource.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1817097