### PR TITLE
Bug 1809498: Stop specifying ES image in CLO

### DIFF
--- a/manifests/4.5/cluster-logging.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/cluster-logging.v4.5.0.clusterserviceversion.yaml
@@ -315,16 +315,10 @@ spec:
                         fieldPath: metadata.name
                   - name: OPERATOR_NAME
                     value: "cluster-logging-operator"
-                  - name: ELASTICSEARCH_IMAGE
-                    value: "quay.io/openshift/origin-logging-elasticsearch6:latest"
                   - name: FLUENTD_IMAGE
                     value: "quay.io/openshift/origin-logging-fluentd:latest"
-                  - name: KIBANA_IMAGE
-                    value: "quay.io/openshift/origin-logging-kibana6:latest"
                   - name: CURATOR_IMAGE
                     value: "quay.io/openshift/origin-logging-curator5:latest"
-                  - name: OAUTH_PROXY_IMAGE
-                    value: "quay.io/openshift/origin-oauth-proxy:latest"
                   - name: PROMTAIL_IMAGE
                     value: "quay.io/openshift/origin-promtail:latest"
   customresourcedefinitions:

--- a/manifests/4.5/image-references
+++ b/manifests/4.5/image-references
@@ -6,14 +6,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cluster-logging-operator:latest
-  - name: logging-elasticsearch6
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-logging-elasticsearch6:latest
-  - name: logging-kibana6
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-logging-kibana6:latest
   - name: logging-curator5
     from:
       kind: DockerImage
@@ -22,10 +14,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-logging-fluentd:latest
-  - name: oauth-proxy
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-oauth-proxy:latest
   - name: promtail
     from:
       kind: DockerImage

--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -244,7 +244,6 @@ func newElasticsearchCR(cluster *logging.ClusterLogging, elasticsearchName strin
 		},
 		Spec: elasticsearch.ElasticsearchSpec{
 			Spec: elasticsearch.ElasticsearchNodeSpec{
-				Image:        utils.GetComponentImage("elasticsearch"),
 				Resources:    *resources,
 				NodeSelector: logStoreSpec.NodeSelector,
 				Tolerations:  logStoreSpec.Tolerations,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -28,12 +28,9 @@ const (
 
 // COMPONENT_IMAGES are thee keys are based on the "container name" + "-{image,version}"
 var COMPONENT_IMAGES = map[string]string{
-	"kibana":        "KIBANA_IMAGE",
-	"kibana-proxy":  "OAUTH_PROXY_IMAGE",
-	"curator":       "CURATOR_IMAGE",
-	"fluentd":       "FLUENTD_IMAGE",
-	"elasticsearch": "ELASTICSEARCH_IMAGE",
-	"promtail":      "PROMTAIL_IMAGE",
+	"curator":  "CURATOR_IMAGE",
+	"fluentd":  "FLUENTD_IMAGE",
+	"promtail": "PROMTAIL_IMAGE",
 }
 
 // GetAnnotation returns the value of an annoation for a given key and true if the key was found


### PR DESCRIPTION
This PR stops specifying the ES image in the elasticsearch CR to avoid image/config mismatch between CLO and EO

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1809498