### PR TITLE
make run does not deploy-eo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,14 +64,10 @@ build-debug:
 
 # Run the CLO locally - see HACKING.md
 RUN_CMD?=go run
-run: deploy-elasticsearch-operator test-cleanup
+run: 
 	@ls $(MANIFESTS)/*crd.yaml | xargs -n1 oc apply -f
 	@mkdir -p $(CURDIR)/tmp
-	@ELASTICSEARCH_IMAGE=quay.io/openshift/origin-logging-elasticsearch6:latest \
 	FLUENTD_IMAGE=$(FLUENTD_IMAGE) \
-	KIBANA_IMAGE=quay.io/openshift/origin-logging-kibana6:latest \
-	CURATOR_IMAGE=quay.io/openshift/origin-logging-curator6:latest \
-	OAUTH_PROXY_IMAGE=quay.io/openshift/origin-oauth-proxy:latest \
 	OPERATOR_NAME=cluster-logging-operator \
 	WATCH_NAMESPACE=$(NAMESPACE) \
 	KUBERNETES_CONFIG=$(KUBECONFIG) \

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -100,6 +100,10 @@ normal way to run an operator, and does not test all aspects of the CLO
 changes to its own custom resources, and creates/updates other resources
 accordingly. This can all be done from outside the cluster.
 
+**Note:** You must run the `make deploy-elasticsearch-operator` as a separate target which will:
+* Deploy the Elasticsearch CRD upon which the CLO depends
+* Define ClusterLogForwarding to the default log store
+
 Examples:
 ```
 make run  # Run the CLO locally

--- a/hack/generate-crd.sh
+++ b/hack/generate-crd.sh
@@ -30,7 +30,7 @@ cp manifests/patches/${KUSTOMIZATIONS_FILE} ${MANIFESTS_DIR}
 echo "---------------------------------------------------------------"
 echo "Kustomize: Patch CRDs for singeltons"
 echo "---------------------------------------------------------------"
-bin/oc kustomize "${MANIFESTS_DIR}" | \
+oc kustomize "${MANIFESTS_DIR}" | \
     awk -v clf="${MANIFESTS_DIR}/${CLF_CRD_FILE}" \
         -v clo="${MANIFESTS_DIR}/${CLO_CRD_FILE}"\
         'BEGIN{filename = clf} /---/ {getline; filename = clo}{print $0> filename}'


### PR DESCRIPTION
This PR updates the Makefile to:

* decouple make run  from automatically deploying EO (doesn't handle already deployed operator nor should it need to)
* remove a non-existent dependent target
* fix CRD to rely on `oc` in the path

cc @alanconway 