### PR TITLE
Add validation to ClusterLogForwarder name required to be "instance"

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,4 +1,0 @@
-Directory for external commands that need to be downloaded or built.
-
-You can copy/link commands here if you want to use a particular executable.
-Otherwise `make` will take the command from `$PATH` or build/download it here.

--- a/hack/get-openshift-client.sh
+++ b/hack/get-openshift-client.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+# Download latest release of openshift-client, intended for use by ../Makefile
+
+set -e
+VERSION=$(curl -s -L  https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.6.0-0.ci/latest | jq --raw-output '.name')
+
+DOWNLOAD_URL=$(curl -s -L  https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.6.0-0.ci/latest | jq --raw-output '.downloadURL')
+
+NAME="openshift-client-linux-$VERSION.tar.gz"
+pushd bin/
+echo "Extracting openshift client binary...."
+curl -sSfL "$DOWNLOAD_URL/$NAME" -O > "$NAME"
+tar xfz "$NAME" oc
+rm "$NAME"
+echo "Done"
+popd

--- a/manifests/4.6/crd-v1-singleton-patch.yaml
+++ b/manifests/4.6/crd-v1-singleton-patch.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata
+  value:
+    type: object
+    properties:
+      name:
+        type: string
+        enum:
+        - "instance"

--- a/manifests/4.6/kustomization.yaml
+++ b/manifests/4.6/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- logging.openshift.io_clusterlogforwarders_crd.yaml
+patchesJson6902:
+- path: crd-v1-singleton-patch.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: clusterlogforwarders.logging.openshift.io

--- a/manifests/4.6/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/manifests/4.6/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -8,9 +8,9 @@ spec:
     kind: ClusterLogForwarder
     listKind: ClusterLogForwarderList
     plural: clusterlogforwarders
-    singular: clusterlogforwarder
     shortNames:
     - clf
+    singular: clusterlogforwarder
   scope: Namespaced
   versions:
   - name: v1
@@ -37,6 +37,11 @@ spec:
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
+            properties:
+              name:
+                enum:
+                - instance
+                type: string
             type: object
           spec:
             description: ClusterLogForwarderSpec defines the desired state of ClusterLogForwarder

--- a/olm_deploy/operatorregistry/Dockerfile
+++ b/olm_deploy/operatorregistry/Dockerfile
@@ -5,7 +5,8 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
 WORKDIR /
 COPY manifests/ /manifests
 
-RUN chmod -R g+w /manifests && rm /manifests/art.yaml /manifests/*/image-references
+RUN chmod -R g+w /manifests && \
+  rm /manifests/art.yaml /manifests/*/image-references /manifests/*/kustomization.yaml /manifests/*/crd-v1-singleton-patch.yaml
 
 COPY olm_deploy/scripts/registry-init.sh /scripts/
 


### PR DESCRIPTION
**Description**
This PR addresses the required schema validation for `ClusterLogForwarder` resources to allow where `metadata.name` has value `instance`.

**Solution**
The approach selected is based on patching the generated CRD file with the on-board openshift client utility `oc kustomize`. The reasoning is that CRD openAPI schema generation is based on kubebuilder annotations, which is limited to explicitly declared fields in the CRD go struct fields. Since metadata fields (i.e. `TypeMeta` and `ObjectMeta`) are declared as embedded structs in the CRD go struct, their fields cannot be annotation via comments.

Kustomize is the onboard utility to patch manifests with kubectl/oc, e.g. to add common labels, namespaces and in extend apply patches.

/cc @jcantrill 