### PR TITLE
Bug 1880012: Move custom Ginkgo matchers to matchers package.

### DIFF
--- a/pkg/apis/logging/v1/cluster_log_forwarder_types_test.go
+++ b/pkg/apis/logging/v1/cluster_log_forwarder_types_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
 var _ = Describe("ClusterLogForwarder", func() {

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 	"gopkg.in/yaml.v2"
 )
 

--- a/pkg/generators/forwarding/fluentd/generators_test.go
+++ b/pkg/generators/forwarding/fluentd/generators_test.go
@@ -3,7 +3,7 @@ package fluentd
 import (
 	"text/template"
 
-	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
 var _ = Describe("Generating fluentd config blocks", func() {

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -5,7 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
 var _ = Describe("Generating fluentd secure forward output store config blocks", func() {

--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -3,7 +3,7 @@ package fluentd
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 
 	v1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 )

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -6,7 +6,7 @@ import (
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	v1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
 var _ = Describe("Generating fluentd legacy output store config blocks", func() {

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
 var _ = Describe("Generating external syslog server output store config blocks", func() {

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -6,7 +6,7 @@ import (
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 
-	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
 var _ = Describe("Generating fluentd config", func() {

--- a/pkg/generators/forwarding/fluentd/source_test.go
+++ b/pkg/generators/forwarding/fluentd/source_test.go
@@ -4,7 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 

--- a/pkg/k8shandler/forwarding_test.go
+++ b/pkg/k8shandler/forwarding_test.go
@@ -13,6 +13,7 @@ import (
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test"
 	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 	core "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/matchers/diff.go
+++ b/test/matchers/diff.go
@@ -1,4 +1,4 @@
-package test
+package matchers
 
 import (
 	"fmt"

--- a/test/matchers/diff_test.go
+++ b/test/matchers/diff_test.go
@@ -1,10 +1,9 @@
-package test_test
+package matchers_test
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	. "github.com/openshift/cluster-logging-operator/test"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
 var _ = Describe("Matchers", func() {


### PR DESCRIPTION
Move all our custom matchers into the 'matchers' package.

Ginko convention uses anonymous imports, but that's a bad idea for anything
else. Therefore Gingko extensions must be in a separate package from other code.

/cc @jcantrill
/assign @jcantrill