### PR TITLE
Bug 1851680: Fix ClusterLogForwarder status reconciliation

### DIFF
--- a/pkg/k8shandler/reconciler.go
+++ b/pkg/k8shandler/reconciler.go
@@ -82,7 +82,7 @@ func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, req
 	// Reconcile Collection
 	err = clusterLoggingRequest.CreateOrUpdateCollection(proxyConfig)
 	forwarder.Status = clusterLoggingRequest.ForwarderRequest.Status
-	logger.DebugObject("ClusterLogForwarder status after updating collection: %v", forwarder.Status)
+	logger.DebugObject("ClusterLogForwarder status after updating collection: %#v", forwarder.Status)
 	if err != nil {
 		msg := fmt.Sprintf("Unable to reconcile collection for %q: %v", clusterLoggingRequest.cluster.Name, err)
 		logger.Errorf(msg)


### PR DESCRIPTION
This PR provides a fix to reconcile the status of ClusterLogFowarder CRs. In detail, the reconciliation runs before updating the status, whereas the order was flipped.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1851680

/cc @alanconway 