### PR TITLE
Bug 1891886: Support Adding log source info to log message

### DIFF
--- a/manifests/4.7/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/manifests/4.7/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -99,6 +99,9 @@ spec:
                     syslog:
                       description: Syslog provides optional extra properties for output type `syslog`
                       properties:
+                        addLogSource:
+                          description: AddLogSource adds log's source information to the log message If the logs are collected from a process; namespace_name, pod_name, container_name is added to the log
+                          type: boolean
                         appName:
                           description: "AppName is APP-NAME part of the syslog-msg header \n AppName needs to be specified if using rfc5424"
                           type: string

--- a/manifests/5.0/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/manifests/5.0/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -99,6 +99,9 @@ spec:
                     syslog:
                       description: Syslog provides optional extra properties for output type `syslog`
                       properties:
+                        addLogSource:
+                          description: AddLogSource adds log's source information to the log message If the logs are collected from a process; namespace_name, pod_name, container_name is added to the log
+                          type: boolean
                         appName:
                           description: "AppName is APP-NAME part of the syslog-msg header \n AppName needs to be specified if using rfc5424"
                           type: string

--- a/pkg/apis/logging/v1/output_types.go
+++ b/pkg/apis/logging/v1/output_types.go
@@ -65,6 +65,12 @@ type Syslog struct {
 	// +optional
 	PayloadKey string `json:"payloadKey,omitempty"`
 
+	// AddLogSource adds log's source information to the log message
+	// If the logs are collected from a process; namespace_name, pod_name, container_name is added to the log
+	//
+	// +optional
+	AddLogSource bool `json:"addLogSource,omitempty"`
+
 	// Rfc specifies the rfc to be used for sending syslog
 	//
 	// Rfc values can be one of:

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -143,6 +143,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         severity debug
     	protocol tcp
     	packet_size 4096
+		hostname "#{ENV['NODE_NAME']}"
 		timeout 60
 		timeout_exception true
 	    keep_alive true
@@ -187,6 +188,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         severity debug
     	protocol udp
     	packet_size 4096
+		hostname "#{ENV['NODE_NAME']}"
         <buffer >
         @type file
         path '/var/lib/fluentd/syslog_receiver'
@@ -225,6 +227,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         severity debug
     	protocol tcp
     	packet_size 4096
+		hostname "#{ENV['NODE_NAME']}"
         tls true
         ca_file '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
         verify_mode true
@@ -272,6 +275,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         severity debug
     	protocol udp
     	packet_size 4096
+		hostname "#{ENV['NODE_NAME']}"
         tls true
         ca_file '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
         verify_mode true
@@ -331,6 +335,93 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					Expect(err).To(BeNil())
 					Expect(len(results)).To(Equal(1))
 					Expect(results[0]).To(EqualTrimLines(tcpWithTLSConf))
+				})
+			})
+			Context("with AddLogSource flag", func() {
+				syslogConfWithAddSource := `<label @SYSLOG_RECEIVER>
+				  <filter **>
+					@type parse_json_field
+					json_fields  message
+					merge_json_log false
+					replace_json_log true
+				  </filter>
+				  <filter **>
+					@type record_modifier
+					<record>
+					  kubernetes_info ${if record.has_key?('kubernetes'); record['kubernetes']; else {}; end}
+					  namespace_info  ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "namespace_name=" + record['kubernetes_info']['namespace_name']; else nil; end}
+					  pod_info        ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "pod_name=" + record['kubernetes_info']['pod_name']; else nil; end}
+					  container_info  ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "container_name=" + record['kubernetes_info']['container_name']; else nil; end}
+					  msg_key         ${if record.has_key?('message') && record['message'] != nil; record['message']; else nil; end}
+					  msg_info        ${if record['msg_key'] != nil && record['msg_key'].is_a?(Hash); require 'json'; "message="+record['message'].to_json; elsif record['msg_key'] != nil; "message="+record['message']; else nil; end}
+					  message         ${if record['msg_key'] != nil && record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; record['namespace_info'] + ", " + record['container_info'] + ", " + record['pod_info'] + ", " + record['msg_info']; else record['message']; end}
+					</record>
+					  remove_keys kubernetes_info, namespace_info, pod_info, container_info, msg_key, msg_info
+				  </filter>
+				  <match **>
+					@type copy
+					<store>
+					  @type remote_syslog
+					  @id syslog_receiver
+					  host sl.svc.messaging.cluster.local
+					  port 9654
+					  rfc rfc5424
+					  facility user
+					  severity debug
+					  protocol tcp
+					  packet_size 4096
+					  hostname "#{ENV['NODE_NAME']}"
+					  tls true
+					  ca_file '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
+					  verify_mode true
+					  timeout 60
+					  timeout_exception true
+					  keep_alive true
+					  keep_alive_idle 75
+					  keep_alive_cnt 9
+					  keep_alive_intvl 7200
+					  <buffer >
+						@type file
+						path '/var/lib/fluentd/syslog_receiver'
+						flush_mode interval
+						flush_interval 1s
+						flush_thread_count 2
+						flush_at_shutdown true
+						retry_type exponential_backoff
+						retry_wait 1s
+						retry_max_interval 60s
+						retry_forever true
+						queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+						total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+						chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+						overflow_action block
+					  </buffer>
+					</store>
+				  </match>
+				</label>`
+				BeforeEach(func() {
+					outputs = []logging.OutputSpec{
+						{
+							Type: "syslog",
+							Name: "syslog-receiver",
+							URL:  "tls://sl.svc.messaging.cluster.local:9654",
+							Secret: &logging.OutputSecretSpec{
+								Name: "some-secret",
+							},
+							OutputTypeSpec: logging.OutputTypeSpec{
+								Syslog: &logging.Syslog{
+									AddLogSource: true,
+									RFC:          "RFC5424",
+								},
+							},
+						},
+					}
+				})
+				It("should produce config to copy log source information to log message", func() {
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
+					Expect(err).To(BeNil())
+					Expect(len(results)).To(Equal(1))
+					Expect(results[0]).To(EqualTrimLines(syslogConfWithAddSource))
 				})
 			})
 		})

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -499,6 +499,7 @@ var _ = Describe("Generating fluentd config", func() {
                 severity debug
               protocol tcp
               packet_size 4096
+			  hostname "#{ENV['NODE_NAME']}"
             timeout 60
             timeout_exception true
               keep_alive true
@@ -552,6 +553,7 @@ var _ = Describe("Generating fluentd config", func() {
                 severity debug
               protocol tcp
               packet_size 4096
+			  hostname "#{ENV['NODE_NAME']}"
             timeout 60
             timeout_exception true
               keep_alive true

--- a/pkg/generators/forwarding/fluentd/syslog_conf.go
+++ b/pkg/generators/forwarding/fluentd/syslog_conf.go
@@ -76,6 +76,10 @@ func (conf *outputLabelConf) PayloadKey() string {
 	return conf.Target.Syslog.PayloadKey
 }
 
+func (conf *outputLabelConf) AddLogSource() bool {
+	return conf.Target.Syslog.AddLogSource
+}
+
 func (conf *outputLabelConf) AppName() string {
 	appname := conf.Target.Syslog.AppName
 	if appname == "" {

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -317,7 +317,7 @@ func (tc *E2ETestFramework) waitForClusterLoggingPodsCompletion(namespace string
 			clolog.Info("No pods found for label selection", "labels", labels)
 			return true, nil
 		}
-		clolog.V(3).Info("still running pods:", len(pods.Items))
+		clolog.V(3).Info("pods still running", "num", len(pods.Items))
 		return false, nil
 	})
 }


### PR DESCRIPTION
### Description
 - A fix for bug [1891886](https://bugzilla.redhat.com/show_bug.cgi?id=1891886).
 - Added a field in LF CRD `AddLogSource`, which when enabled, adds namespace_name, pod_name, container_name to the `message` field of the record.
 - This can be further used with `PayloadKey` set to `"message"` to achieve the same behavior as older syslog plugin.
 - The solution is to add a `record_modifier` section in the fluent config, which copies the `namespace_name` , `pod_name` , `container_name` from the `kubernetes` section, and copies it into `message`
  - also fixed two lint issues in funtional tests

#### Syslog Payload before this change:
```
<15>1 2020-11-15T17:06:14+00:00 fluentd-9hkb4 mytag - - -  {"msgcontent"=>"My life is my message", "timestamp"=>"2020-11-15 17:06:09", "tag_key"=>"rec_tag", "index"=>56}
```

#### Syslog Payload After this change:
```
<15>1 2020-11-16T10:49:37+00:00 crc-j55b9-master-0 mytag - - -  namespace_name=clo-test-6327,pod_name=log-generator-ff9746c49-qxm7l,container_name=log-generator,message={"msgcontent"=>"My life is my message", "timestamp"=>"2020-11-16 10:49:36", "tag_key"=>"rec_tag", "index"=>76}
```

#### Example LF CR :
```
spec:    
  outputs:    
  - name: syslogout    
    syslog:    
      addLogSource: true    
      facility: user    
      payloadKey: message    
      rfc: RFC3164    
      severity: debug    
      tag: mytag    
    type: syslog    
    url: tls://syslog-receiver.openshift-logging.svc:24224    
  pipelines:    
  - inputRefs:    
    - application    
    name: test-app    
    outputRefs:    
    - syslogout    

```
*Note* : This behavior works for both RFC3164 and RFC5424

/cc @alanconway @jcantrill 
/assign @alanconway 


### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1824003#c26 (actual syslog BZ which holds the conversation about the issue faced by customer. This solution is inspired from this BZ, especially comment 26)
- Bugzille: https://bugzilla.redhat.com/show_bug.cgi?id=1891886

