### PR TITLE
Bug 1844445: Fixed CLO crash when reconciling Fluentd

### DIFF
--- a/pkg/k8shandler/forwarding.go
+++ b/pkg/k8shandler/forwarding.go
@@ -41,6 +41,11 @@ func isForwardingEnabled(cluster *logging.ClusterLogging) bool {
 
 func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config string, err error) {
 
+	if clusterRequest.cluster == nil || clusterRequest.cluster.Spec.Collection == nil {
+		logger.Warnf("skipping collection config generation as 'collection' section is not specified in the CLO's CR")
+		return "", nil
+	}
+
 	switch clusterRequest.cluster.Spec.Collection.Logs.Type {
 	case logging.LogCollectionTypeFluentd:
 		break


### PR DESCRIPTION
When CLO's CR created only with the `collection` section and then removed after some time, CLO will crash trying to reconcile Fluentd. This patch fixes that.
The root cause is that when CLO is triggered to restart fluentd, the `collection` section may not be configured in the CLO's CR.