### PR TITLE
Bug 1852341: fix k8s_audit_level placeholder

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -316,7 +316,7 @@ var _ = Describe("Generating fluentd config", func() {
     <filter k8s-audit.log**>
       @type record_transformer
       <record>
-        k8s_audit_level ${record['level']}
+        k8s_audit_level ${level}
       </record>
       remove_keys level
     </filter>
@@ -784,7 +784,7 @@ var _ = Describe("Generating fluentd config", func() {
 				<filter k8s-audit.log**>
 				  @type record_transformer
 				  <record>
-				    k8s_audit_level ${record['level']}
+				    k8s_audit_level ${level}
 				  </record>
 				  remove_keys level
 				</filter>
@@ -1217,7 +1217,7 @@ var _ = Describe("Generating fluentd config", func() {
 				<filter k8s-audit.log**>
 				  @type record_transformer
 				  <record>
-				    k8s_audit_level ${record['level']}
+				    k8s_audit_level ${level}
 				  </record>
 				  remove_keys level
 				</filter>
@@ -2026,7 +2026,7 @@ var _ = Describe("Generating fluentd config", func() {
       <filter k8s-audit.log**>
         @type record_transformer
         <record>
-          k8s_audit_level ${record['level']}
+          k8s_audit_level ${level}
         </record>
         remove_keys level
       </filter>

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           <filter k8s-audit.log**>
             @type record_transformer
             <record>
-              k8s_audit_level ${record['level']}
+              k8s_audit_level ${level}
             </record>
             remove_keys level
           </filter>
@@ -751,7 +751,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           <filter k8s-audit.log**>
             @type record_transformer
             <record>
-              k8s_audit_level ${record['level']}
+              k8s_audit_level ${level}
             </record>
             remove_keys level
           </filter>
@@ -1202,7 +1202,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           <filter k8s-audit.log**>
             @type record_transformer
             <record>
-              k8s_audit_level ${record['level']}
+              k8s_audit_level ${level}
             </record>
             remove_keys level
           </filter>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -213,7 +213,7 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
   <filter k8s-audit.log**>
     @type record_transformer
     <record>
-      k8s_audit_level ${record['level']}
+      k8s_audit_level ${level}
     </record>
     remove_keys level
   </filter>


### PR DESCRIPTION
because the placeholder is within the `record` block we only use it's name

/assign @jcantrill 
/cc @ewolinetz 