### PR TITLE
Bump Dockerfile.e2e to 4.7

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -2,7 +2,7 @@
 # with the cluster logging operator source so we can use all the
 # test scripts to deploy the elasticsearch operator and then
 # test the clusterlogging operator
-FROM registry.svc.ci.openshift.org/ocp/4.6:elasticsearch-operator-src
+FROM registry.svc.ci.openshift.org/ocp/4.7:elasticsearch-operator-src
 ADD . /go/src/github.com/openshift/cluster-logging-operator
 WORKDIR /go/src/github.com/openshift/cluster-logging-operator
 RUN mkdir -p /go/src/github.com/openshift/cluster-logging-operator/bin/


### PR DESCRIPTION
### Description
This PR bumps the Dockerfile.e2e to rely upon the ES 4.7 source image