### PR TITLE
Added render_templates required for operator brew build using cpaas

### DIFF
--- a/render_templates
+++ b/render_templates
@@ -1,0 +1,3 @@
+# This file is required in the cpaas operator build flow
+# reference: https://gitlab.sat.engineering.redhat.com/cpaas/documentation/-/blob/building-operators/schema/product/builds/brew_container_operator.adoc#user-content-render-templates
+


### PR DESCRIPTION
This file is required in the cpaas operator build flow
reference: https://gitlab.sat.engineering.redhat.com/cpaas/documentation/-/blob/building-operators/schema/product/builds/brew_container_operator.adoc#user-content-render-templates

