### PR TITLE
WIP LOG-679: POC for centralized normalizer

### DIFF
--- a/pkg/factory/configmap.go
+++ b/pkg/factory/configmap.go
@@ -1,0 +1,21 @@
+package factory
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//NewConfigMap stubs an instance of Configmap
+func NewConfigMap(configmapName string, namespace string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configmapName,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
+}

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -102,19 +102,24 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection(proxyConfi
 			}
 		}
 	} else {
-		if err = clusterRequest.RemoveServiceAccount("logcollector"); err != nil {
-			return
-		}
-
-		if err = clusterRequest.RemovePriorityClass(clusterLoggingPriorityClassName); err != nil {
-			return
-		}
-
-		if err = clusterRequest.removeFluentd(); err != nil {
-			return
-		}
+		return clusterRequest.UndeployCollector()
 	}
 
+	return nil
+}
+
+func (clusterRequest *ClusterLoggingRequest) UndeployCollector() (err error) {
+	if err = clusterRequest.RemoveServiceAccount("logcollector"); err != nil {
+		return
+	}
+
+	if err = clusterRequest.RemovePriorityClass(clusterLoggingPriorityClassName); err != nil {
+		return
+	}
+
+	if err = clusterRequest.removeFluentd(); err != nil {
+		return
+	}
 	return nil
 }
 

--- a/pkg/k8shandler/logforwarding_topology.go
+++ b/pkg/k8shandler/logforwarding_topology.go
@@ -1,0 +1,70 @@
+package k8shandler
+
+import (
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	topologyapi "github.com/openshift/cluster-logging-operator/pkg/k8shandler/logforwardingtopology"
+	normalizertopology "github.com/openshift/cluster-logging-operator/pkg/k8shandler/logforwardingtopology/normalizer"
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	"github.com/openshift/cluster-logging-operator/pkg/utils"
+)
+
+type edgeTopology struct {
+	requestCluster *ClusterLoggingRequest
+}
+
+func (clusterRequest *ClusterLoggingRequest) ReconcileLogForwardingTopology(proxyConfig *configv1.Proxy) (err error) {
+	desiredTopology := topologyapi.LogForwardingEdgeNormalizationTopology //the legacy default
+	deployedTopology := ""
+
+	if value, found := utils.GetAnnotation(topologyapi.EnableDevPreviewLogForwardingTopologyAnnotation, clusterRequest.Cluster.ObjectMeta); found && strings.ToLower(value) == "true" {
+		desiredTopology, _ = utils.GetAnnotation(topologyapi.LogForwardingTopologyAnnotation, clusterRequest.Cluster.ObjectMeta)
+	}
+	desired, desiredTopology := newLogForwarderTopology(desiredTopology, clusterRequest)
+	if condition := clusterRequest.Cluster.Status.Conditions.GetCondition(topologyapi.LogForwardingTopologyCondition); condition != nil {
+		deployedTopology = string(condition.Reason)
+	}
+	if deployedTopology != desiredTopology {
+		deployed, _ := newLogForwarderTopology(deployedTopology, clusterRequest)
+		if err = deployed.Undeploy(); err != nil {
+			logger.Errorf("There was an error trying to undeploy the the logforwarding topology: %v", err)
+		}
+	}
+	topologyCondition := topologyapi.NewLogForwardingTopologyCondition(desiredTopology)
+	clusterRequest.Cluster.Status.Conditions.SetCondition(topologyCondition)
+	if err = clusterRequest.UpdateStatus(clusterRequest.Cluster); err != nil {
+		logger.Warnf("Unable to update the logforwarding status: %v", err)
+	}
+	return desired.Reconcile(proxyConfig)
+}
+
+func newLogForwarderTopology(topology string, clusterRequest *ClusterLoggingRequest) (topologyapi.LogForwarderTopology, string) {
+
+	switch topology {
+	case topologyapi.LogForwardingCentralNormalizationTopology:
+		return normalizertopology.CentralNormalizerTopology{
+			OwnerRef:                utils.AsOwner(clusterRequest.Cluster),
+			APIClient:               clusterRequest,
+			ReconcilePriorityClass:  clusterRequest.createOrUpdateCollectionPriorityClass,
+			ReconcileServiceAccount: clusterRequest.createOrUpdateCollectorServiceAccount,
+			ReconcileConfigMap:      clusterRequest.CreateOrUpdateConfigMap,
+			ReconcileSecrets:        clusterRequest.createOrUpdateFluentdSecret,
+			RemovePriorityClass:     func() error { return clusterRequest.RemovePriorityClass(clusterLoggingPriorityClassName) },
+			RemoveServiceAccount:    func() error { return clusterRequest.RemoveServiceAccount("logcollector") },
+			RemoveSecrets:           func() error { return clusterRequest.RemoveSecret(fluentdName) },
+		}, topologyapi.LogForwardingCentralNormalizationTopology
+	default:
+	}
+	return edgeTopology{
+		clusterRequest,
+	}, topologyapi.LogForwardingEdgeNormalizationTopology
+}
+
+func (topology edgeTopology) Reconcile(proxyConfig *configv1.Proxy) (err error) {
+	return topology.requestCluster.CreateOrUpdateCollection(proxyConfig)
+}
+
+func (topology edgeTopology) Undeploy() error {
+	return topology.requestCluster.UndeployCollector()
+}

--- a/pkg/k8shandler/logforwardingtopology/api.go
+++ b/pkg/k8shandler/logforwardingtopology/api.go
@@ -1,0 +1,52 @@
+package logforwardingtopology
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-logging-operator/pkg/status"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	//LogForwardingTopologyAnnotation describes the topology to use for log collection.  The absence of the
+	//annotation or a recognized value results in the default topology
+	LogForwardingTopologyAnnotation = "clusterlogging.openshift.io/logforwardingTopology"
+
+	//EnableDevPreviewLogForwardingTopologyAnnotation setting the value to 'true' will cause the operator to evalute
+	//the topology to be used in log forwarding
+	EnableDevPreviewLogForwardingTopologyAnnotation = "clusterlogging.openshift.io/enableDevPreviewTopology"
+
+	//LogForwardingDualEdgeNormalizationTopology deploys multiple containers to each node to collect and normalize log messagges
+	LogForwardingDualEdgeNormalizationTopology = "dualEdgeNormalization"
+
+	//LogForwardingEdgeNormalizationTopology is the default (legacy) topology to deploy a single container to each node to collect and normalize log messages.
+	LogForwardingEdgeNormalizationTopology = "edgeNormalization"
+
+	//LogForwardingCentralNormalizationTopology deploys a single container to each node to collect and forward messages
+	//to a centralized log normalizer
+	LogForwardingCentralNormalizationTopology                      = "centralNormalization"
+	LogForwardingTopologyCondition            status.ConditionType = "LogForwardingTopology"
+)
+
+type APIClient interface {
+	Create(object runtime.Object) error
+	Update(object runtime.Object) (err error)
+	Get(objectName string, object runtime.Object) error
+	Delete(object runtime.Object) error
+}
+
+type LogForwarderTopology interface {
+	Reconcile(proxyConfig *configv1.Proxy) error
+	Undeploy() error
+}
+
+func NewLogForwardingTopologyCondition(topology string) status.Condition {
+	return status.Condition{
+		Type:               LogForwardingTopologyCondition,
+		Status:             core.ConditionTrue,
+		Reason:             status.ConditionReason(topology),
+		Message:            "This is the enabled collector and normalization topology",
+		LastTransitionTime: meta.Now(),
+	}
+}

--- a/pkg/k8shandler/logforwardingtopology/normalizer/collector_config.go
+++ b/pkg/k8shandler/logforwardingtopology/normalizer/collector_config.go
@@ -1,0 +1,83 @@
+package normalizer
+
+const (
+	fluentbitConf = `
+[SERVICE]
+    Log_Level info
+    Parsers_file /etc/fluent-bit/parsers.conf
+
+[INPUT]
+    Name tail
+    Path /var/log/containers/*_openshift*_*.log, /var/log/containers/*_kube*_*.log, /var/log/containers/*_default_*.log
+    Path_Key filename
+    Parser containerd
+    Exclude_Path /var/log/containers/collector*_openshift*_*.log, /var/log/containers/elasticsearch*_openshift*_*.log,/var/log/containers/kibana*_openshift*_*.log,/var/log/containers/normalizer*_openshift*_*.log
+    Tag kubernetes.*
+    DB /var/log/infra-containers.pos.db
+    Refresh_Interval 5
+
+[INPUT]
+    Name tail
+    Path /var/log/containers/*.log
+    Path_Key filename
+    Parser containerd
+    Exclude_Path /var/log/containers/*_openshift*_*.log, /var/log/containers/*_kube*_*.log, /var/log/containers/*_default_*.log
+    Tag kubernetes.*
+    DB /var/log/app-containers.pos.db
+    Refresh_Interval 5
+
+[INPUT]
+    Name tail
+    Path /var/log/audit/audit.log
+    Path_Key filename
+    Parser json
+    Tag linux-audit.log
+    DB /var/log/audit-linux.pos.db
+    Refresh_Interval 5
+
+[INPUT]
+    Name tail
+    Path /var/log/kube-apiserver/audit.log
+    Path_Key filename
+    Parser json
+    Tag k8s-audit.log
+    DB /var/log/audit-k8s.pos.db
+    Refresh_Interval 5
+
+[INPUT]
+    Name tail
+    Path /var/log/oauth-apiserver/audit.log, /var/log/openshift-apiserver/audit.log
+    Path_Key filename
+    Parser json
+    Tag openshift-audit.log
+    DB /var/log/audit-oauth.pos.db
+    Refresh_Interval 5
+
+[INPUT]
+    Name systemd
+    Path /var/log/journal
+    Tag journal
+    DB /var/log/journal.pos.db
+
+[OUTPUT]
+    Name forward
+    Host normalizer.openshift-logging.svc
+    Match *
+`
+	fluetnbitParserConf = `
+[PARSER]
+    Name containerd
+    Format regex
+    Regex /^(?<time>.+) (?<stream>\w+) (?<logtag>[FP]) (?<log>.+)$/
+    Time_Key time
+    Time_Keep on
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+[PARSER]
+    Name json
+    Format json
+    Time_Key requestReceivedTimestamp
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Keep on
+`
+)

--- a/pkg/k8shandler/logforwardingtopology/normalizer/normalizer_config.go
+++ b/pkg/k8shandler/logforwardingtopology/normalizer/normalizer_config.go
@@ -1,0 +1,440 @@
+package normalizer
+
+const fluentConf = `
+## CLO GENERATED CONFIGURATION ###
+# This file is a copy of the fluentd configuration entrypoint
+# which should normally be supplied in a configmap.
+
+<system>
+  @log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
+</system>
+
+# In each section below, pre- and post- includes don't include anything initially;
+# they exist to enable future additions to openshift conf as needed.
+
+## sources
+## ordered so that syslog always runs last...
+<source>
+  @type prometheus
+  bind ''
+  <ssl>
+    enable true
+    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+    private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
+  </ssl>
+</source>
+
+<source>
+  @type prometheus_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
+
+# excluding prometheus_tail_monitor
+# since it leaks namespace/pod info
+# via file paths
+
+# This is considered experimental by the repo
+<source>
+  @type prometheus_output_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+  #@label @CONCAT
+  @label @INGRESS
+  #@label @STDOUT
+  <parse>
+    @type none
+  </parse>
+</source>
+<label @STDOUT>
+  <match **>
+    @type stdout
+  </match>
+</label>
+
+<label @CONCAT>
+  <filter kubernetes.**>
+    @type concat
+    key log
+    partial_key logtag
+    partial_value P
+    separator ''
+  </filter>
+  <match kubernetes.**>
+    @type relabel
+    @label @INGRESS
+  </match>
+</label>
+
+#syslog input config here
+
+<label @INGRESS>
+
+  ## filters
+  <filter **>
+    @type record_modifier
+    char_encoding utf-8
+  </filter>
+
+  <filter journal>
+    @type grep
+    <exclude>
+      key PRIORITY
+      pattern ^7$
+    </exclude>
+  </filter>
+
+  <match journal>
+    @type rewrite_tag_filter
+    # skip to @INGRESS label section
+    @label @INGRESS
+
+    # see if this is a kibana container for special log handling
+    # looks like this:
+    # k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2
+    # we filter these logs through the kibana_transform.conf filter
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_kibana\.
+      tag kubernetes.journal.container.kibana
+    </rule>
+
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_logging-eventrouter-[^_]+_
+      tag kubernetes.journal.container._default_.kubernetes-event
+    </rule>
+
+    # mark logs from default namespace for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_default_
+      tag kubernetes.journal.container._default_
+    </rule>
+
+    # mark logs from kube-* namespaces for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_kube-(.+)_
+      tag kubernetes.journal.container._kube-$1_
+    </rule>
+
+    # mark logs from openshift-* namespaces for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_openshift-(.+)_
+      tag kubernetes.journal.container._openshift-$1_
+    </rule>
+
+    # mark logs from openshift namespace for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_openshift_
+      tag kubernetes.journal.container._openshift_
+    </rule>
+
+    # mark fluentd container logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_.*fluentd
+      tag kubernetes.journal.container.fluentd
+    </rule>
+
+    # this is a kubernetes container
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_
+      tag kubernetes.journal.container
+    </rule>
+
+    # not kubernetes - assume a system log or system container log
+    <rule>
+      key _TRANSPORT
+      pattern .+
+      tag journal.system
+    </rule>
+  </match>
+
+  <filter kubernetes.**>
+    @type kubernetes_metadata
+    kubernetes_url "#{ENV['K8S_HOST_URL']}"
+    cache_size "#{ENV['K8S_METADATA_CACHE_SIZE'] || '1000'}"
+    watch "#{ENV['K8S_METADATA_WATCH'] || 'false'}"
+    use_journal "#{ENV['USE_JOURNAL'] || 'nil'}"
+    ssl_partial_chain "#{ENV['SSL_PARTIAL_CHAIN'] || 'true'}"
+  </filter>
+
+  <filter kubernetes.journal.**>
+    @type parse_json_field
+    merge_json_log "#{ENV['MERGE_JSON_LOG'] || 'false'}"
+    preserve_json_log "#{ENV['PRESERVE_JSON_LOG'] || 'true'}"
+    json_fields "#{ENV['JSON_FIELDS'] || 'MESSAGE,log'}"
+  </filter>
+
+  <filter kubernetes.var.log.containers.**>
+    @type parse_json_field
+    merge_json_log "#{ENV['MERGE_JSON_LOG'] || 'false'}"
+    preserve_json_log "#{ENV['PRESERVE_JSON_LOG'] || 'true'}"
+    json_fields "#{ENV['JSON_FIELDS'] || 'log,MESSAGE'}"
+  </filter>
+
+  <filter kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-**>
+    @type parse_json_field
+    merge_json_log true
+    preserve_json_log true
+    json_fields "#{ENV['JSON_FIELDS'] || 'log,MESSAGE'}"
+  </filter>
+
+  <filter **kibana**>
+    @type record_transformer
+    enable_ruby
+    <record>
+      log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
+    </record>
+    remove_keys req,res,msg,name,level,v,pid,err
+  </filter>
+
+  <filter **>
+    @type viaq_data_model
+    elasticsearch_index_prefix_field 'viaq_index_name'
+    default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
+    extra_keep_fields "#{ENV['CDM_EXTRA_KEEP_FIELDS'] || ''}"
+    keep_empty_fields "#{ENV['CDM_KEEP_EMPTY_FIELDS'] || 'message'}"
+    use_undefined "#{ENV['CDM_USE_UNDEFINED'] || false}"
+    undefined_name "#{ENV['CDM_UNDEFINED_NAME'] || 'undefined'}"
+    rename_time "#{ENV['CDM_RENAME_TIME'] || true}"
+    rename_time_if_missing "#{ENV['CDM_RENAME_TIME_IF_MISSING'] || false}"
+    src_time_name "#{ENV['CDM_SRC_TIME_NAME'] || 'time'}"
+    dest_time_name "#{ENV['CDM_DEST_TIME_NAME'] || '@timestamp'}"
+    pipeline_type "#{ENV['PIPELINE_TYPE'] || 'collector'}"
+    undefined_to_string "#{ENV['CDM_UNDEFINED_TO_STRING'] || 'false'}"
+    undefined_dot_replace_char "#{ENV['CDM_UNDEFINED_DOT_REPLACE_CHAR'] || 'UNUSED'}"
+    undefined_max_num_fields "#{ENV['CDM_UNDEFINED_MAX_NUM_FIELDS'] || '-1'}"
+    process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'false'}"
+    <formatter>
+      tag "system.var.log**"
+      type sys_var_log
+      remove_keys host,pid,ident
+    </formatter>
+    <formatter>
+      tag "journal.system**"
+      type sys_journal
+      remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+    </formatter>
+    <formatter>
+      tag "kubernetes.journal.container**"
+      type k8s_journal
+      remove_keys "#{ENV['K8S_FILTER_REMOVE_KEYS'] || 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'}"
+    </formatter>
+    <formatter>
+      tag "kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-** k8s-audit.log** openshift-audit.log**"
+      type k8s_json_file
+      remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
+      process_kubernetes_events "#{ENV['TRANSFORM_EVENTS'] || 'true'}"
+    </formatter>
+    <formatter>
+      tag "kubernetes.var.log.containers**"
+      type k8s_json_file
+      remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
+    </formatter>
+    <elasticsearch_index_name>
+      enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
+      tag "journal.system** system.var.log** **_default_** **_kube-*_** **_openshift-*_** **_openshift_**"
+      name_type static
+      static_index_name infra-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
+      tag "linux-audit.log** k8s-audit.log** openshift-audit.log**"
+      name_type static
+      static_index_name audit-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled "#{ENV['ENABLE_ES_INDEX_NAME'] || 'true'}"
+      tag "**"
+      name_type static
+      static_index_name app-write
+    </elasticsearch_index_name>
+  </filter>
+
+  <filter **>
+    @type elasticsearch_genid_ext
+    hash_id_key viaq_msg_id
+    alt_key kubernetes.event.metadata.uid
+    alt_tags "#{ENV['GENID_ALT_TAG'] || 'kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.var.log.containers.eventrouter-*.** kubernetes.var.log.containers.cluster-logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'}"
+  </filter>
+
+  #flatten labels to prevent field explosion in ES
+  <filter ** >
+    @type record_transformer
+    enable_ruby true
+    <record>
+      kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+    </record>
+    remove_keys $.kubernetes.labels
+  </filter>
+
+  # Relabel specific source tags to specific intermediary labels for copy processing
+
+  <match **_default_** **_kube-*_** **_openshift-*_** **_openshift_** journal.** system.var.log**>
+    @type relabel
+    @label @_LOGS_INFRA
+  </match>
+
+  <match kubernetes.**>
+    @type relabel
+    @label @_LOGS_APP
+  </match>
+
+  <match **>
+    @type stdout
+  </match>
+
+</label>
+
+# Relabel specific sources (e.g. logs.apps) to multiple pipelines
+<label @_LOGS_APP>
+  <match **>
+    @type copy
+
+    <store>
+      @type relabel
+      @label @CLO_DEFAULT_APP_PIPELINE
+    </store>
+
+
+  </match>
+</label>
+<label @_LOGS_INFRA>
+  <match **>
+    @type copy
+
+    <store>
+      @type relabel
+      @label @CLO_DEFAULT_INFRA_PIPELINE
+    </store>
+
+
+  </match>
+</label>
+
+# Relabel specific pipelines to multiple, outputs (e.g. ES, kafka stores)
+<label @CLO_DEFAULT_APP_PIPELINE>
+  <match **>
+    @type copy
+
+    <store>
+      @type relabel
+      @label @CLO_DEFAULT_OUTPUT_ES
+    </store>
+  </match>
+</label>
+<label @CLO_DEFAULT_INFRA_PIPELINE>
+  <match **>
+    @type copy
+
+    <store>
+      @type relabel
+      @label @CLO_DEFAULT_OUTPUT_ES
+    </store>
+  </match>
+</label>
+
+# Ship logs to specific outputs
+<label @CLO_DEFAULT_OUTPUT_ES>
+  <match retry_clo_default_output_es>
+    @type copy
+    <store>
+      @type elasticsearch
+      @id retry_clo_default_output_es
+      host elasticsearch.openshift-logging.svc.cluster.local
+      port 9200
+      verify_es_version_at_startup false
+      scheme https
+      ssl_version TLSv1_2
+      target_index_key viaq_index_name
+      id_key viaq_msg_id
+      remove_keys viaq_index_name
+      user fluentd
+      password changeme
+      client_key '/var/run/ocp-collector/secrets/fluentd/tls.key'
+      client_cert '/var/run/ocp-collector/secrets/fluentd/tls.crt'
+      ca_file '/var/run/ocp-collector/secrets/fluentd/ca-bundle.crt'
+      type_name _doc
+      write_operation create
+      reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+      reload_after "#{ENV['ES_RELOAD_AFTER'] || '200'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+      sniffer_class_name "#{ENV['ES_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
+      reload_on_failure false
+      # 2 ^ 31
+      request_timeout 2147483648
+      <buffer>
+        @type file
+        path '/var/lib/fluentd/retry_clo_default_output_es'
+        flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
+        flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
+        flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
+        retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+        retry_forever true
+        queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+        chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+        total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+        overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
+      </buffer>
+    </store>
+  </match>
+  <match **>
+    @type copy
+    <store>
+      @type elasticsearch
+      @id clo_default_output_es
+      host elasticsearch.openshift-logging.svc.cluster.local
+      port 9200
+      verify_es_version_at_startup false
+      scheme https
+      ssl_version TLSv1_2
+      target_index_key viaq_index_name
+      id_key viaq_msg_id
+      remove_keys viaq_index_name
+      user fluentd
+      password changeme
+      client_key '/var/run/ocp-collector/secrets/fluentd/tls.key'
+      client_cert '/var/run/ocp-collector/secrets/fluentd/tls.crt'
+      ca_file '/var/run/ocp-collector/secrets/fluentd/ca-bundle.crt'
+      type_name _doc
+      retry_tag retry_clo_default_output_es
+      write_operation create
+      reload_connections "#{ENV['ES_RELOAD_CONNECTIONS'] || 'true'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+      reload_after "#{ENV['ES_RELOAD_AFTER'] || '200'}"
+      # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+      sniffer_class_name "#{ENV['ES_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
+      reload_on_failure false
+      # 2 ^ 31
+      request_timeout 2147483648
+      <buffer>
+        @type file
+        path '/var/lib/fluentd/clo_default_output_es'
+        flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
+        flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
+        flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
+        retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+        retry_forever true
+        queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+        chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
+        total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+        overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'block'}"
+      </buffer>
+    </store>
+  </match>
+</label>
+`

--- a/pkg/k8shandler/logforwardingtopology/normalizer/templates.go
+++ b/pkg/k8shandler/logforwardingtopology/normalizer/templates.go
@@ -1,0 +1,354 @@
+package normalizer
+
+import (
+	"bytes"
+
+	"github.com/openshift/cluster-logging-operator/pkg/utils"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+const (
+	normalizerImageName = "fluentd"
+)
+
+var (
+	serviceProto            core.Service
+	statefulSetProto        apps.StatefulSet
+	collectorDaemonSetProto apps.DaemonSet
+)
+
+func init() {
+	service := &core.Service{}
+	dec := yaml.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(serviceTemplate)), len(serviceTemplate))
+	if err := dec.Decode(&service); err != nil {
+		panic(err)
+	}
+	serviceProto = *service
+	obj := &apps.StatefulSet{}
+	dec = yaml.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(statefulSetTemplate)), len(statefulSetTemplate))
+	if err := dec.Decode(&obj); err != nil {
+		panic(err)
+	}
+	statefulSetProto = *obj
+
+	ds := &apps.DaemonSet{}
+	dec = yaml.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(collectorDaemonSetTemplate)), len(collectorDaemonSetTemplate))
+	if err := dec.Decode(&ds); err != nil {
+		panic(err)
+	}
+	collectorDaemonSetProto = *ds
+}
+func NewCollector() *apps.DaemonSet {
+	image := "quay.io/jcantril/fluent-bit:v1.5.2-rh"
+	//tolerations
+	//nodeselectors
+	//resources
+	ds := collectorDaemonSetProto.DeepCopy()
+	ds.Spec.Template.Spec.Containers[0].Image = image
+	return ds
+}
+
+func NewService() *core.Service {
+	return serviceProto.DeepCopy()
+}
+
+func NewNormalizer() *apps.StatefulSet {
+	statefulset := statefulSetProto.DeepCopy()
+	image := utils.GetComponentImage(normalizerImageName)
+	statefulset.Spec.Template.Spec.Containers[0].Image = image
+	statefulset.Spec.Replicas = utils.GetInt32(4)
+	//tolerations
+	//nodeselectors
+	//resources
+	return statefulset
+}
+
+const serviceTemplate = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: normalizer
+  namespace: openshift-logging
+  labels:
+    component: normalizer
+    logging-infra: normalizer
+    provider: openshift
+spec:
+  ports:
+  - port: 24224
+    name: forward
+  clusterIP: None
+  selector:
+    component: normalizer
+    logging-infra: normalizer
+    provider: openshift
+`
+const statefulSetTemplate = `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    component: normalizer
+    logging-infra: normalizer
+    provider: openshift
+  name: normalizer
+  namespace: openshift-logging
+spec:
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      component: normalizer
+      logging-infra: normalizer
+      provider: openshift
+  serviceName: normalizer
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      creationTimestamp: null
+      labels:
+        component: normalizer
+        logging-infra: normalizer
+        provider: openshift
+      name: normalizer
+    spec:
+      containers:
+      - env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: ALLOWED_PERCENT_OF_DISK
+          value: "100"
+        - name: MERGE_JSON_LOG
+          value: "false"
+        - name: PRESERVE_JSON_LOG
+          value: "true"
+        - name: K8S_HOST_URL
+          value: https://kubernetes.default.svc
+        - name: METRICS_CERT
+          value: /etc/fluent/metrics/tls.crt
+        - name: METRICS_KEY
+          value: /etc/fluent/metrics/tls.key
+        - name: BUFFER_QUEUE_LIMIT
+          value: "32"
+        - name: BUFFER_SIZE_LIMIT
+          value: 8m
+        - name: FILE_BUFFER_LIMIT
+          value: 256Mi
+        - name: FLUENTD_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: fluentd
+              divisor: "0"
+              resource: limits.cpu
+        - name: FLUENTD_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: fluentd
+              divisor: "0"
+              resource: limits.memory
+        - name: NODE_IPV4
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: CDM_KEEP_EMPTY_FIELDS
+          value: message
+        image: registry.svc.ci.openshift.org/ocp/4.6:logging-fluentd
+        imagePullPolicy: Always
+        name: fluentd
+        ports:
+        - containerPort: 24231
+          name: metrics
+          protocol: TCP
+        - containerPort: 24224
+          name: forward
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/fluent/configs.d/user
+          name: config
+          readOnly: true
+        - mountPath: /etc/fluent/configs.d/secure-forward
+          name: secureforwardconfig
+          readOnly: true
+        - mountPath: /etc/ocp-forward
+          name: secureforwardcerts
+          readOnly: true
+        - mountPath: /etc/fluent/configs.d/syslog
+          name: syslogconfig
+          readOnly: true
+        - mountPath: /etc/ocp-syslog
+          name: syslogcerts
+          readOnly: true
+        - mountPath: /opt/app-root/src/run.sh
+          name: entrypoint
+          readOnly: true
+          subPath: run.sh
+        - mountPath: /etc/fluent/keys
+          name: certs
+          readOnly: true
+        - mountPath: /var/lib/fluentd
+          name: filebufferstorage
+        - mountPath: /etc/fluent/metrics
+          name: collector-metrics
+        - mountPath: /var/run/ocp-collector/secrets/fluentd
+          name: clo-default-output-es
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: cluster-logging
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: logcollector
+      serviceAccountName: logcollector
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/disk-pressure
+        operator: Exists
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: normalizer
+        name: config
+      - configMap:
+          defaultMode: 420
+          name: secure-forward
+          optional: true
+        name: secureforwardconfig
+      - name: secureforwardcerts
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: secure-forward
+      - configMap:
+          defaultMode: 420
+          name: syslog
+          optional: true
+        name: syslogconfig
+      - name: syslogcerts
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: syslog
+      - configMap:
+          defaultMode: 420
+          name: normalizer
+        name: entrypoint
+      - name: certs
+        secret:
+          defaultMode: 420
+          secretName: fluentd
+      - name: collector-metrics
+        secret:
+          defaultMode: 420
+          secretName: fluentd-metrics
+      - name: clo-default-output-es
+        secret:
+          defaultMode: 420
+          secretName: fluentd
+  volumeClaimTemplates:
+  - metadata:
+      name: filebufferstorage
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 40Gi
+  templateGeneration: 6
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+`
+const collectorDaemonSetTemplate = `
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    component: collector
+    logging-infra: collector
+    provider: openshift
+  name: collector
+  namespace: openshift-logging
+spec:
+  selector:
+    matchLabels:
+      component: collector
+      logging-infra: collector
+      provider: openshift
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      creationTimestamp: null
+      labels:
+        component: collector
+        logging-infra: collector
+        provider: openshift
+      name: fluentbit
+    spec:
+      containers:
+      - name: fluentbit
+        image: quay.io/jcantril/fluent-bit:v1.5.2-rh
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - mountPath: /var/log
+          name: varlog
+        - mountPath: /etc/fluent-bit
+          name: fluentbit-conf
+        securityContext:
+          privileged: true
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: cluster-logging
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: logcollector
+      serviceAccountName: logcollector
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/disk-pressure
+        operator: Exists
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: fluentbit
+        name: fluentbit-conf
+      - hostPath:
+          path: /var/log
+          type: ""
+        name: varlog
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+          name: fluentd-trusted-ca-bundle
+        name: fluentd-trusted-ca-bundle
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+`

--- a/pkg/k8shandler/reconciler.go
+++ b/pkg/k8shandler/reconciler.go
@@ -50,7 +50,7 @@ func Reconcile(requestCluster *logging.ClusterLogging, requestClient client.Clie
 	}
 
 	// Reconcile Collection
-	if err = clusterLoggingRequest.CreateOrUpdateCollection(proxyConfig); err != nil {
+	if err = clusterLoggingRequest.ReconcileLogForwardingTopology(proxyConfig); err != nil {
 		return fmt.Errorf("Unable to create or update collection for %q: %v", clusterLoggingRequest.Cluster.Name, err)
 	}
 


### PR DESCRIPTION
This PR enables a dev preview POC for a centralized normalizer. By specifying a particular log forwarding topology, the CLO deploys a normalizer and collector.  As implemented:

* edgeNormalization - legacy that exists today where fluentd is deployed on the nodes performing both roles
* centralNormalization - devpreview that creates fluentbit collectors on the nodes writing to fluentd normalizers

Add the following to your clusterlogging instance:

```
apiVersion: logging.openshift.io/v1
kind: ClusterLogging
metadata:
  annotations:
    clusterlogging.openshift.io/enableDevPreviewTopology: "true"
    clusterlogging.openshift.io/logforwardingTopology: centralNormalization
```
**Note**:  This PR does not honor ClusterLogForwarding or the ClusterLogging collection spec.  Any desired changes to the configuration or deployment require the ClusterLogging instance to be placed into unmanaged state

cc @alanconway @sichvoge 