### PR TITLE
Bug 1866619: Default logstore retention policy so default LogForwarding is setup correctly

### DIFF
--- a/pkg/k8shandler/indexmanagement/index_management.go
+++ b/pkg/k8shandler/indexmanagement/index_management.go
@@ -34,15 +34,7 @@ var (
 
 func NewSpec(retentionPolicy *logging.RetentionPoliciesSpec) *esapi.IndexManagementSpec {
 
-	// create a default sane policy if it isn't defined...
-	if retentionPolicy == nil {
-		retentionPolicy = newDefaultPoliciesSpec()
-	}
-	if retentionPolicy.App == nil && retentionPolicy.Infra == nil && retentionPolicy.Audit == nil {
-		logger.Info("Retention policy not defined for any log source. Cannot create Index management spec.")
-		return nil
-	}
-
+	retentionPolicy = newDefaultPoliciesSpec(retentionPolicy)
 	indexManagement := esapi.IndexManagementSpec{}
 	if retentionPolicy.App != nil {
 		hotPhaseAgeApp, err := getHotPhaseAge(retentionPolicy.App.MaxAge)
@@ -80,9 +72,9 @@ func NewSpec(retentionPolicy *logging.RetentionPoliciesSpec) *esapi.IndexManagem
 	return &indexManagement
 }
 
-func newDefaultPoliciesSpec() *logging.RetentionPoliciesSpec {
+func newDefaultPoliciesSpec(spec *logging.RetentionPoliciesSpec) *logging.RetentionPoliciesSpec {
 
-	return &logging.RetentionPoliciesSpec{
+	defaultSpec := &logging.RetentionPoliciesSpec{
 		App: &logging.RetentionPolicySpec{
 			MaxAge: esapi.TimeUnit("7d"),
 		},
@@ -93,6 +85,18 @@ func newDefaultPoliciesSpec() *logging.RetentionPoliciesSpec {
 			MaxAge: esapi.TimeUnit("7d"),
 		},
 	}
+	if spec != nil {
+		if spec.App != nil {
+			defaultSpec.App = spec.App
+		}
+		if spec.Infra != nil {
+			defaultSpec.Infra = spec.Infra
+		}
+		if spec.Audit != nil {
+			defaultSpec.Audit = spec.Audit
+		}
+	}
+	return defaultSpec
 }
 
 func newPolicySpec(name string, maxIndexAge esapi.TimeUnit, hotPhaseAge esapi.TimeUnit) esapi.IndexManagementPolicySpec {

--- a/pkg/k8shandler/indexmanagement/indexmanagement_test.go
+++ b/pkg/k8shandler/indexmanagement/indexmanagement_test.go
@@ -79,17 +79,7 @@ var _ = Describe("Indexmanagement", func() {
 				Expect(spec).To(BeNil())
 			})
 		})
-		Context("retetion policy is not defined for any log source", func() {
-			BeforeEach(func() {
-				retentionPolicy.App = nil
-				retentionPolicy.Infra = nil
-				retentionPolicy.Audit = nil
-			})
-			It("should not generate index management", func() {
-				spec := NewSpec(retentionPolicy)
-				Expect(spec).To(BeNil())
-			})
-		})
+
 	})
 	Describe("IndexManagement Policy creation success", func() {
 		Context("Policy and Mapping generated", func() {
@@ -138,12 +128,18 @@ var _ = Describe("Indexmanagement", func() {
 				retentionPolicy.Infra = nil
 				retentionPolicy.Audit = nil
 			})
-			It("should generate index management for App log source only", func() {
+			It("should generate index management for App log source and default the others", func() {
 				spec := NewSpec(retentionPolicy)
-				Expect(len(spec.Policies)).To(Equal(1))
+				Expect(len(spec.Policies)).To(Equal(3))
 				Expect(spec.Policies[0].Name).To(Equal(PolicyNameApp))
-				Expect(len(spec.Mappings)).To(Equal(1))
+
+				Expect(spec.Policies[1].Phases.Delete.MinAge).To(Equal(defaultPolicy.Infra.MaxAge))
+				Expect(spec.Policies[2].Phases.Delete.MinAge).To(Equal(defaultPolicy.Audit.MaxAge))
+
+				Expect(len(spec.Mappings)).To(Equal(3))
 				Expect(spec.Mappings[0].PolicyRef).To(Equal(PolicyNameApp))
+				Expect(spec.Mappings[1].PolicyRef).To(Equal(PolicyNameInfra))
+				Expect(spec.Mappings[2].PolicyRef).To(Equal(PolicyNameAudit))
 			})
 		})
 	})

--- a/pkg/k8shandler/logstore_test.go
+++ b/pkg/k8shandler/logstore_test.go
@@ -575,7 +575,9 @@ func TestIndexManagementChanges(t *testing.T) {
 	if !different {
 		t.Errorf("Expected that difference would be found due to retention policy change")
 	}
-	if !(diffCR.Spec.IndexManagement.Policies[0].Name == indexmanagement.PolicyNameAudit) {
+
+	if diffCR.Spec.IndexManagement.Policies[2].Name != indexmanagement.PolicyNameAudit ||
+		diffCR.Spec.IndexManagement.Policies[2].Phases.Delete.MinAge != cluster.Spec.LogStore.RetentionPolicy.Audit.MaxAge {
 		t.Errorf("Expected that difference would be found due to retention policy change")
 	}
 }


### PR DESCRIPTION
This PR:
* Defaults the retention policy so that CLO spec's indexManagement for all source types for LogForwarding

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1866619

cc @mburke5678 @alanconway 

Will need a 4.5 backport