### PR TITLE
fix cleanup NS for the prometheus test

### DIFF
--- a/hack/testing-olm/test-999-fluentd-prometheus-metrics.sh
+++ b/hack/testing-olm/test-999-fluentd-prometheus-metrics.sh
@@ -21,7 +21,7 @@ cleanup() {
 
   set +e
   mkdir -p $ARTIFACT_DIR/$test_name
-  gather_logging_resources ${CLUSTER_LOGGING_OPERATOR_NAMESPACE} $ARTIFACT_DIR/$test_name
+  gather_logging_resources ${LOGGING_NS} $ARTIFACT_DIR/$test_name
 
   if [ "${DO_CLEANUP:-true}" == "true" ] ; then
       ${repo_dir}/olm_deploy/scripts/operator-uninstall.sh


### PR DESCRIPTION
This PR:

* fixes the namespace used by the gather script  for the prometheus test