### PR TITLE
Added a wrapper over oc to run oc commands from golang

### DIFF
--- a/test/helpers/oc/command.go
+++ b/test/helpers/oc/command.go
@@ -1,0 +1,24 @@
+package oc
+
+import (
+	"fmt"
+	"time"
+)
+
+// Command is a base interface to run oc commands
+type Command interface {
+	fmt.Stringer
+
+	// Runs an oc command, and returns command  output as result
+	Run() (string, error)
+	// Runs an oc command for the duration, and Kills the command after duration
+	RunFor(time.Duration) (string, error)
+
+	// Runs an oc command, sends command output to stdout
+	Output() error
+	// Runs an oc command for the duration, sends command output to stdout
+	OutputFor(time.Duration) error
+
+	// Kills a command if running
+	Kill() error
+}

--- a/test/helpers/oc/doc.go
+++ b/test/helpers/oc/doc.go
@@ -1,0 +1,28 @@
+package oc
+
+// oc package is a DSL for running oc/kubectl command from withing go programs.
+// Each oc command is exposed as an interface, with methods to  collect command specific arguments.
+// The collected arguments are passed to runner to execute the commad.
+//
+// A feature of this DSL is ability to compose oc commands.
+// e.g. oc.Exec can be composed with oc.Get to fetch arguments for oc.Exec.
+//
+// The following oc.Exec command
+//oc.Exec().
+//  WithNamespace("openshift-logging").
+//  WithPodGetter(oc.Get().
+//	  WithNamespace("openshift-logging").
+//	  Pod().
+//	  Selector("component=elasticsearch").
+//	  OutputJsonpath("{.items[0].metadata.name}")).
+//  Container("elasticsearch").
+//  WithCmd("es_util", " --query=\"_cat/aliases?v&bytes=m\"")
+//
+//  is equivalent to "oc -n openshift-logging exec $(oc -n openshift-logging get pod -l component=elasticsearch -o jsonpath={.items[0].metadata.name}) -c elasticsearch -- es_util --query=\"_cat/aliases?v&bytes=m\""
+
+// TODO(vimalk78)
+// Fix oc.Literal() for exec-ing compisite commands. e.g. -- bash -c 'ls -al | wc -l'
+// Add other oc commands. apply, describe, delete, logs, wait
+// Add tests for more oc.Get resources, deployent, secrets etc
+// Add separate options argument. e.g. oc.Exec(op) where op is collection of 'oc options'
+// Add oc.Command.RunAsync, or expose oc.exec.Cmd.Start/Wait

--- a/test/helpers/oc/exec.go
+++ b/test/helpers/oc/exec.go
@@ -1,0 +1,139 @@
+package oc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Execer is interface for collecting arguments for Exec command
+type Execer interface {
+	Command
+
+	// argument for option --config
+	WithConfig(string) Execer
+	// argument for option -n
+	WithNamespace(string) Execer
+
+	// argument for podname
+	Pod(string) Execer
+	// a command can be composed to get the pod name. e.g. oc.Get or oc.Literal
+	WithPodGetter(Command) Execer
+
+	// argument for option -c
+	Container(string) Execer
+	// a command can be composed to get the container name. e.g. oc.Get or oc.Literal
+	WithContainerGetter(Command) Execer
+
+	// command and argument to be executed in pod
+	// arguments for option --
+	WithCmd(string, ...string) Execer
+}
+
+type exec struct {
+	*runner
+	namespace string
+
+	podname   string
+	podGetter Command
+
+	container       string
+	containerGetter Command
+
+	command     string
+	commandargs []string
+}
+
+// Exec creates an 'oc exec' command
+func Exec() Execer {
+	e := &exec{
+		runner: &runner{},
+	}
+	e.collectArgsFunc = func() []string {
+		return e.args()
+	}
+	return e
+}
+
+func (e *exec) WithConfig(cfg string) Execer {
+	e.configPath = cfg
+	return e
+}
+
+func (e *exec) WithNamespace(namespace string) Execer {
+	e.namespace = namespace
+	return e
+}
+
+func (e *exec) Pod(podname string) Execer {
+	e.podname = podname
+	return e
+}
+
+func (e *exec) WithPodGetter(cmd Command) Execer {
+	e.podGetter = cmd
+	return e
+}
+
+func (e *exec) Container(container string) Execer {
+	e.container = container
+	return e
+}
+
+func (e *exec) WithContainerGetter(cmd Command) Execer {
+	e.containerGetter = cmd
+	return e
+}
+
+func (e *exec) WithCmd(command string, args ...string) Execer {
+	e.command = command
+	e.commandargs = args
+	return e
+}
+
+func (e *exec) String() string {
+	namespaceStr := ""
+	if e.namespace != "" {
+		namespaceStr = fmt.Sprintf("-n %s", e.namespace)
+	}
+	podStr := e.podname
+	if e.podGetter != nil {
+		podStr = fmt.Sprintf("$(%s)", e.podGetter.String())
+	}
+	containerStr := ""
+	if e.container != "" {
+		containerStr = fmt.Sprintf("-c %s", e.container)
+	}
+	if e.containerGetter != nil {
+		containerStr = fmt.Sprintf("-c %s", e.containerGetter.String())
+	}
+	return sanitizeArgStr(fmt.Sprintf("%s %s exec %s %s -- %s %s", e.runner.String(), namespaceStr, podStr, containerStr, e.command, strings.Join(e.commandargs, " ")))
+}
+
+// creates command args to be used by runner
+func (e *exec) args() []string {
+	var err error
+	namespaceStr := ""
+	if e.namespace != "" {
+		namespaceStr = fmt.Sprintf("-n %s", e.namespace)
+	}
+	if e.podGetter != nil {
+		e.podname, err = e.podGetter.Run()
+		if err != nil {
+			e.runner.err = err
+		}
+	}
+	if e.containerGetter != nil {
+		e.container, err = e.containerGetter.Run()
+		if err != nil {
+			e.runner.err = err
+		}
+	}
+	containerStr := ""
+	if e.container != "" {
+		containerStr = fmt.Sprintf("-c %s", e.container)
+	}
+	ocargs := sanitizeArgs(fmt.Sprintf("%s exec %s %s", namespaceStr, e.podname, containerStr))
+	ocargs = append(ocargs, "--", e.command)
+	ocargs = append(ocargs, e.commandargs...)
+	return ocargs
+}

--- a/test/helpers/oc/exec_test.go
+++ b/test/helpers/oc/exec_test.go
@@ -1,0 +1,147 @@
+package oc_test
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
+)
+
+var _ = Describe("oc exec pod", func() {
+	Describe("with given pod name", func() {
+		Context("running a command without args", func() {
+			Describe("String() invocation", func() {
+				It("should form equivalent string", func() {
+					occmd := oc.Exec().
+						WithNamespace("openshift-logging").
+						Pod("mypod").
+						Container("elasticsearch").
+						WithCmd("indices")
+					strcmd := "oc -n openshift-logging exec mypod -c elasticsearch -- indices"
+					Expect(occmd.String()).To(Equal(strcmd))
+				})
+			})
+		})
+		Context("running a command with args", func() {
+			Describe("String() invocation", func() {
+				It("should form equivalent string", func() {
+					occmd := oc.Exec().
+						WithNamespace("openshift-logging").
+						Pod("mypod").
+						Container("elasticsearch").
+						WithCmd("es_util", " --query=\"_cat/aliases?v&bytes=m\"")
+					strcmd := "oc -n openshift-logging exec mypod -c elasticsearch -- es_util --query=\"_cat/aliases?v&bytes=m\""
+					Expect(occmd.String()).To(Equal(strcmd))
+				})
+			})
+			Describe("Run() invocation", func() {
+				var tmpFile *os.File
+				BeforeEach(func() {
+					f, err := os.Create("./podspec.yaml")
+					if err != nil {
+						Fail("failed to create temp file")
+					}
+					if _, err = f.Write([]byte(podSpec)); err != nil {
+						Fail("failed to write to temp file")
+					}
+					if _, err = oc.Literal().From("oc create ns test-log-gen").Run(); err != nil {
+						Fail("failed to create namespace")
+					}
+					if _, err = oc.Literal().From("oc apply -f ./podspec.yaml").Run(); err != nil {
+						Fail("failed to create pod")
+					}
+					tmpFile = f
+					oc.Literal().From("oc -n test-log-gen wait --for=condition=Ready pod/log-generator").Output()
+				})
+				It("should not result in error", func() {
+					oc.Literal().From("oc -n test-log-gen logs log-generator -f").OutputFor(time.Second * 10)
+					occmd := oc.Exec().
+						WithNamespace("test-log-gen").
+						Pod("log-generator").
+						Container("log-generator").
+						WithCmd("ls", "-al")
+					_, err := occmd.Run()
+					if err != nil {
+						Fail("failed to run the exec command")
+					}
+				})
+				AfterEach(func() {
+					oc.Literal().From("oc delete ns test-log-gen").Run()
+					if tmpFile != nil {
+						os.Remove(tmpFile.Name())
+					} else {
+						logger.Error("tmpfile is nil")
+					}
+				})
+			})
+		})
+	})
+	Describe("with a composed pod getter", func() {
+		Context("running a command with args", func() {
+			Describe("String() invocation", func() {
+				It("should form equivalent string", func() {
+					occmd := oc.Exec().
+						WithNamespace("openshift-logging").
+						WithPodGetter(oc.Get().
+							WithNamespace("openshift-logging").
+							Pod().
+							Selector("component=elasticsearch").
+							OutputJsonpath("{.items[0].metadata.name}")).
+						Container("elasticsearch").
+						WithCmd("es_util", " --query=\"_cat/aliases?v&bytes=m\"")
+					strcmd := "oc -n openshift-logging exec $(oc -n openshift-logging get pod -l component=elasticsearch -o jsonpath={.items[0].metadata.name}) -c elasticsearch -- es_util --query=\"_cat/aliases?v&bytes=m\""
+					Expect(occmd.String()).To(Equal(strcmd))
+				})
+			})
+			Describe("Run() invocation", func() {
+				var tmpFile *os.File
+				BeforeEach(func() {
+					f, err := os.Create("./podspec.yaml")
+					if err != nil {
+						Fail("failed to create temp file")
+					}
+					if _, err = f.Write([]byte(podSpec)); err != nil {
+						Fail("failed to write to temp file")
+					}
+					if _, err = oc.Literal().From("oc create ns test-log-gen").Run(); err != nil {
+						Fail("failed to create namespace")
+					}
+					if _, err = oc.Literal().From("oc apply -f ./podspec.yaml").Run(); err != nil {
+						Fail("failed to create pod")
+					}
+					tmpFile = f
+					oc.Literal().From("oc -n test-log-gen wait --for=condition=Ready pod/log-generator").Output()
+				})
+				It("should not result in error", func() {
+					oc.Literal().From("oc -n test-log-gen logs log-generator -f").OutputFor(time.Second * 10)
+					occmd := oc.Exec().
+						WithNamespace("test-log-gen").
+						WithPodGetter(
+							oc.Get().
+								WithNamespace("test-log-gen").
+								Pod().
+								Selector("component=test").
+								OutputJsonpath("{.items[0].metadata.name}")).
+						Container("log-generator").
+						WithCmd("ls", "-al")
+					_, err := occmd.Run()
+					if err != nil {
+						Fail("failed to run the exec command")
+					}
+				})
+				AfterEach(func() {
+					oc.Literal().From("oc delete ns test-log-gen").Run()
+					if tmpFile != nil {
+						os.Remove(tmpFile.Name())
+					} else {
+						logger.Error("tmpfile is nil")
+					}
+				})
+			})
+		})
+	})
+})

--- a/test/helpers/oc/get.go
+++ b/test/helpers/oc/get.go
@@ -1,0 +1,119 @@
+package oc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Getter is interface for collecting arguments for Get command
+type Getter interface {
+	Command
+
+	// argument for option --config
+	WithConfig(string) Getter
+	// argument for option -n
+	WithNamespace(string) Getter
+
+	// sets the Get command to get pod
+	Pod() Getter
+	// argument for resource kind to get
+	Resource(kind string, name string) Getter
+
+	// argument for resource name to get
+	Name(string) Getter
+	// argument for resource selectors
+	Selector(string) Getter
+
+	// sets -o json output
+	OutputJson() Getter
+	// sets -o yaml output
+	OutputYaml() Getter
+	// argument for -o jsonpath output
+	OutputJsonpath(string) Getter
+}
+
+type get struct {
+	*runner
+	namespace string
+
+	kind     string
+	name     string
+	selector string
+
+	output string
+}
+
+// Get creates an 'oc get' command
+func Get() Getter {
+	g := &get{
+		runner: &runner{},
+	}
+	g.collectArgsFunc = func() []string {
+		return g.args()
+	}
+	return g
+}
+
+func (g *get) WithConfig(cfg string) Getter {
+	g.configPath = cfg
+	return g
+}
+
+func (g *get) WithNamespace(namespace string) Getter {
+	g.namespace = namespace
+	return g
+}
+
+func (g *get) Pod() Getter {
+	g.kind = "pod"
+	return g
+}
+
+func (g *get) Name(name string) Getter {
+	g.name = name
+	return g
+}
+
+func (g *get) Selector(s string) Getter {
+	g.selector = s
+	return g
+}
+
+func (g *get) Resource(kind string, name string) Getter {
+	g.kind = kind
+	g.name = name
+	return g
+}
+
+func (g *get) OutputJson() Getter {
+	g.output = "-o json"
+	return g
+}
+
+func (g *get) OutputYaml() Getter {
+	g.output = "-o yaml"
+	return g
+}
+
+func (g *get) OutputJsonpath(path string) Getter {
+	g.output = fmt.Sprintf("-o jsonpath=%s", path)
+	return g
+}
+
+func (g *get) args() []string {
+	namespaceStr := ""
+	if g.namespace != "" {
+		namespaceStr = fmt.Sprintf("-n %s", g.namespace)
+	}
+	str := ""
+	if g.selector != "" {
+		str = fmt.Sprintf("-l %s", g.selector)
+	} else if g.name != "" {
+		str = g.name
+	}
+	return sanitizeArgs(fmt.Sprintf("%s get %s %s %s", namespaceStr, g.kind, str, g.output))
+}
+
+func (g *get) String() string {
+	return fmt.Sprintf("%s %s", g.runner.String(), strings.Join(g.args(), " "))
+}

--- a/test/helpers/oc/get_test.go
+++ b/test/helpers/oc/get_test.go
@@ -1,0 +1,68 @@
+package oc_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
+)
+
+var _ = Describe("oc get pod", func() {
+	Context("with selector", func() {
+		Describe("String() invocation", func() {
+			It("should form equivalent command strings", func() {
+				occmd := oc.Get().
+					Pod().
+					WithNamespace("test-log-gen").
+					Selector("component=test").
+					OutputJsonpath("{.items[0].metadata.name}")
+				strcmd := "oc -n test-log-gen get pod -l component=test -o jsonpath={.items[0].metadata.name}"
+				Expect(occmd.String()).To(Equal(strcmd))
+			})
+		})
+		Describe("invocation", func() {
+			var tmpFile *os.File
+			BeforeEach(func() {
+				f, err := os.Create("./podspec.yaml")
+				if err != nil {
+					Fail("failed to create temp file")
+				}
+				if _, err = f.Write([]byte(podSpec)); err != nil {
+					Fail("failed to write to temp file")
+				}
+				if _, err = oc.Literal().From("oc create ns test-log-gen").Run(); err != nil {
+					Fail("failed to create namespace")
+				}
+				if _, err = oc.Literal().From("oc apply -f ./podspec.yaml").Run(); err != nil {
+					Fail("failed to create pod")
+				}
+				tmpFile = f
+			})
+			It("should not result in error", func() {
+				occmd := oc.Get().
+					WithNamespace("test-log-gen").
+					Pod().
+					Selector("component=test").
+					OutputJsonpath("{.items[0].metadata.name}")
+				str, err := occmd.Run()
+				if err != nil {
+					Fail("failed to run the command")
+				}
+				if str != "log-generator" {
+					Fail("received incorrect pod name")
+				}
+			})
+			AfterEach(func() {
+				oc.Literal().From("oc delete ns test-log-gen").Run()
+				if tmpFile != nil {
+					os.Remove(tmpFile.Name())
+				} else {
+					logger.Error("tmpfile is nil")
+				}
+			})
+		})
+	})
+})

--- a/test/helpers/oc/literal.go
+++ b/test/helpers/oc/literal.go
@@ -1,0 +1,66 @@
+package oc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// For oc commands not a part of this package, e.g. oc.Logs, oc.Apply, oc.Delete etc,
+// oc.Literal is a workaround to run those commands.
+
+// ILiteral is an interface for collecting the command string
+type ILiteral interface {
+	Command
+
+	// an os command string
+	From(string) ILiteral
+}
+
+type literal struct {
+	*runner
+
+	cmdstr string
+}
+
+// Literal takes an oc command string and runs it
+func Literal() ILiteral {
+	l := &literal{
+		runner: &runner{},
+	}
+	l.collectArgsFunc = func() []string {
+		return l.args()
+	}
+	return l
+}
+
+func (l *literal) WithConfig(cfg string) ILiteral {
+	l.configPath = cfg
+	return l
+}
+
+func (l *literal) From(cmd string) ILiteral {
+	l.cmdstr = strings.TrimSpace(cmd)
+	return l
+}
+
+func (l *literal) String() string {
+	split := strings.SplitN(l.cmdstr, " ", 2)
+	if len(split) != 2 {
+		return "command too small"
+	}
+	if split[0] != CMD {
+		return "error: command string must start with 'oc'"
+	}
+	return sanitizeArgStr(fmt.Sprintf("%s %s", l.runner.String(), split[1]))
+}
+
+func (l *literal) args() []string {
+	split := strings.SplitN(l.cmdstr, " ", 2)
+	if len(split) != 2 {
+		return []string{"--help"}
+	}
+	if split[0] != CMD {
+		return []string{"--help"}
+	}
+	return sanitizeArgs(split[1])
+}

--- a/test/helpers/oc/literal_test.go
+++ b/test/helpers/oc/literal_test.go
@@ -1,0 +1,52 @@
+package oc_test
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
+)
+
+var _ = Describe("literal command", func() {
+	Context("", func() {
+		It("should tolerate extra spaces", func() {
+			cmd := oc.Literal().From(" oc  apply    -f   ./tmp/podspec.yaml ")
+			Expect(cmd.String()).To(BeIdenticalTo("oc apply -f ./tmp/podspec.yaml"))
+			cmd = oc.Literal().From("oc   ")
+			Expect(cmd.String()).To(BeIdenticalTo("command too small"))
+			cmd = oc.Literal().From("abc xyz")
+			Expect(cmd.String()).To(BeIdenticalTo("error: command string must start with 'oc'"))
+		})
+	})
+	Context("", func() {
+		var tmpFile *os.File
+		BeforeEach(func() {
+			f, err := os.Create("./podspec.yaml")
+			if err != nil {
+				Fail("failed to create temp file")
+			}
+			if _, err = f.Write([]byte(podSpec)); err != nil {
+				Fail("failed to write to temp file")
+			}
+			tmpFile = f
+		})
+		It("should run complete pod cycle", func() {
+			oc.Literal().From("oc create ns test-log-gen").Output()
+			oc.Literal().From("oc apply -f ./podspec.yaml").Output()
+			oc.Literal().From("oc -n test-log-gen get pod -l component=test -o jsonpath={.items[0].metadata.name}").Output()
+			oc.Literal().From("oc -n test-log-gen wait --for=condition=Ready pod/log-generator").Output()
+			oc.Literal().From("oc -n test-log-gen logs log-generator -f").OutputFor(time.Second * 10)
+			// currently oc.Literal for oc exec does not support bash -c commands
+			oc.Literal().From("oc -n test-log-gen exec log-generator -c log-generator -- ls -al").Output()
+			oc.Literal().From("oc delete ns test-log-gen").Output()
+		})
+		AfterEach(func() {
+			if tmpFile != nil {
+				os.Remove(tmpFile.Name())
+			}
+		})
+	})
+})

--- a/test/helpers/oc/oc_suite_test.go
+++ b/test/helpers/oc/oc_suite_test.go
@@ -1,0 +1,28 @@
+package oc_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const podSpec = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: log-generator
+  labels:
+    component: test
+  namespace: test-log-gen
+spec:
+  containers:
+    - name: log-generator
+      image: docker.io/library/busybox:1.31.1
+      args: ["sh", "-c", "i=0; while true; do echo $i: Test message; i=$((i+1)) ; sleep 1; done"]
+`
+
+func TestOC(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test OC Commands")
+}

--- a/test/helpers/oc/runner.go
+++ b/test/helpers/oc/runner.go
@@ -1,0 +1,136 @@
+package oc
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"strings"
+	"time"
+
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+)
+
+// Runner is for executing the command. It provides implementation for
+// the methods in oc.Command interface.
+// Other commands like oc.Exec, oc.Get, oc.Literal collect their arguments
+// and use Runner to run the commad with arguments.
+// It provides different modes of executing the commands, Run/RunFor/Output/OutputFor
+//
+// As fas as possible, it is to be kept independent of oc command syntax.
+// TODO(vimalk78)
+// Move KUBECONFIG out from here
+
+// CMD is the command to be run by the runner
+const CMD string = "oc"
+
+// runner encapsulates os/exec/Cmd, collects args, and runs CMD
+type runner struct {
+	*osexec.Cmd
+
+	args       []string
+	configPath string
+
+	// This must be set by oc.Commands to collect arguments before calling Run
+	collectArgsFunc func() []string
+
+	tostdout bool
+
+	err error
+}
+
+func (r *runner) Run() (string, error) {
+	if r.err != nil {
+		return "composed command failed", r.err
+	}
+	r.setArgs(r.collectArgsFunc())
+	return r.runCmd()
+}
+
+func (r *runner) runCmd() (string, error) {
+	r.Cmd = osexec.Command(CMD, r.args...)
+	var outbuf bytes.Buffer
+	var errbuf bytes.Buffer
+	if r.tostdout {
+		r.Cmd.Stdout = os.Stdout
+		r.Cmd.Stderr = os.Stderr
+	} else {
+		r.Cmd.Stdout = &outbuf
+		r.Cmd.Stderr = &errbuf
+	}
+	r.Cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", os.Getenv("KUBECONFIG"))}
+	logger.Infof("running: %s %s", r, strings.Join(r.args, " "))
+	err := r.Cmd.Run()
+	if err != nil {
+		if r.tostdout {
+			return "", err
+		}
+		errout := strings.TrimSpace(errbuf.String())
+		logger.Infof("output: %s, error: %v", errout, err)
+		return errout, err
+	}
+	if r.tostdout {
+		return "", nil
+	}
+	out := strings.TrimSpace(outbuf.String())
+	logger.Infof("output: %s", out)
+	return out, nil
+}
+
+func (r *runner) RunFor(d time.Duration) (string, error) {
+	time.AfterFunc(d, func() {
+		r.Kill()
+	})
+	return r.Run()
+}
+
+func (r *runner) Kill() error {
+	if r.Process != nil {
+		return r.Process.Kill()
+	}
+	return nil
+}
+
+func (r *runner) Output() error {
+	r.tostdout = true
+	_, err := r.Run()
+	return err
+}
+
+func (r *runner) OutputFor(d time.Duration) error {
+	r.tostdout = true
+	_, err := r.RunFor(d)
+	return err
+}
+
+func (r *runner) String() string {
+	if r.configPath != "" {
+		return fmt.Sprintf("%s --config %s", CMD, r.configPath)
+	}
+	return CMD
+}
+
+func sanitizeArgStr(argstr string) string {
+	return strings.Join(sanitizeArgs(argstr), " ")
+}
+
+// sanitize the args, removes any unwanted spaces
+func sanitizeArgs(argstr string) []string {
+	outargs := []string{}
+	args := strings.Split(argstr, " ")
+	for _, arg := range args {
+		arg = strings.TrimSpace(arg)
+		if arg != "" {
+			outargs = append(outargs, arg)
+		}
+	}
+	return outargs
+}
+
+func (r *runner) setArgs(args []string) {
+	r.args = args
+}
+
+func (r *runner) setArgsStr(argstr string) {
+	r.args = sanitizeArgs(argstr)
+}


### PR DESCRIPTION
Added a wrapper over oc to run oc commands from golang

 - supports oc.Exec() for 'oc exec'
 - supports oc.Get() for 'oc get' 
 - supports oc.Literal() for other oc commads which do not have a DSL yet. can be added later.
- added unit test cases