### PR TITLE
Reduce resource requests for AWS example to default provisioning

### DIFF
--- a/hack/cr-aws.yaml
+++ b/hack/cr-aws.yaml
@@ -11,9 +11,11 @@ spec:
       storage: {}
       redundancyPolicy: "ZeroRedundancy"
       resources:
-        limits:
-          cpu: 500m
-          memory: 4Gi
+        requests:
+          cpu: 100m
+      storage:
+        size: 10G
+        storageClassName: gp2
   visualization:
     type: "kibana"
     kibana:
@@ -25,4 +27,7 @@ spec:
   collection:
     logs:
       type: "fluentd"
-      fluentd: {}
+      fluentd:
+        resources:
+          requests:
+            cpu: 100m


### PR DESCRIPTION
When deploying default AWS cluster, provisioned CPU resources are limited and without specific resource limitations Elastic-search and Fluentd container do not deploy. 

This PR is reducing the resources required to lower level so that ES and Fluentd  will be deployed 