### PR TITLE
Bug 1862050: Bind fluentd metrics to POD_IP to support ipv4 and ipv6

### DIFF
--- a/hack/testing-olm/test-999-fluentd-prometheus-metrics.sh
+++ b/hack/testing-olm/test-999-fluentd-prometheus-metrics.sh
@@ -71,9 +71,6 @@ os::cmd::try_until_text "oc -n ${LOGGING_NS} get ds fluentd -o jsonpath={.status
 
 fpod=$(oc -n $LOGGING_NS get pod -l component=fluentd -o jsonpath={.items[0].metadata.name} --ignore-not-found)
 
-os::log::info "Checking metrics using 'localhost'..."
-os::cmd::try_until_success "oc -n $LOGGING_NS exec $fpod -- curl -ks https://localhost:24231/metrics" "$((2 * $minute))"
-
 os::log::info "Checking metrics using fluent service address..."
 os::cmd::try_until_success "oc -n $LOGGING_NS exec $fpod -- curl -ks https://fluentd.openshift-logging.svc:24231/metrics" "$((2 * $minute))"
 

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Generating fluentd config", func() {
   ## ordered so that syslog always runs last...
   <source>
     @type prometheus
-    bind ''
+    bind "#{ENV['POD_IP']}"
     <ssl>
       enable true
       certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
@@ -594,7 +594,7 @@ var _ = Describe("Generating fluentd config", func() {
 			## ordered so that syslog always runs last...
 			<source>
 				@type prometheus
-                bind ''
+                bind "#{ENV['POD_IP']}"
 				<ssl>
 					enable true
 					certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
@@ -962,7 +962,7 @@ var _ = Describe("Generating fluentd config", func() {
 			## ordered so that syslog always runs last...
 			<source>
 				@type prometheus
-                bind ''
+                bind "#{ENV['POD_IP']}"
 				<ssl>
 					enable true
 					certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
@@ -1824,7 +1824,7 @@ var _ = Describe("Generating fluentd config", func() {
     ## ordered so that syslog always runs last...
     <source>
       @type prometheus
-      bind ''
+      bind "#{ENV['POD_IP']}"
       <ssl>
         enable true
         certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         ## ordered so that syslog always runs last...
         <source>
           @type prometheus
-          bind ''
+          bind "#{ENV['POD_IP']}"
           <ssl>
             enable true
             certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
@@ -490,7 +490,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         ## ordered so that syslog always runs last...
         <source>
           @type prometheus
-          bind ''
+          bind "#{ENV['POD_IP']}"
           <ssl>
             enable true
             certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
@@ -941,7 +941,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         ## ordered so that syslog always runs last...
         <source>
           @type prometheus
-          bind ''
+          bind "#{ENV['POD_IP']}"
           <ssl>
             enable true
             certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -37,7 +37,7 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 ## ordered so that syslog always runs last...
 <source>
   @type prometheus
-  bind ''
+  bind "#{ENV['POD_IP']}"
   <ssl>
     enable true
     certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -307,6 +307,7 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, proxyConfig *configv1.Pr
 		{Name: "METRICS_CERT", Value: "/etc/fluent/metrics/tls.crt"},
 		{Name: "METRICS_KEY", Value: "/etc/fluent/metrics/tls.key"},
 		{Name: "NODE_IPV4", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.hostIP"}}},
+		{Name: "POD_IP", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"}}},
 	}
 
 	proxyEnv := utils.SetProxyEnvVars(proxyConfig)

--- a/pkg/k8shandler/fluentd_test.go
+++ b/pkg/k8shandler/fluentd_test.go
@@ -5,6 +5,10 @@ import (
 	"reflect"
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+
 	configv1 "github.com/openshift/api/config/v1"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/pkg/constants"
@@ -13,6 +17,28 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var _ = Describe("fluentd.go#newFluentdPodSpec", func() {
+	var (
+		cluster   = &logging.ClusterLogging{}
+		podSpec   v1.PodSpec
+		container v1.Container
+	)
+	BeforeEach(func() {
+		podSpec = newFluentdPodSpec(cluster, nil, nil, logging.ClusterLogForwarderSpec{})
+		container = podSpec.Containers[0]
+	})
+	Describe("when creating of the collector container", func() {
+
+		It("should provide the pod IP as an environment var", func() {
+			Expect(container.Env).To(IncludeEnvVar(v1.EnvVar{Name: "POD_IP",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						APIVersion: "v1", FieldPath: "status.podIP"}}}))
+		})
+	})
+
+})
 
 func TestNewFluentdPodSpecWhenFieldsAreUndefined(t *testing.T) {
 

--- a/pkg/utils/comparators/daemonsets/comparator_test.go
+++ b/pkg/utils/comparators/daemonsets/comparator_test.go
@@ -21,10 +21,10 @@ var _ = Describe("daemonset#AreSame", func() {
 				Template: v1.PodTemplateSpec{
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{},
+							{},
 						},
 						InitContainers: []v1.Container{
-							v1.Container{},
+							{},
 						},
 					},
 				},

--- a/test/matchers/envvar.go
+++ b/test/matchers/envvar.go
@@ -1,0 +1,49 @@
+package matchers
+
+import (
+	"fmt"
+
+	"github.com/openshift/cluster-logging-operator/test"
+	v1 "k8s.io/api/core/v1"
+)
+
+type EnvVarMatcher struct {
+	expected interface{}
+}
+
+// EqualDiff is like Equal but gives cmp.Diff style output.
+func IncludeEnvVar(expected interface{}) *EnvVarMatcher {
+	return &EnvVarMatcher{
+		expected: expected,
+	}
+}
+
+func (m *EnvVarMatcher) Match(actual interface{}) (success bool, err error) {
+	expVar, ok := m.expected.(v1.EnvVar)
+	if !ok {
+		return false, fmt.Errorf("Matcher expects v1.EnvVar")
+	}
+	actualVars, ok := actual.([]v1.EnvVar)
+	if !ok {
+		return false, fmt.Errorf("Matcher expects []v1.EnvVars")
+	}
+	var foundVar *v1.EnvVar
+	for i := range actualVars {
+		if actualVars[i].Name == expVar.Name {
+			foundVar = &actualVars[i]
+			break
+		}
+	}
+	if foundVar == nil {
+		return false, nil
+	}
+	return test.JSONString(foundVar) == test.JSONString(expVar), nil
+}
+
+func (m *EnvVarMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%s\nto contain \n\t%s", test.JSONString(actual), test.JSONString(m.expected))
+}
+
+func (m *EnvVarMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nto not contain \n\t%#v", actual, m.expected)
+}


### PR DESCRIPTION
This PR:
* Modifies fluent conf to bind prometheus endpoint to the podIP to satisfy ipv4 and ipv6
* Removes dead collector code to satisfy linter
* Adds gomega matchers for v1.EnvVar

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1862050