### PR TITLE
Bug 1874746: Fixed ClusterLogging CR status

### DIFF
--- a/hack/generate-crd.sh
+++ b/hack/generate-crd.sh
@@ -21,7 +21,7 @@ mv "deploy/crds/${CLF_CRD_FILE}" "${MANIFESTS_DIR}"
 mv "deploy/crds/${CLO_CRD_FILE}" "${MANIFESTS_DIR}"
 
 echo "---------------------------------------------------------------"
-echo "Kustomize: Patch CRDs for singeltons and backward-compatibility"
+echo "Kustomize: Patch CRDs for singeltons"
 echo "---------------------------------------------------------------"
 oc kustomize "${MANIFESTS_DIR}" | \
     awk -v clf="${MANIFESTS_DIR}/${CLF_CRD_FILE}" \

--- a/manifests/4.6/crd-v1-clusterloggings-patches.yaml
+++ b/manifests/4.6/crd-v1-clusterloggings-patches.yaml
@@ -7,7 +7,3 @@
         type: string
         enum:
         - "instance"
-- op: replace
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/status
-  value:
-    type: object

--- a/manifests/4.6/logging.openshift.io_clusterloggings_crd.yaml
+++ b/manifests/4.6/logging.openshift.io_clusterloggings_crd.yaml
@@ -644,6 +644,373 @@ spec:
                 type: object
             type: object
           status:
+            description: ClusterLoggingStatus defines the observed state of ClusterLogging
+            properties:
+              clusterConditions:
+                description: Conditions is a set of Condition instances.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              collection:
+                properties:
+                  logs:
+                    properties:
+                      fluentdStatus:
+                        properties:
+                          clusterCondition:
+                            additionalProperties:
+                              description: '`operator-sdk generate crds` does not
+                                allow map-of-slice, must use a named type.'
+                              items:
+                                description: "Condition represents an observation
+                                  of an object's state. Conditions are an extension
+                                  mechanism intended to be used when the details of
+                                  an observation are not a priori known or would not
+                                  apply to all instances of a given Kind. \n Conditions
+                                  should be added to explicitly convey properties
+                                  that users and components care about rather than
+                                  requiring those properties to be inferred from other
+                                  observations. Once defined, the meaning of a Condition
+                                  can not be changed arbitrarily - it becomes part
+                                  of the API, and has the same backwards- and forwards-compatibility
+                                  concerns of any other part of the API."
+                                properties:
+                                  lastTransitionTime:
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    type: string
+                                  reason:
+                                    description: ConditionReason is intended to be
+                                      a one-word, CamelCase representation of the
+                                      category of cause of the current status. It
+                                      is intended to be used in concise output, such
+                                      as one-line kubectl get output, and in summarizing
+                                      occurrences of causes.
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    description: "ConditionType is the type of the
+                                      condition and is typically a CamelCased word
+                                      or short phrase. \n Condition types should indicate
+                                      state in the \"abnormal-true\" polarity. For
+                                      example, if the condition indicates when a policy
+                                      is invalid, the \"is valid\" case is probably
+                                      the norm, so the condition should be called
+                                      \"Invalid\"."
+                                    type: string
+                                required:
+                                - status
+                                - type
+                                type: object
+                              type: array
+                            type: object
+                          daemonSet:
+                            type: string
+                          nodes:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          pods:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              curation:
+                properties:
+                  curatorStatus:
+                    items:
+                      properties:
+                        clusterCondition:
+                          additionalProperties:
+                            description: '`operator-sdk generate crds` does not allow
+                              map-of-slice, must use a named type.'
+                            items:
+                              description: "Condition represents an observation of
+                                an object's state. Conditions are an extension mechanism
+                                intended to be used when the details of an observation
+                                are not a priori known or would not apply to all instances
+                                of a given Kind. \n Conditions should be added to
+                                explicitly convey properties that users and components
+                                care about rather than requiring those properties
+                                to be inferred from other observations. Once defined,
+                                the meaning of a Condition can not be changed arbitrarily
+                                - it becomes part of the API, and has the same backwards-
+                                and forwards-compatibility concerns of any other part
+                                of the API."
+                              properties:
+                                lastTransitionTime:
+                                  format: date-time
+                                  type: string
+                                message:
+                                  type: string
+                                reason:
+                                  description: ConditionReason is intended to be a
+                                    one-word, CamelCase representation of the category
+                                    of cause of the current status. It is intended
+                                    to be used in concise output, such as one-line
+                                    kubectl get output, and in summarizing occurrences
+                                    of causes.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: "ConditionType is the type of the condition
+                                    and is typically a CamelCased word or short phrase.
+                                    \n Condition types should indicate state in the
+                                    \"abnormal-true\" polarity. For example, if the
+                                    condition indicates when a policy is invalid,
+                                    the \"is valid\" case is probably the norm, so
+                                    the condition should be called \"Invalid\"."
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          type: object
+                        cronJobs:
+                          type: string
+                        schedules:
+                          type: string
+                        suspended:
+                          type: boolean
+                      type: object
+                    type: array
+                type: object
+              logStore:
+                properties:
+                  elasticsearchStatus:
+                    items:
+                      properties:
+                        cluster:
+                          properties:
+                            activePrimaryShards:
+                              format: int32
+                              type: integer
+                            activeShards:
+                              format: int32
+                              type: integer
+                            initializingShards:
+                              format: int32
+                              type: integer
+                            numDataNodes:
+                              format: int32
+                              type: integer
+                            numNodes:
+                              format: int32
+                              type: integer
+                            pendingTasks:
+                              format: int32
+                              type: integer
+                            relocatingShards:
+                              format: int32
+                              type: integer
+                            status:
+                              type: string
+                            unassignedShards:
+                              format: int32
+                              type: integer
+                          required:
+                          - activePrimaryShards
+                          - activeShards
+                          - initializingShards
+                          - numDataNodes
+                          - numNodes
+                          - pendingTasks
+                          - relocatingShards
+                          - status
+                          - unassignedShards
+                          type: object
+                        clusterConditions:
+                          items:
+                            properties:
+                              lastTransitionTime:
+                                description: Last time the condition transitioned
+                                  from one status to another.
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human-readable message indicating details
+                                  about last transition.
+                                type: string
+                              reason:
+                                description: Unique, one-word, CamelCase reason for
+                                  the condition's last transition.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                description: ClusterConditionType is a valid value
+                                  for ClusterCondition.Type
+                                type: string
+                            required:
+                            - lastTransitionTime
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        clusterHealth:
+                          type: string
+                        clusterName:
+                          type: string
+                        deployments:
+                          items:
+                            type: string
+                          type: array
+                        nodeConditions:
+                          additionalProperties:
+                            items:
+                              properties:
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned
+                                    from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Human-readable message indicating details
+                                    about last transition.
+                                  type: string
+                                reason:
+                                  description: Unique, one-word, CamelCase reason
+                                    for the condition's last transition.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: ClusterConditionType is a valid value
+                                    for ClusterCondition.Type
+                                  type: string
+                              required:
+                              - lastTransitionTime
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          type: object
+                        nodeCount:
+                          format: int32
+                          type: integer
+                        pods:
+                          additionalProperties:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            type: object
+                          type: object
+                        replicaSets:
+                          items:
+                            type: string
+                          type: array
+                        shardAllocationEnabled:
+                          type: string
+                        statefulSets:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              visualization:
+                properties:
+                  kibanaStatus:
+                    items:
+                      description: KibanaStatus defines the observed state of Kibana
+                      properties:
+                        clusterCondition:
+                          additionalProperties:
+                            items:
+                              properties:
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned
+                                    from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Human-readable message indicating details
+                                    about last transition.
+                                  type: string
+                                reason:
+                                  description: Unique, one-word, CamelCase reason
+                                    for the condition's last transition.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: ClusterConditionType is a valid value
+                                    for ClusterCondition.Type
+                                  type: string
+                              required:
+                              - lastTransitionTime
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          type: object
+                        deployment:
+                          type: string
+                        pods:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          type: object
+                        replicaSets:
+                          items:
+                            type: string
+                          type: array
+                        replicas:
+                          format: int32
+                          type: integer
+                      required:
+                      - deployment
+                      - pods
+                      - replicaSets
+                      - replicas
+                      type: object
+                    type: array
+                type: object
             type: object
         type: object
     served: true

--- a/pkg/apis/logging/v1/clusterlogging_types.go
+++ b/pkg/apis/logging/v1/clusterlogging_types.go
@@ -416,7 +416,7 @@ type ElasticsearchStatus struct {
 	// +optional
 	Cluster elasticsearch.ClusterHealth `json:"cluster"`
 	// +optional
-	Pods map[ElasticsearchRoleType]PodStateMap `json:"pods"`
+	Pods map[ElasticsearchRoleType]PodStateMap `json:"pods,omitempty"`
 	// +optional
 	ShardAllocationEnabled elasticsearch.ShardAllocationState `json:"shardAllocationEnabled"`
 	// +optional
@@ -440,11 +440,11 @@ type EventCollectionStatus struct {
 
 type FluentdCollectorStatus struct {
 	// +optional
-	DaemonSet string `json:"daemonSet"`
+	DaemonSet string `json:"daemonSet,omitempty"`
 	// +optional
-	Nodes map[string]string `json:"nodes"`
+	Nodes map[string]string `json:"nodes,omitempty"`
 	// +optional
-	Pods PodStateMap `json:"pods"`
+	Pods PodStateMap `json:"pods,omitempty"`
 	// +optional
 	Conditions map[string]ClusterConditions `json:"clusterCondition,omitempty"`
 }
@@ -538,16 +538,16 @@ const (
 )
 
 const (
-	IncorrectCRName     status.ConditionType = "IncorrectCRName"
-	ContainerWaiting    status.ConditionType = "ContainerWaiting"
-	ContainerTerminated status.ConditionType = "ContainerTerminated"
-	Unschedulable       status.ConditionType = "Unschedulable"
-	NodeStorage         status.ConditionType = "NodeStorage"
-	CollectorDeadEnd    status.ConditionType = "CollectorDeadEnd"
+	IncorrectCRName     ConditionType = "IncorrectCRName"
+	ContainerWaiting    ConditionType = "ContainerWaiting"
+	ContainerTerminated ConditionType = "ContainerTerminated"
+	Unschedulable       ConditionType = "Unschedulable"
+	NodeStorage         ConditionType = "NodeStorage"
+	CollectorDeadEnd    ConditionType = "CollectorDeadEnd"
 )
 
 // `operator-sdk generate crds` does not allow map-of-slice, must use a named type.
-type ClusterConditions status.Conditions
+type ClusterConditions []Condition
 type ElasticsearchClusterConditions []elasticsearch.ClusterCondition
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/k8shandler/status.go
+++ b/pkg/k8shandler/status.go
@@ -158,9 +158,17 @@ func getPodMap(node elasticsearch.ElasticsearchStatus) map[logging.Elasticsearch
 func translatePodMap(podStateMap elasticsearch.PodStateMap) logging.PodStateMap {
 
 	return logging.PodStateMap{
-		logging.PodStateTypeReady:    podStateMap[elasticsearch.PodStateTypeReady],
-		logging.PodStateTypeNotReady: podStateMap[elasticsearch.PodStateTypeNotReady],
-		logging.PodStateTypeFailed:   podStateMap[elasticsearch.PodStateTypeFailed],
+		logging.PodStateTypeReady:    getPodState(podStateMap, elasticsearch.PodStateTypeReady),
+		logging.PodStateTypeNotReady: getPodState(podStateMap, elasticsearch.PodStateTypeNotReady),
+		logging.PodStateTypeFailed:   getPodState(podStateMap, elasticsearch.PodStateTypeFailed),
+	}
+}
+
+func getPodState(podStateMap elasticsearch.PodStateMap, podStateType elasticsearch.PodStateType) []string {
+	if v, ok := podStateMap[podStateType]; ok {
+		return v
+	} else {
+		return []string{}
 	}
 }
 


### PR DESCRIPTION
 - removed crd generation patch which was making an empty status in CRD
 - fixed package name for `ClusterConditions` type. This was causing generated CRD to have a `$ref` field, which fails validation
 - updated clusterlogging status in clusterlogging controller at the end of Reconcile function
 - fixed elasticsearch pod state to return empty array if status not available for a state type, this was causing error like `status.logStore.elasticsearchStatus.pods.client.failed in body must be of type array`


Getting status as:
```
status:
  clusterConditions:
  - lastTransitionTime: "2020-09-08T20:54:00Z"
    status: "False"
    type: CollectorDeadEnd
  collection:
    logs:
      fluentdStatus:
        daemonSet: fluentd
        nodes:
          fluentd-hzjk7: crc-fd5nx-master-0
        pods:
          failed: []
          notReady: []
          ready:
          - fluentd-hzjk7
  curation:
    curatorStatus:
    - cronJobs: curator
      schedules: 30 3 * * *
      suspended: false
  logStore:
    elasticsearchStatus:
    - cluster:
        activePrimaryShards: 4
        activeShards: 4
        initializingShards: 0
        numDataNodes: 1
        numNodes: 1
        pendingTasks: 0
        relocatingShards: 0
        status: green
        unassignedShards: 0
      clusterName: elasticsearch
      nodeConditions:
        elasticsearch-cdm-jbh1itbd-1: []
      nodeCount: 1
      pods:
        client:
          failed: []                                                                                                                                                                                                                          
          notReady: []                                                                                                                                                                                                                        
          ready:                                                                                                                                                                                                                              
          - elasticsearch-cdm-jbh1itbd-1-f85c6ddd5-jgdsz                                                                                                                                                                                      
        data:                                                                                                                                                                                                                                 
          failed: []                                                                                                                                                                                                                          
          notReady: []                                                                                                                                                                                                                        
          ready:                                                                                                                                                                                                                              
          - elasticsearch-cdm-jbh1itbd-1-f85c6ddd5-jgdsz                                                                                                                                                                                      
        master:                                                                                                                                                                                                                               
          failed: []                                                                                                                                                                                                                          
          notReady: []                                                                                                                                                                                                                        
          ready:                                                                                                                                                                                                                              
          - elasticsearch-cdm-jbh1itbd-1-f85c6ddd5-jgdsz                                                                                                                                                                                      
      shardAllocationEnabled: all                                                                                                                                                                                                             
  visualization: {}  
```

/assign @jcantrill 
/cc @alanconway 