### PR TITLE
Speedup build by COPYing less

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-.git/*
-_output/*
-tmp/*


### PR DESCRIPTION
 buildah takes more time to execute COPY if there is a .dockerignore file
 - add individual COPY statements for copying individual files and folders required for `make build`
 - delete .dockerignore