### PR TITLE
Bug 1883777: Fix owner references for ClusterLogging CR

### DIFF
--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -296,8 +296,6 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateCollectorServiceAccou
 		),
 	)
 
-	utils.AddOwnerRefToObject(collectorReaderClusterRoleBinding, utils.AsOwner(cluster))
-
 	err = clusterRequest.Create(collectorReaderClusterRoleBinding)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("Failure creating Log collector %q cluster role binding: %v", collectorReaderClusterRoleBinding.Name, err)

--- a/pkg/k8shandler/rbac.go
+++ b/pkg/k8shandler/rbac.go
@@ -3,7 +3,6 @@ package k8shandler
 import (
 	"fmt"
 
-	"github.com/openshift/cluster-logging-operator/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
@@ -106,8 +105,6 @@ func (clusterRequest *ClusterLoggingRequest) CreateClusterRole(name string, rule
 		},
 		Rules: rules,
 	}
-
-	utils.AddOwnerRefToObject(clusterRole, utils.AsOwner(clusterRequest.cluster))
 
 	err := clusterRequest.Create(clusterRole)
 	if err != nil && !errors.IsAlreadyExists(err) {


### PR DESCRIPTION
### Description
This PR is a manual backport of #713 . It removes all namespace-scoped owners from cluster-scoped resources' `ownerReferences` field. In turn this resolves random GC collection of ClusterLogging CR owned resources, e.g. deployments, Elasticsearch CR.
 
/cc @vimalk78  
/assign @jcantrill  
 
/cherry-pick release-4.4

### Links
- Depending on PR(s):  #713
- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1883777