### PR TITLE
LOG-401:Fluentd - use record_modifier instead of record_transformer

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -399,7 +399,7 @@ var _ = Describe("Generating fluentd config", func() {
       <record>
         kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
       </record>
-      remove_keys $.kubernetes.labels
+      remove_keys record[kubernetes][labels]
     </filter>
   
     # Relabel specific source tags to specific intermediary labels for copy processing
@@ -868,7 +868,7 @@ var _ = Describe("Generating fluentd config", func() {
 					<record>
 						kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
 					</record>
-					remove_keys $.kubernetes.labels
+					remove_keys record[kubernetes][labels]
 				</filter>
 
 
@@ -1302,7 +1302,7 @@ var _ = Describe("Generating fluentd config", func() {
 					<record>
 						kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
 					</record>
-					remove_keys $.kubernetes.labels
+					remove_keys record[kubernetes][labels]
 				</filter>
 
 				# Relabel specific source tags to specific intermediary labels for copy processing
@@ -2122,7 +2122,7 @@ var _ = Describe("Generating fluentd config", func() {
         <record>
           kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
         </record>
-        remove_keys $.kubernetes.labels
+        remove_keys record[kubernetes][labels]
       </filter>
     
       # Relabel specific source tags to specific intermediary labels for copy processing

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -305,8 +305,8 @@ var _ = Describe("Generating fluentd config", func() {
     </filter>
   
     <filter **kibana**>
-      @type record_transformer
-      enable_ruby
+      @type record_modifier
+      char_encoding utf-8
       <record>
         log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
       </record>
@@ -314,8 +314,8 @@ var _ = Describe("Generating fluentd config", func() {
     </filter>
   
     <filter k8s-audit.log**>
-      @type record_transformer
-      enable_ruby
+      @type record_modifier
+      char_encoding utf-8
       <record>
         k8s_audit_level ${record['level']}
         level info
@@ -394,8 +394,8 @@ var _ = Describe("Generating fluentd config", func() {
   
     #flatten labels to prevent field explosion in ES
     <filter ** >
-      @type record_transformer
-      enable_ruby true
+      @type record_modifier
+      char_encoding utf-8
       <record>
         kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
       </record>
@@ -776,8 +776,8 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 
 				<filter **kibana**>
-					@type record_transformer
-					enable_ruby
+					@type record_modifier
+					char_encoding utf-8
 					<record>
 						log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
 					</record>
@@ -785,8 +785,8 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 
 				<filter k8s-audit.log**>
-				  @type record_transformer
-				  enable_ruby
+				  @type record_modifier
+				  char_encoding utf-8
 				  <record>
 				    k8s_audit_level ${record['level']}
 				    level info
@@ -863,8 +863,8 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
-					@type record_transformer
-					enable_ruby true
+					@type record_modifier
+					char_encoding utf-8
 					<record>
 						kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
 					</record>
@@ -1210,8 +1210,8 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 
 				<filter **kibana**>
-					@type record_transformer
-					enable_ruby
+					@type record_modifier
+					char_encoding utf-8
 					<record>
 						log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
 					</record>
@@ -1219,8 +1219,8 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 
 				<filter k8s-audit.log**>
-				  @type record_transformer
-				  enable_ruby
+				  @type record_modifier
+				  char_encoding utf-8
 				  <record>
 				    k8s_audit_level ${record['level']}
 				    level info
@@ -1297,8 +1297,8 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
-					@type record_transformer
-					enable_ruby true
+					@type record_modifier
+					char_encoding utf-8
 					<record>
 						kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
 					</record>
@@ -2028,8 +2028,8 @@ var _ = Describe("Generating fluentd config", func() {
       </filter>
     
       <filter **kibana**>
-        @type record_transformer
-        enable_ruby
+        @type record_modifier
+        char_encoding utf-8
         <record>
           log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
         </record>
@@ -2037,8 +2037,8 @@ var _ = Describe("Generating fluentd config", func() {
       </filter>
     
       <filter k8s-audit.log**>
-        @type record_transformer
-	enable_ruby
+        @type record_modifier
+		char_encoding utf-8
         <record>
           k8s_audit_level ${record['level']}
           level info
@@ -2117,8 +2117,8 @@ var _ = Describe("Generating fluentd config", func() {
     
       #flatten labels to prevent field explosion in ES
       <filter ** >
-        @type record_transformer
-        enable_ruby true
+        @type record_modifier
+        char_encoding utf-8
         <record>
           kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
         </record>

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -398,8 +398,9 @@ var _ = Describe("Generating fluentd config", func() {
       char_encoding utf-8
       <record>
         kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+		for_remove ${record['kubernetes'].delete('labels')}
       </record>
-      remove_keys record["kubernetes"]["labels"]
+      remove_keys for_remove
     </filter>
   
     # Relabel specific source tags to specific intermediary labels for copy processing
@@ -867,8 +868,9 @@ var _ = Describe("Generating fluentd config", func() {
 					char_encoding utf-8
 					<record>
 						kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+						for_remove ${record['kubernetes'].delete('labels')}
 					</record>
-					remove_keys record["kubernetes"]["labels"]
+					remove_keys for_remove
 				</filter>
 
 
@@ -1301,8 +1303,9 @@ var _ = Describe("Generating fluentd config", func() {
 					char_encoding utf-8
 					<record>
 						kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+						for_remove ${record['kubernetes'].delete('labels')}
 					</record>
-					remove_keys record["kubernetes"]["labels"]
+					remove_keys for_remove
 				</filter>
 
 				# Relabel specific source tags to specific intermediary labels for copy processing
@@ -2121,8 +2124,9 @@ var _ = Describe("Generating fluentd config", func() {
         char_encoding utf-8
         <record>
           kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+		  for_remove ${record['kubernetes'].delete('labels')}	
         </record>
-        remove_keys record["kubernetes"]["labels"]
+        remove_keys for_remove
       </filter>
     
       # Relabel specific source tags to specific intermediary labels for copy processing

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -399,7 +399,7 @@ var _ = Describe("Generating fluentd config", func() {
       <record>
         kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
       </record>
-      remove_keys record[kubernetes][labels]
+      remove_keys record["kubernetes"]["labels"]
     </filter>
   
     # Relabel specific source tags to specific intermediary labels for copy processing
@@ -868,7 +868,7 @@ var _ = Describe("Generating fluentd config", func() {
 					<record>
 						kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
 					</record>
-					remove_keys record[kubernetes][labels]
+					remove_keys record["kubernetes"]["labels"]
 				</filter>
 
 
@@ -1302,7 +1302,7 @@ var _ = Describe("Generating fluentd config", func() {
 					<record>
 						kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
 					</record>
-					remove_keys record[kubernetes][labels]
+					remove_keys record["kubernetes"]["labels"]
 				</filter>
 
 				# Relabel specific source tags to specific intermediary labels for copy processing
@@ -2122,7 +2122,7 @@ var _ = Describe("Generating fluentd config", func() {
         <record>
           kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
         </record>
-        remove_keys record[kubernetes][labels]
+        remove_keys record["kubernetes"]["labels"]
       </filter>
     
       # Relabel specific source tags to specific intermediary labels for copy processing

--- a/pkg/generators/forwarding/fluentd/generators_test.go
+++ b/pkg/generators/forwarding/fluentd/generators_test.go
@@ -71,7 +71,8 @@ var _ = Describe("Generating pipeline to output labels", func() {
 		Expect(err).To(BeNil())
 		Expect(got[0]).To(EqualTrimLines(`<label @PIPELINE_1>
   <filter **>
-    @type record_transformer
+    @type record_modifier
+    char_encoding utf-8
     <record>
       openshift { "labels": {"1":"2"} }
     </record>
@@ -100,7 +101,8 @@ var _ = Describe("Generating pipeline to output labels", func() {
 		Expect(err).To(BeNil())
 		Expect(got[0]).To(EqualTrimLines(`<label @PIPELINE_1>
   <filter **>
-    @type record_transformer
+    @type record_modifier
+    char_encoding utf-8
     <record>
       openshift { "labels": {"1":"2","3":"4"} }
     </record>
@@ -135,7 +137,8 @@ var _ = Describe("Generating pipeline to output labels", func() {
 		Expect(err).To(BeNil())
 		Expect(got).To(BeEquivalentTo([]string{`<label @PIPELINE_1>
   <filter **>
-    @type record_transformer
+    @type record_modifier
+	char_encoding utf-8
     <record>
       openshift { "labels": {"1":"2","3":"4"} }
     </record>
@@ -150,7 +153,8 @@ var _ = Describe("Generating pipeline to output labels", func() {
   </match>
 </label>`, `<label @PIPELINE_2>
   <filter **>
-    @type record_transformer
+    @type record_modifier
+	char_encoding utf-8
     <record>
       openshift { "labels": {"5":"6","7":"8"} }
     </record>

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -385,7 +385,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
             </record>
-            remove_keys record[kubernetes][labels]
+            remove_keys record["kubernetes"]["labels"]
           </filter>
 
           # Relabel specific source tags to specific intermediary labels for copy processing
@@ -835,7 +835,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
             </record>
-            remove_keys record[kubernetes][labels]
+            remove_keys record["kubernetes"]["labels"]
           </filter>
 
           # Relabel specific source tags to specific intermediary labels for copy processing
@@ -1287,7 +1287,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
             </record>
-            remove_keys record[kubernetes][labels]
+            remove_keys record["kubernetes"]["labels"]
           </filter>
 
           # Relabel specific source tags to specific intermediary labels for copy processing

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -384,8 +384,9 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             char_encoding utf-8
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+			  for_remove ${record['kubernetes'].delete('labels')}
             </record>
-            remove_keys record["kubernetes"]["labels"]
+            remove_keys for_remove
           </filter>
 
           # Relabel specific source tags to specific intermediary labels for copy processing
@@ -834,8 +835,9 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             char_encoding utf-8
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+              for_remove ${record['kubernetes'].delete('labels')}
             </record>
-            remove_keys record["kubernetes"]["labels"]
+            remove_keys for_remove
           </filter>
 
           # Relabel specific source tags to specific intermediary labels for copy processing
@@ -1286,8 +1288,9 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             char_encoding utf-8
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+              for_remove ${record['kubernetes'].delete('labels')}
             </record>
-            remove_keys record["kubernetes"]["labels"]
+            remove_keys for_remove
           </filter>
 
           # Relabel specific source tags to specific intermediary labels for copy processing

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -291,8 +291,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           </filter>
 
           <filter **kibana**>
-            @type record_transformer
-            enable_ruby
+            @type record_modifier
+            char_encoding utf-8
             <record>
               log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
             </record>
@@ -300,8 +300,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           </filter>
 
           <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
+            @type record_modifier
+            char_encoding utf-8
             <record>
               k8s_audit_level ${record['level']}
               level info
@@ -380,8 +380,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
 
           #flatten labels to prevent field explosion in ES
           <filter ** >
-            @type record_transformer
-            enable_ruby true
+            @type record_modifier
+            char_encoding utf-8
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
             </record>
@@ -741,8 +741,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           </filter>
 
           <filter **kibana**>
-            @type record_transformer
-            enable_ruby
+            @type record_modifier
+            char_encoding utf-8
             <record>
               log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
             </record>
@@ -750,8 +750,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           </filter>
 
           <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
+            @type record_modifier
+            char_encoding utf-8
             <record>
               k8s_audit_level ${record['level']}
               level info
@@ -830,8 +830,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
 
           #flatten labels to prevent field explosion in ES
           <filter ** >
-            @type record_transformer
-            enable_ruby true
+            @type record_modifier
+            char_encoding utf-8
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
             </record>
@@ -1193,8 +1193,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           </filter>
 
           <filter **kibana**>
-            @type record_transformer
-            enable_ruby
+            @type record_modifier
+            char_encoding utf-8
             <record>
               log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
             </record>
@@ -1202,8 +1202,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           </filter>
 
           <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
+            @type record_modifier
+            char_encoding utf-8
             <record>
               k8s_audit_level ${record['level']}
               level info
@@ -1282,8 +1282,8 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
 
           #flatten labels to prevent field explosion in ES
           <filter ** >
-            @type record_transformer
-            enable_ruby true
+            @type record_modifier
+            char_encoding utf-8
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
             </record>

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -385,7 +385,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
             </record>
-            remove_keys $.kubernetes.labels
+            remove_keys record[kubernetes][labels]
           </filter>
 
           # Relabel specific source tags to specific intermediary labels for copy processing
@@ -835,7 +835,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
             </record>
-            remove_keys $.kubernetes.labels
+            remove_keys record[kubernetes][labels]
           </filter>
 
           # Relabel specific source tags to specific intermediary labels for copy processing
@@ -1287,7 +1287,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             <record>
               kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
             </record>
-            remove_keys $.kubernetes.labels
+            remove_keys record[kubernetes][labels]
           </filter>
 
           # Relabel specific source tags to specific intermediary labels for copy processing

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -295,8 +295,9 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
     char_encoding utf-8
     <record>
       kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+      for_remove ${record['kubernetes'].delete('labels')}
     </record>
-    remove_keys record["kubernetes"]["labels"]
+    remove_keys for_remove
   </filter>
 
   # Relabel specific source tags to specific intermediary labels for copy processing

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -202,8 +202,8 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
   </filter>
 
   <filter **kibana**>
-    @type record_transformer
-    enable_ruby
+    @type record_modifier
+    char_encoding utf-8
     <record>
       log ${record['err'] || record['msg'] || record['MESSAGE'] || record['log']}
     </record>
@@ -211,8 +211,8 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
   </filter>
 
   <filter k8s-audit.log**>
-    @type record_transformer
-    enable_ruby
+    @type record_modifier
+    char_encoding utf-8
     <record>
       k8s_audit_level ${record['level']}
       level info
@@ -291,8 +291,8 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 
   #flatten labels to prevent field explosion in ES
   <filter ** >
-    @type record_transformer
-    enable_ruby true
+    @type record_modifier
+    char_encoding utf-8
     <record>
       kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
     </record>
@@ -515,7 +515,8 @@ const pipelineToOutputCopyTemplate = `{{- define "pipelineToOutputCopyTemplate" 
 <label {{labelName .Name}}>
   {{ if .PipelineLabels -}}
   <filter **>
-    @type record_transformer
+    @type record_modifier
+	char_encoding utf-8
     <record>
       openshift { "labels": {{.PipelineLabels}} }
     </record>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -296,7 +296,7 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
     <record>
       kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
     </record>
-    remove_keys record[kubernetes][labels]
+    remove_keys record["kubernetes"]["labels"]
   </filter>
 
   # Relabel specific source tags to specific intermediary labels for copy processing

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -296,7 +296,7 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
     <record>
       kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
     </record>
-    remove_keys $.kubernetes.labels
+    remove_keys record[kubernetes][labels]
   </filter>
 
   # Relabel specific source tags to specific intermediary labels for copy processing


### PR DESCRIPTION
## Description

Use `record_modifier` instead of `record_transformer` to improve throughput and lower CPU usage. 

According to the Fluent docs:
`record_modifier` is faster than `record_transformer`. [(Performance check here)](https://github.com/repeatedly/fluent-plugin-record-modifier/pull/7#issuecomment-169843012). But unlike `record_transformer`, `record_modifier` doesn't support the following features for now:
- tag_suffix and tag_prefix
- dynamic key placeholder 

Don't met such features in code, so this limitation not impact us for these changes.  

### Done in this PR:

- Replace all occurrence of  `record_transformer` with `record_modifier`.
- Remove `enable_ruby` looks like it redundant for `record_modifier`.
- Add `char_encoding utf-8`, here not sure. Is it necessary? 

## Links
JIRA: https://issues.redhat.com/browse/LOG-401

Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>