### PR TITLE
Bug 1871737:  Upgrade CRD apiVersion apiextensions.k8s.io from v1beta1 to v1

### DIFF
--- a/bundle/manifests/cluster-logging.v4.6.0.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.v4.6.0.clusterserviceversion.yaml
@@ -250,6 +250,12 @@ spec:
           verbs:
           - "*"
         - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - "*"
+        - apiGroups:
           - scheduling.k8s.io
           resources:
           - priorityclasses

--- a/bundle/manifests/crd-v1-clusterloggings-patches.yaml
+++ b/bundle/manifests/crd-v1-clusterloggings-patches.yaml
@@ -1,5 +1,5 @@
 - op: replace
-  path: /spec/validation/openAPIV3Schema/properties/metadata
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata
   value:
     type: object
     properties:
@@ -8,6 +8,6 @@
         enum:
         - "instance"
 - op: replace
-  path: /spec/validation/openAPIV3Schema/properties/status
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/status
   value:
     type: object

--- a/bundle/manifests/kustomization.yaml
+++ b/bundle/manifests/kustomization.yaml
@@ -8,9 +8,9 @@ patchesJson6902:
     version: v1
     kind: CustomResourceDefinition
     name: clusterlogforwarders.logging.openshift.io
-- path: crd-v1beta1-clusterloggings-patches.yaml
+- path: crd-v1-clusterloggings-patches.yaml
   target:
     group: apiextensions.k8s.io
-    version: v1beta1
+    version: v1
     kind: CustomResourceDefinition
     name: clusterloggings.logging.openshift.io

--- a/bundle/manifests/logforwardings.crd.yaml
+++ b/bundle/manifests/logforwardings.crd.yaml
@@ -72,6 +72,9 @@ spec:
                       - logs.app
                       - logs.infra
                       - logs.audit
+                  labels:
+                    type: map
+                    description: Pipeline labels in the key:value format
               required:
               - name
               - source

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -192,13 +192,14 @@ spec:
                     url:
                       description: "URL to send log messages to. \n Must be an absolute
                         URL, with a scheme. Valid URL schemes depend on `type`. Special
-                        schemes 'tcp', 'udp' and 'tls' are used for output types that
-                        don't define their own URL scheme.  Example: \n     { type:
-                        syslog, url: tls://syslog.example.com:1234 } \n TLS with server
-                        authentication is enabled by the URL scheme, for example 'tls'
-                        or 'https'.  See `secret` for TLS client authentication. \n
-                        This field is optional and can be empty if there is an output-type
-                        field with alternative connection information."
+                        schemes 'tcp', 'tls', 'udp' and 'udps are used for output
+                        types that don't define their own URL scheme.  Example: \n
+                        \    { type: syslog, url: udps://syslog.example.com:1234 }
+                        \n TLS with server authentication is enabled by the URL scheme,
+                        for example 'tls' or 'https'.  See `secret` for TLS client
+                        authentication. \n This field is optional and can be empty
+                        if there is an output-type field with alternative connection
+                        information."
                       pattern: ^$|[a-zA-z]+:\/\/.*
                       type: string
                   required:
@@ -221,6 +222,11 @@ spec:
                       items:
                         type: string
                       type: array
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels lists labels applied to this pipeline
+                      type: object
                     name:
                       description: Name is optional, but must be unique in the `pipelines`
                         list if provided.

--- a/bundle/manifests/logging.openshift.io_clusterloggings_crd.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterloggings_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterloggings.logging.openshift.io
@@ -12,632 +12,635 @@ spec:
     - cl
     singular: clusterlogging
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: "ClusterLogging is the Schema for the clusterloggings API \n ClusterLogging
-        is the Schema for the clusterloggings API"
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          properties:
-            name:
-              enum:
-              - instance
-              type: string
-          type: object
-        spec:
-          description: Specification of the desired behavior of the Logging cluster.
-          properties:
-            collection:
-              description: Specification of the Collection component for the cluster
-              nullable: true
-              properties:
-                logs:
-                  description: Specification of Log Collection for the cluster
-                  properties:
-                    fluentd:
-                      description: Specification of the Fluentd Log Collection component
-                      properties:
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Define which Nodes the Pods are scheduled on.
-                          nullable: true
-                          type: object
-                        resources:
-                          description: The resource requirements for Fluentd
-                          nullable: true
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        tolerations:
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect>
-                              using the matching operator <operator>.
-                            properties:
-                              effect:
-                                description: Effect indicates the taint effect to
-                                  match. Empty means match all taint effects. When
-                                  specified, allowed values are NoSchedule, PreferNoSchedule
-                                  and NoExecute.
-                                type: string
-                              key:
-                                description: Key is the taint key that the toleration
-                                  applies to. Empty means match all taint keys. If
-                                  the key is empty, operator must be Exists; this
-                                  combination means to match all values and all keys.
-                                type: string
-                              operator:
-                                description: Operator represents a key's relationship
-                                  to the value. Valid operators are Exists and Equal.
-                                  Defaults to Equal. Exists is equivalent to wildcard
-                                  for value, so that a pod can tolerate all taints
-                                  of a particular category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period
-                                  of time the toleration (which must be of effect
-                                  NoExecute, otherwise this field is ignored) tolerates
-                                  the taint. By default, it is not set, which means
-                                  tolerate the taint forever (do not evict). Zero
-                                  and negative values will be treated as 0 (evict
-                                  immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration
-                                  matches to. If the operator is Exists, the value
-                                  should be empty, otherwise just a regular string.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type:
-                      description: The type of Log Collection to configure
-                      type: string
-                  required:
-                  - type
-                  type: object
-              type: object
-            curation:
-              description: Specification of the Curation component for the cluster
-              nullable: true
-              properties:
-                curator:
-                  description: The specification of curation to configure
-                  properties:
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Define which Nodes the Pods are scheduled on.
-                      nullable: true
-                      type: object
-                    resources:
-                      description: The resource requirements for Curator
-                      nullable: true
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    schedule:
-                      description: The cron schedule that the Curator job is run.
-                        Defaults to "30 3 * * *"
-                      type: string
-                    tolerations:
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified,
-                              allowed values are NoSchedule, PreferNoSchedule and
-                              NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration
-                              applies to. Empty means match all taint keys. If the
-                              key is empty, operator must be Exists; this combination
-                              means to match all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship
-                              to the value. Valid operators are Exists and Equal.
-                              Defaults to Equal. Exists is equivalent to wildcard
-                              for value, so that a pod can tolerate all taints of
-                              a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the
-                              taint forever (do not evict). Zero and negative values
-                              will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - schedule
-                  type: object
-                type:
-                  description: The kind of curation to configure
-                  type: string
-              required:
-              - type
-              type: object
-            forwarder:
-              description: Specification for Forwarder component for the cluster
-              nullable: true
-              properties:
-                fluentd:
-                  description: FluentdForwarderSpec represents the configuration for
-                    forwarders of type fluentd.
-                  properties:
-                    buffer:
-                      description: "FluentdBufferSpec represents a subset of fluentd
-                        buffer parameters to tune the buffer configuration for all
-                        fluentd outputs. It supports a subset of parameters to configure
-                        buffer and queue sizing, flush operations and retry flushing.
-                        \n For general parameters refer to: https://docs.fluentd.org/configuration/buffer-section#buffering-parameters
-                        \n For flush parameters refer to: https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
-                        \n For retry parameters refer to: https://docs.fluentd.org/configuration/buffer-section#retries-parameters"
-                      properties:
-                        chunkLimitSize:
-                          description: ChunkLimitSize represents the maximum size
-                            of each chunk. Events will be written into chunks until
-                            the size of chunks become this size.
-                          pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
-                          type: string
-                        flushInterval:
-                          description: 'FlushInterval represents the time duration
-                            to wait between two consecutive flush operations. Takes
-                            only effect used together with `flushMode: interval`.'
-                          pattern: ^([0-9]+)([smhd]{0,1})$
-                          type: string
-                        flushMode:
-                          description: FlushMode represents the mode of the flushing
-                            thread to write chunks. The mode allows lazy (if `time`
-                            parameter set), per interval or immediate flushing.
-                          enum:
-                          - lazy
-                          - interval
-                          - immediate
-                          type: string
-                        flushThreadCount:
-                          description: FlushThreadCount reprents the number of threads
-                            used by the fluentd buffer plugin to flush/write chunks
-                            in parallel.
-                          format: int32
-                          type: integer
-                        overflowAction:
-                          description: 'OverflowAction represents the action for the
-                            fluentd buffer plugin to execute when a buffer queue is
-                            full. (Default: block)'
-                          enum:
-                          - throw_exception
-                          - block
-                          - drop_oldest_chunk
-                          type: string
-                        retryMaxInterval:
-                          description: 'RetryMaxInterval represents the maxixum time
-                            interval for exponential backoff between retries. Takes
-                            only effect if used together with `retryType: exponential_backoff`.'
-                          pattern: ^([0-9]+)([smhd]{0,1})$
-                          type: string
-                        retryType:
-                          description: RetryType represents the type of retrying flush
-                            operations. Flush operations can be retried either periodically
-                            or by applying exponential backoff.
-                          enum:
-                          - exponential_backoff
-                          - periodic
-                          type: string
-                        retryWait:
-                          description: RetryWait represents the time duration between
-                            two consecutive retries to flush buffers for periodic
-                            retries or a constant factor of time on retries with exponential
-                            backoff.
-                          pattern: ^([0-9]+)([smhd]{0,1})$
-                          type: string
-                        totalLimitSize:
-                          description: TotalLimitSize represents the threshold of
-                            node space allowed per fluentd buffer to allocate. Once
-                            this threshold is reached, all append operations will
-                            fail with error (and data will be lost).
-                          pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
-                          type: string
-                      type: object
-                  type: object
-              type: object
-            logStore:
-              description: Specification of the Log Storage component for the cluster
-              nullable: true
-              properties:
-                elasticsearch:
-                  description: Specification of the Elasticsearch Log Store component
-                  properties:
-                    nodeCount:
-                      description: Number of nodes to deploy for Elasticsearch
-                      format: int32
-                      type: integer
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Define which Nodes the Pods are scheduled on.
-                      nullable: true
-                      type: object
-                    proxy:
-                      description: Specification of the Elasticsearch Proxy component
-                      properties:
-                        resources:
-                          description: ResourceRequirements describes the compute
-                            resource requirements.
-                          nullable: true
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                      required:
-                      - resources
-                      type: object
-                    redundancyPolicy:
-                      description: The policy towards data redundancy to specify the
-                        number of redundant primary shards
-                      enum:
-                      - FullRedundancy
-                      - MultipleRedundancy
-                      - SingleRedundancy
-                      - ZeroRedundancy
-                      type: string
-                    resources:
-                      description: The resource requirements for Elasticsearch
-                      nullable: true
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    storage:
-                      description: The storage specification for Elasticsearch data
-                        nodes
-                      nullable: true
-                      properties:
-                        size:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: The capacity of storage to provision.
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        storageClassName:
-                          description: 'The class of storage to provision. More info:
-                            https://kubernetes.io/docs/concepts/storage/storage-classes/'
-                          type: string
-                      type: object
-                    tolerations:
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified,
-                              allowed values are NoSchedule, PreferNoSchedule and
-                              NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration
-                              applies to. Empty means match all taint keys. If the
-                              key is empty, operator must be Exists; this combination
-                              means to match all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship
-                              to the value. Valid operators are Exists and Equal.
-                              Defaults to Equal. Exists is equivalent to wildcard
-                              for value, so that a pod can tolerate all taints of
-                              a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the
-                              taint forever (do not evict). Zero and negative values
-                              will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - nodeCount
-                  type: object
-                retentionPolicy:
-                  description: Retention policy defines the maximum age for an index
-                    after which it should be deleted
-                  nullable: true
-                  properties:
-                    application:
-                      nullable: true
-                      properties:
-                        maxAge:
-                          description: TimeUnit is a time unit like h,m,d
-                          type: string
-                      type: object
-                    audit:
-                      nullable: true
-                      properties:
-                        maxAge:
-                          description: TimeUnit is a time unit like h,m,d
-                          type: string
-                      type: object
-                    infra:
-                      nullable: true
-                      properties:
-                        maxAge:
-                          description: TimeUnit is a time unit like h,m,d
-                          type: string
-                      type: object
-                  type: object
-                type:
-                  description: The type of Log Storage to configure
-                  type: string
-              required:
-              - type
-              type: object
-            managementState:
-              description: Indicator if the resource is 'Managed' or 'Unmanaged' by
-                the operator
-              enum:
-              - Managed
-              - Unmanaged
-              type: string
-            visualization:
-              description: Specification of the Visualization component for the cluster
-              nullable: true
-              properties:
-                kibana:
-                  description: Specification of the Kibana Visualization component
-                  properties:
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Define which Nodes the Pods are scheduled on.
-                      nullable: true
-                      type: object
-                    proxy:
-                      description: Specification of the Kibana Proxy component
-                      properties:
-                        resources:
-                          description: ResourceRequirements describes the compute
-                            resource requirements.
-                          nullable: true
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                      required:
-                      - resources
-                      type: object
-                    replicas:
-                      description: Number of instances to deploy for a Kibana deployment
-                      format: int32
-                      type: integer
-                    resources:
-                      description: The resource requirements for Kibana
-                      nullable: true
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    tolerations:
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified,
-                              allowed values are NoSchedule, PreferNoSchedule and
-                              NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration
-                              applies to. Empty means match all taint keys. If the
-                              key is empty, operator must be Exists; this combination
-                              means to match all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship
-                              to the value. Valid operators are Exists and Equal.
-                              Defaults to Equal. Exists is equivalent to wildcard
-                              for value, so that a pod can tolerate all taints of
-                              a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the
-                              taint forever (do not evict). Zero and negative values
-                              will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - replicas
-                  type: object
-                type:
-                  description: The type of Visualization to configure
-                  type: string
-              required:
-              - type
-              type: object
-          type: object
-        status:
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterLogging is the Schema for the clusterloggings API \n
+          ClusterLogging is the Schema for the clusterloggings API"
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - instance
+                type: string
+            type: object
+          spec:
+            description: Specification of the desired behavior of the Logging cluster.
+            properties:
+              collection:
+                description: Specification of the Collection component for the cluster
+                nullable: true
+                properties:
+                  logs:
+                    description: Specification of Log Collection for the cluster
+                    properties:
+                      fluentd:
+                        description: Specification of the Fluentd Log Collection component
+                        properties:
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: Define which Nodes the Pods are scheduled
+                              on.
+                            nullable: true
+                            type: object
+                          resources:
+                            description: The resource requirements for Fluentd
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          tolerations:
+                            items:
+                              description: The pod this Toleration is attached to
+                                tolerates any taint that matches the triple <key,value,effect>
+                                using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: Effect indicates the taint effect to
+                                    match. Empty means match all taint effects. When
+                                    specified, allowed values are NoSchedule, PreferNoSchedule
+                                    and NoExecute.
+                                  type: string
+                                key:
+                                  description: Key is the taint key that the toleration
+                                    applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists;
+                                    this combination means to match all values and
+                                    all keys.
+                                  type: string
+                                operator:
+                                  description: Operator represents a key's relationship
+                                    to the value. Valid operators are Exists and Equal.
+                                    Defaults to Equal. Exists is equivalent to wildcard
+                                    for value, so that a pod can tolerate all taints
+                                    of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: TolerationSeconds represents the period
+                                    of time the toleration (which must be of effect
+                                    NoExecute, otherwise this field is ignored) tolerates
+                                    the taint. By default, it is not set, which means
+                                    tolerate the taint forever (do not evict). Zero
+                                    and negative values will be treated as 0 (evict
+                                    immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: Value is the taint value the toleration
+                                    matches to. If the operator is Exists, the value
+                                    should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      type:
+                        description: The type of Log Collection to configure
+                        type: string
+                    required:
+                    - type
+                    type: object
+                type: object
+              curation:
+                description: Specification of the Curation component for the cluster
+                nullable: true
+                properties:
+                  curator:
+                    description: The specification of curation to configure
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Define which Nodes the Pods are scheduled on.
+                        nullable: true
+                        type: object
+                      resources:
+                        description: The resource requirements for Curator
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      schedule:
+                        description: The cron schedule that the Curator job is run.
+                          Defaults to "30 3 * * *"
+                        type: string
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - schedule
+                    type: object
+                  type:
+                    description: The kind of curation to configure
+                    type: string
+                required:
+                - type
+                type: object
+              forwarder:
+                description: Specification for Forwarder component for the cluster
+                nullable: true
+                properties:
+                  fluentd:
+                    description: FluentdForwarderSpec represents the configuration
+                      for forwarders of type fluentd.
+                    properties:
+                      buffer:
+                        description: "FluentdBufferSpec represents a subset of fluentd
+                          buffer parameters to tune the buffer configuration for all
+                          fluentd outputs. It supports a subset of parameters to configure
+                          buffer and queue sizing, flush operations and retry flushing.
+                          \n For general parameters refer to: https://docs.fluentd.org/configuration/buffer-section#buffering-parameters
+                          \n For flush parameters refer to: https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
+                          \n For retry parameters refer to: https://docs.fluentd.org/configuration/buffer-section#retries-parameters"
+                        properties:
+                          chunkLimitSize:
+                            description: ChunkLimitSize represents the maximum size
+                              of each chunk. Events will be written into chunks until
+                              the size of chunks become this size.
+                            pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
+                            type: string
+                          flushInterval:
+                            description: 'FlushInterval represents the time duration
+                              to wait between two consecutive flush operations. Takes
+                              only effect used together with `flushMode: interval`.'
+                            pattern: ^([0-9]+)([smhd]{0,1})$
+                            type: string
+                          flushMode:
+                            description: FlushMode represents the mode of the flushing
+                              thread to write chunks. The mode allows lazy (if `time`
+                              parameter set), per interval or immediate flushing.
+                            enum:
+                            - lazy
+                            - interval
+                            - immediate
+                            type: string
+                          flushThreadCount:
+                            description: FlushThreadCount reprents the number of threads
+                              used by the fluentd buffer plugin to flush/write chunks
+                              in parallel.
+                            format: int32
+                            type: integer
+                          overflowAction:
+                            description: 'OverflowAction represents the action for
+                              the fluentd buffer plugin to execute when a buffer queue
+                              is full. (Default: block)'
+                            enum:
+                            - throw_exception
+                            - block
+                            - drop_oldest_chunk
+                            type: string
+                          retryMaxInterval:
+                            description: 'RetryMaxInterval represents the maxixum
+                              time interval for exponential backoff between retries.
+                              Takes only effect if used together with `retryType:
+                              exponential_backoff`.'
+                            pattern: ^([0-9]+)([smhd]{0,1})$
+                            type: string
+                          retryType:
+                            description: RetryType represents the type of retrying
+                              flush operations. Flush operations can be retried either
+                              periodically or by applying exponential backoff.
+                            enum:
+                            - exponential_backoff
+                            - periodic
+                            type: string
+                          retryWait:
+                            description: RetryWait represents the time duration between
+                              two consecutive retries to flush buffers for periodic
+                              retries or a constant factor of time on retries with
+                              exponential backoff.
+                            pattern: ^([0-9]+)([smhd]{0,1})$
+                            type: string
+                          totalLimitSize:
+                            description: TotalLimitSize represents the threshold of
+                              node space allowed per fluentd buffer to allocate. Once
+                              this threshold is reached, all append operations will
+                              fail with error (and data will be lost).
+                            pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              logStore:
+                description: Specification of the Log Storage component for the cluster
+                nullable: true
+                properties:
+                  elasticsearch:
+                    description: Specification of the Elasticsearch Log Store component
+                    properties:
+                      nodeCount:
+                        description: Number of nodes to deploy for Elasticsearch
+                        format: int32
+                        type: integer
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Define which Nodes the Pods are scheduled on.
+                        nullable: true
+                        type: object
+                      proxy:
+                        description: Specification of the Elasticsearch Proxy component
+                        properties:
+                          resources:
+                            description: ResourceRequirements describes the compute
+                              resource requirements.
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                        required:
+                        - resources
+                        type: object
+                      redundancyPolicy:
+                        description: The policy towards data redundancy to specify
+                          the number of redundant primary shards
+                        enum:
+                        - FullRedundancy
+                        - MultipleRedundancy
+                        - SingleRedundancy
+                        - ZeroRedundancy
+                        type: string
+                      resources:
+                        description: The resource requirements for Elasticsearch
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      storage:
+                        description: The storage specification for Elasticsearch data
+                          nodes
+                        nullable: true
+                        properties:
+                          size:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The capacity of storage to provision.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          storageClassName:
+                            description: 'The class of storage to provision. More
+                              info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
+                            type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - nodeCount
+                    type: object
+                  retentionPolicy:
+                    description: Retention policy defines the maximum age for an index
+                      after which it should be deleted
+                    nullable: true
+                    properties:
+                      application:
+                        nullable: true
+                        properties:
+                          maxAge:
+                            description: TimeUnit is a time unit like h,m,d
+                            type: string
+                        type: object
+                      audit:
+                        nullable: true
+                        properties:
+                          maxAge:
+                            description: TimeUnit is a time unit like h,m,d
+                            type: string
+                        type: object
+                      infra:
+                        nullable: true
+                        properties:
+                          maxAge:
+                            description: TimeUnit is a time unit like h,m,d
+                            type: string
+                        type: object
+                    type: object
+                  type:
+                    description: The type of Log Storage to configure
+                    type: string
+                required:
+                - type
+                type: object
+              managementState:
+                description: Indicator if the resource is 'Managed' or 'Unmanaged'
+                  by the operator
+                enum:
+                - Managed
+                - Unmanaged
+                type: string
+              visualization:
+                description: Specification of the Visualization component for the
+                  cluster
+                nullable: true
+                properties:
+                  kibana:
+                    description: Specification of the Kibana Visualization component
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Define which Nodes the Pods are scheduled on.
+                        nullable: true
+                        type: object
+                      proxy:
+                        description: Specification of the Kibana Proxy component
+                        properties:
+                          resources:
+                            description: ResourceRequirements describes the compute
+                              resource requirements.
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                        required:
+                        - resources
+                        type: object
+                      replicas:
+                        description: Number of instances to deploy for a Kibana deployment
+                        format: int32
+                        type: integer
+                      resources:
+                        description: The resource requirements for Kibana
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - replicas
+                    type: object
+                  type:
+                    description: The type of Visualization to configure
+                    type: string
+                required:
+                - type
+                type: object
+            type: object
+          status:
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/hack/generate-crd.sh
+++ b/hack/generate-crd.sh
@@ -14,16 +14,11 @@ echo "--------------------------------------------------------------"
 $OPERATOR_SDK generate k8s
 
 echo "--------------------------------------------------------------"
-echo "Generate CRDs for apiVersion v1beta1"
-echo "--------------------------------------------------------------"
-$OPERATOR_SDK generate crds --crd-version v1beta1
-mv "deploy/crds/${CLO_CRD_FILE}" "${MANIFESTS_DIR}"
-
-echo "--------------------------------------------------------------"
 echo "Generate CRDs for apiVersion v1"
 echo "--------------------------------------------------------------"
 $OPERATOR_SDK generate crds --crd-version v1
 mv "deploy/crds/${CLF_CRD_FILE}" "${MANIFESTS_DIR}"
+mv "deploy/crds/${CLO_CRD_FILE}" "${MANIFESTS_DIR}"
 
 echo "---------------------------------------------------------------"
 echo "Kustomize: Patch CRDs for singeltons and backward-compatibility"

--- a/manifests/4.6/crd-v1-clusterloggings-patches.yaml
+++ b/manifests/4.6/crd-v1-clusterloggings-patches.yaml
@@ -1,5 +1,5 @@
 - op: replace
-  path: /spec/validation/openAPIV3Schema/properties/metadata
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata
   value:
     type: object
     properties:
@@ -8,6 +8,6 @@
         enum:
         - "instance"
 - op: replace
-  path: /spec/validation/openAPIV3Schema/properties/status
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/status
   value:
     type: object

--- a/manifests/4.6/kustomization.yaml
+++ b/manifests/4.6/kustomization.yaml
@@ -8,9 +8,9 @@ patchesJson6902:
     version: v1
     kind: CustomResourceDefinition
     name: clusterlogforwarders.logging.openshift.io
-- path: crd-v1beta1-clusterloggings-patches.yaml
+- path: crd-v1-clusterloggings-patches.yaml
   target:
     group: apiextensions.k8s.io
-    version: v1beta1
+    version: v1
     kind: CustomResourceDefinition
     name: clusterloggings.logging.openshift.io

--- a/manifests/4.6/logging.openshift.io_clusterloggings_crd.yaml
+++ b/manifests/4.6/logging.openshift.io_clusterloggings_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterloggings.logging.openshift.io
@@ -12,632 +12,635 @@ spec:
     - cl
     singular: clusterlogging
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: "ClusterLogging is the Schema for the clusterloggings API \n ClusterLogging
-        is the Schema for the clusterloggings API"
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          properties:
-            name:
-              enum:
-              - instance
-              type: string
-          type: object
-        spec:
-          description: Specification of the desired behavior of the Logging cluster.
-          properties:
-            collection:
-              description: Specification of the Collection component for the cluster
-              nullable: true
-              properties:
-                logs:
-                  description: Specification of Log Collection for the cluster
-                  properties:
-                    fluentd:
-                      description: Specification of the Fluentd Log Collection component
-                      properties:
-                        nodeSelector:
-                          additionalProperties:
-                            type: string
-                          description: Define which Nodes the Pods are scheduled on.
-                          nullable: true
-                          type: object
-                        resources:
-                          description: The resource requirements for Fluentd
-                          nullable: true
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        tolerations:
-                          items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect>
-                              using the matching operator <operator>.
-                            properties:
-                              effect:
-                                description: Effect indicates the taint effect to
-                                  match. Empty means match all taint effects. When
-                                  specified, allowed values are NoSchedule, PreferNoSchedule
-                                  and NoExecute.
-                                type: string
-                              key:
-                                description: Key is the taint key that the toleration
-                                  applies to. Empty means match all taint keys. If
-                                  the key is empty, operator must be Exists; this
-                                  combination means to match all values and all keys.
-                                type: string
-                              operator:
-                                description: Operator represents a key's relationship
-                                  to the value. Valid operators are Exists and Equal.
-                                  Defaults to Equal. Exists is equivalent to wildcard
-                                  for value, so that a pod can tolerate all taints
-                                  of a particular category.
-                                type: string
-                              tolerationSeconds:
-                                description: TolerationSeconds represents the period
-                                  of time the toleration (which must be of effect
-                                  NoExecute, otherwise this field is ignored) tolerates
-                                  the taint. By default, it is not set, which means
-                                  tolerate the taint forever (do not evict). Zero
-                                  and negative values will be treated as 0 (evict
-                                  immediately) by the system.
-                                format: int64
-                                type: integer
-                              value:
-                                description: Value is the taint value the toleration
-                                  matches to. If the operator is Exists, the value
-                                  should be empty, otherwise just a regular string.
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    type:
-                      description: The type of Log Collection to configure
-                      type: string
-                  required:
-                  - type
-                  type: object
-              type: object
-            curation:
-              description: Specification of the Curation component for the cluster
-              nullable: true
-              properties:
-                curator:
-                  description: The specification of curation to configure
-                  properties:
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Define which Nodes the Pods are scheduled on.
-                      nullable: true
-                      type: object
-                    resources:
-                      description: The resource requirements for Curator
-                      nullable: true
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    schedule:
-                      description: The cron schedule that the Curator job is run.
-                        Defaults to "30 3 * * *"
-                      type: string
-                    tolerations:
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified,
-                              allowed values are NoSchedule, PreferNoSchedule and
-                              NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration
-                              applies to. Empty means match all taint keys. If the
-                              key is empty, operator must be Exists; this combination
-                              means to match all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship
-                              to the value. Valid operators are Exists and Equal.
-                              Defaults to Equal. Exists is equivalent to wildcard
-                              for value, so that a pod can tolerate all taints of
-                              a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the
-                              taint forever (do not evict). Zero and negative values
-                              will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - schedule
-                  type: object
-                type:
-                  description: The kind of curation to configure
-                  type: string
-              required:
-              - type
-              type: object
-            forwarder:
-              description: Specification for Forwarder component for the cluster
-              nullable: true
-              properties:
-                fluentd:
-                  description: FluentdForwarderSpec represents the configuration for
-                    forwarders of type fluentd.
-                  properties:
-                    buffer:
-                      description: "FluentdBufferSpec represents a subset of fluentd
-                        buffer parameters to tune the buffer configuration for all
-                        fluentd outputs. It supports a subset of parameters to configure
-                        buffer and queue sizing, flush operations and retry flushing.
-                        \n For general parameters refer to: https://docs.fluentd.org/configuration/buffer-section#buffering-parameters
-                        \n For flush parameters refer to: https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
-                        \n For retry parameters refer to: https://docs.fluentd.org/configuration/buffer-section#retries-parameters"
-                      properties:
-                        chunkLimitSize:
-                          description: ChunkLimitSize represents the maximum size
-                            of each chunk. Events will be written into chunks until
-                            the size of chunks become this size.
-                          pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
-                          type: string
-                        flushInterval:
-                          description: 'FlushInterval represents the time duration
-                            to wait between two consecutive flush operations. Takes
-                            only effect used together with `flushMode: interval`.'
-                          pattern: ^([0-9]+)([smhd]{0,1})$
-                          type: string
-                        flushMode:
-                          description: FlushMode represents the mode of the flushing
-                            thread to write chunks. The mode allows lazy (if `time`
-                            parameter set), per interval or immediate flushing.
-                          enum:
-                          - lazy
-                          - interval
-                          - immediate
-                          type: string
-                        flushThreadCount:
-                          description: FlushThreadCount reprents the number of threads
-                            used by the fluentd buffer plugin to flush/write chunks
-                            in parallel.
-                          format: int32
-                          type: integer
-                        overflowAction:
-                          description: 'OverflowAction represents the action for the
-                            fluentd buffer plugin to execute when a buffer queue is
-                            full. (Default: block)'
-                          enum:
-                          - throw_exception
-                          - block
-                          - drop_oldest_chunk
-                          type: string
-                        retryMaxInterval:
-                          description: 'RetryMaxInterval represents the maxixum time
-                            interval for exponential backoff between retries. Takes
-                            only effect if used together with `retryType: exponential_backoff`.'
-                          pattern: ^([0-9]+)([smhd]{0,1})$
-                          type: string
-                        retryType:
-                          description: RetryType represents the type of retrying flush
-                            operations. Flush operations can be retried either periodically
-                            or by applying exponential backoff.
-                          enum:
-                          - exponential_backoff
-                          - periodic
-                          type: string
-                        retryWait:
-                          description: RetryWait represents the time duration between
-                            two consecutive retries to flush buffers for periodic
-                            retries or a constant factor of time on retries with exponential
-                            backoff.
-                          pattern: ^([0-9]+)([smhd]{0,1})$
-                          type: string
-                        totalLimitSize:
-                          description: TotalLimitSize represents the threshold of
-                            node space allowed per fluentd buffer to allocate. Once
-                            this threshold is reached, all append operations will
-                            fail with error (and data will be lost).
-                          pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
-                          type: string
-                      type: object
-                  type: object
-              type: object
-            logStore:
-              description: Specification of the Log Storage component for the cluster
-              nullable: true
-              properties:
-                elasticsearch:
-                  description: Specification of the Elasticsearch Log Store component
-                  properties:
-                    nodeCount:
-                      description: Number of nodes to deploy for Elasticsearch
-                      format: int32
-                      type: integer
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Define which Nodes the Pods are scheduled on.
-                      nullable: true
-                      type: object
-                    proxy:
-                      description: Specification of the Elasticsearch Proxy component
-                      properties:
-                        resources:
-                          description: ResourceRequirements describes the compute
-                            resource requirements.
-                          nullable: true
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                      required:
-                      - resources
-                      type: object
-                    redundancyPolicy:
-                      description: The policy towards data redundancy to specify the
-                        number of redundant primary shards
-                      enum:
-                      - FullRedundancy
-                      - MultipleRedundancy
-                      - SingleRedundancy
-                      - ZeroRedundancy
-                      type: string
-                    resources:
-                      description: The resource requirements for Elasticsearch
-                      nullable: true
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    storage:
-                      description: The storage specification for Elasticsearch data
-                        nodes
-                      nullable: true
-                      properties:
-                        size:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: The capacity of storage to provision.
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        storageClassName:
-                          description: 'The class of storage to provision. More info:
-                            https://kubernetes.io/docs/concepts/storage/storage-classes/'
-                          type: string
-                      type: object
-                    tolerations:
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified,
-                              allowed values are NoSchedule, PreferNoSchedule and
-                              NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration
-                              applies to. Empty means match all taint keys. If the
-                              key is empty, operator must be Exists; this combination
-                              means to match all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship
-                              to the value. Valid operators are Exists and Equal.
-                              Defaults to Equal. Exists is equivalent to wildcard
-                              for value, so that a pod can tolerate all taints of
-                              a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the
-                              taint forever (do not evict). Zero and negative values
-                              will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - nodeCount
-                  type: object
-                retentionPolicy:
-                  description: Retention policy defines the maximum age for an index
-                    after which it should be deleted
-                  nullable: true
-                  properties:
-                    application:
-                      nullable: true
-                      properties:
-                        maxAge:
-                          description: TimeUnit is a time unit like h,m,d
-                          type: string
-                      type: object
-                    audit:
-                      nullable: true
-                      properties:
-                        maxAge:
-                          description: TimeUnit is a time unit like h,m,d
-                          type: string
-                      type: object
-                    infra:
-                      nullable: true
-                      properties:
-                        maxAge:
-                          description: TimeUnit is a time unit like h,m,d
-                          type: string
-                      type: object
-                  type: object
-                type:
-                  description: The type of Log Storage to configure
-                  type: string
-              required:
-              - type
-              type: object
-            managementState:
-              description: Indicator if the resource is 'Managed' or 'Unmanaged' by
-                the operator
-              enum:
-              - Managed
-              - Unmanaged
-              type: string
-            visualization:
-              description: Specification of the Visualization component for the cluster
-              nullable: true
-              properties:
-                kibana:
-                  description: Specification of the Kibana Visualization component
-                  properties:
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: Define which Nodes the Pods are scheduled on.
-                      nullable: true
-                      type: object
-                    proxy:
-                      description: Specification of the Kibana Proxy component
-                      properties:
-                        resources:
-                          description: ResourceRequirements describes the compute
-                            resource requirements.
-                          nullable: true
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                      required:
-                      - resources
-                      type: object
-                    replicas:
-                      description: Number of instances to deploy for a Kibana deployment
-                      format: int32
-                      type: integer
-                    resources:
-                      description: The resource requirements for Kibana
-                      nullable: true
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    tolerations:
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified,
-                              allowed values are NoSchedule, PreferNoSchedule and
-                              NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration
-                              applies to. Empty means match all taint keys. If the
-                              key is empty, operator must be Exists; this combination
-                              means to match all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship
-                              to the value. Valid operators are Exists and Equal.
-                              Defaults to Equal. Exists is equivalent to wildcard
-                              for value, so that a pod can tolerate all taints of
-                              a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the
-                              taint forever (do not evict). Zero and negative values
-                              will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                  required:
-                  - replicas
-                  type: object
-                type:
-                  description: The type of Visualization to configure
-                  type: string
-              required:
-              - type
-              type: object
-          type: object
-        status:
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterLogging is the Schema for the clusterloggings API \n
+          ClusterLogging is the Schema for the clusterloggings API"
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - instance
+                type: string
+            type: object
+          spec:
+            description: Specification of the desired behavior of the Logging cluster.
+            properties:
+              collection:
+                description: Specification of the Collection component for the cluster
+                nullable: true
+                properties:
+                  logs:
+                    description: Specification of Log Collection for the cluster
+                    properties:
+                      fluentd:
+                        description: Specification of the Fluentd Log Collection component
+                        properties:
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: Define which Nodes the Pods are scheduled
+                              on.
+                            nullable: true
+                            type: object
+                          resources:
+                            description: The resource requirements for Fluentd
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          tolerations:
+                            items:
+                              description: The pod this Toleration is attached to
+                                tolerates any taint that matches the triple <key,value,effect>
+                                using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: Effect indicates the taint effect to
+                                    match. Empty means match all taint effects. When
+                                    specified, allowed values are NoSchedule, PreferNoSchedule
+                                    and NoExecute.
+                                  type: string
+                                key:
+                                  description: Key is the taint key that the toleration
+                                    applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists;
+                                    this combination means to match all values and
+                                    all keys.
+                                  type: string
+                                operator:
+                                  description: Operator represents a key's relationship
+                                    to the value. Valid operators are Exists and Equal.
+                                    Defaults to Equal. Exists is equivalent to wildcard
+                                    for value, so that a pod can tolerate all taints
+                                    of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: TolerationSeconds represents the period
+                                    of time the toleration (which must be of effect
+                                    NoExecute, otherwise this field is ignored) tolerates
+                                    the taint. By default, it is not set, which means
+                                    tolerate the taint forever (do not evict). Zero
+                                    and negative values will be treated as 0 (evict
+                                    immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: Value is the taint value the toleration
+                                    matches to. If the operator is Exists, the value
+                                    should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      type:
+                        description: The type of Log Collection to configure
+                        type: string
+                    required:
+                    - type
+                    type: object
+                type: object
+              curation:
+                description: Specification of the Curation component for the cluster
+                nullable: true
+                properties:
+                  curator:
+                    description: The specification of curation to configure
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Define which Nodes the Pods are scheduled on.
+                        nullable: true
+                        type: object
+                      resources:
+                        description: The resource requirements for Curator
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      schedule:
+                        description: The cron schedule that the Curator job is run.
+                          Defaults to "30 3 * * *"
+                        type: string
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - schedule
+                    type: object
+                  type:
+                    description: The kind of curation to configure
+                    type: string
+                required:
+                - type
+                type: object
+              forwarder:
+                description: Specification for Forwarder component for the cluster
+                nullable: true
+                properties:
+                  fluentd:
+                    description: FluentdForwarderSpec represents the configuration
+                      for forwarders of type fluentd.
+                    properties:
+                      buffer:
+                        description: "FluentdBufferSpec represents a subset of fluentd
+                          buffer parameters to tune the buffer configuration for all
+                          fluentd outputs. It supports a subset of parameters to configure
+                          buffer and queue sizing, flush operations and retry flushing.
+                          \n For general parameters refer to: https://docs.fluentd.org/configuration/buffer-section#buffering-parameters
+                          \n For flush parameters refer to: https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
+                          \n For retry parameters refer to: https://docs.fluentd.org/configuration/buffer-section#retries-parameters"
+                        properties:
+                          chunkLimitSize:
+                            description: ChunkLimitSize represents the maximum size
+                              of each chunk. Events will be written into chunks until
+                              the size of chunks become this size.
+                            pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
+                            type: string
+                          flushInterval:
+                            description: 'FlushInterval represents the time duration
+                              to wait between two consecutive flush operations. Takes
+                              only effect used together with `flushMode: interval`.'
+                            pattern: ^([0-9]+)([smhd]{0,1})$
+                            type: string
+                          flushMode:
+                            description: FlushMode represents the mode of the flushing
+                              thread to write chunks. The mode allows lazy (if `time`
+                              parameter set), per interval or immediate flushing.
+                            enum:
+                            - lazy
+                            - interval
+                            - immediate
+                            type: string
+                          flushThreadCount:
+                            description: FlushThreadCount reprents the number of threads
+                              used by the fluentd buffer plugin to flush/write chunks
+                              in parallel.
+                            format: int32
+                            type: integer
+                          overflowAction:
+                            description: 'OverflowAction represents the action for
+                              the fluentd buffer plugin to execute when a buffer queue
+                              is full. (Default: block)'
+                            enum:
+                            - throw_exception
+                            - block
+                            - drop_oldest_chunk
+                            type: string
+                          retryMaxInterval:
+                            description: 'RetryMaxInterval represents the maxixum
+                              time interval for exponential backoff between retries.
+                              Takes only effect if used together with `retryType:
+                              exponential_backoff`.'
+                            pattern: ^([0-9]+)([smhd]{0,1})$
+                            type: string
+                          retryType:
+                            description: RetryType represents the type of retrying
+                              flush operations. Flush operations can be retried either
+                              periodically or by applying exponential backoff.
+                            enum:
+                            - exponential_backoff
+                            - periodic
+                            type: string
+                          retryWait:
+                            description: RetryWait represents the time duration between
+                              two consecutive retries to flush buffers for periodic
+                              retries or a constant factor of time on retries with
+                              exponential backoff.
+                            pattern: ^([0-9]+)([smhd]{0,1})$
+                            type: string
+                          totalLimitSize:
+                            description: TotalLimitSize represents the threshold of
+                              node space allowed per fluentd buffer to allocate. Once
+                              this threshold is reached, all append operations will
+                              fail with error (and data will be lost).
+                            pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              logStore:
+                description: Specification of the Log Storage component for the cluster
+                nullable: true
+                properties:
+                  elasticsearch:
+                    description: Specification of the Elasticsearch Log Store component
+                    properties:
+                      nodeCount:
+                        description: Number of nodes to deploy for Elasticsearch
+                        format: int32
+                        type: integer
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Define which Nodes the Pods are scheduled on.
+                        nullable: true
+                        type: object
+                      proxy:
+                        description: Specification of the Elasticsearch Proxy component
+                        properties:
+                          resources:
+                            description: ResourceRequirements describes the compute
+                              resource requirements.
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                        required:
+                        - resources
+                        type: object
+                      redundancyPolicy:
+                        description: The policy towards data redundancy to specify
+                          the number of redundant primary shards
+                        enum:
+                        - FullRedundancy
+                        - MultipleRedundancy
+                        - SingleRedundancy
+                        - ZeroRedundancy
+                        type: string
+                      resources:
+                        description: The resource requirements for Elasticsearch
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      storage:
+                        description: The storage specification for Elasticsearch data
+                          nodes
+                        nullable: true
+                        properties:
+                          size:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The capacity of storage to provision.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          storageClassName:
+                            description: 'The class of storage to provision. More
+                              info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
+                            type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - nodeCount
+                    type: object
+                  retentionPolicy:
+                    description: Retention policy defines the maximum age for an index
+                      after which it should be deleted
+                    nullable: true
+                    properties:
+                      application:
+                        nullable: true
+                        properties:
+                          maxAge:
+                            description: TimeUnit is a time unit like h,m,d
+                            type: string
+                        type: object
+                      audit:
+                        nullable: true
+                        properties:
+                          maxAge:
+                            description: TimeUnit is a time unit like h,m,d
+                            type: string
+                        type: object
+                      infra:
+                        nullable: true
+                        properties:
+                          maxAge:
+                            description: TimeUnit is a time unit like h,m,d
+                            type: string
+                        type: object
+                    type: object
+                  type:
+                    description: The type of Log Storage to configure
+                    type: string
+                required:
+                - type
+                type: object
+              managementState:
+                description: Indicator if the resource is 'Managed' or 'Unmanaged'
+                  by the operator
+                enum:
+                - Managed
+                - Unmanaged
+                type: string
+              visualization:
+                description: Specification of the Visualization component for the
+                  cluster
+                nullable: true
+                properties:
+                  kibana:
+                    description: Specification of the Kibana Visualization component
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Define which Nodes the Pods are scheduled on.
+                        nullable: true
+                        type: object
+                      proxy:
+                        description: Specification of the Kibana Proxy component
+                        properties:
+                          resources:
+                            description: ResourceRequirements describes the compute
+                              resource requirements.
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                        required:
+                        - resources
+                        type: object
+                      replicas:
+                        description: Number of instances to deploy for a Kibana deployment
+                        format: int32
+                        type: integer
+                      resources:
+                        description: The resource requirements for Kibana
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - replicas
+                    type: object
+                  type:
+                    description: The type of Visualization to configure
+                    type: string
+                required:
+                - type
+                type: object
+            type: object
+          status:
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/olm_deploy/operatorregistry/Dockerfile
+++ b/olm_deploy/operatorregistry/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /
 COPY manifests/ /manifests
 
 RUN chmod -R g+w /manifests && \
-  rm /manifests/art.yaml /manifests/*/image-references /manifests/*/kustomization.yaml /manifests/*/crd-v1-singleton-patch.yaml /manifests/*/crd-v1beta1-clusterloggings-patches.yaml
+  rm /manifests/art.yaml /manifests/*/image-references /manifests/*/kustomization.yaml /manifests/*/crd-v1-singleton-patch.yaml /manifests/*/crd-v1-clusterloggings-patches.yaml
 
 COPY olm_deploy/scripts/registry-init.sh /scripts/
 


### PR DESCRIPTION
### Description
This PR addresses a recommended upgrade of the `apiVersion` of cluster-logging-operator managed CRDs from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1`. Former is deprecated in upcoming k8s release 1.19 and very likely removed in 1.20. In extent addressing this upgrade sooner than later frees the operator upgrade procedure from limbo to enable installation of version `N` on an OCP cluster version `N-1`, where the cluster version has dropped the deprecated versions.

/cc @jcantrill @ewolinetz 