### PR TITLE
Bug 1862367: fixed application namespace filtering

### DIFF
--- a/pkg/apis/logging/v1/cluster_log_forwarder_types.go
+++ b/pkg/apis/logging/v1/cluster_log_forwarder_types.go
@@ -85,17 +85,17 @@ type InputSpec struct {
 	// Application, if present, enables `application` logs.
 	//
 	// +optional
-	Application *Application `json:"application"`
+	Application *Application `json:"application,omitempty"`
 
 	// Infrastructure, if present, enables `infrastructure` logs.
 	//
 	// +optional
-	Infrastructure *Infrastructure `json:"infrastructure"`
+	Infrastructure *Infrastructure `json:"infrastructure,omitempty"`
 
 	// Audit, if present, enables `audit` logs.
 	//
 	// +optional
-	Audit *Audit `json:"audit"`
+	Audit *Audit `json:"audit,omitempty"`
 }
 
 type Application struct {
@@ -141,7 +141,7 @@ type OutputSpec struct {
 	//
 	// +kubebuilder:validation:Pattern:=`^$|[a-zA-z]+:\/\/.*`
 	// +optional
-	URL string `json:"url"`
+	URL string `json:"url,omitempty"`
 
 	OutputTypeSpec `json:",inline"`
 

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Generating fluentd config", func() {
 		}
 	})
 
-	It("should generats container source config for given namespaces only", func() {
+	It("should generate fluent config for sending given namespaces logs only to output", func() {
 		forwarder = &logging.ClusterLogForwarderSpec{
 			Outputs: []logging.OutputSpec{
 				{
@@ -99,38 +99,463 @@ var _ = Describe("Generating fluentd config", func() {
 				},
 			},
 		}
-		inputs, namespaces := gatherSources(forwarder)
-		results, err := generator.generateSource(inputs, namespaces)
+		results, err := generator.Generate(forwarder, forwarderSpec)
 		Expect(err).To(BeNil())
-		Expect(results).To(HaveLen(1))
-		Expect(results[0]).To(EqualTrimLines(`
-# container logs
-<source>
-  @type tail
-  @id container-input
-  path /var/log/containers/*_project1-namespace_*.log, /var/log/containers/*_project2-namespace_*.log
-  exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
-  pos_file "/var/log/es-containers.log.pos"
-  refresh_interval 5
-  rotate_wait 5
-  tag kubernetes.*
-  read_from_head "true"
-  @label @CONCAT
-  <parse>
-    @type multi_format
-    <pattern>
-      format json
-      time_format '%Y-%m-%dT%H:%M:%S.%N%Z'
-      keep_time_key true
-    </pattern>
-    <pattern>
-      format regexp
-      expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
-      time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
-      keep_time_key true
-    </pattern>
-  </parse>
-</source>
+		Expect(results).To(EqualTrimLines(`
+  ## CLO GENERATED CONFIGURATION ###
+  # This file is a copy of the fluentd configuration entrypoint
+  # which should normally be supplied in a configmap.
+  
+  <system>
+    log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
+  </system>
+  
+  # In each section below, pre- and post- includes don't include anything initially;
+  # they exist to enable future additions to openshift conf as needed.
+  
+  ## sources
+  ## ordered so that syslog always runs last...
+  <source>
+    @type prometheus
+    bind ''
+    <ssl>
+      enable true
+      certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+      private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
+    </ssl>
+  </source>
+  
+  <source>
+    @type prometheus_monitor
+    <labels>
+      hostname ${hostname}
+    </labels>
+  </source>
+  
+  # excluding prometheus_tail_monitor
+  # since it leaks namespace/pod info
+  # via file paths
+  
+  # This is considered experimental by the repo
+  <source>
+    @type prometheus_output_monitor
+    <labels>
+      hostname ${hostname}
+    </labels>
+  </source>
+  # container logs
+  <source>
+    @type tail
+    @id container-input
+    path "/var/log/containers/*.log"
+    exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
+    pos_file "/var/log/es-containers.log.pos"
+    refresh_interval 5
+    rotate_wait 5
+    tag kubernetes.*
+    read_from_head "true"
+    @label @CONCAT
+    <parse>
+      @type multi_format
+      <pattern>
+        format json
+        time_format '%Y-%m-%dT%H:%M:%S.%N%Z'
+        keep_time_key true
+      </pattern>
+      <pattern>
+        format regexp
+        expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+        time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
+        keep_time_key true
+      </pattern>
+    </parse>
+  </source>
+  
+  <label @CONCAT>
+    <filter kubernetes.**>
+      @type concat
+      key log
+      partial_key logtag
+      partial_value P
+      separator ''
+    </filter>
+    <match kubernetes.**>
+      @type relabel
+      @label @INGRESS
+    </match>
+  </label>
+  
+  #syslog input config here
+  
+  <label @INGRESS>
+  
+    ## filters
+    <filter **>
+      @type record_modifier
+      char_encoding utf-8
+    </filter>
+  
+    <filter journal>
+      @type grep
+      <exclude>
+        key PRIORITY
+        pattern ^7$
+      </exclude>
+    </filter>
+  
+    <match journal>
+      @type rewrite_tag_filter
+      # skip to @INGRESS label section
+      @label @INGRESS
+  
+      # see if this is a kibana container for special log handling
+      # looks like this:
+      # k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2
+      # we filter these logs through the kibana_transform.conf filter
+      <rule>
+        key CONTAINER_NAME
+        pattern ^k8s_kibana\.
+        tag kubernetes.journal.container.kibana
+      </rule>
+  
+      <rule>
+        key CONTAINER_NAME
+        pattern ^k8s_[^_]+_logging-eventrouter-[^_]+_
+        tag kubernetes.journal.container._default_.kubernetes-event
+      </rule>
+  
+      # mark logs from default namespace for processing as k8s logs but stored as system logs
+      <rule>
+        key CONTAINER_NAME
+        pattern ^k8s_[^_]+_[^_]+_default_
+        tag kubernetes.journal.container._default_
+      </rule>
+  
+      # mark logs from kube-* namespaces for processing as k8s logs but stored as system logs
+      <rule>
+        key CONTAINER_NAME
+        pattern ^k8s_[^_]+_[^_]+_kube-(.+)_
+        tag kubernetes.journal.container._kube-$1_
+      </rule>
+  
+      # mark logs from openshift-* namespaces for processing as k8s logs but stored as system logs
+      <rule>
+        key CONTAINER_NAME
+        pattern ^k8s_[^_]+_[^_]+_openshift-(.+)_
+        tag kubernetes.journal.container._openshift-$1_
+      </rule>
+  
+      # mark logs from openshift namespace for processing as k8s logs but stored as system logs
+      <rule>
+        key CONTAINER_NAME
+        pattern ^k8s_[^_]+_[^_]+_openshift_
+        tag kubernetes.journal.container._openshift_
+      </rule>
+  
+      # mark fluentd container logs
+      <rule>
+        key CONTAINER_NAME
+        pattern ^k8s_.*fluentd
+        tag kubernetes.journal.container.fluentd
+      </rule>
+  
+      # this is a kubernetes container
+      <rule>
+        key CONTAINER_NAME
+        pattern ^k8s_
+        tag kubernetes.journal.container
+      </rule>
+  
+      # not kubernetes - assume a system log or system container log
+      <rule>
+        key _TRANSPORT
+        pattern .+
+        tag journal.system
+      </rule>
+    </match>
+  
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+      kubernetes_url 'https://kubernetes.default.svc'
+      cache_size '1000'
+      watch 'false'
+      use_journal 'nil'
+      ssl_partial_chain 'true'
+    </filter>
+  
+    <filter kubernetes.journal.**>
+      @type parse_json_field
+      merge_json_log 'false'
+      preserve_json_log 'true'
+      json_fields 'log,MESSAGE'
+    </filter>
+  
+    <filter kubernetes.var.log.containers.**>
+      @type parse_json_field
+      merge_json_log 'false'
+      preserve_json_log 'true'
+      json_fields 'log,MESSAGE'
+    </filter>
+  
+    <filter kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-**>
+      @type parse_json_field
+      merge_json_log true
+      preserve_json_log true
+      json_fields 'log,MESSAGE'
+    </filter>
+  
+    <filter **kibana**>
+      @type record_transformer
+      enable_ruby
+      <record>
+        log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
+      </record>
+      remove_keys req,res,msg,name,level,v,pid,err
+    </filter>
+  
+    <filter k8s-audit.log**>
+      @type record_transformer
+      <record>
+        k8s_audit_level ${record['level']}
+      </record>
+      remove_keys level
+    </filter>
+  
+    <filter **>
+      @type viaq_data_model
+      elasticsearch_index_prefix_field 'viaq_index_name'
+      default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
+      extra_keep_fields ''
+      keep_empty_fields 'message'
+      use_undefined false
+      undefined_name 'undefined'
+      rename_time true
+      rename_time_if_missing false
+      src_time_name 'time'
+      dest_time_name '@timestamp'
+      pipeline_type 'collector'
+      undefined_to_string 'false'
+      undefined_dot_replace_char 'UNUSED'
+      undefined_max_num_fields '-1'
+      process_kubernetes_events 'false'
+      <formatter>
+        tag "system.var.log**"
+        type sys_var_log
+        remove_keys host,pid,ident
+      </formatter>
+      <formatter>
+        tag "journal.system**"
+        type sys_journal
+        remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+      </formatter>
+      <formatter>
+        tag "kubernetes.journal.container**"
+        type k8s_journal
+        remove_keys 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'
+      </formatter>
+      <formatter>
+        tag "kubernetes.var.log.containers.eventrouter-** kubernetes.var.log.containers.cluster-logging-eventrouter-** k8s-audit.log** openshift-audit.log**"
+        type k8s_json_file
+        remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
+        process_kubernetes_events 'true'
+      </formatter>
+      <formatter>
+        tag "kubernetes.var.log.containers**"
+        type k8s_json_file
+        remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
+      </formatter>
+      <elasticsearch_index_name>
+        enabled 'true'
+        tag "journal.system** system.var.log** **_default_** **_kube-*_** **_openshift-*_** **_openshift_**"
+        name_type static
+        static_index_name infra-write
+      </elasticsearch_index_name>
+      <elasticsearch_index_name>
+        enabled 'true'
+        tag "linux-audit.log** k8s-audit.log** openshift-audit.log**"
+        name_type static
+        static_index_name audit-write
+      </elasticsearch_index_name>
+      <elasticsearch_index_name>
+        enabled 'true'
+        tag "**"
+        name_type static
+        static_index_name app-write
+      </elasticsearch_index_name>
+    </filter>
+  
+    <filter **>
+      @type elasticsearch_genid_ext
+      hash_id_key viaq_msg_id
+      alt_key kubernetes.event.metadata.uid
+      alt_tags 'kubernetes.var.log.containers.logging-eventrouter-*.** kubernetes.var.log.containers.eventrouter-*.** kubernetes.var.log.containers.cluster-logging-eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'
+    </filter>
+  
+    #flatten labels to prevent field explosion in ES
+    <filter ** >
+      @type record_transformer
+      enable_ruby true
+      <record>
+        kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+      </record>
+      remove_keys $.kubernetes.labels
+    </filter>
+  
+    # Relabel specific source tags to specific intermediary labels for copy processing
+    # Earlier matchers remove logs so they don't fall through to later ones.
+    # A log source matcher may be null if no pipeline wants that type of log.
+    <match **_default_** **_kube-*_** **_openshift-*_** **_openshift_** journal.** system.var.log**>
+      @type null
+    </match>
+    <match kubernetes.**_project1-namespace_** kubernetes.**_project2-namespace_** >
+      @type relabel
+      @label @_APPLICATION
+    </match>
+    <match linux-audit.log** k8s-audit.log** openshift-audit.log**>
+      @type null
+    </match>
+  
+    <match **>
+      @type stdout
+    </match>
+  
+  </label>
+  
+  # Relabel specific sources (e.g. logs.apps) to multiple pipelines
+  <label @_APPLICATION>
+    <match **>
+      @type copy
+  
+      <store>
+        @type relabel
+        @label @APPS_PIPELINE
+      </store>
+  
+  
+    </match>
+  </label>
+  
+  
+  # Relabel specific pipelines to multiple, outputs (e.g. ES, kafka stores)
+  <label @APPS_PIPELINE>
+    <match **>
+      @type copy
+  
+      <store>
+        @type relabel
+        @label @APPS_ES_1
+      </store>
+      <store>
+        @type relabel
+        @label @APPS_ES_2
+      </store>
+    </match>
+  </label>
+  
+  # Ship logs to specific outputs
+  <label @APPS_ES_1>
+    <match retry_apps_es_1>
+      @type copy
+      <store>
+        @type elasticsearch
+        @id retry_apps_es_1
+        host es.svc.messaging.cluster.local
+        port 9654
+        verify_es_version_at_startup false
+        scheme https
+        ssl_version TLSv1_2
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
+        user fluentd
+        password changeme
+        client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+        client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+        ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        type_name _doc
+        write_operation create
+        reload_connections 'true'
+        # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+        reload_after '200'
+        # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+        reload_on_failure false
+        # 2 ^ 31
+        request_timeout 2147483648
+        <buffer>
+          @type file
+          path '/var/lib/fluentd/retry_apps_es_1'
+          flush_mode interval
+          flush_interval 1s
+          flush_thread_count 2
+          flush_at_shutdown true
+          retry_type exponential_backoff
+          retry_wait 1s
+          retry_max_interval 300s
+          retry_forever true
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+          
+          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+          
+          
+          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+          
+          overflow_action block
+        </buffer>
+      </store>
+    </match>
+    <match **>
+      @type copy
+      <store>
+        @type elasticsearch
+        @id apps_es_1
+        host es.svc.messaging.cluster.local
+        port 9654
+        verify_es_version_at_startup false
+        scheme https
+        ssl_version TLSv1_2
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
+        user fluentd
+        password changeme
+        client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+        client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+        ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        type_name _doc
+        retry_tag retry_apps_es_1
+        write_operation create
+        reload_connections 'true'
+        # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+        reload_after '200'
+        # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+        reload_on_failure false
+        # 2 ^ 31
+        request_timeout 2147483648
+        <buffer>
+          @type file
+          path '/var/lib/fluentd/apps_es_1'
+          flush_mode interval
+          flush_interval 1s
+          flush_thread_count 2
+          flush_at_shutdown true
+          retry_type exponential_backoff
+          retry_wait 1s
+          retry_max_interval 300s
+          retry_forever true
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+          
+          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+          
+          
+          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+          
+          overflow_action block
+        </buffer>
+      </store>
+    </match>
+  </label>
 		`))
 	})
 
@@ -1429,7 +1854,7 @@ var _ = Describe("Generating fluentd config", func() {
     <source>
       @type tail
       @id container-input
-      path /var/log/containers/*_project1_*.log, /var/log/containers/*_project2_*.log
+      path "/var/log/containers/*.log"
       exclude_path ["/var/log/containers/fluentd-*_openshift-logging_*.log", "/var/log/containers/elasticsearch-*_openshift-logging_*.log", "/var/log/containers/kibana-*_openshift-logging_*.log"]
       pos_file "/var/log/es-containers.log.pos"
       refresh_interval 5
@@ -1690,7 +2115,7 @@ var _ = Describe("Generating fluentd config", func() {
         @type null
       </match>
     
-      <match kubernetes.**>
+      <match kubernetes.**_project1_** kubernetes.**_project2_** >
         @type relabel
         @label @_APPLICATION
       </match>

--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -78,7 +78,7 @@ func (engine *ConfigGenerator) Generate(clfSpec *logging.ClusterLogForwarderSpec
 		routeMap = inputsToPipelines(clfSpec)
 	}
 
-	sourceInputLabels, err = engine.generateSource(inputs, namespaces)
+	sourceInputLabels, err = engine.generateSource(inputs)
 	if err != nil {
 
 		logger.Tracef("Error generating source blocks: %v", err)
@@ -120,6 +120,7 @@ func (engine *ConfigGenerator) Generate(clfSpec *logging.ClusterLogForwarderSpec
 		SourceToPipelineLabels     []string
 		PipelinesToOutputLabels    []string
 		OutputLabels               []string
+		AppNamespaces              []string
 	}{
 		engine.includeLegacyForwardConfig,
 		engine.includeLegacySyslogConfig,
@@ -130,6 +131,7 @@ func (engine *ConfigGenerator) Generate(clfSpec *logging.ClusterLogForwarderSpec
 		sourceToPipelineLabels,
 		pipelineToOutputLabels,
 		outputLabels,
+		namespaces.List(),
 	}
 	result, err := engine.Execute("fluentConf", data)
 	if err != nil {

--- a/pkg/generators/forwarding/fluentd/source.go
+++ b/pkg/generators/forwarding/fluentd/source.go
@@ -2,7 +2,6 @@ package fluentd
 
 import (
 	"fmt"
-	"strings"
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/pkg/constants"
@@ -13,17 +12,14 @@ import (
 // We need to also filter them per-user-SourceSpec since different SourceSpecs
 // might request different namespaces.
 
-func (engine *ConfigGenerator) generateSource(sources sets.String, appNs sets.String) (results []string, err error) {
+func (engine *ConfigGenerator) generateSource(sources sets.String) (results []string, err error) {
 	// Order of templates matters.
-	var templates, nsPaths []string
+	var templates []string
 	if sources.Has(logging.InputNameInfrastructure) {
 		templates = append(templates, "inputSourceJournalTemplate")
 	}
 	if sources.Has(logging.InputNameApplication) {
 		templates = append(templates, "inputSourceContainerTemplate")
-		for _, ns := range appNs.List() {
-			nsPaths = append(nsPaths, fmt.Sprintf("/var/log/containers/*_%s_*.log", ns))
-		}
 	}
 	if sources.Has(logging.InputNameAudit) {
 		templates = append(templates, "inputSourceHostAuditTemplate")
@@ -38,13 +34,11 @@ func (engine *ConfigGenerator) generateSource(sources sets.String, appNs sets.St
 		CollectorPodNamePrefix     string
 		LogStorePodNamePrefix      string
 		VisualizationPodNamePrefix string
-		AppNsPaths                 string
 	}{
 		constants.OpenshiftNS,
 		constants.FluentdName,
 		constants.ElasticsearchName,
 		constants.KibanaName,
-		strings.Join(nsPaths, ", "),
 	}
 	for _, template := range templates {
 		result, err := engine.Execute(template, data)

--- a/pkg/generators/forwarding/fluentd/source_test.go
+++ b/pkg/generators/forwarding/fluentd/source_test.go
@@ -23,7 +23,7 @@ var _ = Describe("generating source", func() {
 
 	Context("for only logs.app source", func() {
 		BeforeEach(func() {
-			results, err = generator.generateSource(sets.NewString(logging.InputNameApplication), nil)
+			results, err = generator.generateSource(sets.NewString(logging.InputNameApplication))
 			Expect(err).To(BeNil())
 			Expect(len(results) == 1).To(BeTrue())
 		})
@@ -62,7 +62,7 @@ var _ = Describe("generating source", func() {
 
 	Context("for only logs.infra source", func() {
 		BeforeEach(func() {
-			results, err = generator.generateSource(sets.NewString(logging.InputNameInfrastructure), nil)
+			results, err = generator.generateSource(sets.NewString(logging.InputNameInfrastructure))
 			Expect(err).To(BeNil())
 			Expect(len(results) == 1).To(BeTrue())
 		})
@@ -92,7 +92,7 @@ var _ = Describe("generating source", func() {
 
 	Context("for only logs.audit source", func() {
 		BeforeEach(func() {
-			results, err = generator.generateSource(sets.NewString(logging.InputNameAudit), nil)
+			results, err = generator.generateSource(sets.NewString(logging.InputNameAudit))
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(3))
 		})
@@ -154,7 +154,7 @@ var _ = Describe("generating source", func() {
 	Context("for all log sources", func() {
 
 		BeforeEach(func() {
-			results, err = generator.generateSource(sets.NewString(logging.InputNameApplication, logging.InputNameInfrastructure, logging.InputNameAudit), nil)
+			results, err = generator.generateSource(sets.NewString(logging.InputNameApplication, logging.InputNameInfrastructure, logging.InputNameAudit))
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(5))
 		})

--- a/test/e2e/collection/fluentd/namespace_filtering_test.go
+++ b/test/e2e/collection/fluentd/namespace_filtering_test.go
@@ -1,0 +1,121 @@
+package fluentd
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
+	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
+	apps "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("[Collection] Namespace filtering", func() {
+	_, filename, _, _ := runtime.Caller(0)
+	logger.Infof("Running %s", filename)
+	var (
+		err              error
+		fluentDeployment *apps.Deployment
+		e2e              = helpers.NewE2ETestFramework()
+		rootDir          string
+	)
+	appNamespace1 := "application1"
+	appNamespace2 := "application2"
+
+	BeforeEach(func() {
+		if _, err = oc.Literal().From(fmt.Sprintf("oc create ns %s", appNamespace1)).Run(); err != nil {
+			Fail("failed to create namespace")
+		}
+		if _, err = oc.Literal().From(fmt.Sprintf("oc create ns %s", appNamespace2)).Run(); err != nil {
+			Fail("failed to create namespace")
+		}
+	})
+	BeforeEach(func() {
+		if err := e2e.DeployLogGeneratorWithNamespace(appNamespace1); err != nil {
+			Fail(fmt.Sprintf("Timed out waiting for the log generator 1 to deploy: %v", err))
+		}
+		if err := e2e.DeployLogGeneratorWithNamespace(appNamespace2); err != nil {
+			Fail(fmt.Sprintf("Timed out waiting for the log generator 2 to deploy: %v", err))
+		}
+		rootDir = filepath.Join(filepath.Dir(filename), "..", "..", "..", "..", "/")
+		if fluentDeployment, err = e2e.DeployFluentdReceiver(rootDir, false); err != nil {
+			Fail(fmt.Sprintf("Unable to deploy fluent receiver: %v", err))
+		}
+
+		forwarder := &logging.ClusterLogForwarder{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       logging.ClusterLogForwarderKind,
+				APIVersion: logging.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "instance",
+			},
+			Spec: logging.ClusterLogForwarderSpec{
+				Inputs: []logging.InputSpec{
+					{
+						Name: "application-logs",
+						Application: &logging.Application{
+							Namespaces: []string{appNamespace1},
+						},
+					},
+				},
+				Outputs: []logging.OutputSpec{
+					{
+						Name: fluentDeployment.ObjectMeta.Name,
+						Type: logging.OutputTypeFluentdForward,
+						URL:  fmt.Sprintf("tcp://%s.%s.svc:24224", fluentDeployment.ObjectMeta.Name, fluentDeployment.Namespace),
+					},
+				},
+				Pipelines: []logging.PipelineSpec{
+					{
+						Name:       "test-app",
+						OutputRefs: []string{fluentDeployment.ObjectMeta.Name},
+						InputRefs:  []string{"application-logs"},
+					},
+				},
+			},
+		}
+		if err := e2e.CreateClusterLogForwarder(forwarder); err != nil {
+			Fail(fmt.Sprintf("Unable to create an instance of clusterlogforwarder: %v", err))
+		}
+		cr := helpers.NewClusterLogging(helpers.ComponentTypeCollector)
+		if err := e2e.CreateClusterLogging(cr); err != nil {
+			Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+		}
+		if err := e2e.WaitFor(helpers.ComponentTypeCollector); err != nil {
+			Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", helpers.ComponentTypeCollector, err))
+		}
+
+	})
+	It("should send logs from one namespace only", func() {
+		Expect(e2e.LogStores[fluentDeployment.GetName()].HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs")
+
+		logs, err := e2e.LogStores[fluentDeployment.GetName()].ApplicationLogs(helpers.DefaultWaitForLogsTimeout)
+		Expect(err).To(BeNil(), fmt.Sprintf("Error fetching logs: %v", err))
+		Expect(len(logs)).To(Not(Equal(0)), "There were no documents returned in the logs")
+
+		// verify only appNamespace1 logs appear in Application logs
+		for _, log := range logs {
+			Expect(log.Kubernetes.NamespaceName).To(Equal(appNamespace1), fmt.Sprintf("log %#v", log))
+		}
+	})
+
+	AfterEach(func() {
+		e2e.Cleanup()
+		if _, err = oc.Literal().From(fmt.Sprintf("oc delete ns %s", appNamespace1)).Run(); err != nil {
+			Fail("failed to create namespace")
+		}
+		if _, err = oc.Literal().From(fmt.Sprintf("oc delete ns %s", appNamespace2)).Run(); err != nil {
+			Fail("failed to create namespace")
+		}
+		e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{"fluent-receiver", "fluentd"})
+		e2e.WaitForCleanupCompletion(appNamespace1, []string{"test"})
+		e2e.WaitForCleanupCompletion(appNamespace2, []string{"test"})
+	}, helpers.DefaultCleanUpTimeout)
+
+})

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -98,8 +98,12 @@ func (tc *E2ETestFramework) AddCleanup(fn func() error) {
 }
 
 func (tc *E2ETestFramework) DeployLogGenerator() error {
-	opts := metav1.CreateOptions{}
 	namespace := tc.CreateTestNamespace()
+	return tc.DeployLogGeneratorWithNamespace(namespace)
+}
+
+func (tc *E2ETestFramework) DeployLogGeneratorWithNamespace(namespace string) error {
+	opts := metav1.CreateOptions{}
 	container := corev1.Container{
 		Name:            "log-generator",
 		Image:           "busybox",

--- a/vendor/github.com/onsi/gomega/go.mod
+++ b/vendor/github.com/onsi/gomega/go.mod
@@ -1,5 +1,7 @@
 module github.com/onsi/gomega
 
+go 1.14
+
 require (
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/golang/protobuf v1.2.0
@@ -14,4 +16,3 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.2.4
 )
-


### PR DESCRIPTION
Earlier implementation of application namespace filtering was based on selectively scrapping logs for namespaces in CLF spec.inputs.application.namespaces
CLF approach is to scrape all container logs, and then generate fluent conf according to the CLF spec.pipeline.
Now if namespaces are specified in spec.inputs.application, then <match> filter is used to send only the namespace logs to pipeline.

The logic for dispatching application logs is:
```
if .CollectAppLogs
  if .AppNamespace
    <match $ns>  // tags for namespace only
      @type relabel
      @label @_APPLICATION
    </match>
  else
    <match k8s.**>
      @type relabel
      @label @_APPLICATION
    </match>      
  fi
else
    <match k8s.**>
      @null
    </match>
fi

```


/cc @alanconway @jcantrill 