### PR TITLE
Bug 1834558: Remove trace loglevel for ES

### DIFF
--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -234,9 +234,6 @@ func newElasticsearchCR(cluster *logging.ClusterLogging, elasticsearchName strin
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      elasticsearchName,
 			Namespace: cluster.Namespace,
-			Annotations: map[string]string{
-				"elasticsearch.openshift.io/loglevel": "trace",
-			},
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Elasticsearch",


### PR DESCRIPTION
This PR removes trace loglevel for ES that was introduced in error.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1834558

Introduced by: https://github.com/openshift/cluster-logging-operator/pull/423