### PR TITLE
Bug 1864397: Revert sniffer class deletion for collector es output

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -956,7 +956,7 @@ var _ = Describe("Generating fluentd config", func() {
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 						reload_after '200'
 						# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-						
+					        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'	
 						reload_on_failure false
 						# 2 ^ 31
 						request_timeout 2147483648
@@ -1004,7 +1004,7 @@ var _ = Describe("Generating fluentd config", func() {
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 						reload_after '200'
 						# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-						
+               					sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'	
 						reload_on_failure false
 						# 2 ^ 31
 						request_timeout 2147483648
@@ -1053,7 +1053,7 @@ var _ = Describe("Generating fluentd config", func() {
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 						reload_after '200'
 						# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-						
+						sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'						
 						reload_on_failure false
 						# 2 ^ 31
 						request_timeout 2147483648
@@ -1101,7 +1101,7 @@ var _ = Describe("Generating fluentd config", func() {
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 						reload_after '200'
 						# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-						
+						sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'						
 						reload_on_failure false
 						# 2 ^ 31
 						request_timeout 2147483648
@@ -1150,7 +1150,7 @@ var _ = Describe("Generating fluentd config", func() {
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 						reload_after '200'
 						# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-						
+						sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'						
 						reload_on_failure false
 						# 2 ^ 31
 						request_timeout 2147483648
@@ -1198,7 +1198,7 @@ var _ = Describe("Generating fluentd config", func() {
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 						reload_after '200'
 						# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-						
+						sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'						
 						reload_on_failure false
 						# 2 ^ 31
 						request_timeout 2147483648
@@ -1247,7 +1247,7 @@ var _ = Describe("Generating fluentd config", func() {
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 						reload_after '200'
 						# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-						
+						sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'						
 						reload_on_failure false
 						# 2 ^ 31
 						request_timeout 2147483648
@@ -1295,7 +1295,7 @@ var _ = Describe("Generating fluentd config", func() {
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 						reload_after '200'
 						# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-						
+						sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'						
 						reload_on_failure false
 						# 2 ^ 31
 						request_timeout 2147483648

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 			reload_after '200'
 			# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-			
+			sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'	
 			reload_on_failure false
 			# 2 ^ 31
 			request_timeout 2147483648
@@ -138,7 +138,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 			reload_after '200'
 			# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-			
+			sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
 			reload_on_failure false
 			# 2 ^ 31
 			request_timeout 2147483648
@@ -200,7 +200,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 			reload_after '200'
 			# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-			
+		        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'	
 			reload_on_failure false
 			# 2 ^ 31
 			request_timeout 2147483648
@@ -244,7 +244,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 			reload_after '200'
 			# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-			
+		        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'	
 			reload_on_failure false
 			# 2 ^ 31
 			request_timeout 2147483648

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Generating fluentd config", func() {
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
               # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-              
+              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer' 
               reload_on_failure false
               # 2 ^ 31
               request_timeout 2147483648
@@ -119,7 +119,7 @@ var _ = Describe("Generating fluentd config", func() {
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
               # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-              
+              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'              
               reload_on_failure false
               # 2 ^ 31
               request_timeout 2147483648
@@ -173,7 +173,7 @@ var _ = Describe("Generating fluentd config", func() {
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
               # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-              
+              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'              
               reload_on_failure false
               # 2 ^ 31
               request_timeout 2147483648
@@ -217,7 +217,7 @@ var _ = Describe("Generating fluentd config", func() {
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
               # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-              
+              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'              
               reload_on_failure false
               # 2 ^ 31
               request_timeout 2147483648

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -641,7 +641,7 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
   # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
   reload_after '200'
   # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-  
+  sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
   reload_on_failure false
   # 2 ^ 31
   request_timeout 2147483648


### PR DESCRIPTION
This PR:

Reverts the deletion of the sniffer class to address ssl error experienced by the collector

Ref https://bugzilla.redhat.com/show_bug.cgi?id=1864397