### PR TITLE
make tests less verbose

### DIFF
--- a/hack/common
+++ b/hack/common
@@ -193,7 +193,6 @@ function push_image() {
 #      -kubeconfig=${KUBECONFIG} \
 #      -globalMan ${global_manifest} \
 #      -namespacedMan ${manifest} \
-#      -v \
 #      -parallel=1 \
 #      -singleNamespace | tee -a $ARTIFACT_DIR/test.log
 #

--- a/hack/testing-olm/test-030-collection.sh
+++ b/hack/testing-olm/test-030-collection.sh
@@ -50,7 +50,7 @@ for dir in $(ls -d $TEST_DIR); do
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/collection/cleanup.sh $artifact_dir $GENERATOR_NS" \
     artifact_dir=$artifact_dir \
     GENERATOR_NS=$GENERATOR_NS \
-    go test -v -count=1 -parallel=1 -timeout=60m "$dir" -ginkgo.v -ginkgo.noColor -ginkgo.trace | tee -a "$artifact_dir/test.log" ; then
+    go test -count=1 -parallel=1 -timeout=60m "$dir" -ginkgo.noColor -ginkgo.trace | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "Collection $dir passed"
     os::log::info "======================================================="

--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -56,7 +56,7 @@ for dir in $(ls -d $TEST_DIR); do
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/logforwarding/cleanup.sh $artifact_dir $GENERATOR_NS" \
     artifact_dir=$artifact_dir \
     GENERATOR_NS=$GENERATOR_NS \
-    go test -v -count=1 -parallel=1 -timeout=60m "$dir" -ginkgo.v -ginkgo.noColor -ginkgo.trace | tee -a "$artifact_dir/test.log" ; then
+    go test -count=1 -parallel=1 -timeout=60m "$dir" -ginkgo.noColor -ginkgo.trace | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "Logforwarding $dir passed"
     os::log::info "======================================================="


### PR DESCRIPTION
Removing the -v flag from go test prevents Go from printing any of the
t.Log messages unless the test fails.

/assign @jcantrill 
/cc @igor-karpukhin 