### PR TITLE
Add manifests/5.0 folder for cpaas builds

### DIFF
--- a/manifests/5.0/0100_clusterroles.yaml
+++ b/manifests/5.0/0100_clusterroles.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterlogging-collector-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/manifests/5.0/0110_clusterrolebindings.yaml
+++ b/manifests/5.0/0110_clusterrolebindings.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clusterlogging-collector-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterlogging-collector-metrics
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring 

--- a/manifests/5.0/cluster-logging.v5.0.0.clusterserviceversion.yaml
+++ b/manifests/5.0/cluster-logging.v5.0.0.clusterserviceversion.yaml
@@ -1,0 +1,497 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  # The version value is substituted by the ART pipeline
+  name: clusterlogging.v5.0.0
+  namespace: placeholder
+  labels:
+    "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.ppc64le": supported
+    "operatorframework.io/arch.s390x": supported
+  annotations:
+    "operatorframework.io/suggested-namespace": openshift-logging
+    "operatorframework.io/cluster-monitoring": "true"
+    capabilities: Seamless Upgrades
+    categories: "OpenShift Optional, Logging & Tracing"
+    certified: "false"
+    description: |-
+      The Cluster Logging Operator for OCP provides a means for configuring and managing your aggregated logging stack.
+    containerImage: quay.io/openshift/origin-cluster-logging-operator:latest
+    createdAt: 2018-08-01T08:00:00Z
+    support: AOS Logging
+    # The version value is substituted by the ART pipeline
+    olm.skipRange: ">=4.5.0-0 <5.0.0"
+    alm-examples: |-
+        [
+          {
+            "apiVersion": "logging.openshift.io/v1",
+            "kind": "ClusterLogging",
+            "metadata": {
+              "name": "instance",
+              "namespace": "openshift-logging"
+            },
+            "spec": {
+              "managementState": "Managed",
+              "logStore": {
+                "type": "elasticsearch",
+                "elasticsearch": {
+                  "nodeCount": 3,
+                  "redundancyPolicy": "SingleRedundancy",
+                  "storage": {
+                    "storageClassName": "gp2",
+                    "size": "200G"
+                  }
+                },
+                "retentionPolicy":{
+                  "application":{
+                    "maxAge":"7d"
+                  }
+                }
+              },
+              "visualization": {
+                "type": "kibana",
+                "kibana": {
+                  "replicas": 1
+                }
+              },
+              "curation": {
+                "type": "curator",
+                "curator": {
+                  "schedule": "30 3 * * *"
+                }
+              },
+              "collection": {
+                "logs": {
+                  "type": "fluentd",
+                  "fluentd": {}
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "logging.openshift.io/v1",
+            "kind": "ClusterLogForwarder",
+            "metadata": {
+              "name": "instance",
+              "namespace": "openshift-logging"
+            },
+            "spec": {
+              "outputs": [
+                {
+                  "name": "remote-elasticsearch",
+                  "type": "elasticsearch",
+                  "url": "remote.example.org:9200",
+                  "secret": {
+                    "name": "elasticsearch"
+                  }
+                }
+              ],
+              "pipelines": [
+                {
+                  "name": "enable-default-log-store",
+                  "inputRefs": ["application", "infrastructure", "audit"],
+                  "outputRefs": ["default"]
+                },
+                {
+                  "name": "forward-to-remote",
+                  "inputRefs": ["application"],
+                  "outputRefs": ["remote-elasticsearch"]
+                }
+              ]
+            }
+          }
+        ]
+spec:
+  # The version value is substituted by the ART pipeline
+  version: 5.0.0
+  displayName: Cluster Logging
+  minKubeVersion: 1.18.3
+  description: |
+    # Cluster Logging
+    The Cluster Logging Operator orchestrates and manages the aggregated logging stack as a cluster-wide service.
+
+    ##Features
+    * **Create/Destroy**: Launch and create an aggregated logging stack to support the entire OCP cluster.
+    * **Simplified Configuration**: Configure your aggregated logging cluster's structure like components and end points easily.
+
+    ## Prerequisites and Requirements
+    ### Cluster Logging Namespace
+    Cluster logging and the Cluster Logging Operator is only deployable to the **openshift-logging** namespace. This namespace
+    must be explicitly created by a cluster administrator (e.g. `oc create ns openshift-logging`). To enable metrics
+    service discovery add namespace label `openshift.io/cluster-monitoring: "true"`.
+
+    For additional installation documentation see [Deploying cluster logging](https://docs.openshift.com/container-platform/5.0/logging/cluster-logging-deploying.html)
+    in the OpenShift product documentation.
+
+    ### Elasticsearch Operator
+    The Elasticsearch Operator is responsible for orchestrating and managing cluster logging's Elasticsearch cluster.  This
+    operator must be deployed to the global operator group namespace
+    ### Memory Considerations
+    Elasticsearch is a memory intensive application.  Cluster Logging will specify that each Elasticsearch node needs
+    16G of memory for both request and limit unless otherwise defined in the ClusterLogging custom resource. The initial
+    set of OCP nodes may not be large enough to support the Elasticsearch cluster.  Additional OCP nodes must be added
+    to the OCP cluster if you desire to run with the recommended(or better) memory. Each ES node can operate with a
+    lower memory setting though this is not recommended for production deployments.
+
+  keywords: ['elasticsearch', 'kibana', 'fluentd', 'logging', 'aggregated', 'efk']
+
+  maintainers:
+  - name: Red Hat
+    email: aos-logging@redhat.com
+
+  provider:
+    name: Red Hat
+
+  links:
+  - name: Elastic
+    url: https://www.elastic.co/
+  - name: Fluentd
+    url: https://www.fluentd.org/
+  - name: Documentation
+    url: https://github.com/openshift/cluster-logging-operator/blob/master/README.md
+  - name: Cluster Logging Operator
+    url: https://github.com/openshift/cluster-logging-operator
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: false
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: cluster-logging-operator
+        rules:
+        - apiGroups:
+          - logging.openshift.io
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - serviceaccounts/finalizers
+          - services/finalizers
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - "*"
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - "*"
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - "*"
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - "*"
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          resourceNames:
+          - privileged
+          verbs:
+          - use
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - "*"
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          resourceNames:
+          - "cluster-logging-operator"
+          verbs:
+          - "update"
+      clusterPermissions:
+      - serviceAccountName: cluster-logging-operator
+        rules:
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consoleexternalloglinks
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - "*"
+        - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - "*"
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients
+          verbs:
+          - "*"
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - "*"
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - proxies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - namespaces
+          - services
+          - services/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+      deployments:
+      - name: cluster-logging-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: cluster-logging-operator
+          template:
+            metadata:
+              labels:
+                name: cluster-logging-operator
+            spec:
+              nodeSelector:
+                kubernetes.io/os: linux
+              serviceAccountName: cluster-logging-operator
+              containers:
+              - name: cluster-logging-operator
+                image: quay.io/openshift/origin-cluster-logging-operator:latest
+                imagePullPolicy: IfNotPresent
+                command:
+                - cluster-logging-operator
+                env:
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.annotations['olm.targetNamespaces']
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: OPERATOR_NAME
+                    value: "cluster-logging-operator"
+                  - name: FLUENTD_IMAGE
+                    value: "quay.io/openshift/origin-logging-fluentd:latest"
+                  - name: CURATOR_IMAGE
+                    value: "quay.io/openshift/origin-logging-curator5:latest"
+  customresourcedefinitions:
+    owned:
+    - name: clusterloggings.logging.openshift.io
+      version: v1
+      kind: ClusterLogging
+      displayName: Cluster Logging
+      description: A Cluster Logging instance
+      resources:
+      - kind: Deployment
+        version: v1
+      - kind: DaemonSet
+        version: v1
+      - kind: CronJob
+        version: v1beta1
+      - kind: ReplicaSet
+        version: v1
+      - kind: Pod
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: Secret
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: Route
+        version: v1
+      - kind: Elasticsearch
+        version: v1
+      - kind: ClusterLogForwarder
+        version: v1
+      specDescriptors:
+      - description: The desired number of Kibana Pods for the Visualization component
+        displayName: Kibana Size
+        path: visualization.kibana.replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: Resource requirements for the Kibana pods
+        displayName: Kibana Resource Requirements
+        path: visualization.kibana.resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: The node selector to use for the Kibana Visualization component
+        displayName: Kibana Node Selector
+        path: visualization.kibana.nodeSelector
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:nodeSelector'
+      - description: The desired number of Elasticsearch Nodes for the Log Storage component
+        displayName: Elasticsearch Size
+        path: logStore.elasticsearch.nodeCount
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: Resource requirements for each Elasticsearch node
+        displayName: Elasticsearch Resource Requirements
+        path: logStore.elasticsearch.resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: The node selector to use for the Elasticsearch Log Storage component
+        displayName: Elasticsearch Node Selector
+        path: logStore.elasticsearch.nodeSelector
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:nodeSelector'
+      - description: The storage class name to use for the Elasticsearch Log Storage component
+        displayName: Elasticsearch Storage Class Name
+        path: logStore.elasticsearch.storage.storageClassName
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes:StorageClass'
+      - description: Resource requirements for the Fluentd pods
+        displayName: Fluentd Resource Requirements
+        path: collection.logs.fluentd.resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: The node selector to use for the Fluentd log collection component
+        displayName: Fluentd node selector
+        path: collection.logs.fluentd.nodeSelector
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:nodeSelector'
+      - description: Resource requirements for the Curator pods
+        displayName: Curator Resource Requirements
+        path: curation.curator.resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+      - description: The node selector to use for the Curator component
+        displayName: Curator Node Selector
+        path: curation.curator.nodeSelector
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:nodeSelector'
+      - description: The cron schedule for the Curator component
+        displayName: Curation Schedule
+        path: curation.curator.schedule
+      statusDescriptors:
+      - description: The status for each of the Kibana pods for the Visualization component
+        displayName: Kibana Status
+        path: visualization.kibanaStatus[0].pods
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+      - description: The status for each of the Elasticsearch Client pods for the Log Storage component
+        displayName: Elasticsearch Client Pod Status
+        path: logStore.elasticsearchStatus[0].pods.client
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+      - description: The status for each of the Elasticsearch Data pods for the Log Storage component
+        displayName: Elasticsearch Data Pod Status
+        path: logStore.elasticsearchStatus[0].pods.data
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+      - description: The status for each of the Elasticsearch Master pods for the Log Storage component
+        displayName: Elasticsearch Master Pod Status
+        path: logStore.elasticsearchStatus[0].pods.master
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+      - description: The cluster status for each of the Elasticsearch Clusters for the Log Storage component
+        displayName: Elasticsearch Cluster Health
+        path: logStore.elasticsearchStatus[0].clusterHealth
+      - description: The status for each of the Fluentd pods for the Log Collection component
+        displayName: Fluentd status
+        path: collection.logs.fluentdStatus.pods
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+      - description: The status for migration of a clusterlogging instance
+        displayName: Fluentd status
+        path: migration
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:migrationStatus'
+    - name: clusterlogforwarders.logging.openshift.io
+      version: v1
+      kind: ClusterLogForwarder
+      displayName: Cluster Log Forwarder
+      description: Defines destinations for forwarding selected logs.
+      specDescriptors:
+      - description: Definitions of input selectors for log messages.
+        displayName: Forwarder Inputs
+        path: forwarder.inputs
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:forwarderInputs'
+      - description: Definitions of output destinations for log messages.
+        displayName: Forwarder Outputs
+        path: forwarder.outputs
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:forwarderOutputs'
+      - description: Pipelines collect logs from inputs and forward them to outputs.
+        displayName: Forwarder Pipelines
+        path: forwarder.pipelines
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:forwarderPipelines'
+      statusDescriptors:
+      - description: Status conditions for the forwarder resource.
+        displayName: Forwarder Conditions
+        path: conditions
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:forwarderConditions'
+      - description: Status conditions for individual log inputs
+        displayName: Input Conditions
+        path: inputs
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:inputConditions'
+      - description: Status conditions for individual forwarder outputs
+        displayName: Output Conditions
+        path: outputs
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:outputConditions'
+      - description: Status conditions for forwarder pipelines
+        displayName: Pipeline Conditions
+        path: pipelines
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:pipelineConditions'

--- a/manifests/5.0/image-references
+++ b/manifests/5.0/image-references
@@ -1,0 +1,16 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: cluster-logging-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-cluster-logging-operator:latest
+  - name: logging-curator5
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-logging-curator5:latest
+  - name: logging-fluentd
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-logging-fluentd:latest

--- a/manifests/5.0/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/manifests/5.0/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -1,0 +1,288 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterlogforwarders.logging.openshift.io
+spec:
+  group: logging.openshift.io
+  names:
+    categories:
+    - logging
+    kind: ClusterLogForwarder
+    listKind: ClusterLogForwarderList
+    plural: clusterlogforwarders
+    shortNames:
+    - clf
+    singular: clusterlogforwarder
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterLogForwarder is an API to configure forwarding logs. \n You configure forwarding by specifying a list of `pipelines`, which forward from a set of named inputs to a set of named outputs. \n There are built-in input names for common log categories, and you can define custom inputs to do additional filtering. \n There is a built-in output name for the default openshift log store, but you can define your own outputs with a URL and other connection information to forward logs to other stores or processors, inside or outside the cluster. \n For more details see the documentation on the API fields."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - instance
+                type: string
+            type: object
+          spec:
+            description: ClusterLogForwarderSpec defines the desired state of ClusterLogForwarder
+            properties:
+              inputs:
+                description: "Inputs are named filters for log messages to be forwarded. \n There are three built-in inputs named `application`, `infrastructure` and `audit`. You don't need to define inputs here if those are sufficient for your needs. See `inputRefs` for more."
+                items:
+                  description: InputSpec defines a selector of log messages.
+                  properties:
+                    application:
+                      description: Application, if present, enables `application` logs.
+                      properties:
+                        namespaces:
+                          description: Namespaces is a list of namespaces from which to collect application logs. If the list is empty, logs are collected from all namespaces.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    audit:
+                      description: Audit, if present, enables `audit` logs.
+                      type: object
+                    infrastructure:
+                      description: Infrastructure, if present, enables `infrastructure` logs.
+                      type: object
+                    name:
+                      description: Name used to refer to the input of a `pipeline`.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              outputs:
+                description: "Outputs are named destinations for log messages. \n There is a built-in output named `default` which forwards to the default openshift log store. You can define outputs to forward to other stores or log processors, inside or outside the cluster."
+                items:
+                  description: Output defines a destination for log messages.
+                  properties:
+                    elasticsearch:
+                      type: object
+                    fluentdForward:
+                      type: object
+                    kafka:
+                      description: 'Kafka provides optional extra properties for `type: kafka`'
+                      properties:
+                        brokers:
+                          description: Brokers specifies the list of brokers to register in addition to the main output URL on initial connect to enhance reliability.
+                          items:
+                            type: string
+                          type: array
+                        topic:
+                          description: Topic specifies the target topic to send logs to.
+                          type: string
+                      type: object
+                    name:
+                      description: Name used to refer to the output from a `pipeline`.
+                      type: string
+                    secret:
+                      description: "Secret for secure communication. Secrets must be stored in the namespace containing the cluster logging operator. \n Client-authenticated TLS is enabled if the secret contains keys `tls.crt`, `tls.key` and `ca.crt`. Output types with password authentication will use keys `password` and `username`, not the exposed 'username@password' part of the `url`."
+                      properties:
+                        name:
+                          description: Name of a secret in the namespace configured for log forwarder secrets.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    syslog:
+                      description: Syslog provides optional extra properties for output type `syslog`
+                      properties:
+                        appName:
+                          description: "AppName is APP-NAME part of the syslog-msg header \n AppName needs to be specified if using rfc5424"
+                          type: string
+                        facility:
+                          description: "Facility to set on outgoing syslog records. \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1. The value can be a decimal integer. Facility keywords are not standardized, this API recognizes at least the following case-insensitive keywords (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels): \n     kernel user mail daemon auth syslog lpr news     uucp cron authpriv ftp ntp security console solaris-cron     local0 local1 local2 local3 local4 local5 local6 local7"
+                          type: string
+                        msgID:
+                          description: "MsgID is MSGID part of the syslog-msg header \n MsgID needs to be specified if using rfc5424"
+                          type: string
+                        payloadKey:
+                          description: PayloadKey specifies record field to use as payload.
+                          type: string
+                        procID:
+                          description: "ProcID is PROCID part of the syslog-msg header \n ProcID needs to be specified if using rfc5424"
+                          type: string
+                        rfc:
+                          default: RFC5424
+                          description: "Rfc specifies the rfc to be used for sending syslog \n Rfc values can be one of:  - RFC3164 (https://tools.ietf.org/html/rfc3164)  - RFC5424 (https://tools.ietf.org/html/rfc5424) \n If unspecified, RFC5424 will be assumed."
+                          enum:
+                          - RFC3164
+                          - RFC5424
+                          type: string
+                        severity:
+                          description: "Severity to set on outgoing syslog records. \n Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1 The value can be a decimal integer or one of these case-insensitive keywords: \n     Emergency Alert Critical Error Warning Notice Informational Debug"
+                          type: string
+                        tag:
+                          description: Tag specifies a record field to use as tag.
+                          type: string
+                        trimPrefix:
+                          description: TrimPrefix is a prefix to trim from the tag.
+                          type: string
+                      type: object
+                    type:
+                      description: Type of output plugin.
+                      enum:
+                      - syslog
+                      - fluentdForward
+                      - elasticsearch
+                      - kafka
+                      type: string
+                    url:
+                      description: "URL to send log messages to. \n Must be an absolute URL, with a scheme. Valid URL schemes depend on `type`. Special schemes 'tcp', 'tls', 'udp' and 'udps are used for output types that don't define their own URL scheme.  Example: \n     { type: syslog, url: udps://syslog.example.com:1234 } \n TLS with server authentication is enabled by the URL scheme, for example 'tls' or 'https'.  See `secret` for TLS client authentication. \n This field is optional and can be empty if there is an output-type field with alternative connection information."
+                      pattern: ^$|[a-zA-z]+:\/\/.*
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+              pipelines:
+                description: Pipelines forward the messages selected by a set of inputs to a set of outputs.
+                items:
+                  properties:
+                    inputRefs:
+                      description: "InputRefs lists the names (`input.name`) of inputs to this pipeline. \n The following built-in input names are always available: \n `application` selects all logs from application pods. \n `infrastructure` selects logs from openshift and kubernetes pods and some node logs. \n `audit` selects node logs related to security audits."
+                      items:
+                        type: string
+                      type: array
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels lists labels applied to this pipeline
+                      type: object
+                    name:
+                      description: Name is optional, but must be unique in the `pipelines` list if provided.
+                      type: string
+                    outputRefs:
+                      description: "OutputRefs lists the names (`output.name`) of outputs from this pipeline. \n The following built-in names are always available: \n 'default' Output to the default log store provided by ClusterLogging."
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - inputRefs
+                  - outputRefs
+                  type: object
+                type: array
+            type: object
+          status:
+            description: ClusterLogForwarder represents the current status of ClusterLogForwarder
+            properties:
+              conditions:
+                description: Conditions of the log forwarder.
+                items:
+                  description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              inputs:
+                additionalProperties:
+                  description: Conditions is a set of Condition instances.
+                  items:
+                    description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                description: Inputs maps input name to condition of the input.
+                type: object
+              outputs:
+                additionalProperties:
+                  description: Conditions is a set of Condition instances.
+                  items:
+                    description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                description: Outputs maps output name to condition of the output.
+                type: object
+              pipelines:
+                additionalProperties:
+                  description: Conditions is a set of Condition instances.
+                  items:
+                    description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                description: Pipelines maps pipeline name to condition of the pipeline.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/5.0/logging.openshift.io_clusterloggings_crd.yaml
+++ b/manifests/5.0/logging.openshift.io_clusterloggings_crd.yaml
@@ -1,0 +1,792 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterloggings.logging.openshift.io
+spec:
+  group: logging.openshift.io
+  names:
+    categories:
+    - logging
+    kind: ClusterLogging
+    listKind: ClusterLoggingList
+    plural: clusterloggings
+    shortNames:
+    - cl
+    singular: clusterlogging
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.managementState
+      name: Management State
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterLogging is the Schema for the clusterloggings API \n ClusterLogging is the Schema for the clusterloggings API"
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                enum:
+                - instance
+                type: string
+            type: object
+          spec:
+            description: Specification of the desired behavior of the Logging cluster.
+            properties:
+              collection:
+                description: Specification of the Collection component for the cluster
+                nullable: true
+                properties:
+                  logs:
+                    description: Specification of Log Collection for the cluster
+                    properties:
+                      fluentd:
+                        description: Specification of the Fluentd Log Collection component
+                        properties:
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: Define which Nodes the Pods are scheduled on.
+                            nullable: true
+                            type: object
+                          resources:
+                            description: The resource requirements for Fluentd
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          tolerations:
+                            items:
+                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      type:
+                        description: The type of Log Collection to configure
+                        type: string
+                    required:
+                    - type
+                    type: object
+                type: object
+              curation:
+                description: Specification of the Curation component for the cluster
+                nullable: true
+                properties:
+                  curator:
+                    description: The specification of curation to configure
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Define which Nodes the Pods are scheduled on.
+                        nullable: true
+                        type: object
+                      resources:
+                        description: The resource requirements for Curator
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      schedule:
+                        description: The cron schedule that the Curator job is run. Defaults to "30 3 * * *"
+                        type: string
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - schedule
+                    type: object
+                  type:
+                    description: The kind of curation to configure
+                    type: string
+                required:
+                - type
+                type: object
+              forwarder:
+                description: Specification for Forwarder component for the cluster
+                nullable: true
+                properties:
+                  fluentd:
+                    description: FluentdForwarderSpec represents the configuration for forwarders of type fluentd.
+                    properties:
+                      buffer:
+                        description: "FluentdBufferSpec represents a subset of fluentd buffer parameters to tune the buffer configuration for all fluentd outputs. It supports a subset of parameters to configure buffer and queue sizing, flush operations and retry flushing. \n For general parameters refer to: https://docs.fluentd.org/configuration/buffer-section#buffering-parameters \n For flush parameters refer to: https://docs.fluentd.org/configuration/buffer-section#flushing-parameters \n For retry parameters refer to: https://docs.fluentd.org/configuration/buffer-section#retries-parameters"
+                        properties:
+                          chunkLimitSize:
+                            description: ChunkLimitSize represents the maximum size of each chunk. Events will be written into chunks until the size of chunks become this size.
+                            pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
+                            type: string
+                          flushInterval:
+                            description: 'FlushInterval represents the time duration to wait between two consecutive flush operations. Takes only effect used together with `flushMode: interval`.'
+                            pattern: ^([0-9]+)([smhd]{0,1})$
+                            type: string
+                          flushMode:
+                            description: FlushMode represents the mode of the flushing thread to write chunks. The mode allows lazy (if `time` parameter set), per interval or immediate flushing.
+                            enum:
+                            - lazy
+                            - interval
+                            - immediate
+                            type: string
+                          flushThreadCount:
+                            description: FlushThreadCount reprents the number of threads used by the fluentd buffer plugin to flush/write chunks in parallel.
+                            format: int32
+                            type: integer
+                          overflowAction:
+                            description: 'OverflowAction represents the action for the fluentd buffer plugin to execute when a buffer queue is full. (Default: block)'
+                            enum:
+                            - throw_exception
+                            - block
+                            - drop_oldest_chunk
+                            type: string
+                          retryMaxInterval:
+                            description: 'RetryMaxInterval represents the maxixum time interval for exponential backoff between retries. Takes only effect if used together with `retryType: exponential_backoff`.'
+                            pattern: ^([0-9]+)([smhd]{0,1})$
+                            type: string
+                          retryType:
+                            description: RetryType represents the type of retrying flush operations. Flush operations can be retried either periodically or by applying exponential backoff.
+                            enum:
+                            - exponential_backoff
+                            - periodic
+                            type: string
+                          retryWait:
+                            description: RetryWait represents the time duration between two consecutive retries to flush buffers for periodic retries or a constant factor of time on retries with exponential backoff.
+                            pattern: ^([0-9]+)([smhd]{0,1})$
+                            type: string
+                          totalLimitSize:
+                            description: TotalLimitSize represents the threshold of node space allowed per fluentd buffer to allocate. Once this threshold is reached, all append operations will fail with error (and data will be lost).
+                            pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              logStore:
+                description: Specification of the Log Storage component for the cluster
+                nullable: true
+                properties:
+                  elasticsearch:
+                    description: Specification of the Elasticsearch Log Store component
+                    properties:
+                      nodeCount:
+                        description: Number of nodes to deploy for Elasticsearch
+                        format: int32
+                        type: integer
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Define which Nodes the Pods are scheduled on.
+                        nullable: true
+                        type: object
+                      proxy:
+                        description: Specification of the Elasticsearch Proxy component
+                        properties:
+                          resources:
+                            description: ResourceRequirements describes the compute resource requirements.
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                        required:
+                        - resources
+                        type: object
+                      redundancyPolicy:
+                        description: The policy towards data redundancy to specify the number of redundant primary shards
+                        enum:
+                        - FullRedundancy
+                        - MultipleRedundancy
+                        - SingleRedundancy
+                        - ZeroRedundancy
+                        type: string
+                      resources:
+                        description: The resource requirements for Elasticsearch
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      storage:
+                        description: The storage specification for Elasticsearch data nodes
+                        nullable: true
+                        properties:
+                          size:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The capacity of storage to provision.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          storageClassName:
+                            description: 'The class of storage to provision. More info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
+                            type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - nodeCount
+                    type: object
+                  retentionPolicy:
+                    description: Retention policy defines the maximum age for an index after which it should be deleted
+                    nullable: true
+                    properties:
+                      application:
+                        nullable: true
+                        properties:
+                          maxAge:
+                            description: TimeUnit is a time unit like h,m,d
+                            type: string
+                        type: object
+                      audit:
+                        nullable: true
+                        properties:
+                          maxAge:
+                            description: TimeUnit is a time unit like h,m,d
+                            type: string
+                        type: object
+                      infra:
+                        nullable: true
+                        properties:
+                          maxAge:
+                            description: TimeUnit is a time unit like h,m,d
+                            type: string
+                        type: object
+                    type: object
+                  type:
+                    description: The type of Log Storage to configure
+                    type: string
+                required:
+                - type
+                type: object
+              managementState:
+                description: Indicator if the resource is 'Managed' or 'Unmanaged' by the operator
+                enum:
+                - Managed
+                - Unmanaged
+                type: string
+              visualization:
+                description: Specification of the Visualization component for the cluster
+                nullable: true
+                properties:
+                  kibana:
+                    description: Specification of the Kibana Visualization component
+                    properties:
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Define which Nodes the Pods are scheduled on.
+                        nullable: true
+                        type: object
+                      proxy:
+                        description: Specification of the Kibana Proxy component
+                        properties:
+                          resources:
+                            description: ResourceRequirements describes the compute resource requirements.
+                            nullable: true
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                        required:
+                        - resources
+                        type: object
+                      replicas:
+                        description: Number of instances to deploy for a Kibana deployment
+                        format: int32
+                        type: integer
+                      resources:
+                        description: The resource requirements for Kibana
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      tolerations:
+                        items:
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - replicas
+                    type: object
+                  type:
+                    description: The type of Visualization to configure
+                    type: string
+                required:
+                - type
+                type: object
+            type: object
+          status:
+            description: ClusterLoggingStatus defines the observed state of ClusterLogging
+            properties:
+              clusterConditions:
+                description: Conditions is a set of Condition instances.
+                items:
+                  description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              collection:
+                properties:
+                  logs:
+                    properties:
+                      fluentdStatus:
+                        properties:
+                          clusterCondition:
+                            additionalProperties:
+                              description: '`operator-sdk generate crds` does not allow map-of-slice, must use a named type.'
+                              items:
+                                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                                properties:
+                                  lastTransitionTime:
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    type: string
+                                  reason:
+                                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                                    type: string
+                                required:
+                                - status
+                                - type
+                                type: object
+                              type: array
+                            type: object
+                          daemonSet:
+                            type: string
+                          nodes:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          pods:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              curation:
+                properties:
+                  curatorStatus:
+                    items:
+                      properties:
+                        clusterCondition:
+                          additionalProperties:
+                            description: '`operator-sdk generate crds` does not allow map-of-slice, must use a named type.'
+                            items:
+                              description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
+                              properties:
+                                lastTransitionTime:
+                                  format: date-time
+                                  type: string
+                                message:
+                                  type: string
+                                reason:
+                                  description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          type: object
+                        cronJobs:
+                          type: string
+                        schedules:
+                          type: string
+                        suspended:
+                          type: boolean
+                      type: object
+                    type: array
+                type: object
+              logStore:
+                properties:
+                  elasticsearchStatus:
+                    items:
+                      properties:
+                        cluster:
+                          properties:
+                            activePrimaryShards:
+                              format: int32
+                              type: integer
+                            activeShards:
+                              format: int32
+                              type: integer
+                            initializingShards:
+                              format: int32
+                              type: integer
+                            numDataNodes:
+                              format: int32
+                              type: integer
+                            numNodes:
+                              format: int32
+                              type: integer
+                            pendingTasks:
+                              format: int32
+                              type: integer
+                            relocatingShards:
+                              format: int32
+                              type: integer
+                            status:
+                              type: string
+                            unassignedShards:
+                              format: int32
+                              type: integer
+                          required:
+                          - activePrimaryShards
+                          - activeShards
+                          - initializingShards
+                          - numDataNodes
+                          - numNodes
+                          - pendingTasks
+                          - relocatingShards
+                          - status
+                          - unassignedShards
+                          type: object
+                        clusterConditions:
+                          items:
+                            properties:
+                              lastTransitionTime:
+                                description: Last time the condition transitioned from one status to another.
+                                format: date-time
+                                type: string
+                              message:
+                                description: Human-readable message indicating details about last transition.
+                                type: string
+                              reason:
+                                description: Unique, one-word, CamelCase reason for the condition's last transition.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                description: ClusterConditionType is a valid value for ClusterCondition.Type
+                                type: string
+                            required:
+                            - lastTransitionTime
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        clusterHealth:
+                          type: string
+                        clusterName:
+                          type: string
+                        deployments:
+                          items:
+                            type: string
+                          type: array
+                        nodeConditions:
+                          additionalProperties:
+                            items:
+                              properties:
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Human-readable message indicating details about last transition.
+                                  type: string
+                                reason:
+                                  description: Unique, one-word, CamelCase reason for the condition's last transition.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: ClusterConditionType is a valid value for ClusterCondition.Type
+                                  type: string
+                              required:
+                              - lastTransitionTime
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          type: object
+                        nodeCount:
+                          format: int32
+                          type: integer
+                        pods:
+                          additionalProperties:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            type: object
+                          type: object
+                        replicaSets:
+                          items:
+                            type: string
+                          type: array
+                        shardAllocationEnabled:
+                          type: string
+                        statefulSets:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              visualization:
+                properties:
+                  kibanaStatus:
+                    items:
+                      description: KibanaStatus defines the observed state of Kibana
+                      properties:
+                        clusterCondition:
+                          additionalProperties:
+                            items:
+                              properties:
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Human-readable message indicating details about last transition.
+                                  type: string
+                                reason:
+                                  description: Unique, one-word, CamelCase reason for the condition's last transition.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: ClusterConditionType is a valid value for ClusterCondition.Type
+                                  type: string
+                              required:
+                              - lastTransitionTime
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          type: object
+                        deployment:
+                          type: string
+                        pods:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          type: object
+                        replicaSets:
+                          items:
+                            type: string
+                          type: array
+                        replicas:
+                          format: int32
+                          type: integer
+                      required:
+                      - deployment
+                      - pods
+                      - replicaSets
+                      - replicas
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
### Description
 - Logging productization will build logging versions 5.0 onwards.
 - To build logging operator bundle images, we need CSV with 5.0 version.

*Note* : This should not interfere with ART builds, as ocp-build-data only configures 4.7 version

/cc @jcantrill @syedriko 
/assign @jcantrill 
