### PR TITLE
Remove need for LOGGING_SHARE_DIR in tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # Define the target to run if make is called with no arguments.
 default: check
 
-export LOG_LEVEL?=9
 export KUBECONFIG?=$(HOME)/.kube/config
 
 export GOBIN=$(CURDIR)/bin
@@ -64,7 +63,7 @@ build-debug:
 
 # Run the CLO locally - see HACKING.md
 RUN_CMD?=go run
-run: 
+run:
 	@ls $(MANIFESTS)/*crd.yaml | xargs -n1 oc apply -f
 	@mkdir -p $(CURDIR)/tmp
 	CURATOR_IMAGE=quay.io/openshift/origin-logging-curator:latest \
@@ -73,7 +72,6 @@ run:
 	WATCH_NAMESPACE=$(NAMESPACE) \
 	KUBERNETES_CONFIG=$(KUBECONFIG) \
 	WORKING_DIR=$(CURDIR)/tmp \
-	LOGGING_SHARE_DIR=$(CURDIR)/files \
 	$(RUN_CMD) cmd/manager/main.go
 
 run-debug:
@@ -148,8 +146,6 @@ test-functional:
 test-unit:
 	CURATOR_IMAGE=quay.io/openshift/origin-logging-curator:latest \
 	FLUENTD_IMAGE=$(FLUENTD_IMAGE) \
-	LOGGING_SHARE_DIR=$(CURDIR)/files \
-	LOG_LEVEL=$(LOG_LEVEL) \
 	go test -cover -race ./pkg/...
 
 test-cluster:

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/ViaQ/logerr/log"
@@ -181,12 +182,21 @@ func GetFileContents(filePath string) []byte {
 	return contents
 }
 
+const defaultShareDir = "/usr/share/logging"
+
 func GetShareDir() string {
-	shareDir := os.Getenv("LOGGING_SHARE_DIR")
-	if shareDir == "" {
-		return "/usr/share/logging"
+	// shareDir is <repo-root>/files - try to find from working dir.
+	const sep = string(os.PathSeparator)
+	const repoRoot = sep + "cluster-logging-operator" + sep
+	wd, err := os.Getwd()
+	if err != nil {
+		return defaultShareDir
 	}
-	return shareDir
+	i := strings.LastIndex(wd, repoRoot)
+	if i >= 0 {
+		return filepath.Join(wd[0:i+len(repoRoot)] + "files")
+	}
+	return defaultShareDir
 }
 
 func GetScriptsDir() string {


### PR DESCRIPTION
Use the current working directory to locate /cluster-logging-operator/files.
Drop the env var LOGGING_SHARE_DIR.
Allows all tests to run directly with `go test`, with no extra environment settings.

/cc @blockloop
/assign @alanconway