### PR TITLE
[release-4.4] Bug 1852639: fixing kibana not rolling out with updated secret

### DIFF
--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -292,6 +292,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateKibanaDeployment(prox
 
 				hashKey := fmt.Sprintf("%s%s", constants.SecretHashPrefix, secretName)
 				if current.Spec.Template.ObjectMeta.Annotations[hashKey] != kibanaDeployment.Spec.Template.ObjectMeta.Annotations[hashKey] {
+					current.Spec.Template.ObjectMeta.Annotations[hashKey] = kibanaDeployment.Spec.Template.ObjectMeta.Annotations[hashKey]
 					different = true
 				}
 			}


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/elasticsearch-operator/pull/392

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1852639