### PR TITLE
Bug 1855220: Update trustedCA hash for visualization component

### DIFF
--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -280,7 +280,10 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateKibanaDeployment(prox
 			current, different := isDeploymentDifferent(current, kibanaDeployment)
 
 			// Check trustedCA certs have been updated or not by comparing the hash values in annotation.
-			if current.Spec.Template.ObjectMeta.Annotations[constants.TrustedCABundleHashName] != kibanaDeployment.Spec.Template.ObjectMeta.Annotations[constants.TrustedCABundleHashName] {
+			currentTrustedCAHash := current.Spec.Template.ObjectMeta.Annotations[constants.TrustedCABundleHashName]
+			desiredTrustedCAHash := kibanaDeployment.Spec.Template.ObjectMeta.Annotations[constants.TrustedCABundleHashName]
+			if currentTrustedCAHash != desiredTrustedCAHash {
+				current.Spec.Template.ObjectMeta.Annotations[constants.TrustedCABundleHashName] = desiredTrustedCAHash
 				different = true
 			}
 
@@ -757,7 +760,7 @@ func newKibanaPodSpec(cluster *logging.ClusterLogging, kibanaName string, elasti
 
 	addTrustedCAVolume := false
 	// If trusted CA bundle ConfigMap exists and its hash value is non-zero, mount the bundle.
-	if trustedCABundleCM != nil && hasTrustedCABundle(trustedCABundleCM) {
+	if hasTrustedCABundle(trustedCABundleCM) {
 		addTrustedCAVolume = true
 		kibanaProxyContainer.VolumeMounts = append(kibanaProxyContainer.VolumeMounts,
 			v1.VolumeMount{


### PR DESCRIPTION
### Description
This PR addresses a missing backport of the kibana trusted CA bundle hash reconciliation in **release-4.4**. This is a amendment to #524 for the visualization component namely Kibana.

To address:
- https://bugzilla.redhat.com/show_bug.cgi?id=1855220
- https://bugzilla.redhat.com/show_bug.cgi?id=1833273 (Kibana only, as fluentd addressed by #524)
- https://bugzilla.redhat.com/show_bug.cgi?id=1833288 (Kibana only, as fluentd addressed by #524)

### Notes to the patch manager
The original issue affected the reconciliation of a custom CA bundle for fluentd and kibana. This PR is an extra amendment for #524, that addressed unfortunately only fluentd in **release-4.4**. The reconciliation of Kibana moved in 4.5 from `cluster-logging-operator` to `elasticsearch-operator` w/o breaking any API or user experience. The issue was fixed in 4.5 by #517 for `cluster-logging-operator` and [#351](https://github.com/openshift/elasticsearch-operator/pull/351) for `elasticsearch-operator`. However, backporting it to release-4.4 missed to introduce the changes of openshift/elasticsearch-operator#351 back into the `cluster-logging-operator` code base.

/cc @ewolinetz @igor-karpukhin 