### PR TITLE
Bug 1886856: Add keep-alive backend for elasticsearch store

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -477,6 +477,7 @@ var _ = Describe("Generating fluentd config", func() {
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
         type_name _doc
+        http_backend typhoeus
         write_operation create
         reload_connections 'true'
         # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -528,6 +529,7 @@ var _ = Describe("Generating fluentd config", func() {
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
         type_name _doc
         retry_tag retry_apps_es_1
+        http_backend typhoeus
         write_operation create
         reload_connections 'true'
         # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1407,6 +1409,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
 						type_name _doc
+                        http_backend typhoeus
 						write_operation create
 						reload_connections 'true'
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1455,6 +1458,7 @@ var _ = Describe("Generating fluentd config", func() {
 						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_infra_es
+                        http_backend typhoeus
 						write_operation create
 						reload_connections 'true'
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1504,6 +1508,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 						type_name _doc
+                        http_backend typhoeus
 						write_operation create
 						reload_connections 'true'
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1552,6 +1557,7 @@ var _ = Describe("Generating fluentd config", func() {
 						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_apps_es_1
+                        http_backend typhoeus
 						write_operation create
 						reload_connections 'true'
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1601,6 +1607,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
 						type_name _doc
+                        http_backend typhoeus
 						write_operation create
 						reload_connections 'true'
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1649,6 +1656,7 @@ var _ = Describe("Generating fluentd config", func() {
 						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_apps_es_2
+                        http_backend typhoeus
 						write_operation create
 						reload_connections 'true'
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1698,6 +1706,7 @@ var _ = Describe("Generating fluentd config", func() {
 						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
 						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
 						type_name _doc
+                        http_backend typhoeus
 						write_operation create
 						reload_connections 'true'
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -1746,6 +1755,7 @@ var _ = Describe("Generating fluentd config", func() {
 						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_audit_es
+                        http_backend typhoeus
 						write_operation create
 						reload_connections 'true'
 						# https://github.com/uken/fluent-plugin-elasticsearch#reload-after

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
 			ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 			type_name _doc
+            http_backend typhoeus
 			write_operation create
 			reload_connections 'true'
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -133,6 +134,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 			type_name _doc
 			retry_tag retry_oncluster_elasticsearch
+            http_backend typhoeus
 			write_operation create
 			reload_connections 'true'
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -195,6 +197,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			password changeme
 
 			type_name _doc
+            http_backend typhoeus
 			write_operation create
 			reload_connections 'true'
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -239,6 +242,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 
 			type_name _doc
 			retry_tag retry_other_elasticsearch
+            http_backend typhoeus
 			write_operation create
 			reload_connections 'true'
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Generating fluentd config", func() {
               password changeme
 
               type_name _doc
+              http_backend typhoeus
               write_operation create
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -120,6 +121,7 @@ var _ = Describe("Generating fluentd config", func() {
 
               type_name _doc
               retry_tag retry_other_elasticsearch
+              http_backend typhoeus
               write_operation create
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -191,6 +193,7 @@ var _ = Describe("Generating fluentd config", func() {
               password changeme
 
               type_name _doc
+              http_backend typhoeus
               write_operation create
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -235,6 +238,7 @@ var _ = Describe("Generating fluentd config", func() {
 
               type_name _doc
               retry_tag retry_other_elasticsearch
+              http_backend typhoeus
               write_operation create
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -289,6 +293,7 @@ var _ = Describe("Generating fluentd config", func() {
               password changeme
 
               type_name _doc
+              http_backend typhoeus
               write_operation create
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
@@ -333,6 +338,7 @@ var _ = Describe("Generating fluentd config", func() {
 
               type_name _doc
               retry_tag retry_other_elasticsearch
+              http_backend typhoeus
               write_operation create
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -657,6 +657,7 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
 {{- if .Hints.Has "include_retry_tag" }}
   retry_tag {{.RetryTag}}
 {{- end }}
+  http_backend typhoeus
   write_operation create
   reload_connections 'true'
   # https://github.com/uken/fluent-plugin-elasticsearch#reload-after


### PR DESCRIPTION
### Description
This PR is using the `http_backend typhoeus` configuration for elasticsearch store to enable keep-alive.
 
/cc @blockloop 
/assign @ewolinetz 

### Links:
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1886856
- Depending PRs: openshift/origin-aggregated-logging#2010