### PR TITLE
Image build that avoids COPY . .

### DIFF
--- a/Dockerfile.nocopy
+++ b/Dockerfile.nocopy
@@ -1,0 +1,30 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+WORKDIR /go/src/github.com/openshift/cluster-logging-operator
+RUN make build
+RUN cp -r bin/cluster-logging-operator manifests /tmp
+
+FROM centos:centos7
+RUN INSTALL_PKGS=" \
+      openssl \
+      " && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir /tmp/ocp-clo && \
+    chmod og+w /tmp/ocp-clo
+COPY --from=builder /tmp/cluster-logging-operator /usr/bin/
+COPY scripts/* /usr/bin/scripts/
+RUN mkdir -p /usr/share/logging/
+COPY files/ /usr/share/logging/
+
+COPY --from=builder /tmp/manifests/ /manifests
+RUN rm /manifests/art.yaml
+
+# this is required because the operator invokes a script as `bash scripts/cert_generation.sh`
+WORKDIR /usr/bin
+ENTRYPOINT ["/usr/bin/cluster-logging-operator"]
+LABEL io.k8s.display-name="OpenShift cluster-logging-operator" \
+      io.k8s.description="This is a component of OpenShift Container Platform that manages the lifecycle of the Aggregated logging stack." \
+      io.openshift.tags="openshift,logging,cluster-logging" \
+      com.redhat.delivery.appregistry=true \
+      maintainer="AOS Logging <aos-logging@redhat.com>"

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ clean:
 
 image:
 	@if [ $${SKIP_BUILD:-false} = false ] ; then \
-		podman build -t $(IMAGE_TAG) . ; \
+		podman build --no-cache -v `pwd`:/go/src/github.com/openshift/cluster-logging-operator:z -t $(IMAGE_TAG) -f Dockerfile.nocopy .; \
 	fi
 
 lint: fmt


### PR DESCRIPTION
Before:
```
$ time make image
STEP 1: FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
STEP 2: WORKDIR /go/src/github.com/openshift/cluster-logging-operator
--> eb7e8344ec7
STEP 3: COPY . .
--> f99f161081a
STEP 4: RUN make build
go build  -o bin/cluster-logging-operator ./cmd/manager
--> 7cefdda8688
...
real	9m44.601s
user	8m28.172s
sys	5m51.587s
```

After:
```
$ time make image
STEP 1: FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
STEP 2: WORKDIR /go/src/github.com/openshift/cluster-logging-operator
--> 7e2ed2bf8c0
STEP 3: RUN make build
go build  -o bin/cluster-logging-operator ./cmd/manager
--> 5d786a94e60
STEP 4: RUN cp -r bin/cluster-logging-operator manifests /tmp
--> 5c60beaa7c8
...
real	1m10.234s
user	1m50.531s
sys	0m20.490s
```