### PR TITLE
Bug 1833486: Collector config changes to address performance versus 4.4

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -108,9 +108,9 @@ var _ = Describe("Generating fluentd config", func() {
   path "/var/log/containers/*_project1-namespace_*.log", "/var/log/containers/*_project2-namespace_*.log"
   exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
   pos_file "/var/log/es-containers.log.pos"
-  pos_file_compaction_interval 300
-  refresh_interval 5
-  rotate_wait 1
+  pos_file_compaction_interval 1800
+  refresh_interval 1
+  rotate_wait 300
   tag kubernetes.*
   read_from_head "true"
   @label @CONCAT
@@ -201,9 +201,9 @@ var _ = Describe("Generating fluentd config", func() {
 				path "/var/log/containers/*.log"
 				exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 				pos_file "/var/log/es-containers.log.pos"
-				pos_file_compaction_interval 300
-				refresh_interval 5
-				rotate_wait 1
+				pos_file_compaction_interval 1800
+				refresh_interval 1
+				rotate_wait 300
 				tag kubernetes.*
 				read_from_head "true"
 				@label @CONCAT
@@ -587,9 +587,9 @@ var _ = Describe("Generating fluentd config", func() {
 				path "/var/log/containers/*.log"
 				exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 				pos_file "/var/log/es-containers.log.pos"
-				pos_file_compaction_interval 300
-				refresh_interval 5
-				rotate_wait 1
+				pos_file_compaction_interval 1800
+				refresh_interval 1
+				rotate_wait 300
 				tag kubernetes.*
 				read_from_head "true"
 				@label @CONCAT
@@ -616,7 +616,7 @@ var _ = Describe("Generating fluentd config", func() {
               @label @INGRESS
               path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
               pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
-              pos_file_compaction_interval 300
+              pos_file_compaction_interval 1800
               tag linux-audit.log
               <parse>
                 @type viaq_host_audit
@@ -630,7 +630,7 @@ var _ = Describe("Generating fluentd config", func() {
               @label @INGRESS
               path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
               pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
-              pos_file_compaction_interval 300
+              pos_file_compaction_interval 1800
               tag k8s-audit.log
               <parse>
                 @type json
@@ -648,7 +648,7 @@ var _ = Describe("Generating fluentd config", func() {
               @label @INGRESS
               path "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log'}"
               pos_file "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log.pos'}"
-              pos_file_compaction_interval 300
+              pos_file_compaction_interval 1800
               tag openshift-audit.log
               <parse>
                 @type json

--- a/pkg/generators/forwarding/fluentd/source_test.go
+++ b/pkg/generators/forwarding/fluentd/source_test.go
@@ -36,9 +36,9 @@ var _ = Describe("generating source", func() {
 			path "/var/log/containers/*.log"
 			exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 			pos_file "/var/log/es-containers.log.pos"
-			pos_file_compaction_interval 300
-			refresh_interval 5
-			rotate_wait 1
+			pos_file_compaction_interval 1800
+			refresh_interval 1
+			rotate_wait 300
 			tag kubernetes.*
 			read_from_head "true"
 			@label @CONCAT
@@ -107,7 +107,7 @@ var _ = Describe("generating source", func() {
               @label @INGRESS
               path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
               pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
-              pos_file_compaction_interval 300
+              pos_file_compaction_interval 1800
               tag linux-audit.log
               <parse>
                 @type viaq_host_audit
@@ -122,7 +122,7 @@ var _ = Describe("generating source", func() {
               @label @INGRESS
               path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
               pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
-              pos_file_compaction_interval 300
+              pos_file_compaction_interval 1800
               tag k8s-audit.log
               <parse>
                 @type json
@@ -141,7 +141,7 @@ var _ = Describe("generating source", func() {
               @label @INGRESS
               path "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log'}"
               pos_file "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log.pos'}"
-              pos_file_compaction_interval 300
+              pos_file_compaction_interval 1800
               tag openshift-audit.log
               <parse>
                 @type json
@@ -196,9 +196,9 @@ var _ = Describe("generating source", func() {
 				path "/var/log/containers/*.log"
 				exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 				pos_file "/var/log/es-containers.log.pos"
-				pos_file_compaction_interval 300
-				refresh_interval 5
-				rotate_wait 1
+				pos_file_compaction_interval 1800
+				refresh_interval 1
+				rotate_wait 300
 				tag kubernetes.*
 				read_from_head "true"
 				@label @CONCAT
@@ -232,7 +232,7 @@ var _ = Describe("generating source", func() {
                 @label @INGRESS
                 path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
                 pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
-                pos_file_compaction_interval 300
+                pos_file_compaction_interval 1800
                 tag linux-audit.log
                 <parse>
                   @type viaq_host_audit
@@ -247,7 +247,7 @@ var _ = Describe("generating source", func() {
                 @label @INGRESS
                 path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
                 pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
-                pos_file_compaction_interval 300
+                pos_file_compaction_interval 1800
                 tag k8s-audit.log
                 <parse>
                   @type json
@@ -266,7 +266,7 @@ var _ = Describe("generating source", func() {
                 @label @INGRESS
                 path "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log'}"
                 pos_file "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log.pos'}"
-                pos_file_compaction_interval 300
+                pos_file_compaction_interval 1800
                 tag openshift-audit.log
                 <parse>
                   @type json

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -382,9 +382,9 @@ const inputSourceContainerTemplate = `{{- define "inputSourceContainerTemplate" 
   {{end -}}
   exclude_path ["/var/log/containers/{{.CollectorPodNamePrefix}}-*_{{.LoggingNamespace}}_*.log", "/var/log/containers/{{.LogStorePodNamePrefix}}-*_{{.LoggingNamespace}}_*.log", "/var/log/containers/{{.VisualizationPodNamePrefix}}-*_{{.LoggingNamespace}}_*.log"]
   pos_file "/var/log/es-containers.log.pos"
-  pos_file_compaction_interval 300
-  refresh_interval 5
-  rotate_wait 1
+  pos_file_compaction_interval 1800
+  refresh_interval 1
+  rotate_wait 300
   tag kubernetes.*
   read_from_head "true"
   @label @CONCAT
@@ -413,7 +413,7 @@ const inputSourceHostAuditTemplate = `{{- define "inputSourceHostAuditTemplate" 
   @label @INGRESS
   path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
   pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
-  pos_file_compaction_interval 300
+  pos_file_compaction_interval 1800
   tag linux-audit.log
   <parse>
     @type viaq_host_audit
@@ -429,7 +429,7 @@ const inputSourceK8sAuditTemplate = `{{- define "inputSourceK8sAuditTemplate" -}
   @label @INGRESS
   path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
   pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
-  pos_file_compaction_interval 300
+  pos_file_compaction_interval 1800
   tag k8s-audit.log
   <parse>
     @type json
@@ -449,7 +449,7 @@ const inputSourceOpenShiftAuditTemplate = `{{- define "inputSourceOpenShiftAudit
   @label @INGRESS
   path "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log'}"
   pos_file "#{ENV['OPENSHIFT_AUDIT_FILE'] || '/var/log/openshift-apiserver/audit.log.pos'}"
-  pos_file_compaction_interval 300
+  pos_file_compaction_interval 1800
   tag openshift-audit.log
   <parse>
     @type json


### PR DESCRIPTION
This PR provides additional collector config changes to address performance versus 4.4:

* Bumps rotate_wait to allow fluent to continue to collect rotated logs
* Drops the new file interval
* Extends the pos_file_compact_interval which seems to affect dropped messages for short runs with high load

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1833486