### PR TITLE
Bug 1833486: Improve fluent performance in comparison to 4.4 

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -108,8 +108,9 @@ var _ = Describe("Generating fluentd config", func() {
   path "/var/log/containers/*_project1-namespace_*.log", "/var/log/containers/*_project2-namespace_*.log"
   exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
   pos_file "/var/log/es-containers.log.pos"
+  pos_file_compaction_interval 300
   refresh_interval 5
-  rotate_wait 5
+  rotate_wait 1
   tag kubernetes.*
   read_from_head "true"
   @label @CONCAT
@@ -200,8 +201,9 @@ var _ = Describe("Generating fluentd config", func() {
 				path "/var/log/containers/*.log"
 				exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 				pos_file "/var/log/es-containers.log.pos"
+				pos_file_compaction_interval 300
 				refresh_interval 5
-				rotate_wait 5
+				rotate_wait 1
 				tag kubernetes.*
 				read_from_head "true"
 				@label @CONCAT
@@ -479,6 +481,7 @@ var _ = Describe("Generating fluentd config", func() {
 					path '/var/lib/fluentd/secureforward_receiver'
 					queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
 					chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+					total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 					flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 					flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 					flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
@@ -584,8 +587,9 @@ var _ = Describe("Generating fluentd config", func() {
 				path "/var/log/containers/*.log"
 				exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 				pos_file "/var/log/es-containers.log.pos"
+				pos_file_compaction_interval 300
 				refresh_interval 5
-				rotate_wait 5
+				rotate_wait 1
 				tag kubernetes.*
 				read_from_head "true"
 				@label @CONCAT
@@ -612,6 +616,7 @@ var _ = Describe("Generating fluentd config", func() {
               @label @INGRESS
               path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
               pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
+              pos_file_compaction_interval 300
               tag linux-audit.log
               <parse>
                 @type viaq_host_audit
@@ -625,6 +630,7 @@ var _ = Describe("Generating fluentd config", func() {
               @label @INGRESS
               path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
               pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
+              pos_file_compaction_interval 300
               tag k8s-audit.log
               <parse>
                 @type json
@@ -642,6 +648,7 @@ var _ = Describe("Generating fluentd config", func() {
               @label @INGRESS
               path "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log'}"
               pos_file "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log.pos'}"
+              pos_file_compaction_interval 300
               tag openshift-audit.log
               <parse>
                 @type json
@@ -1004,6 +1011,7 @@ var _ = Describe("Generating fluentd config", func() {
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
 					</store>
@@ -1048,6 +1056,7 @@ var _ = Describe("Generating fluentd config", func() {
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
 					</store>
@@ -1093,6 +1102,7 @@ var _ = Describe("Generating fluentd config", func() {
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
 					</store>
@@ -1137,6 +1147,7 @@ var _ = Describe("Generating fluentd config", func() {
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
 					</store>
@@ -1182,6 +1193,7 @@ var _ = Describe("Generating fluentd config", func() {
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
 					</store>
@@ -1226,6 +1238,7 @@ var _ = Describe("Generating fluentd config", func() {
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
 					</store>
@@ -1271,6 +1284,7 @@ var _ = Describe("Generating fluentd config", func() {
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
 					</store>
@@ -1315,6 +1329,7 @@ var _ = Describe("Generating fluentd config", func() {
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
 					</store>

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -477,7 +477,7 @@ var _ = Describe("Generating fluentd config", func() {
 				<buffer>
 					@type file
 					path '/var/lib/fluentd/secureforward_receiver'
-					queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+					queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
 					chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 					flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 					flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
@@ -1002,7 +1002,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1046,7 +1046,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1091,7 +1091,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1135,7 +1135,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1180,7 +1180,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1224,7 +1224,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1269,7 +1269,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>
@@ -1313,7 +1313,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 							retry_forever true
-							queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 							overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 						</buffer>

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
@@ -145,7 +145,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
@@ -203,7 +203,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
@@ -243,7 +243,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 				retry_forever true
-				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
 		</store>
@@ -147,6 +148,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
 		</store>
@@ -205,6 +207,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
 		</store>
@@ -245,6 +248,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 				overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 			</buffer>
 		</store>

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 	   <buffer>
 	     @type file
 	     path '/var/lib/fluentd/secureforward_receiver'
-	     queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+	     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
 	     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 	     flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 	     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
@@ -102,7 +102,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			  <buffer>
 				@type file
 				path '/var/lib/fluentd/secureforward_receiver'
-				queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
 				flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -60,6 +60,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 	     path '/var/lib/fluentd/secureforward_receiver'
 	     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
 	     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+	     total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 	     flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 	     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 	     flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
@@ -104,6 +105,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 				path '/var/lib/fluentd/secureforward_receiver'
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 				flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -158,6 +158,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
     		retry_forever true
         	queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+        	total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
     		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
     	</buffer>
     </store>
@@ -192,6 +193,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
     		retry_forever true
         	queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+        	total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
     		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
     	</buffer>
     </store>
@@ -235,6 +237,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
     		retry_forever true
         	queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+        	total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
     		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
     	</buffer>
     </store>
@@ -272,6 +275,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
     		retry_forever true
         	queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+        	total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
     		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
     	</buffer>
     </store>

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
     		flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
     		retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
     		retry_forever true
-    		queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+        	queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
     		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
     	</buffer>
@@ -190,7 +190,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
     		flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
     		retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
     		retry_forever true
-    		queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+        	queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
     		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
     	</buffer>
@@ -233,7 +233,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
     		flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
     		retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
     		retry_forever true
-    		queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+        	queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
     		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
     	</buffer>
@@ -270,7 +270,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
     		flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
     		retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
     		retry_forever true
-    		queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+        	queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
     		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
     	</buffer>

--- a/pkg/generators/forwarding/fluentd/source_test.go
+++ b/pkg/generators/forwarding/fluentd/source_test.go
@@ -36,8 +36,9 @@ var _ = Describe("generating source", func() {
 			path "/var/log/containers/*.log"
 			exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 			pos_file "/var/log/es-containers.log.pos"
+			pos_file_compaction_interval 300
 			refresh_interval 5
-			rotate_wait 5
+			rotate_wait 1
 			tag kubernetes.*
 			read_from_head "true"
 			@label @CONCAT
@@ -106,6 +107,7 @@ var _ = Describe("generating source", func() {
               @label @INGRESS
               path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
               pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
+              pos_file_compaction_interval 300
               tag linux-audit.log
               <parse>
                 @type viaq_host_audit
@@ -120,6 +122,7 @@ var _ = Describe("generating source", func() {
               @label @INGRESS
               path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
               pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
+              pos_file_compaction_interval 300
               tag k8s-audit.log
               <parse>
                 @type json
@@ -138,6 +141,7 @@ var _ = Describe("generating source", func() {
               @label @INGRESS
               path "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log'}"
               pos_file "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log.pos'}"
+              pos_file_compaction_interval 300
               tag openshift-audit.log
               <parse>
                 @type json
@@ -192,8 +196,9 @@ var _ = Describe("generating source", func() {
 				path "/var/log/containers/*.log"
 				exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 				pos_file "/var/log/es-containers.log.pos"
+				pos_file_compaction_interval 300
 				refresh_interval 5
-				rotate_wait 5
+				rotate_wait 1
 				tag kubernetes.*
 				read_from_head "true"
 				@label @CONCAT
@@ -227,6 +232,7 @@ var _ = Describe("generating source", func() {
                 @label @INGRESS
                 path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
                 pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
+                pos_file_compaction_interval 300
                 tag linux-audit.log
                 <parse>
                   @type viaq_host_audit
@@ -241,6 +247,7 @@ var _ = Describe("generating source", func() {
                 @label @INGRESS
                 path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
                 pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
+                pos_file_compaction_interval 300
                 tag k8s-audit.log
                 <parse>
                   @type json
@@ -259,6 +266,7 @@ var _ = Describe("generating source", func() {
                 @label @INGRESS
                 path "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log'}"
                 pos_file "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log.pos'}"
+                pos_file_compaction_interval 300
                 tag openshift-audit.log
                 <parse>
                   @type json

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -563,7 +563,7 @@ tls_cert_path {{ .SecretPath "ca-bundle.crt"}}
 <buffer>
   @type file
   path '{{.BufferPath}}'
-  queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
   chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
   flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
   flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
@@ -626,7 +626,7 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
     retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
     retry_forever true
-    queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+    queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
     overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
   </buffer>
@@ -696,7 +696,7 @@ const storeSyslogTemplate = `{{- define "storeSyslog" -}}
 		flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 		retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
 		retry_forever true
-		queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+    		queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
 		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 	</buffer>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -382,8 +382,9 @@ const inputSourceContainerTemplate = `{{- define "inputSourceContainerTemplate" 
   {{end -}}
   exclude_path ["/var/log/containers/{{.CollectorPodNamePrefix}}-*_{{.LoggingNamespace}}_*.log", "/var/log/containers/{{.LogStorePodNamePrefix}}-*_{{.LoggingNamespace}}_*.log", "/var/log/containers/{{.VisualizationPodNamePrefix}}-*_{{.LoggingNamespace}}_*.log"]
   pos_file "/var/log/es-containers.log.pos"
+  pos_file_compaction_interval 300
   refresh_interval 5
-  rotate_wait 5
+  rotate_wait 1
   tag kubernetes.*
   read_from_head "true"
   @label @CONCAT
@@ -412,6 +413,7 @@ const inputSourceHostAuditTemplate = `{{- define "inputSourceHostAuditTemplate" 
   @label @INGRESS
   path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
   pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
+  pos_file_compaction_interval 300
   tag linux-audit.log
   <parse>
     @type viaq_host_audit
@@ -427,6 +429,7 @@ const inputSourceK8sAuditTemplate = `{{- define "inputSourceK8sAuditTemplate" -}
   @label @INGRESS
   path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
   pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
+  pos_file_compaction_interval 300
   tag k8s-audit.log
   <parse>
     @type json
@@ -446,6 +449,7 @@ const inputSourceOpenShiftAuditTemplate = `{{- define "inputSourceOpenShiftAudit
   @label @INGRESS
   path "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log'}"
   pos_file "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log.pos'}"
+  pos_file_compaction_interval 300
   tag openshift-audit.log
   <parse>
     @type json
@@ -565,6 +569,7 @@ tls_cert_path {{ .SecretPath "ca-bundle.crt"}}
   path '{{.BufferPath}}'
   queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
   chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
+  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
   flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
   flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
   flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
@@ -628,6 +633,7 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
     retry_forever true
     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+    total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
     overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
   </buffer>
 </store>
@@ -698,6 +704,7 @@ const storeSyslogTemplate = `{{- define "storeSyslog" -}}
 		retry_forever true
     		queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 		chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+    		total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 		overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
 	</buffer>
 </store>

--- a/test/files/secure-forward.conf
+++ b/test/files/secure-forward.conf
@@ -11,7 +11,7 @@
   <buffer>
     @type file
     path '/var/lib/fluentd/secureforwardlegacy'
-    queue_limit_length "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+    queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m' }"
     flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"


### PR DESCRIPTION
This PR addresses the performance variance from 4.4:

* Reverts the change to the number of queued chunks: #479
* Cap disk usage based an a percent and total_byte_limit
* modify the rotate_wait parameter to 1.0
* Configure pos_file_compaction_interval to 5m to address

https://bugzilla.redhat.com/show_bug.cgi?id=1833486