### PR TITLE
Bug 1886856: Increase es proxy default memory resources to 256Mi

### DIFF
--- a/pkg/k8shandler/defaults.go
+++ b/pkg/k8shandler/defaults.go
@@ -8,7 +8,7 @@ var (
 	defaultEsMemory     resource.Quantity = resource.MustParse("16Gi")
 	defaultEsCpuRequest resource.Quantity = resource.MustParse("1")
 
-	defaultEsProxyMemory     resource.Quantity = resource.MustParse("64Mi")
+	defaultEsProxyMemory     resource.Quantity = resource.MustParse("256Mi")
 	defaultEsProxyCpuRequest resource.Quantity = resource.MustParse("100m")
 
 	defaultKibanaMemory     resource.Quantity = resource.MustParse("736Mi")


### PR DESCRIPTION
### Description
The current default memory requests and limits for elasticsearch-proxy are set to 64Mi. This is a too tight budget according to openshift/elasticsearch-operator#523

In turn this results into container restarts that have impact on serving elasticsearch requests reliably. This PR addresses this issue by bumping the elasticsearch-proxy request/limits from `64Mi` to `256Mi`
 
/cc @blockloop 
/assign @ewolinetz 
 
/cherry-pick release-4.6
 
### Links
- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1886856