### PR TITLE
Bug 1870898: Revert WATCH_NAMESPACE to unbreak clusterlogging

### DIFF
--- a/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
@@ -327,7 +327,9 @@ spec:
                 - cluster-logging-operator
                 env:
                   - name: WATCH_NAMESPACE
-                    value: ""
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.annotations['olm.targetNamespaces']
                   - name: POD_NAME
                     valueFrom:
                       fieldRef:


### PR DESCRIPTION
This PR reverts a change in https://github.com/openshift/cluster-logging-operator/pull/580 that breaks watching clusterlogging

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1870898

cc @ecordell please advise how we can watch target NS for one kind but watch global for a different cluster scoped resource