### PR TITLE
Remove need for LOGGING_SHARE_DIR in tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ run: deploy-elasticsearch-operator test-cleanup
 	WATCH_NAMESPACE=$(NAMESPACE) \
 	KUBERNETES_CONFIG=$(KUBECONFIG) \
 	WORKING_DIR=$(CURDIR)/tmp \
-	LOGGING_SHARE_DIR=$(CURDIR)/files \
 	$(RUN_CMD) cmd/manager/main.go
 
 run-debug:
@@ -120,7 +119,6 @@ deploy-example: deploy
 	oc create -n $(NAMESPACE) -f hack/cr.yaml
 
 test-unit:
-	LOGGING_SHARE_DIR=$(CURDIR)/files \
 	LOG_LEVEL=fatal \
 	go test -cover -race ./pkg/...
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -179,12 +180,21 @@ func GetFileContents(filePath string) []byte {
 	return contents
 }
 
+const defaultShareDir = "/usr/share/logging"
+
 func GetShareDir() string {
-	shareDir := os.Getenv("LOGGING_SHARE_DIR")
-	if shareDir == "" {
-		return "/usr/share/logging"
+	// shareDir is <repo-root>/files - try to find from working dir.
+	const sep = string(os.PathSeparator)
+	const repoRoot = sep + "cluster-logging-operator" + sep
+	wd, err := os.Getwd()
+	if err != nil {
+		return defaultShareDir
 	}
-	return shareDir
+	i := strings.LastIndex(wd, repoRoot)
+	if i >= 0 {
+		return filepath.Join(wd[0:i+len(repoRoot)] + "files")
+	}
+	return defaultShareDir
 }
 
 func GetScriptsDir() string {


### PR DESCRIPTION
Use the working directory for tests to locate /cluster-logging-operator/files, drop the env var LOGGING_SHARE_DIR. Allows all tests to run directly with `go test`