### PR TITLE
[release-4.3] Bug 1855322: Add support label for s390x & ppc64le

### DIFF
--- a/manifests/4.3/cluster-logging.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/4.3/cluster-logging.v4.3.0.clusterserviceversion.yaml
@@ -6,6 +6,10 @@ metadata:
   # The version value is substituted by the ART pipeline
   name: clusterlogging.v4.3.0
   namespace: placeholder
+  labels:
+    "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.ppc64le": supported
+    "operatorframework.io/arch.s390x": supported
   annotations:
     capabilities: Seamless Upgrades
     categories: "OpenShift Optional, Logging & Tracing"


### PR DESCRIPTION
In order for the cluster-logging-operator to be correctly filtered in
the OperatorHub for s390x and ppc64le we need to add the correct arch
label as supported.

(cherry picked from commit 78e1e2b728a9aeae6400f2e9a8b364bb0df7985b)