### PR TITLE
redirect must-gather output to a file

### DIFF
--- a/hack/testing-olm/utils
+++ b/hack/testing-olm/utils
@@ -12,7 +12,7 @@ gather_logging_resources() {
   local outdir=${2:-$ARTIFACT_DIR}
   local runtime=${3:-$(date +%s)}
   outdir=$outdir/$runtime
-  mkdir $outdir ||:
-  oc adm must-gather --image=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift/origin-cluster-logging-operator:latest} --dest-dir=$outdir
+  mkdir -p $outdir ||:
+  oc adm must-gather --image=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift/origin-cluster-logging-operator:latest} --dest-dir=$outdir -- /usr/bin/gather > must-gather.log 2>&1
   set -e
 }

--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -31,3 +31,14 @@ oc -n $NAMESPACE get "${csv_name}" -o yaml > "${clo_folder}/csv"
 oc -n $NAMESPACE get clusterlogging instance -o yaml > "${clo_folder}/cr"
 oc -n $NAMESPACE get logforwarding instance -o yaml > "${clo_folder}/logforwarding_cr" ||:
 oc -n $NAMESPACE get clusterlogforwarder instance -o yaml > "${clo_folder}/clusterlogforwarder_cr" ||:
+
+oc -n ${NAMESPACE} get configmaps -o yaml > ${clo_folder}/configmaps.yaml 2>&1 || :
+oc -n ${NAMESPACE} get secrets -o yaml > ${clo_folder}/secrets.yaml 2>&1 || :
+oc -n ${NAMESPACE} get cronjobs -o yaml > ${clo_folder}/cronjobs.yaml 2>&1 || :
+oc -n ${NAMESPACE} get deployments -o wide > ${clo_folder}/deployments.txt 2>&1 ||    :
+oc -n ${NAMESPACE} get ds -o wide > ${clo_folder}/daemonsets.txt 2>&1 ||    :
+oc -n ${NAMESPACE} get pods -o wide > ${clo_folder}/pods.txt 2>&1 || :
+oc -n ${NAMESPACE} extract secret/elasticsearch --to=${clo_folder} ||:
+oc -n ${NAMESPACE} extract configmap/fluentd --to=${clo_folder} ||:
+oc -n ${NAMESPACE} extract configmap/secure-forward --to=${clo_folder} ||:
+oc -n ${NAMESPACE} extract secret/secure-forward --to=${clo_folder} ||:

--- a/must-gather/collection-scripts/gather_elasticsearch_operator_resources
+++ b/must-gather/collection-scripts/gather_elasticsearch_operator_resources
@@ -28,3 +28,11 @@ oc -n $NAMESPACE get deployment elasticsearch-operator -o yaml > $eo_folder/depl
 
 csv_name="$(oc -n $NAMESPACE get csv -o name | grep 'elasticsearch-operator')"
 oc -n $NAMESPACE get "${csv_name}" -o yaml > "${eo_folder}/csv"
+oc -n openshift-logging exec -c elasticsearch \
+    $(oc -n openshift-logging get pods -l component=elasticsearch -o jsonpath={.items[0].metadata.name}) \
+    -- indices > ${eo_folder}/indices.txt||:
+
+oc -n $NAMESPACE get deployment elasticsearch-operator -o wide > ${eo_folder}/eo-deployment.txt 2>&1 || :
+oc -n $NAMESPACE describe deployment elasticsearch-operator > ${eo_folder}/eo-deployment.describe 2>&1 || :
+oc -n $NAMESPACE logs deployment/elasticsearch-operator > ${eo_folder}/elasticsearch-operator.logs 2>&1 || :
+


### PR DESCRIPTION
`oc must-gather` produces about 6000 lines of output while gathering for one failed test case.
This PR redirects the output of `oc must-gather` to `must-gather.log`

Also added back commands to get logging resources in must-gather scripts

