### PR TITLE
Remove obsoete throttle-config

### DIFF
--- a/files/fluentd/fluentd-throttle-config.yaml
+++ b/files/fluentd/fluentd-throttle-config.yaml
@@ -1,7 +1,0 @@
-# Logging example fluentd throttling config file
-
-#example-project:
-#  read_lines_limit: 10
-#
-#.operations:
-#  read_lines_limit: 100

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -210,7 +210,6 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateFluentdConfigMap(flue
 		clusterRequest.cluster.Namespace,
 		map[string]string{
 			"fluent.conf":          fluentConf,
-			"throttle-config.yaml": string(utils.GetFileContents(utils.GetShareDir() + "/fluentd/fluentd-throttle-config.yaml")),
 			"run.sh":               string(utils.GetFileContents(utils.GetShareDir() + "/fluentd/run.sh")),
 		},
 	)


### PR DESCRIPTION
This PR
* removes the throttle config which is no longer used in collection conf

cc @alanconway 