### PR TITLE
Update ViaQ/logerr to resolve nil pointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 // Pinned to kubernetes-1.18.3
 require (
 	cloud.google.com/go v0.54.0 // indirect
-	github.com/ViaQ/logerr v0.0.0-20201005161545-59fa62e1e498
+	github.com/ViaQ/logerr v1.0.3
 	github.com/coreos/prometheus-operator v0.38.1-0.20200424145508-7e176fda06cc
 	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
 	github.com/go-openapi/spec v0.19.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/O
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/ViaQ/logerr v0.0.0-20201005161545-59fa62e1e498 h1:9i8Ah3ZqY1j2PQ/Ib2NHfBaa8pLUVbu+VkVIYkPkPgE=
-github.com/ViaQ/logerr v0.0.0-20201005161545-59fa62e1e498/go.mod h1:KCNTKsS4LgOp1oIDXkWxGWs4Fqwu/SdfyfUcIShsjPE=
+github.com/ViaQ/logerr v1.0.3 h1:vtNvkHm0UICS3Bv2MHkGr4PDJnIuDZ1tJIjUl+pfJ4U=
+github.com/ViaQ/logerr v1.0.3/go.mod h1:KCNTKsS4LgOp1oIDXkWxGWs4Fqwu/SdfyfUcIShsjPE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/vendor/github.com/ViaQ/logerr/kverrors/doc.go
+++ b/vendor/github.com/ViaQ/logerr/kverrors/doc.go
@@ -1,4 +1,4 @@
-// package errors provides structured errors
+// Package kverrors provides structured errors
 //
 // errors can be used with pkg/log to further enhance structured logging
 package kverrors

--- a/vendor/github.com/ViaQ/logerr/log/doc.go
+++ b/vendor/github.com/ViaQ/logerr/log/doc.go
@@ -1,2 +1,2 @@
-// package log provides structured logging
+// Package log provides structured logging
 package log

--- a/vendor/github.com/ViaQ/logerr/log/log.go
+++ b/vendor/github.com/ViaQ/logerr/log/log.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"os"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -10,6 +11,7 @@ import (
 )
 
 const (
+	// KeyError is the key used to store the error
 	KeyError = "cause"
 )
 
@@ -20,12 +22,8 @@ var (
 	logger = zapr.NewLogger(zap.NewNop())
 
 	defaultConfig = &zap.Config{
-		Level:       zap.NewAtomicLevelAt(zap.InfoLevel),
-		Development: false,
-		Sampling: &zap.SamplingConfig{
-			Initial:    100,
-			Thereafter: 100,
-		},
+		Level:             zap.NewAtomicLevelAt(zap.InfoLevel),
+		Development:       false,
 		Encoding:          "json",
 		EncoderConfig:     zap.NewProductionEncoderConfig(),
 		OutputPaths:       []string{"stdout"},
@@ -88,6 +86,8 @@ func UseLogger(l logr.Logger) {
 	useLogger(l)
 }
 
+// useLogger sets the logger to l without mtx.Lock()
+// To use mtx.Lock see UseLogger
 func useLogger(l logr.Logger) {
 	logger = WrapLogger(l)
 }
@@ -125,6 +125,20 @@ func WithVerbosity(level uint8) Option {
 		c.Level = zap.NewAtomicLevelAt(zapcore.Level(l))
 	}
 }
+
+// WithOutputs sets OutputPaths to std and ErrOutputPaths to err
+func WithOutputs(std, err []string) Option {
+	return func(c *zap.Config) {
+		c.OutputPaths = std
+		c.ErrorOutputPaths = err
+	}
+}
+
+// WithNoOutputs sets the outs to os.DevNull
+func WithNoOutputs() Option {
+	return WithOutputs([]string{os.DevNull}, []string{os.DevNull})
+}
+
 
 // Info logs a non-error message with the given key/value pairs as context.
 //

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,7 +16,7 @@ github.com/Azure/go-autorest/tracing
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
-# github.com/ViaQ/logerr v0.0.0-20201005161545-59fa62e1e498
+# github.com/ViaQ/logerr v1.0.3
 ## explicit
 github.com/ViaQ/logerr/kverrors
 github.com/ViaQ/logerr/log


### PR DESCRIPTION
This PR:

* updated viaq/logerr to  v1.0.3 to resolve:

```
Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
2020-10-27T13:41:17.243934783Z goroutine 1559 [running]:
2020-10-27T13:41:17.243934783Z k8s.io/apimachinery/pkg/util/runtime.logPanic(0x15deca0, 0x232cb40)
2020-10-27T13:41:17.243934783Z 	/go/src/github.com/openshift/cluster-logging-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa6
2020-10-27T13:41:17.243934783Z k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
2020-10-27T13:41:17.243934783Z 	/go/src/github.com/openshift/cluster-logging-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x89
2020-10-27T13:41:17.243934783Z panic(0x15deca0, 0x232cb40)
2020-10-27T13:41:17.243934783Z 	/usr/lib/golang/src/runtime/panic.go:969 +0x175
2020-10-27T13:41:17.243934783Z github.com/ViaQ/logerr/log.(*Logger).Error(0xc0004a95c0, 0x0, 0x0, 0x17c16f5, 0x1d, 0x0, 0x0, 0x0)
2020-10-27T13:41:17.243934783Z 	/go/src/github.com/openshift/cluster-logging-operator/vendor/github.com/ViaQ/logerr/log/logger.go:40 +0x20d
```