### PR TITLE
Bug 1732698: Fix fetching node count from elastichsearch status

### DIFF
--- a/pkg/k8shandler/status.go
+++ b/pkg/k8shandler/status.go
@@ -107,12 +107,11 @@ func (clusterRequest *ClusterLoggingRequest) getElasticsearchStatus() ([]logging
 
 	if len(esList.Items) != 0 {
 		for _, cluster := range esList.Items {
-
 			nodeConditions := make(map[string]logging.ElasticsearchClusterConditions)
 
 			nodeStatus := logging.ElasticsearchStatus{
 				ClusterName:            cluster.Name,
-				NodeCount:              cluster.Spec.Nodes[0].NodeCount,
+				NodeCount:              cluster.Status.Cluster.NumNodes,
 				ClusterHealth:          cluster.Status.ClusterHealth,
 				Cluster:                cluster.Status.Cluster,
 				Pods:                   getPodMap(cluster.Status),


### PR DESCRIPTION
This PR addresses the node count reporting for elasticsearch nodes in the CLO status field. In detail on a setup with more than three nodes the elasticsearch-operator will create more than one deployments. Thus picking up the node count from the spec is not the correct approach.