### PR TITLE
Bug 1895607: Store secrets in one place and utilize mutex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ FROM registry.svc.ci.openshift.org/ocp/4.6:cli as origincli
 FROM registry.svc.ci.openshift.org/ocp/4.6:base
 RUN INSTALL_PKGS=" \
       openssl \
+      file \
       rsync \
       " && \
     yum install -y $INSTALL_PKGS && \

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,8 @@ test-functional:
 .PHONY: test-functional
 
 test-unit:
+	CURATOR_IMAGE=quay.io/openshift/origin-logging-curator:latest \
+	FLUENTD_IMAGE=$(FLUENTD_IMAGE) \
 	LOGGING_SHARE_DIR=$(CURDIR)/files \
 	LOG_LEVEL=$(LOG_LEVEL) \
 	go test -cover -race ./pkg/...

--- a/pkg/certificates/certificates.go
+++ b/pkg/certificates/certificates.go
@@ -1,0 +1,27 @@
+package certificates
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/openshift/cluster-logging-operator/pkg/logger"
+)
+
+func GenerateCertificates(namespace, scriptsDir, logStoreName, workDir string) (err error, updated bool) {
+	script := fmt.Sprintf("%s/cert_generation.sh", scriptsDir)
+	return RunCertificatesScript(namespace, logStoreName, workDir, script)
+}
+
+func RunCertificatesScript(namespace, logStoreName, workDir, script string) (err error, updated bool) {
+	logger.Tracef("Running script %s workdir %s namespace %s logstore %s", script, workDir, namespace, logStoreName)
+	cmd := exec.Command(script, workDir, namespace, logStoreName)
+	out, err := cmd.Output()
+	result := string(out)
+	logger.Tracef("Cert generation result %s / err: %v", result, err)
+	if result != "" {
+		updated = true
+		logger.Infof("cert_generation output: %s", result)
+	}
+	logger.Tracef("Returning err: %v , updated: %v", err, updated)
+	return err, updated
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,6 +24,9 @@ const (
 	LogStoreURL         = "https://" + ElasticsearchFQDN + ":" + ElasticsearchPort
 	MasterCASecretName  = "master-certs"
 	CollectorSecretName = "fluentd"
+
+	/* #nosec - suppressing rule G101 */
+	KibanaSessionSecretName = "kibana-session-secret"
 )
 
 var ReconcileForGlobalProxyList = []string{FluentdTrustedCAName}

--- a/pkg/k8shandler/certificates.go
+++ b/pkg/k8shandler/certificates.go
@@ -2,160 +2,98 @@ package k8shandler
 
 import (
 	"fmt"
-	"os/exec"
+	"io/ioutil"
+	"path"
+	"sync"
 
+	"github.com/openshift/cluster-logging-operator/pkg/certificates"
 	"github.com/openshift/cluster-logging-operator/pkg/constants"
 	"github.com/openshift/cluster-logging-operator/pkg/logger"
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-var deprecatedKeys = sets.NewString("app-ca", "app-key", "app-cert", "infra-ca", "infra-key", "infra-cert")
+var mutex sync.Mutex
 
-// golang doesn't allow for const maps
-var secretCertificates = map[string]map[string]string{
-	"master-certs": {
-		"masterca":  "ca.crt",
-		"masterkey": "ca.key",
-	},
-	"elasticsearch": {
-		"elasticsearch.key": "elasticsearch.key",
-		"elasticsearch.crt": "elasticsearch.crt",
-		"logging-es.key":    "logging-es.key",
-		"logging-es.crt":    "logging-es.crt",
-		"admin-key":         "system.admin.key",
-		"admin-cert":        "system.admin.crt",
-		"admin-ca":          "ca.crt",
-	},
-	"kibana": {
-		"ca":   "ca.crt",
-		"key":  "system.logging.kibana.key",
-		"cert": "system.logging.kibana.crt",
-	},
-	"kibana-proxy": {
-		"server-key":     "kibana-internal.key",
-		"server-cert":    "kibana-internal.crt",
-		"session-secret": "kibana-session-secret",
-	},
-	"curator": {
-		"ca":       "ca.crt",
-		"key":      "system.logging.curator.key",
-		"cert":     "system.logging.curator.crt",
-		"ops-ca":   "ca.crt",
-		"ops-key":  "system.logging.curator.key",
-		"ops-cert": "system.logging.curator.crt",
-	},
-	"fluentd": {
-		"ca-bundle.crt": "ca.crt",
-		"tls.key":       "system.logging.fluentd.key",
-		"tls.crt":       "system.logging.fluentd.crt",
-	},
+//Syncronize blocks single threads access using the certificate mutex
+func Synchronize(action func() error) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return action()
 }
 
-func (clusterRequest *ClusterLoggingRequest) extractSecretToFile(secretName string, key string, toFile string) (err error) {
-	secret, err := clusterRequest.GetSecret(secretName)
+func (clusterRequest *ClusterLoggingRequest) extractMasterCerts() (err error) {
+	secret, err := clusterRequest.GetSecret(constants.MasterCASecretName)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("Unable to get secret %s: %v", constants.MasterCASecretName, err)
+	}
+	workDir := utils.GetWorkingDir()
+	for name, value := range secret.Data {
+		if err != utils.WriteToWorkingDirFile(path.Join(workDir, name), value) {
 			return err
 		}
-		return fmt.Errorf("Unable to extract secret %s to file: %v", secretName, err)
 	}
 
-	value, ok := secret.Data[key]
-
-	// check to see if the map value exists
-	if !ok {
-		if deprecatedKeys.Has(key) {
-			logger.Infof("No secret data %q found. Please be aware but likely not an issue for deprecated keys: %v", key, deprecatedKeys.List())
-		} else {
-			logger.Warnf("No secret data %q found", key)
-
-		}
-		return nil
-	}
-
-	return utils.WriteToWorkingDirFile(toFile, value)
+	return nil
 }
 
 func (clusterRequest *ClusterLoggingRequest) writeSecret() (err error) {
 
+	secrets, err := loadFilesFromWorkingDir()
+	if err != nil {
+		return err
+	}
 	secret := NewSecret(
 		constants.MasterCASecretName,
 		clusterRequest.Cluster.Namespace,
-		map[string][]byte{
-			"masterca":  utils.GetWorkingDirFileContents("ca.crt"),
-			"masterkey": utils.GetWorkingDirFileContents("ca.key"),
-		})
-
+		secrets,
+	)
 	utils.AddOwnerRefToObject(secret, utils.AsOwner(clusterRequest.Cluster))
 
-	err = clusterRequest.CreateOrUpdateSecret(secret)
+	return clusterRequest.CreateOrUpdateSecret(secret)
+}
+
+func loadFilesFromWorkingDir() (map[string][]byte, error) {
+	workDir := utils.GetWorkingDir()
+	files, err := ioutil.ReadDir(workDir)
 	if err != nil {
-		return
+		return nil, err
 	}
-
-	return nil
-}
-
-func (clusterRequest *ClusterLoggingRequest) readSecrets() (err error) {
-
-	for secretName, certMap := range secretCertificates {
-		if err = clusterRequest.extractCertificates(secretName, certMap); err != nil {
-			return
+	results := map[string][]byte{}
+	for _, f := range files {
+		content := utils.GetFileContents(path.Join(workDir, f.Name()))
+		if content != nil {
+			results[f.Name()] = content
+		} else {
+			logger.Infof("The content is nil for certificate file: %s", f.Name())
 		}
 	}
-
-	return nil
-}
-
-func (clusterRequest *ClusterLoggingRequest) extractCertificates(secretName string, certs map[string]string) (err error) {
-
-	for secretKey, certPath := range certs {
-		if err = clusterRequest.extractSecretToFile(secretName, secretKey, certPath); err != nil {
-			if errors.IsNotFound(err) {
-				return nil
-			}
-			return
-		}
-	}
-
-	return nil
+	return results, nil
 }
 
 //CreateOrUpdateCertificates for a cluster logging instance
 func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCertificates() (err error) {
+	return Synchronize(func() error {
+		if err = clusterRequest.extractMasterCerts(); err != nil {
+			fmt.Printf("Error %v", err)
+			return err
+		}
 
-	// Pull master signing cert out from secret in logging.Spec.SecretName
-	if err = clusterRequest.readSecrets(); err != nil {
-		return
-	}
+		scriptsDir := utils.GetScriptsDir()
+		updated := false
+		if err, updated = certificates.GenerateCertificates(clusterRequest.Cluster.Namespace, scriptsDir, "elasticsearch", utils.GetWorkingDir()); err != nil {
+			return fmt.Errorf("Error running script: %v", err)
+		}
+		logger.Tracef("Writing secret updated: %v", updated)
+		if updated {
+			if err = clusterRequest.writeSecret(); err != nil {
+				return err
+			}
+		}
 
-	scriptsDir := utils.GetScriptsDir()
-	if err = GenerateCertificates(clusterRequest.Cluster.Namespace, scriptsDir, "elasticsearch", utils.DefaultWorkingDir); err != nil {
-		return fmt.Errorf("Error running script: %v", err)
-	}
-
-	if err = clusterRequest.writeSecret(); err != nil {
-		return
-	}
-
-	return nil
-}
-
-func GenerateCertificates(namespace, scriptsDir, logStoreName, workDir string) (err error) {
-	script := fmt.Sprintf("%s/cert_generation.sh", scriptsDir)
-	return RunCertificatesScript(namespace, logStoreName, workDir, script)
-}
-
-func RunCertificatesScript(namespace, logStoreName, workDir, script string) (err error) {
-	logger.Debugf("Running script '%s %s %s %s'", script, workDir, namespace, logStoreName)
-	cmd := exec.Command(script, workDir, namespace, logStoreName)
-	result, err := cmd.Output()
-	if logger.IsDebugEnabled() {
-		logger.Debugf("cert_generation output: %s", string(result))
-		logger.Debugf("err: %v", err)
-	}
-	return err
+		return nil
+	})
 }

--- a/pkg/k8shandler/certificates_test.go
+++ b/pkg/k8shandler/certificates_test.go
@@ -15,6 +15,7 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/pkg/constants"
+	"github.com/openshift/cluster-logging-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -94,7 +95,7 @@ var _ = Describe("Reconciling", func() {
 			clusterRequest *ClusterLoggingRequest
 		)
 
-		BeforeEach(func() {
+		BeforeSuite(func() {
 			client = fake.NewFakeClient(
 				cluster,
 				masterCASecret,
@@ -108,7 +109,10 @@ var _ = Describe("Reconciling", func() {
 				Client:  client,
 				Cluster: cluster,
 			}
-
+			if err := os.RemoveAll(utils.GetWorkingDir()); err != nil {
+				Fail(fmt.Sprintf("%v", err))
+			}
+			os.Setenv("WORKING_DIR", utils.GetWorkingDir())
 			os.Setenv("SCRIPTS_DIR", scriptsDir)
 			_ = clusterRequest.CreateOrUpdateCertificates()
 		})
@@ -118,8 +122,8 @@ var _ = Describe("Reconciling", func() {
 			key := types.NamespacedName{Name: constants.MasterCASecretName, Namespace: constants.OpenshiftNS}
 			Expect(client.Get(context.TODO(), key, secret)).Should(Succeed())
 
-			Expect(secret).Should(SucceedParse(constants.MasterCASecretName))
-			Expect(secret).Should(SucceedVerifyX509("masterca", "masterca", "openshift-cluster-logging-signer", nil, nil, nil))
+			Expect(secret).Should(ContainKeys("ca.key", "ca.crt", "ca.db", "ca.serial.txt"))
+			Expect(secret).Should(SucceedVerifyX509("ca.crt", "ca.crt", "openshift-cluster-logging-signer", nil, nil, nil))
 		})
 
 		Context("for log store", func() {
@@ -134,7 +138,13 @@ var _ = Describe("Reconciling", func() {
 					"elasticsearch.openshift-logging.svc",
 					"elasticsearch.cluster.local",
 				}
-				Expect(secret).Should(SucceedParse(constants.ElasticsearchName))
+				Expect(secret).Should(ContainKeys("elasticsearch.key",
+					"elasticsearch.crt",
+					"logging-es.key",
+					"logging-es.crt",
+					"admin-key",
+					"admin-cert",
+					"admin-ca"))
 				Expect(secret).Should(SucceedVerifyCert("admin-ca", "elasticsearch.crt", "elasticsearch", san))
 			})
 
@@ -148,7 +158,13 @@ var _ = Describe("Reconciling", func() {
 					"elasticsearch.openshift-logging.svc",
 					"elasticsearch.cluster.local",
 				}
-				Expect(secret).Should(SucceedParse(constants.ElasticsearchName))
+				Expect(secret).Should(ContainKeys("elasticsearch.key",
+					"elasticsearch.crt",
+					"logging-es.key",
+					"logging-es.crt",
+					"admin-key",
+					"admin-cert",
+					"admin-ca"))
 				Expect(secret).Should(SucceedVerifyCert("admin-ca", "logging-es.crt", "elasticsearch", san))
 			})
 
@@ -158,7 +174,13 @@ var _ = Describe("Reconciling", func() {
 				key := types.NamespacedName{Name: constants.ElasticsearchName, Namespace: constants.OpenshiftNS}
 				Expect(client.Get(context.TODO(), key, secret)).Should(Succeed())
 
-				Expect(secret).Should(SucceedParse(constants.ElasticsearchName))
+				Expect(secret).Should(ContainKeys("elasticsearch.key",
+					"elasticsearch.crt",
+					"logging-es.key",
+					"logging-es.crt",
+					"admin-key",
+					"admin-cert",
+					"admin-ca"))
 				Expect(secret).Should(SucceedVerifyCert("admin-ca", "admin-cert", "system.admin", nil))
 			})
 		})
@@ -170,7 +192,7 @@ var _ = Describe("Reconciling", func() {
 				key := types.NamespacedName{Name: constants.FluentdName, Namespace: constants.OpenshiftNS}
 				Expect(client.Get(context.TODO(), key, secret)).Should(Succeed())
 
-				Expect(secret).Should(SucceedParse(constants.FluentdName))
+				Expect(secret).Should(ContainKeys("ca-bundle.crt", "tls.crt", "tls.key"))
 				Expect(secret).Should(SucceedVerifyCert("ca-bundle.crt", "tls.crt", "system.logging.fluentd", nil))
 			})
 		})
@@ -182,7 +204,7 @@ var _ = Describe("Reconciling", func() {
 				key := types.NamespacedName{Name: constants.KibanaName, Namespace: constants.OpenshiftNS}
 				Expect(client.Get(context.TODO(), key, secret)).Should(Succeed())
 
-				Expect(secret).Should(SucceedParse(constants.KibanaName))
+				Expect(secret).Should(ContainKeys("ca", "key", "cert"))
 				Expect(secret).Should(SucceedVerifyCert("ca", "cert", "system.logging.kibana", nil))
 			})
 
@@ -192,7 +214,7 @@ var _ = Describe("Reconciling", func() {
 				key := types.NamespacedName{Name: constants.KibanaProxyName, Namespace: constants.OpenshiftNS}
 				Expect(client.Get(context.TODO(), key, secret)).Should(Succeed())
 
-				Expect(secret).Should(SucceedParse(constants.KibanaProxyName))
+				Expect(secret).Should(ContainKeys("session-secret", "server-key", "server-cert"))
 			})
 		})
 
@@ -203,39 +225,34 @@ var _ = Describe("Reconciling", func() {
 				key := types.NamespacedName{Name: constants.CuratorName, Namespace: constants.OpenshiftNS}
 				Expect(client.Get(context.TODO(), key, secret)).Should(Succeed())
 
-				Expect(secret).Should(SucceedParse(constants.CuratorName))
+				Expect(secret).Should(ContainKeys("ca", "key", "cert", "ops-ca", "ops-key", "ops-cert"))
 				Expect(secret).Should(SucceedVerifyCert("ca", "cert", "system.logging.curator", nil))
 			})
 		})
 	})
 })
 
-func SucceedParse(secretName string) gomegatypes.GomegaMatcher {
-	return &succeedParseMatcher{secretName: secretName}
+func ContainKeys(secretKeys ...string) gomegatypes.GomegaMatcher {
+	return &secretKeysMatcher{keys: secretKeys}
 }
 
-type succeedParseMatcher struct {
-	secretName string
+type secretKeysMatcher struct {
+	keys []string
 }
 
-func (matcher *succeedParseMatcher) Match(actual interface{}) (bool, error) {
+func (matcher *secretKeysMatcher) Match(actual interface{}) (bool, error) {
 	secret, ok := actual.(*corev1.Secret)
 	if !ok || secret == nil {
-		return false, fmt.Errorf("SuceedParse expects a non-nil *corev1.Secret")
+		return false, fmt.Errorf("ContainKeys expects a non-nil *corev1.Secret")
 	}
 
 	if secret.Data == nil || len(secret.Data) == 0 {
-		return false, fmt.Errorf("failed to read data from secret %q", matcher.secretName)
+		return false, fmt.Errorf("failed to read data from secret %q", secret.Name)
 	}
 
-	secretRef, ok := secretCertificates[matcher.secretName]
-	if !ok {
-		return false, fmt.Errorf("failed to load certificate reference for: %s", matcher.secretName)
-	}
-
-	for want := range secret.Data {
+	for _, want := range matcher.keys {
 		found := false
-		for k := range secretRef {
+		for k := range secret.Data {
 			if k == want {
 				found = true
 				break
@@ -243,18 +260,18 @@ func (matcher *succeedParseMatcher) Match(actual interface{}) (bool, error) {
 		}
 
 		if !found {
-			return false, fmt.Errorf("failed to find key %q for secret %q", want, matcher.secretName)
+			return false, fmt.Errorf("failed to find key %q in secret %q", want, secret.Name)
 		}
 	}
 
 	return true, nil
 }
 
-func (matcher *succeedParseMatcher) FailureMessage(actual interface{}) (message string) {
+func (matcher *secretKeysMatcher) FailureMessage(actual interface{}) (message string) {
 	return ""
 }
 
-func (matcher *succeedParseMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (matcher *secretKeysMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	return ""
 }
 
@@ -293,7 +310,6 @@ func (matcher *succeedVerifyX509Matcher) Match(actual interface{}) (bool, error)
 	if secret.Data == nil || len(secret.Data) == 0 {
 		return false, fmt.Errorf("failed to read data from secret")
 	}
-
 	roots, cert, err := loadX509Cert(secret.Data[matcher.caKey], secret.Data[matcher.certKey])
 	if err != nil {
 		return false, fmt.Errorf("Failed to parse X509 certificate: %s", err.Error())

--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -145,15 +145,20 @@ func (clusterRequest *ClusterLoggingRequest) removeElasticsearch() (err error) {
 	return nil
 }
 func LoadElasticsearchSecretMap() map[string][]byte {
-	return map[string][]byte{
-		"elasticsearch.key": utils.GetWorkingDirFileContents("elasticsearch.key"),
-		"elasticsearch.crt": utils.GetWorkingDirFileContents("elasticsearch.crt"),
-		"logging-es.key":    utils.GetWorkingDirFileContents("logging-es.key"),
-		"logging-es.crt":    utils.GetWorkingDirFileContents("logging-es.crt"),
-		"admin-key":         utils.GetWorkingDirFileContents("system.admin.key"),
-		"admin-cert":        utils.GetWorkingDirFileContents("system.admin.crt"),
-		"admin-ca":          utils.GetWorkingDirFileContents("ca.crt"),
-	}
+	var results = map[string][]byte{}
+	_ = Synchronize(func() error {
+		results = map[string][]byte{
+			"elasticsearch.key": utils.GetWorkingDirFileContents("elasticsearch.key"),
+			"elasticsearch.crt": utils.GetWorkingDirFileContents("elasticsearch.crt"),
+			"logging-es.key":    utils.GetWorkingDirFileContents("logging-es.key"),
+			"logging-es.crt":    utils.GetWorkingDirFileContents("logging-es.crt"),
+			"admin-key":         utils.GetWorkingDirFileContents("system.admin.key"),
+			"admin-cert":        utils.GetWorkingDirFileContents("system.admin.crt"),
+			"admin-ca":          utils.GetWorkingDirFileContents("ca.crt"),
+		}
+		return nil
+	})
+	return results
 }
 func (clusterRequest *ClusterLoggingRequest) createOrUpdateElasticsearchSecret() error {
 

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -197,15 +197,19 @@ func (clusterRequest *ClusterLoggingRequest) removeOldKibana() (err error) {
 }
 
 func (clusterRequest *ClusterLoggingRequest) createOrUpdateKibanaSecret() error {
-
-	kibanaSecret := NewSecret(
-		"kibana",
-		clusterRequest.Cluster.Namespace,
-		map[string][]byte{
+	var secrets = map[string][]byte{}
+	_ = Synchronize(func() error {
+		secrets = map[string][]byte{
 			"ca":   utils.GetWorkingDirFileContents("ca.crt"),
 			"key":  utils.GetWorkingDirFileContents("system.logging.kibana.key"),
 			"cert": utils.GetWorkingDirFileContents("system.logging.kibana.crt"),
-		})
+		}
+		return nil
+	})
+	kibanaSecret := NewSecret(
+		"kibana",
+		clusterRequest.Cluster.Namespace,
+		secrets)
 
 	utils.AddOwnerRefToObject(kibanaSecret, utils.AsOwner(clusterRequest.Cluster))
 
@@ -214,21 +218,18 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateKibanaSecret() error 
 		return err
 	}
 
-	var sessionSecret []byte
-
-	sessionSecret = utils.GetWorkingDirFileContents("kibana-session-secret")
-	if sessionSecret == nil {
-		sessionSecret = utils.GetRandomWord(32)
-	}
-
+	_ = Synchronize(func() error {
+		secrets = map[string][]byte{
+			"session-secret": utils.GetWorkingDirFileContents(constants.KibanaSessionSecretName),
+			"server-key":     utils.GetWorkingDirFileContents("kibana-internal.key"),
+			"server-cert":    utils.GetWorkingDirFileContents("kibana-internal.crt"),
+		}
+		return nil
+	})
 	proxySecret := NewSecret(
 		"kibana-proxy",
 		clusterRequest.Cluster.Namespace,
-		map[string][]byte{
-			"session-secret": sessionSecret,
-			"server-key":     utils.GetWorkingDirFileContents("kibana-internal.key"),
-			"server-cert":    utils.GetWorkingDirFileContents("kibana-internal.crt"),
-		})
+		secrets)
 
 	utils.AddOwnerRefToObject(proxySecret, utils.AsOwner(clusterRequest.Cluster))
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -200,13 +200,15 @@ func GetScriptsDir() string {
 func GetWorkingDirFileContents(filePath string) []byte {
 	return GetFileContents(GetWorkingDirFilePath(filePath))
 }
-
-func GetWorkingDirFilePath(toFile string) string {
+func GetWorkingDir() string {
 	workingDir := os.Getenv("WORKING_DIR")
 	if workingDir == "" {
 		workingDir = DefaultWorkingDir
 	}
-	return path.Join(workingDir, toFile)
+	return workingDir
+}
+func GetWorkingDirFilePath(toFile string) string {
+	return path.Join(GetWorkingDir(), toFile)
 }
 
 func WriteToWorkingDirFile(toFile string, value []byte) error {

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/ginkgo"
 	cl "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/pkg/certificates"
 	k8shandler "github.com/openshift/cluster-logging-operator/pkg/k8shandler"
 	"github.com/openshift/cluster-logging-operator/pkg/logger"
 	"github.com/openshift/cluster-logging-operator/pkg/utils"
@@ -554,7 +555,7 @@ func (tc *E2ETestFramework) CreatePipelineSecret(pwd, logStoreName, secretName s
 		return nil, err
 	}
 	scriptsDir := fmt.Sprintf("%s/scripts", pwd)
-	if err = k8shandler.GenerateCertificates(OpenshiftLoggingNS, scriptsDir, logStoreName, workingDir); err != nil {
+	if err, _ = certificates.GenerateCertificates(OpenshiftLoggingNS, scriptsDir, logStoreName, workingDir); err != nil {
 		return nil, err
 	}
 	data := map[string][]byte{


### PR DESCRIPTION
(cherry picked from commit 02e1cea8a0930101db016d0e1376b38e1023701e)
Description
This PR updates the certificate generation code to:

Add info message why certs are being (re)generated
Adds a mutex to the cert code to ensure changes are made in a single threaded fashion
Moves stashing of generated certs to the "master-certs" secret
/assign @syedriko @alanconway

Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1895607
* https://github.com/openshift/cluster-logging-operator/pull/765