### PR TITLE
Attempt a fix to functional test flake

### DIFF
--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -250,7 +250,7 @@ func (engine *ConfigGenerator) generatePipelineToOutputLabels(pipelines []loggin
 func (engine *ConfigGenerator) generateOutputLabelBlocks(outputs []logging.OutputSpec, outputConf *logging.ForwarderSpec) ([]string, error) {
 	configs := []string{}
 	if log.V(3).Enabled() {
-		log.V(3).Info("Evaluating forwarder logging...", len(outputs))
+		log.V(3).Info("Evaluating forwarder logging...", "output length", len(outputs))
 	}
 	for _, output := range outputs {
 		log.V(3).Info("Generate output type", "type", output.Type)

--- a/test/helpers/oc/runner.go
+++ b/test/helpers/oc/runner.go
@@ -67,7 +67,7 @@ func (r *runner) runCmd() (string, error) {
 			return "", err
 		}
 		errout := strings.TrimSpace(errbuf.String())
-		log.Info("output", errout, "error", err)
+		log.Info("command result", "output", errout, "error", err)
 		return errout, err
 	}
 	if r.tostdout {


### PR DESCRIPTION
Attempt a fix to functional test flake
 - wait for fluentd service to be ready before curl-ing it
 - fixed "odd number of arguments" to structured logging in oc/runner
### Description
The metrics functional test fails because `curl` to the metrics endpoint fails. So wait for the service endpoint to have IPs before attempting to curl it.

/cc @jcantrill 
/assign @alanconway 

