### PR TITLE
Bug 1883079: Resolve missing 'use_nil'

### DIFF
--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -88,8 +88,8 @@ var _ = Describe("Generating external kafka server output store config block", f
            default_topic topic
            use_event_time true
            ssl_ca_cert '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
-           ssl_client_cert "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.crt') ? '/var/run/ocp-collector/secrets/some-secret/tls.crt' : use_nil}"
-           ssl_client_cert_key "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.key') ? '/var/run/ocp-collector/secrets/some-secret/tls.key' : use_nil}"
+           ssl_client_cert "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.crt') ? '/var/run/ocp-collector/secrets/some-secret/tls.crt' : nil}"
+           ssl_client_cert_key "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.key') ? '/var/run/ocp-collector/secrets/some-secret/tls.key' : nil}"
            <format>
                @type json
            </format>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -785,8 +785,8 @@ use_event_time true
 {{ $tlsCert := .SecretPath "tls.crt" }}
 {{ $tlsKey := .SecretPath "tls.key" }}
 ssl_ca_cert '{{ .SecretPath "ca-bundle.crt"}}'
-ssl_client_cert "#{File.exist?('{{ $tlsCert }}') ? '{{ $tlsCert }}' : use_nil}"
-ssl_client_cert_key "#{File.exist?('{{ $tlsKey }}') ? '{{ $tlsKey }}' : use_nil}"
+ssl_client_cert "#{File.exist?('{{ $tlsCert }}') ? '{{ $tlsCert }}' : nil}"
+ssl_client_cert_key "#{File.exist?('{{ $tlsKey }}') ? '{{ $tlsKey }}' : nil}"
 {{ end -}}
 <format>
   @type json


### PR DESCRIPTION
This PR resolves a missing method by returning empty string if a cert file does not exist

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1883079

Depends on https://github.com/fluent/fluent-plugin-kafka/pull/374 long term