### PR TITLE
Bug 1856940: Add kafka mTLS conditional support

### DIFF
--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -81,8 +81,8 @@ var _ = Describe("Generating external kafka server output store config block", f
            brokers broker1-kafka.svc.messaging.cluster.local:9092
            default_topic topic
            ssl_ca_cert '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
-           ssl_client_cert '/var/run/ocp-collector/secrets/some-secret/tls.crt'
-           ssl_client_cert_key '/var/run/ocp-collector/secrets/some-secret/tls.key'
+           ssl_client_cert "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.crt') ? '/var/run/ocp-collector/secrets/some-secret/tls.crt' : use_nil}"
+           ssl_client_cert_key "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.key') ? '/var/run/ocp-collector/secrets/some-secret/tls.key' : use_nil}"
            <format>
                @type json
            </format>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -715,9 +715,11 @@ const storeKafkaTemplate = `{{- define "storeKafka" -}}
 brokers {{.Brokers}}
 default_topic {{.Topic}}
 {{ if .Target.Secret -}}
+{{ $tlsCert := .SecretPath "tls.crt" }}
+{{ $tlsKey := .SecretPath "tls.key" }}
 ssl_ca_cert '{{ .SecretPath "ca-bundle.crt"}}'
-ssl_client_cert '{{ .SecretPath "tls.crt"}}'
-ssl_client_cert_key '{{ .SecretPath "tls.key"}}'
+ssl_client_cert "#{File.exist?('{{ $tlsCert }}') ? '{{ $tlsCert }}' : use_nil}"
+ssl_client_cert_key "#{File.exist?('{{ $tlsKey }}') ? '{{ $tlsKey }}' : use_nil}"
 {{ end -}}
 <format>
   @type json


### PR DESCRIPTION
### Description
This PR addresses the missing conditional configuration for kafka mTLS support. In detail the fluentd configuration sets the client cert and key only if the calculated paths from the secretRef exists on runtime.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1856940

/cc @igor-karpukhin @jcantrill 