### PR TITLE
Bug 1852341: fix legacy syslog k8s Metadata

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -352,6 +352,15 @@ var _ = Describe("Generating fluentd config", func() {
 					</record>
 					remove_keys req,res,msg,name,level,v,pid,err
 				</filter>
+
+				<filter k8s-audit.log**>
+				  @type record_transformer
+				  <record>
+				    k8s_audit_level ${record['level']}
+				  </record>
+				  remove_keys level
+				</filter>
+
 				<filter **>
 					@type viaq_data_model
 					elasticsearch_index_prefix_field 'viaq_index_name'
@@ -765,6 +774,15 @@ var _ = Describe("Generating fluentd config", func() {
 					</record>
 					remove_keys req,res,msg,name,level,v,pid,err
 				</filter>
+
+				<filter k8s-audit.log**>
+				  @type record_transformer
+				  <record>
+				    k8s_audit_level ${record['level']}
+				  </record>
+				  remove_keys level
+				</filter>
+
 				<filter **>
 					@type viaq_data_model
 					elasticsearch_index_prefix_field 'viaq_index_name'
@@ -1564,6 +1582,14 @@ var _ = Describe("Generating fluentd config", func() {
         remove_keys req,res,msg,name,level,v,pid,err
       </filter>
     
+      <filter k8s-audit.log**>
+        @type record_transformer
+        <record>
+          k8s_audit_level ${record['level']}
+        </record>
+        remove_keys level
+      </filter>
+
       <filter **>
         @type viaq_data_model
         elasticsearch_index_prefix_field 'viaq_index_name'

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -299,6 +299,14 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             remove_keys req,res,msg,name,level,v,pid,err
           </filter>
 
+          <filter k8s-audit.log**>
+            @type record_transformer
+            <record>
+              k8s_audit_level ${record['level']}
+            </record>
+            remove_keys level
+          </filter>
+
           <filter **>
             @type viaq_data_model
             elasticsearch_index_prefix_field 'viaq_index_name'
@@ -737,6 +745,14 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
               log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
             </record>
             remove_keys req,res,msg,name,level,v,pid,err
+          </filter>
+
+          <filter k8s-audit.log**>
+            @type record_transformer
+            <record>
+              k8s_audit_level ${record['level']}
+            </record>
+            remove_keys level
           </filter>
 
           <filter **>
@@ -1178,6 +1194,14 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
               log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
             </record>
             remove_keys req,res,msg,name,level,v,pid,err
+          </filter>
+
+          <filter k8s-audit.log**>
+            @type record_transformer
+            <record>
+              k8s_audit_level ${record['level']}
+            </record>
+            remove_keys level
           </filter>
 
           <filter **>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -210,6 +210,14 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
     remove_keys req,res,msg,name,level,v,pid,err
   </filter>
 
+  <filter k8s-audit.log**>
+    @type record_transformer
+    <record>
+      k8s_audit_level ${record['level']}
+    </record>
+    remove_keys level
+  </filter>
+
   <filter **>
     @type viaq_data_model
     elasticsearch_index_prefix_field 'viaq_index_name'


### PR DESCRIPTION
The `use_record true` setting is trying to use the "level" from the k8s
audit log which [is Metadata](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy). I believe we need to relabel k8s audit logs
"level" field to "k8s_audit_level" so that fluentd doesn't try to use it
as the severity and we can retain the original information.