### PR TITLE
rely on config to dictate loglevel in lieu of runtime args

### DIFF
--- a/files/fluentd/run.sh
+++ b/files/fluentd/run.sh
@@ -17,13 +17,13 @@ fi
 
 if [[ $VERBOSE ]]; then
   set -ex
-  fluentdargs="$fluentdargs -vv --log-event-verbose"
+  fluentdargs="$fluentdargs --log-event-verbose"
   echo ">>>>>> ENVIRONMENT VARS <<<<<"
   env | sort
   echo ">>>>>>>>>>>>><<<<<<<<<<<<<<<<"
 else
   set -e
-  fluentdargs="-q --suppress-config-dump $fluentdargs"
+  fluentdargs="--suppress-config-dump $fluentdargs"
 fi
 
 

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Generating fluentd config", func() {
 			# which should normally be supplied in a configmap.
 			
 			<system>
-  				@log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
+  				log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
 			</system>
 			
 			# In each section below, pre- and post- includes don't include anything initially;
@@ -519,7 +519,7 @@ var _ = Describe("Generating fluentd config", func() {
 			# which should normally be supplied in a configmap.
 			
 			<system>
-  				@log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
+  				log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
 			</system>
 			
 			# In each section below, pre- and post- includes don't include anything initially;

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -25,7 +25,7 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 # which should normally be supplied in a configmap.
 
 <system>
-  @log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
+  log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
 </system>
 
 # In each section below, pre- and post- includes don't include anything initially;

--- a/test/helpers/fluentd.go
+++ b/test/helpers/fluentd.go
@@ -27,7 +27,7 @@ const (
 	receiverName             = "fluent-receiver"
 	secureFluentConfTemplate = `
 <system>
-	@log_level info
+	log_level info
 </system>
 <source>
   @type forward
@@ -64,7 +64,7 @@ const (
 	`
 	unsecureFluentConf = `
 <system>
-	@log_level warn
+	log_level warn
 </system>
 <source>
   @type forward


### PR DESCRIPTION
This PR:
* removes cli switches to control loglevel favoring a level defined in config.
* corrects system log_level to remove '@' in accordance with the docs

During testing I discovered no logs were being created because the command lineswitch takes precedence over config which hides valueable info