### PR TITLE
Bug 1852341: fix syslog k8s audit level conflict

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -315,10 +315,11 @@ var _ = Describe("Generating fluentd config", func() {
   
     <filter k8s-audit.log**>
       @type record_transformer
+      enable_ruby
       <record>
-        k8s_audit_level ${level}
+        k8s_audit_level ${record['level']}
+        level info
       </record>
-      remove_keys level
     </filter>
   
     <filter **>
@@ -783,10 +784,11 @@ var _ = Describe("Generating fluentd config", func() {
 
 				<filter k8s-audit.log**>
 				  @type record_transformer
+				  enable_ruby
 				  <record>
-				    k8s_audit_level ${level}
+				    k8s_audit_level ${record['level']}
+				    level info
 				  </record>
-				  remove_keys level
 				</filter>
 
 				<filter **>
@@ -1216,10 +1218,11 @@ var _ = Describe("Generating fluentd config", func() {
 
 				<filter k8s-audit.log**>
 				  @type record_transformer
+				  enable_ruby
 				  <record>
-				    k8s_audit_level ${level}
+				    k8s_audit_level ${record['level']}
+				    level info
 				  </record>
-				  remove_keys level
 				</filter>
 
 				<filter **>
@@ -2025,10 +2028,11 @@ var _ = Describe("Generating fluentd config", func() {
     
       <filter k8s-audit.log**>
         @type record_transformer
+	enable_ruby
         <record>
-          k8s_audit_level ${level}
+          k8s_audit_level ${record['level']}
+          level info
         </record>
-        remove_keys level
       </filter>
 
       <filter **>

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -301,10 +301,11 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
 
           <filter k8s-audit.log**>
             @type record_transformer
+            enable_ruby
             <record>
-              k8s_audit_level ${level}
+              k8s_audit_level ${record['level']}
+              level info
             </record>
-            remove_keys level
           </filter>
 
           <filter **>
@@ -750,10 +751,11 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
 
           <filter k8s-audit.log**>
             @type record_transformer
+            enable_ruby
             <record>
-              k8s_audit_level ${level}
+              k8s_audit_level ${record['level']}
+              level info
             </record>
-            remove_keys level
           </filter>
 
           <filter **>
@@ -1201,10 +1203,11 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
 
           <filter k8s-audit.log**>
             @type record_transformer
+            enable_ruby
             <record>
-              k8s_audit_level ${level}
+              k8s_audit_level ${record['level']}
+              level info
             </record>
-            remove_keys level
           </filter>
 
           <filter **>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -212,10 +212,11 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 
   <filter k8s-audit.log**>
     @type record_transformer
+    enable_ruby
     <record>
-      k8s_audit_level ${level}
+      k8s_audit_level ${record['level']}
+      level info
     </record>
-    remove_keys level
   </filter>
 
   <filter **>


### PR DESCRIPTION
Also depends on
https://github.com/openshift/origin-aggregated-logging/pull/1978

This change along with the OAL above provides the following output.
This was tested by creating rsyslog, configuring LF -> rsyslog, and
setting rsyslog to log to stdout

```
2020-09-04T16:26:44+00:00 fluentd-94rcl fluentd: kind:Event#011apiVersion:audit.k8s.io/v1#011level:info#011auditID:a0fad62d-99f1-4cbd-97a0-0f5b7d37039b#011stage:ResponseComplete#011requestURI:/apis/batch/v1beta1/namespaces/openshift-logging/cronjobs/elasticsearch-delete-app/status#011verb:update#011user:{"username"=>"system:serviceaccount:kube-system:cronjob-controller", "uid"=>"c9f0cc6f-90d6-4c2a-829e-3dbcf6585242", "groups"=>["system:serviceaccounts", "system:serviceaccounts:kube-system", "system:authenticated"]}#011sourceIPs:["::1"]#011userAgent:kube-controller-manager/v1.18.3+8b0a82f (linux/amd64) kubernetes/8b0a82f/system:serviceaccount:kube-system:cronjob-controller#011objectRef:{"resource"=>"cronjobs", "namespace"=>"openshift-logging", "name"=>"elasticsearch-delete-app", "uid"=>"222b3bb4-03f0-444d-8958-49789484c197", "apiGroup"=>"batch", "apiVersion"=>"v1beta1", "resourceVersion"=>"74794", "subresource"=>"status"}#011responseStatus:{"code"=>200}#011requestReceivedTimestamp:2020-09-04T16:26:44.374554Z#011stageTimestamp:2020-09-04T16:26:44.377541Z#011annotations:{"authorization.k8s.io/decision"=>"allow", "authorization.k8s.io/reason"=>"RBAC: allowed by ClusterRoleBinding \"system:controller:cronjob-controller\" of ClusterRole \"system:controller:cronjob-controller\" to ServiceAccount \"cronjob-controller/kube-system\""}#011k8s_audit_level:Metadata#011message:#011hostname:ip-10-0-214-88.us-west-2.compute.internal#011pipeline_metadata:{"collector"=>{"ipaddr4"=>"10.0.214.88", "inputname"=>"fluent-plugin-systemd", "name"=>"fluentd", "received_at"=>"2020-09-04T16:26:44.377904+00:00", "version"=>"1.7.4 1.6.0"}}#011@timestamp:2020-09-04T16:26:44.374554+00:00#011viaq_index_name:audit-write#011viaq_msg_id:NWE0Njk2MjYtYzRkZS00MWE2LTk5ZTItN2NiYjUzZWExMjRk#011kubernetes:{}#011openshift:{"labels"=>{"logforwarder"=>"audit-log"}}
```

/cc @ewolinetz 
/assign @jcantrill  