### PR TITLE
Add must-gather plugin image for cluster-logging stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ To install a released version of cluster logging see the [Openshift Documentatio
 
 To experiment or contribute to the development of cluster logging, see [HACKING.md](./docs/HACKING.md)
 
+To debug the cluster logging stack, see [README.md](./must-gather/README.md)
+
 To find currently known Cluster Logging Operator issues with work-arounds, see the [Troubleshooting](./docs/troubleshooting.md) guide.
 
 [Elasticsearch Operator]: https://github.com/openshift/elasticsearch-operator

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -1,0 +1,168 @@
+cluster-logging must-gather
+=================
+
+`cluster-logging-must-gather` is a tool built on top of [OpenShift must-gather](https://github.com/openshift/must-gather)
+that expands its capabilities to gather Openshift Cluster Logging information.
+
+### Usage
+```sh
+oc adm must-gather --image=quay.io/openshift/origin-cluster-logging-operator -- /usr/bin/gather
+```
+
+The command above will create a local directory with a dump of the cluster-logging state.
+Note that this command will only get data related to the cluster-logging part of the OpenShift cluster.
+
+You will get a dump of:
+- The openshift-logging namespace and its children objects
+- The openshift-operators-redhat namespace and its children objects
+- The cluster-logging install objects
+- All cluster-logging CRD's definitions
+- All nodes objects
+- All persistent volumes objects
+- Custom logs, configurations and health status per component, i.e. collection, logStore, curation, visualization
+
+In order to get data about other parts of the cluster (not specific to cluster-logging) you should
+run `oc adm must-gather` (without passing a custom image). Run `oc adm must-gather -h` to see more options.
+
+Example must-gather for cluster-logging output:
+```
+├── cluster-logging
+│  ├── clo
+│  │  ├── cluster-logging-operator-74dd5994f-6ttgt
+│  │  ├── clusterlogforwarder_cr
+│  │  ├── cr
+│  │  ├── csv
+│  │  ├── deployment
+│  │  └── logforwarding_cr
+│  ├── collector
+│  │  ├── fluentd-2tr64
+│  ├── curator
+│  │  └── curator-1596028500-zkz4s
+│  ├── eo
+│  │  ├── csv
+│  │  ├── deployment
+│  │  └── elasticsearch-operator-7dc7d97b9d-jb4r4
+│  ├── es
+│  │  ├── cluster-elasticsearch
+│  │  │  ├── aliases
+│  │  │  ├── health
+│  │  │  ├── indices
+│  │  │  ├── latest_documents.json
+│  │  │  ├── nodes
+│  │  │  ├── nodes_stats.json
+│  │  │  └── thread_pool
+│  │  ├── cr
+│  │  ├── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
+│  │  └── logs
+│  │     ├── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
+│  ├── install
+│  │  ├── co_logs
+│  │  ├── install_plan
+│  │  ├── olmo_logs
+│  │  └── subscription
+│  └── kibana
+│     ├── cr
+│     ├── kibana-9d69668d4-2rkvz
+├── cluster-scoped-resources
+│  └── core
+│     ├── nodes
+│     │  ├── ip-10-0-146-180.eu-west-1.compute.internal.yaml
+│     └── persistentvolumes
+│        ├── pvc-0a8d65d9-54aa-4c44-9ecc-33d9381e41c1.yaml
+├── event-filter.html
+├── gather-debug.log
+└── namespaces
+   ├── openshift-logging
+   │  ├── apps
+   │  │  ├── daemonsets.yaml
+   │  │  ├── deployments.yaml
+   │  │  ├── replicasets.yaml
+   │  │  └── statefulsets.yaml
+   │  ├── batch
+   │  │  ├── cronjobs.yaml
+   │  │  └── jobs.yaml
+   │  ├── core
+   │  │  ├── configmaps.yaml
+   │  │  ├── endpoints.yaml
+   │  │  ├── events
+   │  │  │  ├── curator-1596021300-wn2ks.162634ebf0055a94.yaml
+   │  │  │  ├── curator.162638330681bee2.yaml
+   │  │  │  ├── elasticsearch-delete-app-1596020400-gm6nl.1626341a296c16a1.yaml
+   │  │  │  ├── elasticsearch-delete-audit-1596020400-9l9n4.1626341a2af81bbd.yaml
+   │  │  │  ├── elasticsearch-delete-infra-1596020400-v98tk.1626341a2d821069.yaml
+   │  │  │  ├── elasticsearch-rollover-app-1596020400-cc5vc.1626341a3019b238.yaml
+   │  │  │  ├── elasticsearch-rollover-audit-1596020400-s8d5s.1626341a31f7b315.yaml
+   │  │  │  ├── elasticsearch-rollover-infra-1596020400-7mgv8.1626341a35ea59ed.yaml
+   │  │  ├── events.yaml
+   │  │  ├── persistentvolumeclaims.yaml
+   │  │  ├── pods.yaml
+   │  │  ├── replicationcontrollers.yaml
+   │  │  ├── secrets.yaml
+   │  │  └── services.yaml
+   │  ├── openshift-logging.yaml
+   │  ├── pods
+   │  │  ├── cluster-logging-operator-74dd5994f-6ttgt
+   │  │  │  ├── cluster-logging-operator
+   │  │  │  │  └── cluster-logging-operator
+   │  │  │  │     └── logs
+   │  │  │  │        ├── current.log
+   │  │  │  │        ├── previous.insecure.log
+   │  │  │  │        └── previous.log
+   │  │  │  └── cluster-logging-operator-74dd5994f-6ttgt.yaml
+   │  │  ├── cluster-logging-operator-registry-6df49d7d4-mxxff
+   │  │  │  ├── cluster-logging-operator-registry
+   │  │  │  │  └── cluster-logging-operator-registry
+   │  │  │  │     └── logs
+   │  │  │  │        ├── current.log
+   │  │  │  │        ├── previous.insecure.log
+   │  │  │  │        └── previous.log
+   │  │  │  ├── cluster-logging-operator-registry-6df49d7d4-mxxff.yaml
+   │  │  │  └── mutate-csv-and-generate-sqlite-db
+   │  │  │     └── mutate-csv-and-generate-sqlite-db
+   │  │  │        └── logs
+   │  │  │           ├── current.log
+   │  │  │           ├── previous.insecure.log
+   │  │  │           └── previous.log
+   │  │  ├── curator-1596028500-zkz4s
+   │  │  ├── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
+   │  │  ├── elasticsearch-delete-app-1596030300-bpgcx
+   │  │  │  ├── elasticsearch-delete-app-1596030300-bpgcx.yaml
+   │  │  │  └── indexmanagement
+   │  │  │     └── indexmanagement
+   │  │  │        └── logs
+   │  │  │           ├── current.log
+   │  │  │           ├── previous.insecure.log
+   │  │  │           └── previous.log
+   │  │  ├── fluentd-2tr64
+   │  │  │  ├── fluentd
+   │  │  │  │  └── fluentd
+   │  │  │  │     └── logs
+   │  │  │  │        ├── current.log
+   │  │  │  │        ├── previous.insecure.log
+   │  │  │  │        └── previous.log
+   │  │  │  ├── fluentd-2tr64.yaml
+   │  │  │  └── fluentd-init
+   │  │  │     └── fluentd-init
+   │  │  │        └── logs
+   │  │  │           ├── current.log
+   │  │  │           ├── previous.insecure.log
+   │  │  │           └── previous.log
+   │  │  ├── kibana-9d69668d4-2rkvz
+   │  │  │  ├── kibana
+   │  │  │  │  └── kibana
+   │  │  │  │     └── logs
+   │  │  │  │        ├── current.log
+   │  │  │  │        ├── previous.insecure.log
+   │  │  │  │        └── previous.log
+   │  │  │  ├── kibana-9d69668d4-2rkvz.yaml
+   │  │  │  └── kibana-proxy
+   │  │  │     └── kibana-proxy
+   │  │  │        └── logs
+   │  │  │           ├── current.log
+   │  │  │           ├── previous.insecure.log
+   │  │  │           └── previous.log
+   │  └── route.openshift.io
+   │     └── routes.yaml
+   └── openshift-operators-redhat
+      ├── ...
+```

--- a/must-gather/collection-scripts/common
+++ b/must-gather/collection-scripts/common
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+get_env() {
+  local pod=$1
+  local env_file=$2/$pod
+  local ns=${3:-$NAMESPACE}
+  local pattern=${4:-"Dockerfile-*logging*"}
+  echo ---- Env for $pod
+  containers=$(oc -n $ns get po $pod -o jsonpath='{.spec.containers[*].name}')
+  for container in $containers
+  do
+    dockerfile=$(oc -n $ns exec $pod -c $container -- find /root/buildinfo -name $pattern || :)
+    if [ -n "$dockerfile" ]
+    then
+      echo Image info: $dockerfile > $env_file
+      oc -n $ns exec $pod -c $container -- grep -o "\"build-date\"=\"[^[:blank:]]*\"" $dockerfile >> $env_file || echo "---- Unable to get build date"
+    fi
+    echo -- Environment Variables >> $env_file
+    oc -n $ns exec $pod -c $container -- env | sort >> $env_file
+  done
+}

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,0 +1,37 @@
+#!/bin/bash
+BASE_COLLECTION_PATH="${1:-/must-gather}"
+mkdir -p "${BASE_COLLECTION_PATH}"
+
+# resource list
+resources=()
+
+# cluser logging operator namespace
+resources+=(ns/openshift-logging)
+
+# elatiscsearch operator namespace
+resources+=(ns/openshift-operators-redhat)
+
+# cluster-scoped resources
+resources+=(nodes)
+resources+=(events)
+resources+=(persistentvolumes)
+
+# run the collection of resources using must-gather
+for resource in ${resources[@]}; do
+  oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" --all-namespaces "${resource}" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+done
+
+{
+    # Call operator and installation gather scripts
+    ./gather_cluster_logging_operator_resources "$BASE_COLLECTION_PATH"
+    ./gather_elasticsearch_operator_resources "$BASE_COLLECTION_PATH"
+    ./gather_install_resources "$BASE_COLLECTION_PATH"
+
+    # Call per component gather scripts
+    ./gather_collection_resources "$BASE_COLLECTION_PATH"
+    ./gather_curation_resources "$BASE_COLLECTION_PATH"
+    ./gather_logstore_resources "$BASE_COLLECTION_PATH"
+    ./gather_visualization_resources "$BASE_COLLECTION_PATH"
+} >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+
+exit 0

--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+source ./common
+
+# Expect base collection path as an argument
+BASE_COLLECTION_PATH=$1
+
+# Use PWD as base path if no argument is passed
+if [ "${BASE_COLLECTION_PATH}" = "" ]; then
+    BASE_COLLECTION_PATH=$(pwd)
+fi
+
+NAMESPACE="openshift-logging"
+
+CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
+clo_folder="$CLO_COLLECTION_PATH/clo"
+
+echo "Gathering data for cluster-logging-operator"
+mkdir -p "$clo_folder"
+
+pods=$(oc -n $NAMESPACE get pods -l name=cluster-logging-operator -o jsonpath={.items[*].metadata.name})
+for pod in $pods
+do
+    get_env $pod $clo_folder $NAMESPACE "Dockerfile-*operator*"
+done
+
+oc -n $NAMESPACE get deployment cluster-logging-operator -o yaml > $clo_folder/deployment
+
+csv_name="$(oc -n $NAMESPACE get csv -o name | grep 'cluster-logging-operator')"
+oc -n $NAMESPACE get "${csv_name}" -o yaml > "${clo_folder}/csv"
+oc -n $NAMESPACE get clusterlogging instance -o yaml > "${clo_folder}/cr"
+oc -n $NAMESPACE get logforwarding instance -o yaml > "${clo_folder}/logforwarding_cr" ||:
+oc -n $NAMESPACE get clusterlogforwarder instance -o yaml > "${clo_folder}/clusterlogforwarder_cr" ||:

--- a/must-gather/collection-scripts/gather_collection_resources
+++ b/must-gather/collection-scripts/gather_collection_resources
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+source ./common
+
+# Expect base collection path as an argument
+BASE_COLLECTION_PATH=$1
+
+# Use PWD as base path if no argument is passed
+if [ "${BASE_COLLECTION_PATH}" = "" ]; then
+    BASE_COLLECTION_PATH=$(pwd)
+fi
+
+NAMESPACE="openshift-logging"
+
+CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
+collector_folder="$CLO_COLLECTION_PATH/collector"
+
+check_collector_connectivity() {
+  local pod=$1
+  echo "--Connectivity between $pod and elasticsearch" >> $collector_folder/$pod
+
+  es_host=$(oc -n $NAMESPACE  get pod $pod  -o jsonpath='{.spec.containers[0].env[?(@.name=="ES_HOST")].value}')
+  es_port=$(oc -n $NAMESPACE  get pod $pod  -o jsonpath='{.spec.containers[0].env[?(@.name=="ES_PORT")].value}')
+  collector=fluent
+  container=fluentd
+
+  echo "  with ca" >> $collector_folder/$pod
+  oc -n $NAMESPACE exec $pod -c $container -- curl -ILvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert --cacert /etc/$collector/keys/ca -XGET https://$es_host:$es_port &>> $collector_folder/$pod
+
+  echo "  without ca" >> $collector_folder/$pod
+  oc -n $NAMESPACE exec $pod -c $container -- curl -ILkvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert -XGET https://$es_host:$es_port &>> $collector_folder/$pod
+}
+
+check_collector_persistence() {
+  local pod=$1
+  echo "--Persistence stats for pod $pod" >> $collector_folder/$pod
+
+  collector=fluentd
+  fbstoragePath=$(oc -n $NAMESPACE get daemonset $collector -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[?(@.name=="filebufferstorage")].mountPath}')
+
+  if [ -z "$fbstoragePath" ] ; then
+    echo "No filebuffer storage defined" >>  $collector_folder/$pod
+  else
+    oc -n $NAMESPACE exec $pod -c $collector -- df -h $fbstoragePath >> $collector_folder/$pod
+    oc -n $NAMESPACE exec $pod -c $collector -- ls -lr $fbstoragePath >> $collector_folder/$pod
+  fi
+}
+
+echo "Gathering data for collection component"
+echo "-- Checking Collector health"
+mkdir -p $collector_folder
+
+pods="$(oc -n $NAMESPACE get pods -l logging-infra=fluentd -o jsonpath={.items[*].metadata.name})"
+for pod in $pods
+do
+    echo "---- Collector pod: $pod"
+    get_env $pod $collector_folder "$NAMESPACE"
+    check_collector_connectivity $pod
+    check_collector_persistence $pod
+done

--- a/must-gather/collection-scripts/gather_curation_resources
+++ b/must-gather/collection-scripts/gather_curation_resources
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+source ./common
+
+# Expect base collection path as an argument
+BASE_COLLECTION_PATH=$1
+
+# Use PWD as base path if no argument is passed
+if [ "${BASE_COLLECTION_PATH}" = "" ]; then
+    BASE_COLLECTION_PATH=$(pwd)
+fi
+
+NAMESPACE="openshift-logging"
+
+CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
+curator_folder="$CLO_COLLECTION_PATH/curator"
+
+check_curator_connectivity() {
+  local cron=$1
+  echo "-- Connectivity between $cron and elasticsearch" >> $curator_folder/$pod
+  es_host=$(oc -n $NAMESPACE get cronjob $cron  -o jsonpath='{.spec.containers[0].env[?(@.name=="ES_HOST")].value}')
+  es_port=$(oc -n $NAMESPACE get cronjob $cron  -o jsonpath='{.spec.containers[0].env[?(@.name=="ES_PORT")].value}')
+  echo "  with ca" >> $curator_folder/$pod
+  oc -n $NAMESPACE debug cronjob/$cron -- curl -ILvs --key /etc/curator/keys/key --cert /etc/curator/keys/cert --cacert /etc/curator/keys/ca -XGET https://$es_host:$es_port &>> $curator_folder/$pod
+  echo "  without ca" >> $curator_folder/$pod
+  oc -n $NAMESPACE debug cronjob/$cron -- curl -ILkvs --key /etc/curator/keys/key --cert /etc/curator/keys/cert -XGET https://$es_host:$es_port &>> $curator_folder/$pod
+}
+
+
+echo "Gathering data for curation component"
+echo "-- Checking Curator health"
+curator_pods=$(oc -n $NAMESPACE get pods -l logging-infra=curator -o jsonpath={.items[*].metadata.name})
+mkdir -p $curator_folder
+for pod in $curator_pods
+do
+    echo "---- Curator pod: $pod"
+    get_env $pod $curator_folder
+done
+
+check_curator_connectivity curator

--- a/must-gather/collection-scripts/gather_elasticsearch_operator_resources
+++ b/must-gather/collection-scripts/gather_elasticsearch_operator_resources
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+source ./common
+
+# Expect base collection path as an argument
+BASE_COLLECTION_PATH=$1
+
+# Use PWD as base path if no argument is passed
+if [ "${BASE_COLLECTION_PATH}" = "" ]; then
+    BASE_COLLECTION_PATH=$(pwd)
+fi
+
+NAMESPACE="openshift-operators-redhat"
+
+CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
+eo_folder="$CLO_COLLECTION_PATH/eo"
+
+echo "Gathering data for elasticsearch-operator"
+mkdir -p "$eo_folder"
+
+pods=$(oc -n $NAMESPACE get pods -l name=elasticsearch-operator -o jsonpath={.items[*].metadata.name})
+for pod in $pods
+do
+    get_env $pod $eo_folder $NAMESPACE "Dockerfile-*operator*"
+done
+
+oc -n $NAMESPACE get deployment elasticsearch-operator -o yaml > $eo_folder/deployment
+
+csv_name="$(oc -n $NAMESPACE get csv -o name | grep 'elasticsearch-operator')"
+oc -n $NAMESPACE get "${csv_name}" -o yaml > "${eo_folder}/csv"

--- a/must-gather/collection-scripts/gather_install_resources
+++ b/must-gather/collection-scripts/gather_install_resources
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+source ./common
+
+# Expect base collection path as an argument
+BASE_COLLECTION_PATH=$1
+
+# Use PWD as base path if no argument is passed
+if [ "${BASE_COLLECTION_PATH}" = "" ]; then
+    BASE_COLLECTION_PATH=$(pwd)
+fi
+
+NAMESPACE="openshift-logging"
+
+CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
+install_folder="$CLO_COLLECTION_PATH/install"
+
+echo "Gathering data for install info"
+mkdir -p "$install_folder"
+
+echo "-- Subscription"
+oc get -n ${NAMESPACE} subscription -o yaml > "$install_folder/subscription"
+
+echo "-- Install Plan"
+oc get -n ${NAMESPACE} installplan -o yaml > "$install_folder/install_plan"
+
+echo "-- Catalog Operator logs"
+oc logs -n openshift-operator-lifecycle-manager -l app=catalog-operator > "$install_folder/co_logs"
+
+echo "-- OLM Operator logs"
+oc logs -n openshift-operator-lifecycle-manager -l app=olm-operator > "$install_folder/olmo_logs"

--- a/must-gather/collection-scripts/gather_logstore_resources
+++ b/must-gather/collection-scripts/gather_logstore_resources
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+source ./common
+
+# Expect base collection path as an argument
+BASE_COLLECTION_PATH=$1
+
+# Use PWD as base path if no argument is passed
+if [ "${BASE_COLLECTION_PATH}" = "" ]; then
+    BASE_COLLECTION_PATH=$(pwd)
+fi
+
+NAMESPACE="openshift-logging"
+
+CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
+es_folder="$CLO_COLLECTION_PATH/es"
+
+get_es_logs() {
+  local pod=$1
+  local logs_folder=$2/logs
+  echo "-- POD $pod Elasticsearch Logs"
+
+  if [ ! -d "$logs_folder" ]
+  then
+    mkdir -p $logs_folder
+  fi
+
+  path=/elasticsearch/persistent/elasticsearch/logs
+  exists=$( oc -n $NAMESPACE exec $pod -c elasticsearch -- ls ${path} 2> /dev/null ) || :
+
+  if [ -z "$exists" ]; then
+    path=/elasticsearch/elasticsearch/logs
+  fi
+
+  exists=$( oc -n $NAMESPACE exec $pod -c elasticsearch -- ls ${path} 2> /dev/null ) || :
+  if [ -z "$exists" ]; then
+    echo "---- Unable to get ES logs from pod $pod"
+  else
+    oc -n $NAMESPACE rsync -c elasticsearch -q $pod:$path $logs_folder 2> /dev/null || echo "---- Unable to get ES logs from pod $pod"
+    mv -f $logs_folder/logs $logs_folder/$pod
+    nice xz $logs_folder/$pod/*
+  fi
+}
+
+list_es_storage() {
+  local pod=$1
+  local mountPath=$(oc -n $NAMESPACE get pod $pod -o jsonpath='{.spec.containers[0].volumeMounts[?(@.name=="elasticsearch-storage")].mountPath}')
+  echo "-- Persistence files" >> $es_folder/$pod
+
+  oc -n $NAMESPACE exec -c elasticsearch $pod -- ls -lR $mountPath >> $es_folder/$pod
+}
+
+get_elasticsearch_status() {
+  local comp=$1
+  local pod=${2:-""}
+
+  if [ -z "$pod" ] ; then
+      echo "Skipping elasticsearch status because no pod was found for $1"
+      return
+  fi
+
+  local cluster_folder=$es_folder/cluster-$comp
+  mkdir -p $cluster_folder
+
+  curl_es='curl -s --max-time 5 --key /etc/elasticsearch/secret/admin-key --cert /etc/elasticsearch/secret/admin-cert --cacert /etc/elasticsearch/secret/admin-ca https://localhost:9200'
+  local cat_items=(health nodes aliases thread_pool)
+  for cat_item in ${cat_items[@]}
+  do
+    oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/$cat_item
+  done
+
+  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/indices?v\&bytes=m &> $cluster_folder/indices
+  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_search?sort=@timestamp:desc\&pretty > $cluster_folder/latest_documents.json
+  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_nodes/stats?pretty > $cluster_folder/nodes_stats.json
+
+  local health=$(oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/health?h=status)
+  if [ -z "$health" ]
+  then
+    echo "Unable to get health from $1"
+  elif [ $health != "green" ]
+  then
+    echo "Gathering additional cluster information Cluster status is $health"
+
+    cat_items=(recovery shards pending_tasks)
+    for cat_item in ${cat_items[@]}
+    do
+      oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/$cat_item
+    done
+
+    oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/shards?h=index,shard,prirep,state,unassigned.reason,unassigned.description | grep UNASSIGNED &> $cluster_folder/unassigned_shards
+  fi
+}
+
+get_elasticsearch_cr() {
+  oc get -n ${NAMESPACE} elasticsearch elasticsearch -o yaml > $es_folder/cr
+}
+
+echo "Gathering data for logstore component"
+echo "-- Checking Elasticsearch health"
+mkdir -p $es_folder
+
+es_pods=$(oc -n $NAMESPACE get pods -l component=elasticsearch -o jsonpath={.items[*].metadata.name})
+for pod in $es_pods
+do
+    echo "---- Elasticsearch pod: $pod"
+    get_env $pod $es_folder "$NAMESPACE"
+    get_es_logs $pod $es_folder
+    list_es_storage $pod
+done
+
+anypod=""
+for comp in "elasticsearch"
+do
+    echo "-- Getting Elasticsearch cluster info from logging-${comp} pod"
+    anypod=$(oc -n $NAMESPACE get pod --selector="component=${comp}" --no-headers | grep Running | awk '{print$1}' | tail -1 || :)
+    get_elasticsearch_status ${comp} ${anypod}
+done
+
+echo "-- Gather Elasticsearch CR"
+get_elasticsearch_cr

--- a/must-gather/collection-scripts/gather_visualization_resources
+++ b/must-gather/collection-scripts/gather_visualization_resources
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+source ./common
+
+# Expect base collection path as an argument
+BASE_COLLECTION_PATH=$1
+
+# Use PWD as base path if no argument is passed
+if [ "${BASE_COLLECTION_PATH}" = "" ]; then
+    BASE_COLLECTION_PATH=$(pwd)
+fi
+
+NAMESPACE="openshift-logging"
+
+CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
+kibana_folder="$CLO_COLLECTION_PATH/kibana"
+
+check_kibana_connectivity() {
+  pod=$1
+
+  echo "---- Connectivity between $pod and elasticsearch" >> $kibana_folder/$pod
+  es_url=$(oc -n $NAMESPACE get pod $pod  -o jsonpath='{.spec.containers[?(@.name=="kibana")].env[?(@.name=="ELASTICSEARCH_URL")].value}')
+
+  echo "  with ca" >> $kibana_folder/$pod
+  oc -n $NAMESPACE exec $pod -c kibana -- curl -ILvs --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert --cacert /etc/kibana/keys/ca -XGET $es_url &>> $kibana_folder/$pod
+
+  echo "  without ca" >> $kibana_folder/$pod
+  oc -n $NAMESPACE exec $pod -c kibana -- curl -ILkvs --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert -XGET $es_url &>> $kibana_folder/$pod
+}
+
+get_kibana_cr() {
+  oc get -n ${NAMESPACE} kibana kibana -o yaml > $kibana_folder/cr
+}
+
+echo "Gathering data for visualization component"
+echo "-- Checking Kibana health"
+mkdir -p $kibana_folder
+
+kibana_pods=$(oc -n $NAMESPACE get pods -l logging-infra=kibana -o jsonpath={.items[*].metadata.name})
+for pod in $kibana_pods
+do
+    echo "---- Kibana pod: $pod"
+    get_env $pod $kibana_folder "$NAMESPACE"
+    check_kibana_connectivity $pod
+done
+
+echo "-- Gather Kibana CR"
+get_kibana_cr


### PR DESCRIPTION
### Description
This PR provides a must-gather plugin image for the `oc adm must-gather` facility to align cluster-logging's debugging practices within the openshift organization. The implementation is basically a break out of the established [origin-aggregated-logging/logging-dump.sh](https://github.com/openshift/origin-aggregated-logging/blob/master/hack/logging-dump.sh) but with several improvements and benefits:
1. The dump of standard k8s resources and their logs (e.g. deployments, services, secrets, pods, cronjobs, etc.) is automated via `oc adm inspect` and follows a well-known filesystem structure.
2. The former `logging-dump.sh` checks and dumps are grouped in separate `gather_$COMPONENT_resources` scripts and in turn improve maintenance and extensibility.
3. Users can easily identify that our stacks provides a `must-gather` plugin image by looking on the top-level repo directory or the docs. The can use it directly instead of requesting the `logging-dump` script in BZs or forum channels.
4. The packaging model in a container hardens the gathering process from polluted user environments.
5. The must-gather output for standard k8s resource either namespace-scoped or cluster-scoped ensures that users can easily navigate through the output as they do with other operators.

### Open questions
- Where to place on the docs? [HERE???](https://docs.openshift.com/container-platform/4.5/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data)
- Where to host the image on quay.io? proposed: `quay.io/cluster-logging-dev/cluster-logging-must-gather`

### Want more, just convince yourself
**Note:** First of all ensure a running clusterlogging instance. Then execute:
```
oc adm must-gather --image quay.io/periklis/cluster-logging-must-gather
```

/cc @jcantrill @ewolinetz @alanconway 