### PR TITLE
LOG-949: Always reconcile services to desired state

### DIFF
--- a/pkg/factory/service.go
+++ b/pkg/factory/service.go
@@ -1,0 +1,30 @@
+package factory
+
+import (
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//NewService stubs an instance of a Service
+func NewService(serviceName string, namespace string, selectorComponent string, servicePorts []core.ServicePort) *core.Service {
+	return &core.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: core.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"logging-infra": "support",
+			},
+		},
+		Spec: core.ServiceSpec{
+			Selector: map[string]string{
+				"component": selectorComponent,
+				"provider":  "openshift",
+			},
+			Ports: servicePorts,
+		},
+	}
+}

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -63,7 +63,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection(proxyConfi
 			log.Error(err, "unable to calculate MD5 hash")
 			return
 		}
-		if err = clusterRequest.createOrUpdateFluentdService(); err != nil {
+		if err = clusterRequest.reconcileFluentdService(); err != nil {
 			return
 		}
 

--- a/pkg/k8shandler/service.go
+++ b/pkg/k8shandler/service.go
@@ -5,38 +5,14 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
+	"github.com/openshift/cluster-logging-operator/pkg/factory"
 	core "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-//NewService stubs an instance of a Service
-func NewService(serviceName string, namespace string, selectorComponent string, servicePorts []core.ServicePort) *core.Service {
-	return &core.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: core.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"logging-infra": "support",
-			},
-		},
-		Spec: core.ServiceSpec{
-			Selector: map[string]string{
-				"component": selectorComponent,
-				"provider":  "openshift",
-			},
-			Ports: servicePorts,
-		},
-	}
-}
 
 //RemoveService with given name and namespace
 func (clusterRequest *ClusterLoggingRequest) RemoveService(serviceName string) error {
 
-	service := NewService(
+	service := factory.NewService(
 		serviceName,
 		clusterRequest.Cluster.Namespace,
 		serviceName,

--- a/pkg/utils/comparators/services/comparator.go
+++ b/pkg/utils/comparators/services/comparator.go
@@ -1,0 +1,34 @@
+package services
+
+import (
+	"reflect"
+
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	"github.com/openshift/cluster-logging-operator/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+)
+
+//AreSame compares for equality and return true equal otherwise false
+func AreSame(current *v1.Service, desired *v1.Service) bool {
+	logger.Tracef("Comparing Services current %v to desired %v", current, desired)
+
+	if !utils.AreMapsSame(current.ObjectMeta.Labels, desired.ObjectMeta.Labels) {
+		logger.Debugf("Service %q label change", current.Name)
+		return false
+	}
+	if !utils.AreMapsSame(current.Spec.Selector, desired.Spec.Selector) {
+		logger.Debugf("Service %q Selector change", current.Name)
+		return false
+	}
+	if len(current.Spec.Ports) != len(desired.Spec.Ports) {
+		return false
+	}
+	for i, port := range current.Spec.Ports {
+		dPort := desired.Spec.Ports[i]
+		if !reflect.DeepEqual(port, dPort) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/utils/comparators/services/comparator_test.go
+++ b/pkg/utils/comparators/services/comparator_test.go
@@ -1,0 +1,68 @@
+package services_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openshift/cluster-logging-operator/pkg/utils/comparators/services"
+)
+
+var _ = Describe("services#AreSame", func() {
+
+	var (
+		current, desired *v1.Service
+	)
+
+	BeforeEach(func() {
+		current = &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+			},
+			Spec: v1.ServiceSpec{
+				Selector: map[string]string{},
+				Ports:    []v1.ServicePort{},
+			},
+		}
+		desired = current.DeepCopy()
+
+	})
+
+	Context("when evaluating labels", func() {
+		It("should recognize they are the same", func() {
+			Expect(AreSame(current, desired)).To(BeTrue())
+		})
+
+		It("should recognize they are different", func() {
+			desired.Labels["foo"] = "bar"
+			Expect(AreSame(current, desired)).To(BeFalse())
+		})
+	})
+	Context("when evaluating selectors", func() {
+		It("should recognize they are the same", func() {
+			Expect(AreSame(current, desired)).To(BeTrue())
+		})
+
+		It("should recognize they are different", func() {
+			desired.Spec.Selector["foo"] = "bar"
+			Expect(AreSame(current, desired)).To(BeFalse())
+		})
+	})
+	Context("when evaluating ServicePorts", func() {
+		It("should recognize they are the same", func() {
+			Expect(AreSame(current, desired)).To(BeTrue())
+		})
+
+		It("should recognize they are different lengths", func() {
+			desired.Spec.Ports = append(desired.Spec.Ports, v1.ServicePort{})
+			Expect(AreSame(current, desired)).To(BeFalse())
+		})
+
+		It("should recognize they are different content", func() {
+			current.Spec.Ports = append(desired.Spec.Ports, v1.ServicePort{Name: "bar", Port: 1051})
+			desired.Spec.Ports = append(desired.Spec.Ports, v1.ServicePort{Name: "bar", Port: 1050})
+			Expect(AreSame(current, desired)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/utils/comparators/services/suite_test.go
+++ b/pkg/utils/comparators/services/suite_test.go
@@ -1,0 +1,13 @@
+package services_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Services Comparator Suite")
+}

--- a/test/helpers/fluentd.go
+++ b/test/helpers/fluentd.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/openshift/cluster-logging-operator/pkg/factory"
 	"github.com/openshift/cluster-logging-operator/pkg/k8shandler"
 	clolog "github.com/ViaQ/logerr/log"
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
@@ -361,7 +362,7 @@ func (tc *E2ETestFramework) DeployFluentdReceiver(rootDir string, secure bool) (
 	if err != nil {
 		return nil, err
 	}
-	service := k8shandler.NewService(
+	service := factory.NewService(
 		serviceAccount.Name,
 		OpenshiftLoggingNS,
 		serviceAccount.Name,

--- a/test/helpers/kafka/broker.go
+++ b/test/helpers/kafka/broker.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"fmt"
 
+	"github.com/openshift/cluster-logging-operator/pkg/factory"
 	"github.com/openshift/cluster-logging-operator/pkg/k8shandler"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -265,7 +266,7 @@ func NewBrokerService(namespace string) *v1.Service {
 			Port: kafkaInsidePort,
 		},
 	}
-	return k8shandler.NewService(DeploymentName, namespace, kafkaBrokerComponent, ports)
+	return factory.NewService(DeploymentName, namespace, kafkaBrokerComponent, ports)
 }
 
 func NewBrokerRBAC(namespace string) (*rbacv1.ClusterRole, *rbacv1.ClusterRoleBinding) {

--- a/test/helpers/kafka/zookeeper.go
+++ b/test/helpers/kafka/zookeeper.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"github.com/openshift/cluster-logging-operator/pkg/factory"
 	"github.com/openshift/cluster-logging-operator/pkg/k8shandler"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -207,7 +208,7 @@ func NewZookeeperService(namespace string) *v1.Service {
 			Port: zookeeperLeaderElectionPort,
 		},
 	}
-	return k8shandler.NewService(zookeeperDeploymentName, namespace, zookeeperComponent, ports)
+	return factory.NewService(zookeeperDeploymentName, namespace, zookeeperComponent, ports)
 }
 
 func NewZookeeperConfigMap(namespace string) *v1.ConfigMap {

--- a/test/helpers/syslog.go
+++ b/test/helpers/syslog.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/openshift/cluster-logging-operator/pkg/factory"
 	"github.com/openshift/cluster-logging-operator/pkg/k8shandler"
 	clolog "github.com/ViaQ/logerr/log"
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
@@ -429,7 +430,7 @@ func (tc *E2ETestFramework) DeploySyslogReceiver(testDir string, protocol corev1
 	if err != nil {
 		return nil, err
 	}
-	service := k8shandler.NewService(
+	service := factory.NewService(
 		serviceAccount.Name,
 		OpenshiftLoggingNS,
 		serviceAccount.Name,


### PR DESCRIPTION
This PR addresses tech debt to:

* Constantly reconcile services to the state desired by the operator
* Move service constructor into an appropriately named factory package
* Add service comparator into the utils pkge

https://issues.redhat.com/browse/LOG-949