### PR TITLE
Use a real URL parser, only accept well-formed absolute URLs for output.url.

### DIFF
--- a/docs/output_url_field.md
+++ b/docs/output_url_field.md
@@ -1,0 +1,30 @@
+# Using the clusterlogforwarder.output.url field
+
+The `clusterlogforwarder.output.url` field requires a valid absolute URL.  An
+'absolute' URL is one with non-empty `scheme` and `host:port` parts, in other
+words it must start with "something://hostname". User and password parts
+(e.g. http://user:pass@hostname) are *not allowed*, credentials should be
+provided in the `output.secret` field.
+
+In some cases an output type may provide an alternative way to configure
+connections, e.g. the `output.kafka.brokers` field. In such cases the output.url
+can be omitted. Using the output.url field is preferred whenever possible, but
+some output features may not be available via URL (e.g. kafka allows multiple
+failover addresses via `output.kafka.brokers`).
+
+Some output types define a URL scheme, for example elasticsearch uses `http` and
+`https`. Other output types (e.g. syslog) don't define a "natural" URL
+scheme. For those output types we use these special schemes:
+
+* tcp: insecure TCP connection.
+* tls: secure TLS over TCP connection.
+* udp: insecure UDP packets.
+* udps: secure TLS over UDP packets.
+
+If the url scheme is a TLS secure scheme (https, tls, udps) then the
+`output.secret` MUST NOT be empty, it provides the TLS certificates. If the URL
+scheme is insecure, then `output.secret` is normally empty, but MAY be used for
+username/password credentials (e.g. for `fluentForward` secure connections)
+
+
+

--- a/manifests/4.6/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/manifests/4.6/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -192,13 +192,14 @@ spec:
                     url:
                       description: "URL to send log messages to. \n Must be an absolute
                         URL, with a scheme. Valid URL schemes depend on `type`. Special
-                        schemes 'tcp', 'udp' and 'tls' are used for output types that
-                        don't define their own URL scheme.  Example: \n     { type:
-                        syslog, url: tls://syslog.example.com:1234 } \n TLS with server
-                        authentication is enabled by the URL scheme, for example 'tls'
-                        or 'https'.  See `secret` for TLS client authentication. \n
-                        This field is optional and can be empty if there is an output-type
-                        field with alternative connection information."
+                        schemes 'tcp', 'tls', 'udp' and 'udps are used for output
+                        types that don't define their own URL scheme.  Example: \n
+                        \    { type: syslog, url: udps://syslog.example.com:1234 }
+                        \n TLS with server authentication is enabled by the URL scheme,
+                        for example 'tls' or 'https'.  See `secret` for TLS client
+                        authentication. \n This field is optional and can be empty
+                        if there is an output-type field with alternative connection
+                        information."
                       pattern: ^$|[a-zA-z]+:\/\/.*
                       type: string
                   required:

--- a/pkg/apis/logging/v1/cluster_log_forwarder_types.go
+++ b/pkg/apis/logging/v1/cluster_log_forwarder_types.go
@@ -129,10 +129,10 @@ type OutputSpec struct {
 	// URL to send log messages to.
 	//
 	// Must be an absolute URL, with a scheme. Valid URL schemes depend on `type`.
-	// Special schemes 'tcp', 'udp' and 'tls' are used for output types that don't
+	// Special schemes 'tcp', 'tls', 'udp' and 'udps are used for output types that don't
 	// define their own URL scheme.  Example:
 	//
-	//     { type: syslog, url: tls://syslog.example.com:1234 }
+	//     { type: syslog, url: udps://syslog.example.com:1234 }
 	//
 	// TLS with server authentication is enabled by the URL scheme, for
 	// example 'tls' or 'https'.  See `secret` for TLS client authentication.

--- a/pkg/generators/forwarding/fluentd/fluent_conf.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf.go
@@ -8,10 +8,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/pkg/url"
 )
 
 var replacer = strings.NewReplacer(" ", "_", "-", "_", ".", "_")
-var protocolSeparator = "://"
 
 type outputLabelConf struct {
 	Name            string
@@ -22,15 +22,17 @@ type outputLabelConf struct {
 	TemplateContext *template.Template
 	hints           sets.String
 	storeTemplate   string
+	URL             *url.URL
 }
 
-func newOutputLabelConf(t *template.Template, storeTemplate string, target logging.OutputSpec, config *logging.ForwarderSpec, fluentTags ...string) *outputLabelConf {
-	if target.Type == logging.OutputTypeSyslog && target.Syslog == nil {
-		target.Syslog = &logging.Syslog{
-			RFC: "RFC5424",
-		}
+func newOutputLabelConf(t *template.Template, storeTemplate string, target logging.OutputSpec, config *logging.ForwarderSpec, fluentTags ...string) (*outputLabelConf, error) {
+	u, err := url.ParseAbsoluteOrEmpty(target.URL)
+	if err != nil {
+		return nil, fmt.Errorf("url field: %v", err)
 	}
-
+	if target.Type == logging.OutputTypeSyslog && target.Syslog == nil {
+		target.Syslog = &logging.Syslog{RFC: "RFC5424"}
+	}
 	return &outputLabelConf{
 		Name:            target.Name,
 		Target:          target,
@@ -38,8 +40,10 @@ func newOutputLabelConf(t *template.Template, storeTemplate string, target loggi
 		forwarder:       config,
 		fluentTags:      sets.NewString(fluentTags...),
 		storeTemplate:   storeTemplate,
-	}
+		URL:             u,
+	}, nil
 }
+
 func (conf *outputLabelConf) StoreTemplate() string {
 	return conf.storeTemplate
 }
@@ -52,33 +56,27 @@ func (conf *outputLabelConf) Hints() sets.String {
 func (conf *outputLabelConf) Template() *template.Template {
 	return conf.TemplateContext
 }
-func (conf *outputLabelConf) Host() string {
-	endpoint := stripProtocol(conf.Target.URL)
-	return strings.Split(endpoint, ":")[0]
-}
+func (conf *outputLabelConf) Host() string { return conf.URL.Hostname() }
 
 func (conf *outputLabelConf) Port() string {
-	endpoint := stripProtocol(conf.Target.URL)
-	parts := strings.Split(endpoint, ":")
-	if len(parts) == 1 {
+	p := conf.URL.Port()
+	if p == "" {
 		return "9200"
 	}
-	return parts[1]
+	return p
 }
 
+// Protocol returns the insecure base protocol name used in fluentd configuration.
 func (conf *outputLabelConf) Protocol() string {
-	endpoint := conf.Target.URL
-	if index := strings.Index(endpoint, protocolSeparator); index != -1 {
-		return endpoint[:index]
+	protocol := strings.ToLower(conf.URL.Scheme)
+	switch protocol {
+	case "tls":
+		return "tcp" // Fluentd uses "tcp" for TLS connections, TLS is dealt with elsewhere.
+	case "udps":
+		return "udp"
+	default:
+		return protocol
 	}
-	return ""
-}
-
-func stripProtocol(endpoint string) string {
-	if index := strings.Index(endpoint, protocolSeparator); index != -1 {
-		endpoint = endpoint[index+len(protocolSeparator):]
-	}
-	return endpoint
 }
 
 func (conf *outputLabelConf) BufferPath() string {

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Generating fluentd config", func() {
 				{
 					Type:   logging.OutputTypeElasticsearch,
 					Name:   "apps-es-1",
-					URL:    "es.svc.messaging.cluster.local:9654",
+					URL:    "https://es.svc.messaging.cluster.local:9654",
 					Secret: &logging.OutputSecretSpec{Name: "my-es-secret"},
 				},
 				{
@@ -45,7 +45,7 @@ var _ = Describe("Generating fluentd config", func() {
 				{
 					Type: logging.OutputTypeElasticsearch,
 					Name: "audit-es",
-					URL:  "es.svc.audit.cluster:9654",
+					URL:  "https://es.svc.audit.cluster:9654",
 					Secret: &logging.OutputSecretSpec{
 						Name: "my-audit-secret",
 					},
@@ -77,7 +77,7 @@ var _ = Describe("Generating fluentd config", func() {
 				{
 					Type: logging.OutputTypeElasticsearch,
 					Name: "apps-es-1",
-					URL:  "es.svc.messaging.cluster.local:9654",
+					URL:  "https://es.svc.messaging.cluster.local:9654",
 					Secret: &logging.OutputSecretSpec{
 						Name: "my-es-secret",
 					},
@@ -141,7 +141,7 @@ var _ = Describe("Generating fluentd config", func() {
 				{
 					Type: "fluentdForward",
 					Name: "secureforward-receiver",
-					URL:  "es.svc.messaging.cluster.local:9654",
+					URL:  "http://es.svc.messaging.cluster.local:9654",
 				},
 			},
 			Pipelines: []logging.PipelineSpec{

--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -259,10 +259,13 @@ func (engine *ConfigGenerator) generateOutputLabelBlocks(outputs []logging.Outpu
 		default:
 			return nil, fmt.Errorf("Unknown outpt type: %v", output.Type)
 		}
-		conf := newOutputLabelConf(engine.Template, engine.storeTemplate, output, outputConf)
+		conf, err := newOutputLabelConf(engine.Template, engine.storeTemplate, output, outputConf)
+		if err != nil {
+			return nil, fmt.Errorf("generating fluentd output label: %v", err)
+		}
 		result, err := engine.Execute(engine.outputTemplate, conf)
 		if err != nil {
-			return nil, fmt.Errorf("Error generating fluentd config Processing template outputLabelConf: %v", err)
+			return nil, fmt.Errorf("generating fluent output label: %v", err)
 		}
 		configs = append(configs, result)
 	}

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				{
 					Type: logging.OutputTypeElasticsearch,
 					Name: "oncluster-elasticsearch",
-					URL:  "es.svc.messaging.cluster.local:9654",
+					URL:  "https://es.svc.messaging.cluster.local:9654",
 					Secret: &logging.OutputSecretSpec{
 						Name: "my-es-secret",
 					},
@@ -171,7 +171,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				{
 					Type: logging.OutputTypeElasticsearch,
 					Name: "other-elasticsearch",
-					URL:  "es.svc.messaging.cluster.local:9654",
+					URL:  "http://es.svc.messaging.cluster.local:9654",
 				},
 			}
 		})

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 				{
 					Type: "fluentdForward",
 					Name: "secureforward-receiver",
-					URL:  "es.svc.messaging.cluster.local:9654",
+					URL:  "https://es.svc.messaging.cluster.local:9654",
 					Secret: &logging.OutputSecretSpec{
 						Name: "my-infra-secret",
 					},
@@ -91,7 +91,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 				{
 					Type: "fluentdForward",
 					Name: "secureforward-receiver",
-					URL:  "es.svc.messaging.cluster.local:9654",
+					URL:  "http://es.svc.messaging.cluster.local:9654",
 				},
 			}
 		})
@@ -103,7 +103,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			<match **>
 				# https://docs.fluentd.org/v1.0/articles/in_forward
 			  @type forward
-	   
+
 			  <buffer>
 				@type file
 				path '/var/lib/fluentd/secureforward_receiver'

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					{
 						Type: "syslog",
 						Name: "syslog-receiver",
-						URL:  "sl.svc.messaging.cluster.local:9654",
+						URL:  "tcp://sl.svc.messaging.cluster.local:9654",
 					},
 				}
 			})
@@ -319,7 +319,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 						{
 							Type: "syslog",
 							Name: "syslog-receiver",
-							URL:  "tcp://sl.svc.messaging.cluster.local:9654",
+							URL:  "tls://sl.svc.messaging.cluster.local:9654",
 							Secret: &logging.OutputSecretSpec{
 								Name: "some-secret",
 							},
@@ -359,7 +359,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 						{
 							Type: "syslog",
 							Name: "syslog-receiver",
-							URL:  "udp://sl.svc.messaging.cluster.local:9654",
+							URL:  "udps://sl.svc.messaging.cluster.local:9654",
 							Secret: &logging.OutputSecretSpec{
 								Name: "some-secret",
 							},

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Generating fluentd config", func() {
 				{
 					Type: loggingv1.OutputTypeElasticsearch,
 					Name: "other-elasticsearch",
-					URL:  "es.svc.messaging.cluster.local:9654",
+					URL:  "http://es.svc.messaging.cluster.local:9654",
 				},
 			}
 		})
@@ -259,7 +259,7 @@ var _ = Describe("Generating fluentd config", func() {
 				{
 					Type: "fluentdForward",
 					Name: "secureforward-receiver",
-					URL:  "es.svc.messaging.cluster.local:9654",
+					URL:  "http://es.svc.messaging.cluster.local:9654",
 				},
 			}
 		})

--- a/pkg/generators/forwarding/fluentd/syslog_conf.go
+++ b/pkg/generators/forwarding/fluentd/syslog_conf.go
@@ -72,19 +72,6 @@ func (conf *outputLabelConf) Tag() string {
 	return tag
 }
 
-func (conf *outputLabelConf) SyslogProtocol() string {
-	switch strings.ToLower(conf.Protocol()) {
-	case "":
-		fallthrough
-	case "tls":
-		return "tcp"
-	case "udp":
-		return "udp"
-	default:
-		return conf.Protocol()
-	}
-}
-
 func (conf *outputLabelConf) PayloadKey() string {
 	return conf.Target.Syslog.PayloadKey
 }

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -698,7 +698,7 @@ const storeSyslogTemplate = `{{- define "storeSyslog" -}}
 	{{if .Target.Syslog.Tag -}}
 	program {{.Tag}}
 	{{end -}}
-	protocol {{.SyslogProtocol}}
+	protocol {{.Protocol}}
 	packet_size 4096
 {{ if .Target.Secret -}}
   tls true

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -1,0 +1,53 @@
+// package url provides operations on URLs and URL schemes for log forwarding destinations.
+package url
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ParseAbsolute parses an absolute URL - one with non-empty Scheme and Host.
+// Returned errors include the string s.
+func ParseAbsolute(s string) (*URL, error) {
+	if s == "" {
+		return nil, fmt.Errorf("empty")
+	}
+	u, err := url.Parse(s)
+	switch {
+	case err != nil:
+		return nil, err
+	case u.Scheme == "":
+		return nil, fmt.Errorf("no scheme: %v", u)
+	case u.Host == "":
+		return nil, fmt.Errorf("no host: %v", u)
+	}
+	return u, nil
+}
+
+// ParseAbsoluteOrEmpty is like ParseAbsolute but returns an empty
+// URL rather than an error if s == "".
+func ParseAbsoluteOrEmpty(s string) (*URL, error) {
+	if s == "" {
+		return &url.URL{}, nil
+	} else {
+		return ParseAbsolute(s)
+	}
+}
+
+// IsTLSScheme returns true if scheme is recognized as needing TLS security,
+// for example "https", "tls" or "udps"
+func IsTLSScheme(scheme string) bool {
+	switch strings.ToLower(scheme) {
+	case "https", "tls", "udps":
+		return true
+	default:
+		return false
+	}
+}
+
+// Stubs for net/url types/functions so it's not necessary to import it as well.
+
+type URL = url.URL
+
+func Parse(s string) (*URL, error) { return url.Parse(s) }

--- a/test/e2e/logforwarding/fluent/forward_to_fluent_test.go
+++ b/test/e2e/logforwarding/fluent/forward_to_fluent_test.go
@@ -78,7 +78,6 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 						},
 					},
 				}
-				logger.Infof("FIXME creating %v", forwarder)
 				if err := e2e.CreateClusterLogForwarder(forwarder); err != nil {
 					Fail(fmt.Sprintf("Unable to create an instance of clusterlogforwarder: %v", err))
 				}


### PR DESCRIPTION
Use url.Parse() for all URL parsing, require that URLs be well formed and absolute 