### PR TITLE
Bug 1852889: Bump minKubeVersion to 1.18.3

### DIFF
--- a/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ spec:
   # The version value is substituted by the ART pipeline
   version: 4.6.0
   displayName: Cluster Logging
-  minKubeVersion: 1.17.1
+  minKubeVersion: 1.18.3
   description: |
     # Cluster Logging
     The Cluster Logging Operator orchestrates and manages the aggregated logging stack as a cluster-wide service.


### PR DESCRIPTION
This PR addresses a bump of minKubeVersion to 1.18.3 because cluster-logging-operator is using client-go 1.18.x-only APIs and complies with 1.18.x upstream deprecation removals (See #576)

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1852889