### PR TITLE
bug 1882524: manifests/4.6: bundle contents must be kube entities

### DIFF
--- a/manifests/4.6/crd-v1-clusterloggings-patches.yaml
+++ b/manifests/4.6/crd-v1-clusterloggings-patches.yaml
@@ -1,9 +1,0 @@
-- op: replace
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata
-  value:
-    type: object
-    properties:
-      name:
-        type: string
-        enum:
-        - "instance"

--- a/manifests/4.6/crd-v1-singleton-patch.yaml
+++ b/manifests/4.6/crd-v1-singleton-patch.yaml
@@ -1,9 +1,0 @@
-- op: replace
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata
-  value:
-    type: object
-    properties:
-      name:
-        type: string
-        enum:
-        - "instance"


### PR DESCRIPTION
I am given to believe that all contents of the bundle manifests must be kube entities. These patch files aren't, and so they're causing validation failures, [for example](http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-metadata-validation-test/cluster-logging-operator-bundle-container-v4.6.0.202009230045.p0-1/4cadb816-9318-4bf5-8526-adede7f58348/operator-catalog-initialization-output.txt)

`error adding operator bundle : error decoding CRD: no kind \"CustomResourceDefinition\" is registered for version \"apiextensions.k8s.io/v1\" in scheme \"pkg/registry/bundle.go:15\", could not decode contents of file /tmp/cache-662056478/manifests-350466143/cluster-logging/4.6.0-202009230045.p0/crd-v1-clusterloggings-patches.yaml into package`

I don't know if you can wrap these in some kind of entity or something, but they can't ship as is.