### PR TITLE
Bug 1833288: Fix trusted ca bundle and hash reconciliation

### DIFF
--- a/pkg/controller/trustedcabundle/trustedcabundle_controller.go
+++ b/pkg/controller/trustedcabundle/trustedcabundle_controller.go
@@ -64,7 +64,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 var _ reconcile.Reconciler = &ReconcileTrustedCABundle{}
 
-// ReconcileProxyConfig reconciles a ClusterLogging object
+//ReconcileTrustedCABundle reconciles the trusted CA bundle config map.
 type ReconcileTrustedCABundle struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
@@ -77,13 +77,9 @@ type ReconcileTrustedCABundle struct {
 // When the user configured and/or system certs are updated, the pods are triggered to restart.
 func (r *ReconcileTrustedCABundle) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 
-	// do one for fluentd and one for kibana separate...
-	if utils.ContainsString(constants.ReconcileForGlobalProxyList, request.Name) {
-
-		if err := k8shandler.ReconcileForTrustedCABundle(request.Name, r.client); err != nil {
-			// Failed to reconcile - requeuing.
-			return reconcileResult, err
-		}
+	if err := k8shandler.ReconcileForTrustedCABundle(request.Name, r.client); err != nil {
+		// Failed to reconcile - requeuing.
+		return reconcileResult, err
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -349,11 +349,13 @@ func isDaemonsetDifferent(current *apps.DaemonSet, desired *apps.DaemonSet) (*ap
 		current.Spec.Template.Spec.Containers[0].Env = desired.Spec.Template.Spec.Containers[0].Env
 		different = true
 	}
+
 	if !utils.PodVolumeEquivalent(current.Spec.Template.Spec.Volumes, desired.Spec.Template.Spec.Volumes) {
 		logrus.Infof("Collector volumes change found, updating %q", current.Name)
 		current.Spec.Template.Spec.Volumes = desired.Spec.Template.Spec.Volumes
 		different = true
 	}
+
 	if !reflect.DeepEqual(current.Spec.Template.Spec.Containers[0].VolumeMounts, desired.Spec.Template.Spec.Containers[0].VolumeMounts) {
 		logrus.Infof("Collector container volumemounts change found, updating %q", current.Name)
 		current.Spec.Template.Spec.Containers[0].VolumeMounts = desired.Spec.Template.Spec.Containers[0].VolumeMounts

--- a/pkg/k8shandler/collection_test.go
+++ b/pkg/k8shandler/collection_test.go
@@ -1,0 +1,194 @@
+package k8shandler
+
+import (
+	"context"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1alpha1"
+	"github.com/openshift/cluster-logging-operator/pkg/constants"
+	esloggingv1 "github.com/openshift/elasticsearch-operator/pkg/apis/logging/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Reconciling", func() {
+	defer GinkgoRecover()
+
+	_ = loggingv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	_ = monitoringv1.AddToScheme(scheme.Scheme)
+
+	var (
+		cluster = &loggingv1.ClusterLogging{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "instance",
+				Namespace: constants.OpenshiftNS,
+				Annotations: map[string]string{
+					ForwardingAnnotation: "enabled",
+				},
+			},
+			Spec: loggingv1.ClusterLoggingSpec{
+				ManagementState: loggingv1.ManagementStateManaged,
+				Collection: &loggingv1.CollectionSpec{
+					Logs: loggingv1.LogCollectionSpec{
+						Type:        loggingv1.LogCollectionTypeFluentd,
+						FluentdSpec: loggingv1.FluentdSpec{},
+					},
+				},
+				LogStore: &loggingv1.LogStoreSpec{
+					Type: loggingv1.LogStoreTypeElasticsearch,
+					ElasticsearchSpec: loggingv1.ElasticsearchSpec{
+						NodeCount:        1,
+						RedundancyPolicy: esloggingv1.ZeroRedundancy,
+					},
+				},
+			},
+		}
+		fwSpec = loggingv1alpha1.ForwardingSpec{
+			DisableDefaultForwarding: false,
+			Pipelines:                []loggingv1alpha1.PipelineSpec{},
+		}
+		fluentdSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fluentd",
+				Namespace: cluster.GetNamespace(),
+			},
+		}
+		fluentdCABundle = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.FluentdTrustedCAName,
+				Namespace: cluster.GetNamespace(),
+				Labels: map[string]string{
+					constants.InjectTrustedCABundleLabel: "true",
+				},
+			},
+			Data: map[string]string{
+				constants.TrustedCABundleKey: `
+                  -----BEGIN CERTIFICATE-----
+                  <PEM_ENCODED_CERT>
+                  -----END CERTIFICATE-------
+                `,
+			},
+		}
+		proxy = &configv1.Proxy{
+			Spec: configv1.ProxySpec{
+				TrustedCA: configv1.ConfigMapNameReference{
+					Name: "custom-ca-bundle",
+				},
+			},
+		}
+	)
+
+	Describe("Collection", func() {
+		var (
+			client         client.Client
+			clusterRequest *ClusterLoggingRequest
+		)
+
+		Context("when cluster proxy present", func() {
+			var (
+				customCABundle = `
+                  -----BEGIN CERTIFICATE-----
+                  <PEM_ENCODED_CERT1>
+                  -----END CERTIFICATE-------
+                  -----BEGIN CERTIFICATE-----
+                  <PEM_ENCODED_CERT2>
+                  -----END CERTIFICATE-------
+                `
+				trustedCABundleVolume = corev1.Volume{
+					Name: constants.FluentdTrustedCAName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: constants.FluentdTrustedCAName,
+							},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  constants.TrustedCABundleKey,
+									Path: constants.TrustedCABundleMountFile,
+								},
+							},
+						},
+					},
+				}
+				trustedCABundleVolumeMount = corev1.VolumeMount{
+					Name:      constants.FluentdTrustedCAName,
+					ReadOnly:  true,
+					MountPath: constants.TrustedCABundleMountDir,
+				}
+			)
+			BeforeEach(func() {
+				client = fake.NewFakeClient(
+					cluster,
+					fluentdSecret,
+					fluentdCABundle,
+				)
+
+				clusterRequest = &ClusterLoggingRequest{
+					client:  client,
+					cluster: cluster,
+					ForwardingRequest: &loggingv1alpha1.LogForwarding{
+						Spec: fwSpec,
+					},
+					ForwardingSpec: fwSpec,
+				}
+			})
+
+			It("should use the default CA bundle in fluentd", func() {
+				Expect(clusterRequest.CreateOrUpdateCollection(proxy)).Should(Succeed())
+
+				key := types.NamespacedName{Name: constants.FluentdTrustedCAName, Namespace: cluster.GetNamespace()}
+				fluentdCaBundle := &corev1.ConfigMap{}
+				Expect(client.Get(context.TODO(), key, fluentdCaBundle)).Should(Succeed())
+				Expect(fluentdCABundle.Data).To(Equal(fluentdCaBundle.Data))
+
+				key = types.NamespacedName{Name: constants.FluentdName, Namespace: cluster.GetNamespace()}
+				ds := &appsv1.DaemonSet{}
+				Expect(client.Get(context.TODO(), key, ds)).Should(Succeed())
+
+				trustedCABundleHash := ds.Spec.Template.Annotations[constants.TrustedCABundleHashName]
+				Expect(calcTrustedCAHashValue(fluentdCABundle)).To(Equal(trustedCABundleHash))
+				Expect(ds.Spec.Template.Spec.Volumes).To(ContainElement(trustedCABundleVolume))
+				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(trustedCABundleVolumeMount))
+			})
+
+			It("should use the injected custom CA bundle in fluentd", func() {
+				// Reconcile w/o custom CA bundle
+				Expect(clusterRequest.CreateOrUpdateCollection(proxy)).To(Succeed())
+
+				// Inject custom CA bundle into fluentd config map
+				injectedCABundle := fluentdCABundle.DeepCopy()
+				injectedCABundle.Data[constants.TrustedCABundleKey] = customCABundle
+				Expect(client.Update(context.TODO(), injectedCABundle)).Should(Succeed())
+
+				// Reconcile with injected custom CA bundle
+				clusterRequest = &ClusterLoggingRequest{
+					client:  client,
+					cluster: cluster,
+					ForwardingRequest: &loggingv1alpha1.LogForwarding{
+						Spec: fwSpec,
+					},
+					ForwardingSpec: fwSpec,
+				}
+				Expect(clusterRequest.CreateOrUpdateCollection(proxy)).Should(Succeed())
+
+				key := types.NamespacedName{Name: constants.FluentdName, Namespace: cluster.GetNamespace()}
+				ds := &appsv1.DaemonSet{}
+				Expect(client.Get(context.TODO(), key, ds)).Should(Succeed())
+
+				trustedCABundleHash := ds.Spec.Template.Annotations[constants.TrustedCABundleHashName]
+				Expect(calcTrustedCAHashValue(injectedCABundle)).To(Equal(trustedCABundleHash))
+				Expect(ds.Spec.Template.Spec.Volumes).To(ContainElement(trustedCABundleVolume))
+				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(trustedCABundleVolumeMount))
+			})
+		})
+	})
+})

--- a/pkg/k8shandler/configmap.go
+++ b/pkg/k8shandler/configmap.go
@@ -4,18 +4,18 @@ import (
 	"fmt"
 	"reflect"
 
-	core "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 )
 
 //NewConfigMap stubs an instance of Configmap
-func NewConfigMap(configmapName string, namespace string, data map[string]string) *core.ConfigMap {
-	return &core.ConfigMap{
+func NewConfigMap(configmapName string, namespace string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
-			APIVersion: core.SchemeGroupVersion.String(),
+			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configmapName,
@@ -25,22 +25,16 @@ func NewConfigMap(configmapName string, namespace string, data map[string]string
 	}
 }
 
-func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateTrustedCaBundleConfigMap(configMap *core.ConfigMap) error {
-	return clusterRequest.createOrUpdateConfigMap(configMap, false)
-}
-
-func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateConfigMap(configMap *core.ConfigMap) error {
-	return clusterRequest.createOrUpdateConfigMap(configMap, true)
-}
-
-func (clusterRequest *ClusterLoggingRequest) createOrUpdateConfigMap(configMap *core.ConfigMap, checkData bool) error {
+//CreateOrUpdateConfigMap creates a new config map resource unless it exists whereas it will update
+//the existing config map if the data section changed.
+func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateConfigMap(configMap *corev1.ConfigMap) error {
 	err := clusterRequest.Create(configMap)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("Failure creating configmap: %v", err)
 		}
 
-		current := &core.ConfigMap{}
+		current := &corev1.ConfigMap{}
 
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if err = clusterRequest.Get(configMap.Name, current); err != nil {
@@ -52,12 +46,10 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateConfigMap(configMap *
 				return fmt.Errorf("Failed to get %v configmap for %q: %v", configMap.Name, clusterRequest.cluster.Name, err)
 			}
 
-			if checkData {
-				if reflect.DeepEqual(configMap.Data, current.Data) {
-					return nil
-				}
-				current.Data = configMap.Data
+			if reflect.DeepEqual(configMap.Data, current.Data) {
+				return nil
 			}
+			current.Data = configMap.Data
 
 			changed := false
 			// if configMap specified labels ensure that current has them...

--- a/pkg/k8shandler/trustedcabundle.go
+++ b/pkg/k8shandler/trustedcabundle.go
@@ -6,17 +6,16 @@ import (
 	"github.com/openshift/cluster-logging-operator/pkg/constants"
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
 	"github.com/sirupsen/logrus"
-	core "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 )
 
-/*
- * Create or update Trusted CA Bundle ConfigMap
- * By setting label "config.openshift.io/inject-trusted-cabundle: true", the cert is automatically filled/updated.
- */
-func (clusterRequest *ClusterLoggingRequest) createOrUpdateTrustedCABundleConfigMap(configMapName string) error {
-	logrus.Debug("createOrUpdateTrustedCABundleConfigMap...")
+//createOrGetTrustedCABundleConfigMap creates or returns an existing Trusted CA Bundle ConfigMap.
+//By setting label "config.openshift.io/inject-trusted-cabundle: true", the cert is automatically filled/updated.
+func (clusterRequest *ClusterLoggingRequest) createOrGetTrustedCABundleConfigMap(name string) (*corev1.ConfigMap, error) {
+	logrus.Debug("createOrGetTrustedCABundleConfigMap...")
 	configMap := NewConfigMap(
-		configMapName,
+		name,
 		clusterRequest.cluster.Namespace,
 		map[string]string{
 			constants.TrustedCABundleKey: "",
@@ -27,11 +26,26 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateTrustedCABundleConfig
 
 	utils.AddOwnerRefToObject(configMap, utils.AsOwner(clusterRequest.cluster))
 
-	err := clusterRequest.CreateOrUpdateTrustedCaBundleConfigMap(configMap)
-	return err
+	err := clusterRequest.Create(configMap)
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("failed to create trusted CA bundle config map %q for %q: %s", name, clusterRequest.cluster.Name, err)
+		}
+
+		// Get the existing config map which may include an injected CA bundle
+		if err = clusterRequest.Get(configMap.Name, configMap); err != nil {
+			if errors.IsNotFound(err) {
+				// the object doesn't exist -- it was likely culled
+				// recreate it on the next time through if necessary
+				return nil, fmt.Errorf("failed to find trusted CA bundle config map %q for %q: %s", name, clusterRequest.cluster.Name, err)
+			}
+			return nil, fmt.Errorf("failed to get trusted CA bundle config map %q for %q: %s", name, clusterRequest.cluster.Name, err)
+		}
+	}
+	return configMap, err
 }
 
-func hasTrustedCABundle(configMap *core.ConfigMap) bool {
+func hasTrustedCABundle(configMap *corev1.ConfigMap) bool {
 	if configMap == nil {
 		return false
 	}
@@ -43,7 +57,7 @@ func hasTrustedCABundle(configMap *core.ConfigMap) bool {
 	}
 }
 
-func calcTrustedCAHashValue(configMap *core.ConfigMap) (string, error) {
+func calcTrustedCAHashValue(configMap *corev1.ConfigMap) (string, error) {
 	hashValue := ""
 	var err error
 

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -230,10 +230,12 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateKibanaDeployment(prox
 
 	kibanaTrustBundle := &v1.ConfigMap{}
 
-	// Create cluster proxy trusted CA bundle.
-	err = clusterRequest.createOrUpdateTrustedCABundleConfigMap(constants.KibanaTrustedCAName)
-	if err != nil {
-		return
+	// Create cluster proxy trusted CA bundle
+	if proxyConfig != nil {
+		kibanaTrustBundle, err = clusterRequest.createOrGetTrustedCABundleConfigMap(constants.KibanaTrustedCAName)
+		if err != nil {
+			return
+		}
 	}
 
 	kibanaPodSpec := newKibanaPodSpec(clusterRequest.cluster, "kibana", "elasticsearch.openshift-logging.svc.cluster.local", proxyConfig, kibanaTrustBundle)


### PR DESCRIPTION
This PR addresses a backport of #517 and openshift/elasticsearch-operator#351 for **release-4.4*. The change set needs to be added manually because Kibana is reconciled by cluster-logging-operator until release 4.4.

To address:
- https://bugzilla.redhat.com/show_bug.cgi?id=1833288
- https://bugzilla.redhat.com/show_bug.cgi?id=1833273