### PR TITLE
Bug 1880926: Fix owner references for ClusterLogging CR

### DIFF
--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -297,8 +297,6 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateCollectorServiceAccou
 		),
 	)
 
-	utils.AddOwnerRefToObject(collectorReaderClusterRoleBinding, utils.AsOwner(cluster))
-
 	err = clusterRequest.Create(collectorReaderClusterRoleBinding)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("Failure creating Log collector %q cluster role binding: %v", collectorReaderClusterRoleBinding.Name, err)

--- a/pkg/k8shandler/rbac.go
+++ b/pkg/k8shandler/rbac.go
@@ -3,7 +3,6 @@ package k8shandler
 import (
 	"fmt"
 
-	"github.com/openshift/cluster-logging-operator/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
@@ -106,8 +105,6 @@ func (clusterRequest *ClusterLoggingRequest) CreateClusterRole(name string, rule
 		},
 		Rules: rules,
 	}
-
-	utils.AddOwnerRefToObject(clusterRole, utils.AsOwner(clusterRequest.Cluster))
 
 	err := clusterRequest.Create(clusterRole)
 	if err != nil && !errors.IsAlreadyExists(err) {


### PR DESCRIPTION
### Description
This PR addresses a mismatch in using `ownerReferences` for ClusterLogging CR dependents. Based on the following list the operator reconciler cluster-scoped dependents that poison the kubernetes gargbage collector cache. In turn the ClusterLogging CR and its namespace dependents get deleted as discussed in this upstream [PR](https://github.com/kubernetes/kubernetes/issues/65200) as well as noted on the [docs](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents).

```
"Service/fluentd"
"CronJob/curator"
"ConfigMap/curator"
"ConfigMap/fluentd"
"ConfigMap/fluentd-trusted-ca-bundle"
"Secret/curator"
"Secret/elasticsearch"
"Secret/fluentd"
"Secret/kibana"
"Secret/kibana-proxy"
"Secret/master-certs"
"ServiceAccount/curator"
"ServiceAccount/logcollector"

"ClusterRole/metadata-reader"
"ClusterRoleBinding/cluster-logging-metadata-reader"

"Role/log-collector-privileged"
"RoleBinding/log-collector-privileged-binding"
"ServiceMonitor/fluentd"
"PrometheusRule/fluentd"
"Elasticsearch/elasticsearch"
"Kibana/kibana"
```

/cc @vimalk78  
/assign @jcantrill  
 
/cherry-pick release-4.5
 
#### Links

- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1880926 (in dependency: https://bugzilla.redhat.com/show_bug.cgi?id=1882450)