### PR TITLE
Make it predictable which Dockerfile is used for CLO image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,11 +91,9 @@ clean:
 	go clean -cache -testcache ./...
 
 PATCH?=Dockerfile.patch
-Dockerfile.local: Dockerfile $(PATCH)
-	patch -o Dockerfile.local Dockerfile $(PATCH)
-
-image: Dockerfile.local
+image:
 	@if [ $${SKIP_BUILD:-false} = false ] ; then \
+		patch -o Dockerfile.local Dockerfile $(PATCH) && \
 		podman build -t $(IMAGE_TAG) . -f Dockerfile.local; \
 	fi
 


### PR DESCRIPTION
### Description

Made behavior of `make image` surprise-free as to which Dockerfile is used to build the CLO image. Before this change, the first Dockefile patch used to build CLO image would "stick" in Dockerfile.local and subsequent invocations of `[PATCH=...] make image` would keep using the same Dockerfile.local, regardless of the value of PATCH. Here's an illustration:

#### Before:
```
First image build, building with the CentOS base image, correct behavior:
[syedriko@localhost cluster-logging-operator]$ PATCH=Dockerfile.centos.patch make image
...
STEP 16: FROM centos:centos8 AS centos
...

Building with the default PATCH, expecting the OCP 4.7 base image, getting CentOS
[syedriko@localhost cluster-logging-operator]$ make image
...
STEP 16: FROM centos:centos8 AS centos
...

Building with the explicit PATCH for OCP 4.7 base image, still getting the CentOS base:
[syedriko@localhost cluster-logging-operator]$ PATCH=Dockerfile.patch make image
...
STEP 16: FROM centos:centos8 AS centos
...

Remove Dockerfile.local

rm Dockerfile.local

Default PATCH for OCP 4.7 base, that's what we're getting:
[syedriko@localhost cluster-logging-operator]$ make image
...
STEP 17: FROM registry.svc.ci.openshift.org/ocp/4.7:base
...

Explicit PATCH for CentOS, still getting OCP 4.7 base:
[syedriko@localhost cluster-logging-operator]$ PATCH=Dockerfile.centos.patch make image
...
STEP 17: FROM registry.svc.ci.openshift.org/ocp/4.7:base
...
```

#### After:

```
Base image matches the specified PATCH:

Building with the default PATCH, expecting OCP 4.7 base image, getting the OCP 4.7:
[syedriko@localhost cluster-logging-operator]$ make image
...
STEP 17: FROM registry.svc.ci.openshift.org/ocp/4.7:base
...

Asking for CentOS base, getting the CentOS base:
[syedriko@localhost cluster-logging-operator]$ PATCH=Dockerfile.centos.patch make image
...
STEP 16: FROM centos:centos8 AS centos
...

Asking for OCP 4.7 base, getting the OCP 4.7 base:
[syedriko@localhost cluster-logging-operator]$ PATCH=Dockerfile.patch make image
...
STEP 17: FROM registry.svc.ci.openshift.org/ocp/4.7:base
...
```

/cc @jcantrill
/assign @alanconway
