### PR TITLE
Bug 1811879: Docs URL in the CLO description refers to 4.1, v. 4.5

### DIFF
--- a/manifests/4.5/cluster-logging.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/cluster-logging.v4.5.0.clusterserviceversion.yaml
@@ -118,7 +118,7 @@ spec:
     must be explicitly created by a cluster administrator (e.g. `oc create ns openshift-logging`). To enable metrics
     service discovery add namespace label `openshift.io/cluster-monitoring: "true"`.
 
-    For additional installation documentation see [Deploying cluster logging](https://docs.openshift.com/container-platform/4.1/logging/efk-logging-deploying.html)
+    For additional installation documentation see [Deploying cluster logging](https://docs.openshift.com/container-platform/4.5/logging/cluster-logging-deploying.html)
     in the OpenShift product documentation.
 
     ### Elasticsearch Operator


### PR DESCRIPTION
The Cluster Logging Operator info page in the OCP web console links to the 4.1 version of the Cluster Logging documentation.