### PR TITLE
Patch Dockerfile to use CentOS images.

### DIFF
--- a/Dockerfile.centos.patch
+++ b/Dockerfile.centos.patch
@@ -1,0 +1,27 @@
+--- Dockerfile	2020-10-16 10:26:19.124105649 -0400
++++ Dockerfile.centos	2020-10-16 10:28:25.713003840 -0400
+@@ -1,4 +1,4 @@
+-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
++FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+ WORKDIR /go/src/github.com/openshift/cluster-logging-operator
+ 
+ # COPY steps are in the reverse order of frequency of change
+@@ -17,9 +17,8 @@
+ 
+ RUN make build
+ 
+-FROM registry.svc.ci.openshift.org/ocp/4.7:cli AS origincli
++FROM centos:centos7 AS centos
+ 
+-FROM registry.svc.ci.openshift.org/ocp/4.7:base
+ RUN INSTALL_PKGS=" \
+       openssl \
+       rsync \
+@@ -38,7 +37,6 @@
+ COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/manifests /manifests
+ RUN rm /manifests/art.yaml
+ 
+-COPY --from=origincli /usr/bin/oc /usr/bin/
+ COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/must-gather/collection-scripts/* /usr/bin/
+ 
+ # this is required because the operator invokes a script as `bash scripts/cert_generation.sh`

--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,12 @@ clean:
 	@rm -rf bin tmp _output
 	go clean -cache -testcache ./...
 
-image:
+PATCH?=Dockerfile.patch
+Dockerfile.local: Dockerfile $(PATCH)
+	patch -o Dockerfile.local Dockerfile $(PATCH)
+
+image: Dockerfile.local
 	@if [ $${SKIP_BUILD:-false} = false ] ; then \
-		cp Dockerfile Dockerfile.local ; \
-		patch Dockerfile.local Dockerfile.patch ; \
 		podman build -t $(IMAGE_TAG) . -f Dockerfile.local; \
 	fi
 
@@ -154,7 +156,7 @@ test-cluster:
 MANIFEST_VERSION?="4.6"
 generate-bundle: regenerate $(OPM)
 	MANIFEST_VERSION=${MANIFEST_VERSION} hack/generate-bundle.sh
-	
+
 .PHONY: generate-bundle
 
 # NOTE: This is the CI e2e entry point.

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -35,6 +35,13 @@ To run the e2e tests:
 
 NOTE: e2e tests require a clean cluster starting point, `make undeploy-all` will provide it.
 
+NOTE: There is a temporary issue with openshift base images using RHEL8
+repositories that are not accessible to all. This will be fixed, but until it is
+you can build using CentOS as the base instead:
+
+    PATCH=Dockerfile.centos.patch make ...
+
+
 ## Testing Overview
 
 There are two types of test:


### PR DESCRIPTION
The default Dockerfile is using RHEL8 repositories that are not accessible to all.
This will be fixed, but meantime, this enables optional built with CentOS packages:

    PATCH=Dockerfile.centos.patch make ...

/assign @jcantrill
/cc @periklis