### PR TITLE
Bug 1888420: Add collector source input metrics

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Generating fluentd config", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
-    @label @CONCAT
+    @label @MEASURE
     <parse>
       @type multi_format
       <pattern>
@@ -170,7 +170,56 @@ var _ = Describe("Generating fluentd config", func() {
       </pattern>
     </parse>
   </source>
-  
+  <label @MEASURE>
+	<filter **>
+		@type record_transformer
+		enable_ruby
+		<record>
+		msg_size ${record.to_s.length}
+		</record>
+	</filter>
+	<filter **>
+		@type prometheus
+		<metric>
+		name cluster_logging_collector_input_record_total
+		type counter
+		desc The total number of incoming records
+		<labels>
+			tag ${tag}
+			hostname ${hostname}
+		</labels>
+		</metric>
+	</filter>
+	<filter **>
+		@type prometheus
+		<metric>
+		name cluster_logging_collector_input_record_bytes
+		type counter
+		desc The total bytes of incoming records
+		key msg_size
+		<labels>
+			tag ${tag}
+			hostname ${hostname}
+		</labels>
+		</metric>
+	</filter>
+	<filter **>
+		@type record_transformer
+		remove_keys msg_size
+	</filter>
+	<match journal>
+		@type relabel
+		@label @INGRESS
+	</match>
+	<match *audit.log>
+		@type relabel
+		@label @INGRESS
+	</match>
+	<match kubernetes.**>
+		@type relabel
+		@label @CONCAT
+	</match>
+	</label>  
   <label @CONCAT>
     <filter kubernetes.**>
       @type concat
@@ -638,7 +687,7 @@ var _ = Describe("Generating fluentd config", func() {
 				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
-				@label @CONCAT
+				@label @MEASURE
 				<parse>
 				@type multi_format
 				<pattern>
@@ -654,7 +703,56 @@ var _ = Describe("Generating fluentd config", func() {
 				</pattern>
 				</parse>
 			</source>
-
+			<label @MEASURE>
+				<filter **>
+				@type record_transformer
+				enable_ruby
+				<record>
+					msg_size ${record.to_s.length}
+				</record>
+				</filter>
+				<filter **>
+				@type prometheus
+				<metric>
+					name cluster_logging_collector_input_record_total
+					type counter
+					desc The total number of incoming records
+					<labels>
+					tag ${tag}
+					hostname ${hostname}
+					</labels>
+				</metric>
+				</filter>
+				<filter **>
+				@type prometheus
+				<metric>
+					name cluster_logging_collector_input_record_bytes
+					type counter
+					desc The total bytes of incoming records
+					key msg_size
+					<labels>
+					tag ${tag}
+					hostname ${hostname}
+					</labels>
+				</metric>
+				</filter>
+				<filter **>
+				@type record_transformer
+				remove_keys msg_size
+				</filter>
+				<match journal>
+				@type relabel
+				@label @INGRESS
+				</match>
+				<match *audit.log>
+				@type relabel
+				@label @INGRESS
+				</match>
+				<match kubernetes.**>
+				@type relabel
+				@label @CONCAT
+				</match>
+			</label>
 			<label @CONCAT>
 				<filter kubernetes.**>
 				@type concat
@@ -1000,7 +1098,7 @@ var _ = Describe("Generating fluentd config", func() {
 			<source>
 				@type systemd
 				@id systemd-input
-				@label @INGRESS
+				@label @MEASURE
 				path '/var/log/journal'
 				<storage>
 					@type local
@@ -1025,7 +1123,7 @@ var _ = Describe("Generating fluentd config", func() {
 				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
-				@label @CONCAT
+				@label @MEASURE
 				<parse>
 				@type multi_format
 				<pattern>
@@ -1046,7 +1144,7 @@ var _ = Describe("Generating fluentd config", func() {
             <source>
               @type tail
               @id audit-input
-              @label @INGRESS
+              @label @MEASURE
               path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
               pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
               tag linux-audit.log
@@ -1059,7 +1157,7 @@ var _ = Describe("Generating fluentd config", func() {
             <source>
               @type tail
               @id k8s-audit-input
-              @label @INGRESS
+              @label @MEASURE
               path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
               pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
               tag k8s-audit.log
@@ -1072,23 +1170,72 @@ var _ = Describe("Generating fluentd config", func() {
 			  </parse>
 			</source>
 
-            # Openshift audit logs
-            <source>
-              @type tail
-              @id openshift-audit-input
-              @label @INGRESS
-              path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
-              pos_file /var/log/oauth-apiserver.audit.log
-              tag openshift-audit.log
-              <parse>
-                @type json
-                time_key requestReceivedTimestamp
-                # In case folks want to parse based on the requestReceivedTimestamp key
-                keep_time_key true
-                time_format %Y-%m-%dT%H:%M:%S.%N%z
-              </parse>
-            </source>
-
+			# Openshift audit logs
+			<source>
+				@type tail
+				@id openshift-audit-input
+				@label @MEASURE
+				path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+				pos_file /var/log/oauth-apiserver.audit.log
+				tag openshift-audit.log
+				<parse>
+				@type json
+				time_key requestReceivedTimestamp
+				# In case folks want to parse based on the requestReceivedTimestamp key
+				keep_time_key true
+				time_format %Y-%m-%dT%H:%M:%S.%N%z
+			  </parse>
+			</source>
+			<label @MEASURE>
+				<filter **>
+					@type record_transformer
+					enable_ruby
+					<record>
+					msg_size ${record.to_s.length}
+					</record>
+				</filter>
+				<filter **>
+					@type prometheus
+					<metric>
+					name cluster_logging_collector_input_record_total
+					type counter
+					desc The total number of incoming records
+					<labels>
+						tag ${tag}
+						hostname ${hostname}
+					</labels>
+					</metric>
+				</filter>
+				<filter **>
+					@type prometheus
+					<metric>
+						name cluster_logging_collector_input_record_bytes
+						type counter
+						desc The total bytes of incoming records
+						key msg_size
+						<labels>
+							tag ${tag}
+							hostname ${hostname}
+						</labels>
+				  </metric>
+				</filter>
+				<filter **>
+				  @type record_transformer
+				  remove_keys msg_size
+				</filter>
+				<match journal>
+				  @type relabel
+				  @label @INGRESS
+				</match>
+				<match *audit.log>
+				  @type relabel
+				  @label @INGRESS
+				 </match>
+				<match kubernetes.**>
+				  @type relabel
+				  @label @CONCAT
+				</match>
+			</label>
 			<label @CONCAT>
 				<filter kubernetes.**>
 				@type concat
@@ -1877,7 +2024,7 @@ var _ = Describe("Generating fluentd config", func() {
       rotate_wait 5
       tag kubernetes.*
       read_from_head "true"
-      @label @CONCAT
+      @label @MEASURE
       <parse>
         @type multi_format
         <pattern>
@@ -1893,7 +2040,56 @@ var _ = Describe("Generating fluentd config", func() {
         </pattern>
       </parse>
     </source>
-    
+	<label @MEASURE>
+	<filter **>
+	  @type record_transformer
+	  enable_ruby
+	  <record>
+		msg_size ${record.to_s.length}
+	  </record>
+	</filter>
+	<filter **>
+	  @type prometheus
+	  <metric>
+		name cluster_logging_collector_input_record_total
+		type counter
+		desc The total number of incoming records
+		<labels>
+		  tag ${tag}
+		  hostname ${hostname}
+		</labels>
+	  </metric>
+	</filter>
+	<filter **>
+	  @type prometheus
+	  <metric>
+		name cluster_logging_collector_input_record_bytes
+		type counter
+		desc The total bytes of incoming records
+		key msg_size
+		<labels>
+		  tag ${tag}
+		  hostname ${hostname}
+		</labels>
+	  </metric>
+	</filter>
+	<filter **>
+	  @type record_transformer
+	  remove_keys msg_size
+	</filter>
+	<match journal>
+	  @type relabel
+	  @label @INGRESS
+	</match>
+	<match *audit.log>
+	  @type relabel
+	  @label @INGRESS
+	 </match>
+	<match kubernetes.**>
+	  @type relabel
+	  @label @CONCAT
+	</match>
+  </label>
     <label @CONCAT>
       <filter kubernetes.**>
         @type concat

--- a/pkg/generators/forwarding/fluentd/source_test.go
+++ b/pkg/generators/forwarding/fluentd/source_test.go
@@ -40,7 +40,7 @@ var _ = Describe("generating source", func() {
 			rotate_wait 5
 			tag kubernetes.*
 			read_from_head "true"
-			@label @CONCAT
+			@label @MEASURE
 			<parse>
 			  @type multi_format
 			  <pattern>
@@ -79,7 +79,7 @@ var _ = Describe("generating source", func() {
 			<source>
 				@type systemd
 				@id systemd-input
-				@label @INGRESS
+				@label @MEASURE
 				path '/var/log/journal'
 				<storage>
 				@type local
@@ -107,7 +107,7 @@ var _ = Describe("generating source", func() {
 			  rotate_wait 5
 			  tag kubernetes.*
 			  read_from_head "true"
-			  @label @CONCAT
+			  @label @MEASURE
 			  <parse>
 				@type multi_format
 				<pattern>
@@ -140,7 +140,7 @@ var _ = Describe("generating source", func() {
             <source>
               @type tail
               @id audit-input
-              @label @INGRESS
+              @label @MEASURE
               path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
               pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
               tag linux-audit.log
@@ -154,7 +154,7 @@ var _ = Describe("generating source", func() {
             <source>
               @type tail
               @id k8s-audit-input
-              @label @INGRESS
+              @label @MEASURE
               path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
               pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
               tag k8s-audit.log
@@ -172,7 +172,7 @@ var _ = Describe("generating source", func() {
             <source>
               @type tail
               @id openshift-audit-input
-              @label @INGRESS
+              @label @MEASURE
               path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
               pos_file /var/log/oauth-apiserver.audit.log
               tag openshift-audit.log
@@ -203,7 +203,7 @@ var _ = Describe("generating source", func() {
 			<source>
 				@type systemd
 				@id systemd-input
-				@label @INGRESS
+				@label @MEASURE
 				path '/var/log/journal'
 				<storage>
 				@type local
@@ -233,7 +233,7 @@ var _ = Describe("generating source", func() {
 				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
-				@label @CONCAT
+				@label @MEASURE
 				<parse>
 				  @type multi_format
 				  <pattern>
@@ -261,7 +261,7 @@ var _ = Describe("generating source", func() {
               <source>
                 @type tail
                 @id audit-input
-                @label @INGRESS
+                @label @MEASURE
                 path "#{ENV['AUDIT_FILE'] || '/var/log/audit/audit.log'}"
                 pos_file "#{ENV['AUDIT_POS_FILE'] || '/var/log/audit/audit.log.pos'}"
                 tag linux-audit.log
@@ -275,7 +275,7 @@ var _ = Describe("generating source", func() {
               <source>
                 @type tail
                 @id k8s-audit-input
-                @label @INGRESS
+                @label @MEASURE
                 path "#{ENV['K8S_AUDIT_FILE'] || '/var/log/kube-apiserver/audit.log'}"
                 pos_file "#{ENV['K8S_AUDIT_POS_FILE'] || '/var/log/kube-apiserver/audit.log.pos'}"
                 tag k8s-audit.log
@@ -293,7 +293,7 @@ var _ = Describe("generating source", func() {
               <source>
                 @type tail
                 @id openshift-audit-input
-                @label @INGRESS
+                @label @MEASURE
                 path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
                 pos_file /var/log/oauth-apiserver.audit.log
                 tag openshift-audit.log


### PR DESCRIPTION
This PR add input source metrics for fluent collector so we may start understand what's happening at the collection piont

* adds `cluster_logging_collector_input_record_total{tag:, hostname:}`
* adds `cluster_logging_collector_input_record_bytes{tag:, hostname:}` this is an approximation

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1888420

![image](https://user-images.githubusercontent.com/4548408/96175411-ddc0a400-0ef8-11eb-8cac-7d7772b84f35.png)

cc @blockloop 