### PR TITLE
Bug 1851381: Add condition when log collection is missing outputs

### DIFF
--- a/pkg/apis/logging/v1/clusterlogging_types.go
+++ b/pkg/apis/logging/v1/clusterlogging_types.go
@@ -255,6 +255,7 @@ const (
 	ContainerTerminated ClusterConditionType = "ContainerTerminated"
 	Unschedulable       ClusterConditionType = "Unschedulable"
 	NodeStorage         ClusterConditionType = "NodeStorage"
+	CollectorDeadEnd    ClusterConditionType = "CollectorDeadEnd"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/k8shandler/conditions.go
+++ b/pkg/k8shandler/conditions.go
@@ -1,0 +1,91 @@
+package k8shandler
+
+// the purpose of this file is give an easy means to update/add clusterconditions
+
+import (
+	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (clusterRequest *ClusterLoggingRequest) UpdateCondition(conditionType logging.ClusterConditionType, message, reason string, status v1.ConditionStatus) error {
+
+	condition := clusterRequest.GetCondition(conditionType)
+
+	condition.Message = message
+	condition.Reason = reason
+	condition.Status = status
+
+	found := false
+	updated := false
+	for index, clusterCondition := range clusterRequest.cluster.Status.Conditions {
+		if clusterCondition.Type == condition.Type {
+			found = true
+			if condition.Status == v1.ConditionFalse {
+				clusterRequest.cluster.Status.Conditions = removeCondition(clusterRequest.cluster.Status.Conditions, index)
+				updated = true
+			} else {
+				if isConditionDifferent(clusterCondition, condition) {
+					condition.LastTransitionTime = metav1.Now()
+					clusterRequest.cluster.Status.Conditions[index] = condition
+					updated = true
+				}
+			}
+			break
+		}
+	}
+
+	if !found {
+		if condition.Status == v1.ConditionTrue {
+			condition.LastTransitionTime = metav1.Now()
+			clusterRequest.cluster.Status.Conditions = append(clusterRequest.cluster.Status.Conditions, condition)
+			updated = true
+		}
+	}
+
+	if updated {
+		return clusterRequest.UpdateStatus(clusterRequest.cluster)
+	}
+
+	return nil
+}
+
+func (clusterRequest *ClusterLoggingRequest) GetCondition(conditionType logging.ClusterConditionType) logging.ClusterCondition {
+
+	for _, clusterCondition := range clusterRequest.cluster.Status.Conditions {
+		if clusterCondition.Type == conditionType {
+			return clusterCondition
+		}
+	}
+
+	return logging.ClusterCondition{
+		Type: conditionType,
+	}
+}
+
+// we use this to remove a condition from the list of clusterConditions
+// typically when the status == v1.ConditionFalse
+func removeCondition(conditions []logging.ClusterCondition, index int) []logging.ClusterCondition {
+	return append(conditions[:index], conditions[index+1:]...)
+}
+
+func isConditionDifferent(lhs, rhs logging.ClusterCondition) bool {
+
+	if lhs.Type != rhs.Type {
+		return true
+	}
+
+	if lhs.Status != rhs.Status {
+		return true
+	}
+
+	if lhs.Reason != rhs.Reason {
+		return true
+	}
+
+	if lhs.Message != rhs.Message {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
### Description
This change set addresses a manual cherry pick for 8d0d82ff to handle cluster logging setups w/o a log store and log forwarding instances. In addition it improves the missing error handling for the else branch in the original commit.

### Notes to the patch-manger
This PR for release 4.4 is different to the parent PR for 4.5 because 8d0d82ff was introduced by a sprint enhancement task w/o noticing the broken feature. In addition the patch for 4.5 as well for 4.6 is a consequence of introducing Elastiscsearch 6. The target release 4.4 is still based on Elasticsearch 5. 

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1851381