### PR TITLE
Bump golang builder to 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-logging-operator
 
 # COPY steps are in the reverse order of frequency of change


### PR DESCRIPTION
This PR is a spin off from #635 to update the golang builder to 1.14 first. This is a prerequisite for the Registry-Replacer in openshift/release.

/cc @alanconway 