### PR TITLE
Fixing test flakes

### DIFF
--- a/hack/testing-olm/utils
+++ b/hack/testing-olm/utils
@@ -13,6 +13,6 @@ gather_logging_resources() {
   local runtime=${3:-$(date +%s)}
   outdir=$outdir/$runtime
   mkdir -p $outdir ||:
-  oc adm must-gather --image=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift/origin-cluster-logging-operator:latest} --dest-dir=$outdir -- /usr/bin/gather > must-gather.log 2>&1
+  oc adm must-gather --image=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift/origin-cluster-logging-operator:latest} --dest-dir=$outdir -- /usr/bin/gather > $outdir/must-gather.log 2>&1
   set -e
 }

--- a/test/e2e/logforwarding/cleanup.sh
+++ b/test/e2e/logforwarding/cleanup.sh
@@ -13,4 +13,4 @@ oc -n "$GENERATOR_NS" get pods -o yaml > "$artifact_dir/$runtime/log-generator.p
 
 oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- tail -n 20000 /var/log/infra.log > "$artifact_dir/$runtime/syslog-receiver.log" ||:
 oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- cat /rsyslog/etc/rsyslog.conf > "$artifact_dir/$runtime/syslog-receiver.conf" ||:
-oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=kafka-consumer-clo-topic -o name| sed 's/pod\///') -- cat /shared/consumed.logs > "$artifact_dir/$runtime/kafka-consumer-clo-topic.log" ||:
+oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=kafka-consumer-clo-topic -o name| sed 's/pod\///') -- tail -n 5000 /shared/consumed.logs > "$artifact_dir/$runtime/kafka-consumer-clo-topic.log" ||:

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -19,7 +20,8 @@ func WaitForDaemonSet(t *testing.T, kubeclient kubernetes.Interface, namespace, 
 				t.Logf("Waiting for availability of %s daemonset\n", name)
 				return false, nil
 			}
-			return false, err
+			logger.Errorf("Error getting Daemonsets %v", err)
+			return false, nil
 		}
 		return true, nil
 	})

--- a/test/helpers/elasticsearch.go
+++ b/test/helpers/elasticsearch.go
@@ -129,9 +129,15 @@ func (es *ElasticLogStore) HasApplicationLogs(timeToWait time.Duration) (bool, e
 
 func (es *ElasticLogStore) HasAuditLogs(timeToWait time.Duration) (bool, error) {
 	err := wait.Poll(defaultRetryInterval, timeToWait, func() (done bool, err error) {
+		errorCount := 0
 		indices, err := es.Indices()
 		if err != nil {
-			return false, err
+			logger.Errorf("Error retrieving indices from elasticsearch %v", err)
+			errorCount++
+			if errorCount > 5 {
+				return false, err
+			}
+			return false, nil
 		}
 		return indices.HasAuditLogs(), nil
 	})

--- a/test/helpers/fluentd.go
+++ b/test/helpers/fluentd.go
@@ -112,7 +112,8 @@ func (fluent *fluentReceiverLogStore) hasLogs(file string, timeToWait time.Durat
 	err = wait.Poll(defaultRetryInterval, timeToWait, func() (done bool, err error) {
 		output, err := fluent.tc.PodExec(OpenshiftLoggingNS, pods.Items[0].Name, "fluent-receiver", []string{"bash", "-c", cmd})
 		if err != nil {
-			return false, err
+			logger.Errorf("Failed to fetch logs from fluent-receiver %v", err)
+			return false, nil
 		}
 		value, err := strconv.Atoi(strings.TrimSpace(output))
 		if err != nil {
@@ -143,7 +144,8 @@ func (fluent *fluentReceiverLogStore) logs(file string, timeToWait time.Duration
 	result := ""
 	err = wait.Poll(defaultRetryInterval, timeToWait, func() (done bool, err error) {
 		if result, err = fluent.tc.PodExec(OpenshiftLoggingNS, pods.Items[0].Name, "fluent-receiver", []string{"bash", "-c", cmd}); err != nil {
-			return false, err
+			logger.Errorf("Failed to fetch logs from fluent-receiver %v", err)
+			return false, nil
 		}
 		return true, nil
 	})

--- a/test/helpers/kafka.go
+++ b/test/helpers/kafka.go
@@ -32,7 +32,8 @@ func (kr *kafkaReceiver) HasInfraStructureLogs(timeout time.Duration) (bool, err
 	err := wait.Poll(defaultRetryInterval, timeout, func() (done bool, err error) {
 		logs, err := kr.tc.consumedLogs(kr.app.Name, loggingv1.InputNameInfrastructure)
 		if err != nil {
-			return false, err
+			logger.Errorf("Error occured while fetching %s logs %v", loggingv1.InputNameInfrastructure, err)
+			return false, nil
 		}
 		return logs.ByIndex(InfraIndexPrefix).NonEmpty(), nil
 	})
@@ -43,7 +44,8 @@ func (kr *kafkaReceiver) HasApplicationLogs(timeout time.Duration) (bool, error)
 	err := wait.Poll(defaultRetryInterval, timeout, func() (done bool, err error) {
 		logs, err := kr.tc.consumedLogs(kr.app.Name, loggingv1.InputNameApplication)
 		if err != nil {
-			return false, err
+			logger.Errorf("Error occured while fetching %s logs %v", loggingv1.InputNameApplication, err)
+			return false, nil
 		}
 		return logs.ByIndex(ProjectIndexPrefix).NonEmpty(), nil
 	})
@@ -54,7 +56,8 @@ func (kr *kafkaReceiver) HasAuditLogs(timeout time.Duration) (bool, error) {
 	err := wait.Poll(defaultRetryInterval, timeout, func() (done bool, err error) {
 		logs, err := kr.tc.consumedLogs(kr.app.Name, loggingv1.InputNameAudit)
 		if err != nil {
-			return false, err
+			logger.Errorf("Error occured while fetching %s logs %v", loggingv1.InputNameAudit, err)
+			return false, nil
 		}
 		return logs.ByIndex(AuditIndexPrefix).NonEmpty(), nil
 	})
@@ -114,7 +117,7 @@ func (tc *E2ETestFramework) consumedLogs(rcvName, inputName string) (logs, error
 	}
 
 	logger.Debugf("Pod %s", pods.Items[0].Name)
-	cmd := "cat /shared/consumed.logs"
+	cmd := "tail -n 5000 /shared/consumed.logs"
 	stdout, err := tc.PodExec(OpenshiftLoggingNS, pods.Items[0].Name, name, []string{"bash", "-c", cmd})
 	if err != nil {
 		return nil, err

--- a/test/helpers/syslog.go
+++ b/test/helpers/syslog.go
@@ -158,7 +158,8 @@ func (syslog *syslogReceiverLogStore) hasLogs(file string, timeToWait time.Durat
 	err = wait.Poll(defaultRetryInterval, timeToWait, func() (done bool, err error) {
 		output, err := syslog.tc.PodExec(OpenshiftLoggingNS, podName, "syslog-receiver", []string{"bash", "-c", cmd})
 		if err != nil {
-			return false, err
+			logger.Errorf("failed to fetch logs from syslog-receiver %v", err)
+			return false, nil
 		}
 		value, err := strconv.Atoi(strings.TrimSpace(output))
 		if err != nil {
@@ -193,6 +194,7 @@ func (syslog *syslogReceiverLogStore) grepLogs(expr string, logfile string, time
 	err = wait.Poll(defaultRetryInterval, timeToWait, func() (bool, error) {
 		output, err := syslog.tc.PodExec(OpenshiftLoggingNS, pods.Items[0].Name, "syslog-receiver", []string{"bash", "-c", cmd})
 		if err != nil {
+			logger.Errorf("failed to fetch logs from syslog-receiver %v", err)
 			return false, nil
 		}
 		value = strings.TrimSpace(output)


### PR DESCRIPTION
1. Changed `cat /shared/consumed.logs` to `tail -n 5000 /shared/consumed.logs` to limit the logs are fetched from pod
2. fixed closure in wait.Poll to return nil if the command in closure gets an error
3. fixed location of `must-gather.log`
4. fixed log generator namespace already exists error
