### PR TITLE
Trivial change to make linter happy.

### DIFF
--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -183,7 +183,7 @@ func inputsToPipelines(fwdspec *logging.ClusterLogForwarderSpec) logging.RouteMa
 
 //generateSourceToPipelineLabels generates fluentd label stanzas to fan source types to multiple pipelines
 func (engine *ConfigGenerator) generateSourceToPipelineLabels(sourcesToPipelines logging.RouteMap) ([]string, error) {
-	var configs []string
+	configs := []string{}
 	for sourceType, pipelineNames := range sourcesToPipelines {
 		data := struct {
 			IncludeLegacySecureForward bool
@@ -206,7 +206,7 @@ func (engine *ConfigGenerator) generateSourceToPipelineLabels(sourcesToPipelines
 }
 
 func (engine *ConfigGenerator) generatePipelineToOutputLabels(pipelines []logging.PipelineSpec) ([]string, error) {
-	var configs []string
+	configs := []string{}
 	for _, pipeline := range pipelines {
 		var jsonLabels string
 
@@ -249,7 +249,7 @@ func (engine *ConfigGenerator) generatePipelineToOutputLabels(pipelines []loggin
 //  </match>
 // </label>
 func (engine *ConfigGenerator) generateOutputLabelBlocks(outputs []logging.OutputSpec, outputConf *logging.ForwarderSpec) ([]string, error) {
-	var configs []string
+	configs := []string{}
 	logger.Debugf("Evaluating %v forwarder logging...", len(outputs))
 	for _, output := range outputs {
 		logger.Debugf("Generate output type %v", output.Type)


### PR DESCRIPTION
Note: the "consider preallocating" linter warns if a slice variable is declared using `var x []foo`. If you know up front an upper bound for the size of the slice you can pre-allocate with `x := make([]foo, maxlen)` which is more efficient.  If you are deliberately starting with a 0 length slice use `x := []foo{}` which is equivalent to the `var` form but satisfies the linter.

/cc @jcantrill