### PR TITLE
Bug 1847413: Fix E2E olm registry migration

### DIFF
--- a/olm_deploy/operatorregistry/Dockerfile
+++ b/olm_deploy/operatorregistry/Dockerfile
@@ -12,3 +12,8 @@ COPY olm_deploy/scripts/registry-init.sh /scripts/
 COPY --from=registry-builder /bin/initializer /usr/bin/initializer
 COPY --from=registry-builder /bin/registry-server /usr/bin/registry-server
 COPY --from=registry-builder /bin/grpc_health_probe /usr/bin/grpc_health_probe
+
+# Change working directory to enable registry migrations
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1843702
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1827612
+WORKDIR /bundle


### PR DESCRIPTION
This PR addresses a newly incorporated change in the operator registry image that needs a temporary directory to back the bundles database before migrating. (See operator-framework/operator-registry#332)

**Needs backport:** release-4.5