### PR TITLE
LOG-784: Remove managementState in the csv example

### DIFF
--- a/manifests/4.7/cluster-logging.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/cluster-logging.v4.7.0.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     support: AOS Logging
     # The version value is substituted by the ART pipeline
     olm.skipRange: ">=4.5.0-0 <4.7.0"
-    alm-examples: |-
+    olm-examples: |-
         [
           {
             "apiVersion": "logging.openshift.io/v1",
@@ -33,7 +33,6 @@ metadata:
               "namespace": "openshift-logging"
             },
             "spec": {
-              "managementState": "Managed",
               "logStore": {
                 "type": "elasticsearch",
                 "elasticsearch": {


### PR DESCRIPTION
- managementState is set to true as default

### Description

Remove `managementState` in the CSV example manefist.

/cc @jcantrill 
/assign @jcantrill 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-784
