### PR TITLE
Bug 1857094: Add validation for URL parameter for LF CR

### DIFF
--- a/hack/generate-crd.sh
+++ b/hack/generate-crd.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set -e
+set -euo pipefail
 
 MANIFESTS_DIR=${1:-"manifests/${OCP_VERSION}"}
 CLF_CRD_FILE="logging.openshift.io_clusterlogforwarders_crd.yaml"

--- a/manifests/4.6/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/manifests/4.6/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -196,7 +196,10 @@ spec:
                         don't define their own URL scheme.  Example: \n     { type:
                         syslog, url: tls://syslog.example.com:1234 } \n TLS with server
                         authentication is enabled by the URL scheme, for example 'tls'
-                        or 'https'.  See `secret` for TLS client authentication."
+                        or 'https'.  See `secret` for TLS client authentication. \n
+                        This field is optional and can be empty if there is an output-type
+                        field with alternative connection information."
+                      pattern: ^$|[a-zA-z]+:\/\/.*
                       type: string
                   required:
                   - name

--- a/pkg/apis/logging/v1/cluster_log_forwarder_types.go
+++ b/pkg/apis/logging/v1/cluster_log_forwarder_types.go
@@ -137,6 +137,9 @@ type OutputSpec struct {
 	// TLS with server authentication is enabled by the URL scheme, for
 	// example 'tls' or 'https'.  See `secret` for TLS client authentication.
 	//
+	// This field is optional and can be empty if there is an output-type field with alternative connection information.
+	//
+	// +kubebuilder:validation:Pattern:=`^$|[a-zA-z]+:\/\/.*`
 	// +optional
 	URL string `json:"url"`
 

--- a/test/e2e/collection/fluentd/flatten_labels_test.go
+++ b/test/e2e/collection/fluentd/flatten_labels_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Fluentd message filtering", func() {
 					{
 						Name: fluentDeployment.ObjectMeta.Name,
 						Type: logging.OutputTypeFluentdForward,
-						URL:  fmt.Sprintf("%s.%s.svc:24224", fluentDeployment.ObjectMeta.Name, fluentDeployment.Namespace),
+						URL:  fmt.Sprintf("tcp://%s.%s.svc:24224", fluentDeployment.ObjectMeta.Name, fluentDeployment.Namespace),
 					},
 				},
 				Pipelines: []logging.PipelineSpec{

--- a/test/e2e/logforwarding/elasticsearchunmanaged/forward_to_unmanaged_elasticsearch_test.go
+++ b/test/e2e/logforwarding/elasticsearchunmanaged/forward_to_unmanaged_elasticsearch_test.go
@@ -60,7 +60,7 @@ var _ = Describe("ClusterLogForwarder", func() {
 								Name: pipelineSecret.ObjectMeta.Name,
 							},
 							Type: logging.OutputTypeElasticsearch,
-							URL:  fmt.Sprintf("%s.%s.svc:9200", elasticsearch.Name, elasticsearch.Namespace),
+							URL:  fmt.Sprintf("https://%s.%s.svc:9200", elasticsearch.Name, elasticsearch.Namespace),
 						},
 					},
 					Pipelines: []logging.PipelineSpec{

--- a/test/e2e/logforwarding/fluent/forward_to_fluent_test.go
+++ b/test/e2e/logforwarding/fluent/forward_to_fluent_test.go
@@ -55,7 +55,7 @@ var _ = Describe("ClusterLogForwarder", func() {
 							{
 								Name: fluentDeployment.ObjectMeta.Name,
 								Type: logging.OutputTypeFluentdForward,
-								URL:  fmt.Sprintf("%s.%s.svc:24224", fluentDeployment.ObjectMeta.Name, fluentDeployment.Namespace),
+								URL:  fmt.Sprintf("tcp://%s.%s.svc:24224", fluentDeployment.ObjectMeta.Name, fluentDeployment.Namespace),
 							},
 						},
 						Pipelines: []logging.PipelineSpec{
@@ -131,7 +131,7 @@ var _ = Describe("ClusterLogForwarder", func() {
 							{
 								Name: fluentDeployment.ObjectMeta.Name,
 								Type: logging.OutputTypeFluentdForward,
-								URL:  fmt.Sprintf("%s.%s.svc:24224", fluentDeployment.ObjectMeta.Name, fluentDeployment.Namespace),
+								URL:  fmt.Sprintf("tcp://%s.%s.svc:24224", fluentDeployment.ObjectMeta.Name, fluentDeployment.Namespace),
 								Secret: &logging.OutputSecretSpec{
 									Name: fluentDeployment.ObjectMeta.Name,
 								},

--- a/test/e2e/logforwarding/multiple_outputs/forward_to_multiple_outputs_test.go
+++ b/test/e2e/logforwarding/multiple_outputs/forward_to_multiple_outputs_test.go
@@ -139,20 +139,24 @@ func newClusterLogForwarder(fluentRcv *apps.Deployment, elasticsearch *eologging
 	fluentdOutput := loggingv1.OutputSpec{
 		Name: fluentRcv.GetName(),
 		Type: loggingv1.OutputTypeFluentdForward,
-		URL:  fmt.Sprintf("%s.%s.svc:24224", fluentRcv.GetName(), fluentRcv.GetNamespace()),
+		URL:  fmt.Sprintf("tcp://%s.%s.svc:24224", fluentRcv.GetName(), fluentRcv.GetNamespace()),
 	}
 
 	elasticOutput := loggingv1.OutputSpec{
 		Name: elasticsearch.GetName(),
 		Type: loggingv1.OutputTypeElasticsearch,
-		URL:  fmt.Sprintf("%s.%s.svc:9200", elasticsearch.GetName(), elasticsearch.GetNamespace()),
 	}
 
+	var schema string
 	if pipelineSecret != nil {
+		schema = "https"
 		elasticOutput.Secret = &loggingv1.OutputSecretSpec{
 			Name: pipelineSecret.GetName(),
 		}
+	} else {
+		schema = "http"
 	}
+	elasticOutput.URL = fmt.Sprintf("%s://%s.%s.svc:9200", schema, elasticsearch.GetName(), elasticsearch.GetNamespace())
 
 	return &loggingv1.ClusterLogForwarder{
 		TypeMeta: metav1.TypeMeta{

--- a/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
@@ -111,7 +111,7 @@ var _ = Describe("LogForwarder", func() {
 					Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 				}
 				if protocol == corev1.ProtocolTCP {
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 				} else {
 					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("udp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 				}
@@ -156,7 +156,7 @@ var _ = Describe("LogForwarder", func() {
 						if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, true, helpers.RFC5424); err != nil {
 							Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 						}
-						forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+						forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 						forwarder.Spec.Outputs[0].Secret = &logging.OutputSecretSpec{
 							Name: syslogDeployment.ObjectMeta.Name,
 						}
@@ -188,7 +188,7 @@ var _ = Describe("LogForwarder", func() {
 					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, true, helpers.RFC5424); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 					forwarder.Spec.Outputs[0].Secret = &logging.OutputSecretSpec{
 						Name: syslogDeployment.ObjectMeta.Name,
 					}
@@ -218,7 +218,7 @@ var _ = Describe("LogForwarder", func() {
 					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, true, helpers.RFC5424); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 					forwarder.Spec.Outputs[0].Secret = &logging.OutputSecretSpec{
 						Name: syslogDeployment.ObjectMeta.Name,
 					}
@@ -255,7 +255,7 @@ var _ = Describe("LogForwarder", func() {
 					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, true, helpers.RFC5424); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 					forwarder.Spec.Outputs[0].Secret = &logging.OutputSecretSpec{
 						Name: syslogDeployment.ObjectMeta.Name,
 					}
@@ -290,7 +290,7 @@ var _ = Describe("LogForwarder", func() {
 					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, true, helpers.RFC5424); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 					forwarder.Spec.Outputs[0].Secret = &logging.OutputSecretSpec{
 						Name: syslogDeployment.ObjectMeta.Name,
 					}
@@ -328,7 +328,7 @@ var _ = Describe("LogForwarder", func() {
 					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, true, helpers.RFC5424); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 					forwarder.Spec.Outputs[0].Secret = &logging.OutputSecretSpec{
 						Name: syslogDeployment.ObjectMeta.Name,
 					}
@@ -394,7 +394,7 @@ var _ = Describe("LogForwarder", func() {
 					Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 				}
 				if protocol == corev1.ProtocolTCP {
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 				} else {
 					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("udp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 				}
@@ -443,7 +443,7 @@ var _ = Describe("LogForwarder", func() {
 					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, true, helpers.RFC3164); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 					forwarder.Spec.Outputs[0].Secret = &logging.OutputSecretSpec{
 						Name: syslogDeployment.ObjectMeta.Name,
 					}
@@ -468,7 +468,7 @@ var _ = Describe("LogForwarder", func() {
 					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, true, helpers.RFC3164); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 					forwarder.Spec.Outputs[0].Secret = &logging.OutputSecretSpec{
 						Name: syslogDeployment.ObjectMeta.Name,
 					}
@@ -494,7 +494,7 @@ var _ = Describe("LogForwarder", func() {
 					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, true, helpers.RFC3164); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 					forwarder.Spec.Outputs[0].Secret = &logging.OutputSecretSpec{
 						Name: syslogDeployment.ObjectMeta.Name,
 					}
@@ -527,7 +527,7 @@ var _ = Describe("LogForwarder", func() {
 					if syslogDeployment, err = e2e.DeploySyslogReceiver(testDir, corev1.ProtocolTCP, true, helpers.RFC3164); err != nil {
 						Fail(fmt.Sprintf("Unable to deploy syslog receiver: %v", err))
 					}
-					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
+					forwarder.Spec.Outputs[0].URL = fmt.Sprintf("tcp://%s.%s.svc:24224", syslogDeployment.ObjectMeta.Name, syslogDeployment.Namespace)
 					forwarder.Spec.Outputs[0].Secret = &logging.OutputSecretSpec{
 						Name: syslogDeployment.ObjectMeta.Name,
 					}


### PR DESCRIPTION
* `URL` parameter of `OutputSpec` for `ClusterLogForwardings` made mandatory