### PR TITLE
Bug 1868068: Evaluate daemonset init containers during reconciliation

### DIFF
--- a/pkg/k8shandler/fluentd_test.go
+++ b/pkg/k8shandler/fluentd_test.go
@@ -17,7 +17,7 @@ import (
 func TestNewFluentdPodSpecWhenFieldsAreUndefined(t *testing.T) {
 
 	cluster := &logging.ClusterLogging{}
-	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name", nil, nil, logging.ClusterLogForwarderSpec{})
+	podSpec := newFluentdPodSpec(cluster, nil, nil, logging.ClusterLogForwarderSpec{})
 
 	if len(podSpec.Containers) != 1 {
 		t.Error("Exp. there to be 1 fluentd container")
@@ -53,7 +53,7 @@ func TestNewFluentdPodSpecWhenResourcesAreDefined(t *testing.T) {
 			},
 		},
 	}
-	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name", nil, nil, logging.ClusterLogForwarderSpec{})
+	podSpec := newFluentdPodSpec(cluster, nil, nil, logging.ClusterLogForwarderSpec{})
 
 	if len(podSpec.Containers) != 1 {
 		t.Error("Exp. there to be 1 fluentd container")
@@ -95,7 +95,7 @@ func TestFluentdPodSpecHasTaintTolerations(t *testing.T) {
 			},
 		},
 	}
-	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name", nil, nil, logging.ClusterLogForwarderSpec{})
+	podSpec := newFluentdPodSpec(cluster, nil, nil, logging.ClusterLogForwarderSpec{})
 
 	if !reflect.DeepEqual(podSpec.Tolerations, expectedTolerations) {
 		t.Errorf("Exp. the tolerations to be %v but was %v", expectedTolerations, podSpec.Tolerations)
@@ -118,7 +118,7 @@ func TestNewFluentdPodSpecWhenSelectorIsDefined(t *testing.T) {
 			},
 		},
 	}
-	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name", nil, nil, logging.ClusterLogForwarderSpec{})
+	podSpec := newFluentdPodSpec(cluster, nil, nil, logging.ClusterLogForwarderSpec{})
 
 	if !reflect.DeepEqual(podSpec.NodeSelector, expSelector) {
 		t.Errorf("Exp. the nodeSelector to be %q but was %q", expSelector, podSpec.NodeSelector)
@@ -150,7 +150,7 @@ func TestNewFluentdPodNoTolerations(t *testing.T) {
 		},
 	}
 
-	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name", nil, nil, logging.ClusterLogForwarderSpec{})
+	podSpec := newFluentdPodSpec(cluster, nil, nil, logging.ClusterLogForwarderSpec{})
 	tolerations := podSpec.Tolerations
 
 	if !utils.AreTolerationsSame(tolerations, expTolerations) {
@@ -195,7 +195,7 @@ func TestNewFluentdPodWithTolerations(t *testing.T) {
 		},
 	}
 
-	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name", nil, nil, logging.ClusterLogForwarderSpec{})
+	podSpec := newFluentdPodSpec(cluster, nil, nil, logging.ClusterLogForwarderSpec{})
 	tolerations := podSpec.Tolerations
 
 	if !utils.AreTolerationsSame(tolerations, expTolerations) {
@@ -209,7 +209,7 @@ func TestNewFluentdPodSpecWhenProxyConfigExists(t *testing.T) {
 	httpproxy := "http://proxy-user@test.example.com/3128/"
 	noproxy := ".cluster.local,localhost"
 	caBundle := fmt.Sprint("-----BEGIN CERTIFICATE-----\n<PEM_ENCODED_CERT>\n-----END CERTIFICATE-----\n")
-	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name",
+	podSpec := newFluentdPodSpec(cluster,
 		&configv1.Proxy{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Proxy",
@@ -270,7 +270,7 @@ func TestFluentdPodInitContainerWithDefaultForwarding(t *testing.T) {
 		Outputs: []logging.OutputSpec{{Name: "default"}},
 	}
 
-	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name", nil, nil, spec)
+	podSpec := newFluentdPodSpec(cluster, nil, nil, spec)
 
 	if len(podSpec.InitContainers) == 0 {
 		t.Error("Expected pod to have defined init container")
@@ -289,7 +289,7 @@ func TestFluentdPodNoInitContainerWithOutDefaultForwarding(t *testing.T) {
 		},
 	}
 
-	podSpec := newFluentdPodSpec(cluster, "test-app-name", "test-infra-name", nil, nil, logging.ClusterLogForwarderSpec{})
+	podSpec := newFluentdPodSpec(cluster, nil, nil, logging.ClusterLogForwarderSpec{})
 	if len(podSpec.InitContainers) > 0 {
 		t.Error("Expected pod to have no init containers")
 	}

--- a/pkg/utils/comparators/daemonsets/comparator.go
+++ b/pkg/utils/comparators/daemonsets/comparator.go
@@ -1,0 +1,85 @@
+package daemonsets
+
+import (
+	"reflect"
+
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	"github.com/openshift/cluster-logging-operator/pkg/utils"
+	apps "k8s.io/api/apps/v1"
+)
+
+//AreSame compares daemonset for equality and return true equal otherwise false
+func AreSame(current *apps.DaemonSet, desired *apps.DaemonSet) bool {
+	logger.Tracef("Comparing DaemonSets current %v to desired %v", current, desired)
+
+	if !utils.AreMapsSame(current.Spec.Template.Spec.NodeSelector, desired.Spec.Template.Spec.NodeSelector) {
+		logger.Debugf("DaemonSet %q nodeSelector change", current.Name)
+		return false
+	}
+
+	if !utils.AreTolerationsSame(current.Spec.Template.Spec.Tolerations, desired.Spec.Template.Spec.Tolerations) {
+		logger.Debugf("DaemonSet %q tolerations change", current.Name)
+		return false
+	}
+
+	if !utils.PodVolumeEquivalent(current.Spec.Template.Spec.Volumes, desired.Spec.Template.Spec.Volumes) {
+		logger.Debugf("DaemonSet %q volumes change", current.Name)
+		return false
+	}
+
+	if len(current.Spec.Template.Spec.Containers) != len(desired.Spec.Template.Spec.Containers) {
+		logger.Debugf("DaemonSet %q number of containers changed", current.Name)
+		return false
+	}
+
+	if isDaemonsetImageDifference(current, desired) {
+		logger.Debugf("DaemonSet %q image change", current.Name)
+		return false
+	}
+
+	if utils.AreResourcesDifferent(current, desired) {
+		logger.Debugf("DaemonSet %q resource(s) change", current.Name)
+		return false
+	}
+
+	if !utils.EnvValueEqual(current.Spec.Template.Spec.Containers[0].Env, desired.Spec.Template.Spec.Containers[0].Env) {
+		logger.Infof("Collector container EnvVar change found, updating %q", current.Name)
+		logger.Debugf("Collector envvars - current: %v, desired: %v", current.Spec.Template.Spec.Containers[0].Env, desired.Spec.Template.Spec.Containers[0].Env)
+		current.Spec.Template.Spec.Containers[0].Env = desired.Spec.Template.Spec.Containers[0].Env
+		return false
+	}
+
+	if !reflect.DeepEqual(current.Spec.Template.Spec.Containers[0].VolumeMounts, desired.Spec.Template.Spec.Containers[0].VolumeMounts) {
+		logger.Debugf("Daemonset %q container volumemounts change", current.Name)
+		return false
+	}
+
+	if len(current.Spec.Template.Spec.InitContainers) != len(desired.Spec.Template.Spec.InitContainers) {
+		logger.Debugf("DaemonSet %q number of init containers changed", current.Name)
+		return false
+	}
+	for i, container := range current.Spec.Template.Spec.InitContainers {
+		if container.Image != desired.Spec.Template.Spec.InitContainers[i].Image {
+			logger.Debugf("Daemonset %q initcontainer %q image is different from desired %q", current.Name, container.Name, desired.Spec.Template.Spec.InitContainers[i].Name)
+			return false
+		}
+	}
+
+	return true
+}
+
+func isDaemonsetImageDifference(current *apps.DaemonSet, desired *apps.DaemonSet) bool {
+
+	for _, curr := range current.Spec.Template.Spec.Containers {
+		for _, des := range desired.Spec.Template.Spec.Containers {
+			// Only compare the images of containers with the same name
+			if curr.Name == des.Name {
+				if curr.Image != des.Image {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/utils/comparators/daemonsets/comparator_test.go
+++ b/pkg/utils/comparators/daemonsets/comparator_test.go
@@ -1,0 +1,65 @@
+package daemonsets_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/cluster-logging-operator/pkg/utils/comparators/daemonsets"
+)
+
+var _ = Describe("daemonset#AreSame", func() {
+
+	var (
+		current, desired *apps.DaemonSet
+	)
+
+	BeforeEach(func() {
+		current = &apps.DaemonSet{
+			Spec: apps.DaemonSetSpec{
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							v1.Container{},
+						},
+						InitContainers: []v1.Container{
+							v1.Container{},
+						},
+					},
+				},
+			},
+		}
+		desired = current.DeepCopy()
+
+	})
+
+	Context("when evaluating containers", func() {
+
+		It("should recognize the numbers are different", func() {
+			container := v1.Container{}
+			desired.Spec.Template.Spec.Containers = append(desired.Spec.Template.Spec.Containers, container)
+			Expect(daemonsets.AreSame(current, desired)).To(BeFalse())
+		})
+
+		It("should recognize different images", func() {
+			desired.Spec.Template.Spec.Containers[0].Image = "bar"
+			Expect(daemonsets.AreSame(current, desired)).To(BeFalse())
+		})
+	})
+
+	Context("when evaluating init containers", func() {
+
+		It("should recognize the numbers are different", func() {
+			container := v1.Container{}
+			desired.Spec.Template.Spec.InitContainers = append(desired.Spec.Template.Spec.InitContainers, container)
+			Expect(daemonsets.AreSame(current, desired)).To(BeFalse())
+		})
+
+		It("should recognize different images", func() {
+			desired.Spec.Template.Spec.InitContainers[0].Image = "bar"
+			Expect(daemonsets.AreSame(current, desired)).To(BeFalse())
+		})
+	})
+
+})

--- a/pkg/utils/comparators/daemonsets/suite_test.go
+++ b/pkg/utils/comparators/daemonsets/suite_test.go
@@ -1,0 +1,13 @@
+package daemonsets_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Daemonset Comparator Suite")
+}


### PR DESCRIPTION
This PR:

* Evaluates daemonset init containers when reconciling the collector
* Refactors daemonset comparison to no longer mutate incoming daemonsets
* Renames the method to retrieve the TrustedCAHash to be a getter instead of getter/mutator

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1868068