### PR TITLE
Bug 1857206: Use fluentd event time for processing logs to kafka

### DIFF
--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Generating external kafka server output store config block", f
            @type kafka2
            brokers broker1-kafka.svc.messaging.cluster.local:9092
            default_topic topic
+           use_event_time true
            <format>
                @type json
            </format>
@@ -80,6 +81,7 @@ var _ = Describe("Generating external kafka server output store config block", f
            @type kafka2
            brokers broker1-kafka.svc.messaging.cluster.local:9092
            default_topic topic
+           use_event_time true
            ssl_ca_cert '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
            ssl_client_cert '/var/run/ocp-collector/secrets/some-secret/tls.crt'
            ssl_client_cert_key '/var/run/ocp-collector/secrets/some-secret/tls.key'
@@ -126,6 +128,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 	       @type kafka2
 	       brokers broker1-kafka.svc.messaging.cluster.local:9092,broker2-kafka.svc.messaging.cluster.local:9092
 	       default_topic topic
+         use_event_time true
 	       <format>
 	           @type json
 	       </format>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -714,6 +714,7 @@ const storeKafkaTemplate = `{{- define "storeKafka" -}}
 @type kafka2
 brokers {{.Brokers}}
 default_topic {{.Topic}}
+use_event_time true
 {{ if .Target.Secret -}}
 ssl_ca_cert '{{ .SecretPath "ca-bundle.crt"}}'
 ssl_client_cert '{{ .SecretPath "tls.crt"}}'


### PR DESCRIPTION
### Description
This PR addresses a fix to use Fluentd EventTime instead of ruby's time for nanosecond precision.

To address: https://bugzilla.redhat.com/show_bug.cgi?id=1857206

/cc @jcantrill @vimalk78 