### PR TITLE
Bug 1836044: Log LF generations warnings only on error

### DIFF
--- a/pkg/k8shandler/forwarding.go
+++ b/pkg/k8shandler/forwarding.go
@@ -67,9 +67,8 @@ func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config s
 			)
 	}
 	generatedConfig, err := generator.Generate(&clusterRequest.ForwardingSpec)
-	logger.Warnf("Unable to generate log confguraiton: %v", err)
-
 	if err != nil {
+		logger.Warnf("Unable to generate log confguraiton: %v", err)
 		return "",
 			clusterRequest.UpdateCondition(
 				logging.CollectorDeadEnd,


### PR DESCRIPTION
To address: https://bugzilla.redhat.com/show_bug.cgi?id=1836044