### PR TITLE
Updating cluster-logging-operator builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-logging-operator
 
 # COPY steps are in the reverse order of frequency of change
@@ -17,9 +17,9 @@ COPY pkg ./pkg
 
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:cli as origincli
+FROM registry.svc.ci.openshift.org/ocp/4.7:cli AS origincli
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 RUN INSTALL_PKGS=" \
       openssl \
       rsync \


### PR DESCRIPTION
Updating cluster-logging-operator builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/cluster-logging-operator.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.