### PR TITLE
Revert "Bug 1852889: Bump minKubeVersion to 1.18.3"

### DIFF
--- a/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
@@ -107,7 +107,7 @@ spec:
   # The version value is substituted by the ART pipeline
   version: 4.6.0
   displayName: Cluster Logging
-  minKubeVersion: 1.17.1
+  minKubeVersion: 1.17.0
   description: |
     # Cluster Logging
     The Cluster Logging Operator orchestrates and manages the aggregated logging stack as a cluster-wide service.

--- a/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
@@ -107,7 +107,7 @@ spec:
   # The version value is substituted by the ART pipeline
   version: 4.6.0
   displayName: Cluster Logging
-  minKubeVersion: 1.18.3
+  minKubeVersion: 1.17.1
   description: |
     # Cluster Logging
     The Cluster Logging Operator orchestrates and manages the aggregated logging stack as a cluster-wide service.


### PR DESCRIPTION
### Description
This PR  reverts commit 9f47fcb62f5fa5be7707b30d60c7aa4b4ad50fdf and in extend downgrades the `minKubeVersion` to `1.17.0`, because apiserver on CI is still on `v1.17.0-alpha.0.7867+649a587b0a0f5d-dirty`