### PR TITLE
Fix Makefile removing 'test-cleanup' as dependency for 'run'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ build-debug:
 
 # Run the CLO locally - see HACKING.md
 RUN_CMD?=go run
-run: deploy-elasticsearch-operator test-cleanup
+run: deploy-elasticsearch-operator
 	@ls $(MANIFESTS)/*crd.yaml | xargs -n1 oc apply -f
 	@mkdir -p $(CURDIR)/tmp
 	@ELASTICSEARCH_IMAGE=quay.io/openshift/origin-logging-elasticsearch6:latest \


### PR DESCRIPTION
The Makefile 'run' step is dependent on 'test-cleanup' that do not exist in the Makefile. 

This PR is removing that dependency