### PR TITLE
Add placeholder for functional Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,10 @@ undeploy-elasticsearch-operator:
 deploy-example: deploy
 	oc create -n $(NAMESPACE) -f hack/cr.yaml
 
+test-functional:
+	@echo "FIXME"
+.PHONY: test-functional
+
 test-unit:
 	LOGGING_SHARE_DIR=$(CURDIR)/files \
 	LOG_LEVEL=fatal \


### PR DESCRIPTION
This PR adds a placeholder for functional tests so that we can enable CI