### PR TITLE
Bug 1833486: Revert rotate_wait and refresh_interval to 4.4 setting

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -110,8 +110,8 @@ var _ = Describe("Generating fluentd config", func() {
   exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
   pos_file "/var/log/es-containers.log.pos"
   pos_file_compaction_interval 1800
-  refresh_interval 1
-  rotate_wait 300
+  refresh_interval 5
+  rotate_wait 5
   tag kubernetes.*
   read_from_head "true"
   @label @CONCAT
@@ -203,8 +203,8 @@ var _ = Describe("Generating fluentd config", func() {
 				exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 				pos_file "/var/log/es-containers.log.pos"
 				pos_file_compaction_interval 1800
-				refresh_interval 1
-				rotate_wait 300
+				refresh_interval 5
+				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
 				@label @CONCAT
@@ -570,8 +570,8 @@ var _ = Describe("Generating fluentd config", func() {
 				exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 				pos_file "/var/log/es-containers.log.pos"
 				pos_file_compaction_interval 1800
-				refresh_interval 1
-				rotate_wait 300
+				refresh_interval 5
+				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
 				@label @CONCAT

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -92,8 +92,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
           pos_file "/var/log/es-containers.log.pos"
           pos_file_compaction_interval 1800
-          refresh_interval 1
-          rotate_wait 300
+          refresh_interval 5
+          rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
           @label @CONCAT
@@ -536,8 +536,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
           pos_file "/var/log/es-containers.log.pos"
           pos_file_compaction_interval 1800
-          refresh_interval 1
-          rotate_wait 300
+          refresh_interval 5
+          rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
           @label @CONCAT
@@ -981,8 +981,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
           pos_file "/var/log/es-containers.log.pos"
           pos_file_compaction_interval 1800
-          refresh_interval 1
-          rotate_wait 300
+          refresh_interval 5
+          rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
           @label @CONCAT

--- a/pkg/generators/forwarding/fluentd/source_test.go
+++ b/pkg/generators/forwarding/fluentd/source_test.go
@@ -37,8 +37,8 @@ var _ = Describe("generating source", func() {
 			exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 			pos_file "/var/log/es-containers.log.pos"
 			pos_file_compaction_interval 1800
-			refresh_interval 1
-			rotate_wait 300
+			refresh_interval 5
+			rotate_wait 5
 			tag kubernetes.*
 			read_from_head "true"
 			@label @CONCAT
@@ -197,8 +197,8 @@ var _ = Describe("generating source", func() {
 				exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
 				pos_file "/var/log/es-containers.log.pos"
 				pos_file_compaction_interval 1800
-				refresh_interval 1
-				rotate_wait 300
+				refresh_interval 5
+				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
 				@label @CONCAT

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -386,8 +386,8 @@ const inputSourceContainerTemplate = `{{- define "inputSourceContainerTemplate" 
   exclude_path ["/var/log/containers/{{.CollectorPodNamePrefix}}-*_{{.LoggingNamespace}}_*.log", "/var/log/containers/{{.LogStorePodNamePrefix}}-*_{{.LoggingNamespace}}_*.log", "/var/log/containers/{{.VisualizationPodNamePrefix}}-*_{{.LoggingNamespace}}_*.log"]
   pos_file "/var/log/es-containers.log.pos"
   pos_file_compaction_interval 1800
-  refresh_interval 1
-  rotate_wait 300
+  refresh_interval 5
+  rotate_wait 5
   tag kubernetes.*
   read_from_head "true"
   @label @CONCAT


### PR DESCRIPTION
This PR reverts configuration setting to 4.4 values:

* rotate_wait 5 sec
* watch_interval 5 sec

Tested these values with both 1.7.4 of fluent and 1.11.1 and was able to successfully test 2,500 m/s consistently.  Noted with 1.7.4 when changing rotate_wait there was some message duplication