### PR TITLE
bug 1793551: image-references: remove promtail

### DIFF
--- a/manifests/4.5/image-references
+++ b/manifests/4.5/image-references
@@ -14,7 +14,3 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-logging-fluentd:latest
-  - name: promtail
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-promtail:refBz1793551


### PR DESCRIPTION
I think I misunderstood the point of this file, thinking something outside ART cared about it. If we're not looking to replace promtail downstream, I don't see a point in keeping it here -- it just forces us to look up an image and not do anything with it.

I think removing it would be a better solution for https://bugzilla.redhat.com/show_bug.cgi?id=1793551