### PR TITLE
Bug 1875461: Updating CLO csv per operator one-click report

### DIFF
--- a/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/cluster-logging.v4.6.0.clusterserviceversion.yaml
@@ -142,7 +142,7 @@ spec:
     email: aos-logging@redhat.com
 
   provider:
-    name: Red Hat, Inc
+    name: Red Hat
 
   links:
   - name: Elastic
@@ -401,6 +401,11 @@ spec:
         path: logStore.elasticsearch.nodeSelector
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:nodeSelector'
+      - description: The storage class name to use for the Elasticsearch Log Storage component
+        displayName: Elasticsearch Storage Class Name
+        path: logStore.elasticsearch.storage.storageClassName
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:StorageClass'
       - description: Resource requirements for the Fluentd pods
         displayName: Fluentd Resource Requirements
         path: collection.logs.fluentd.resources


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1875461 by making changes based on:

Per slide 6 suggestion - 
```
Add “urn:alm:descriptor:io.kubernetes:StorageClass” specDescriptor in CSV for “logStore.elasticsearch.storage.storageClassName“


Now the template is hard coded as “gp2”, which tripped GCP users up without obvious error messages surface on the UI or in YAML. 
Hence, a dropdown menu for choosing “StorageClass” may help.
```

Per slide 8 suggestion -
```
Drop the “Inc” from provider
```