### PR TITLE
Fix must-gather copy script directives for imagebuilder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/manife
 RUN rm /manifests/art.yaml
 
 COPY --from=origincli /usr/bin/oc /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/must-gather/* /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/must-gather/collection-scripts/* /usr/bin/
 
 # this is required because the operator invokes a script as `bash scripts/cert_generation.sh`
 WORKDIR /usr/bin


### PR DESCRIPTION
### Description
This PR addresses the broken builds of the cluster-logging-operator image including the must-gather scripts with imagebuilder.

/cc @jcantrill @alanconway 