### PR TITLE
Bug 1868280: fixing csv permissions to allow creation of servicemonitor object

### DIFF
--- a/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
@@ -186,6 +186,7 @@ spec:
           - secrets
           - serviceaccounts
           - serviceaccounts/finalizers
+          - services/finalizers
           verbs:
           - "*"
         - apiGroups:


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1868280

Adds a missing permission for service/finalizers that caused the following error upon operator start up:
```
{"level":"info","ts":1597218564.8095691,"logger":"cmd","msg":"Could not create ServiceMonitor object","error":"servicemonitors.monitoring.coreos.com \"cluster-logging-operator-metrics\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
```