### PR TITLE
Reduce the footprint of the cluster-logging-operator-registry image

### DIFF
--- a/olm_deploy/operatorregistry/Dockerfile
+++ b/olm_deploy/operatorregistry/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/operator-framework/upstream-registry-builder AS registry-builder
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 WORKDIR /
 COPY manifests/ /manifests


### PR DESCRIPTION
### Description
This PR reduces the size of the cluster-logging-operator-registry image from 1.1 GB to 333 MB:

#### Before
```
$ podman image tree 308e10de91df
Image ID: 308e10de91df
Tags:     [127.0.0.1:5000/openshift/cluster-logging-operator-registry:latest]
Size:     1.118GB
Image Layers
├──  ID: 613be09ab3c0 Size: 211.1MB
├──  ID: 7da2b7b70275 Size: 840.7MB Top Layer of: [registry.svc.ci.openshift.org/openshift/release:golang-1.12]
├──  ID: fbb3dfca0f9f Size: 93.18kB
├──  ID: 0b886c8657e8 Size: 6.656kB
├──  ID: 4b7d0e54bc4b Size: 4.608kB
├──  ID: b9fc83ae7f75 Size: 27.92MB
├──  ID: 790d6e04469e Size: 28.63MB
└──  ID: c1041eb51c25 Size:  9.93MB Top Layer of: [127.0.0.1:5000/openshift/cluster-logging-operator-registry:latest]
```

#### After
```
$ podman image tree 127.0.0.1:5000/openshift/cluster-logging-operator-registry:latest
Image ID: e44ceaff015c
Tags:     [127.0.0.1:5000/openshift/cluster-logging-operator-registry:latest]
Size:     332.5MB
Image Layers
├──  ID: 226bfaae015f Size: 210.9MB
├──  ID: 1da86dd5dbd9 Size: 20.48kB
├──  ID: 186cc8c306d7 Size: 17.81MB
├──  ID: 91485e999e6c Size: 1.701MB
├──  ID: 87c57e253743 Size: 35.48MB Top Layer of: [registry.svc.ci.openshift.org/ocp/4.7:base]
├──  ID: db614927a669 Size: 110.6kB
├──  ID: bab8ad1a7cd8 Size: 6.144kB
├──  ID: 50a82705cad5 Size: 4.608kB
├──  ID: a75c2af68997 Size: 27.92MB
├──  ID: cbb597b82308 Size: 28.65MB
└──  ID: 1b0bd8da9954 Size:  9.93MB Top Layer of: [127.0.0.1:5000/openshift/cluster-logging-operator-registry:latest]
```

/cc vimalk78
/assign ewolinetz
