### PR TITLE
Fix `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ include .bingo/Variables.mk
 export GOROOT=$(shell go env GOROOT)
 export GOFLAGS=-mod=vendor
 export GO111MODULE=on
+export GODEBUG=x509ignoreCN=0
 
 export APP_NAME=cluster-logging-operator
 export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(APP_NAME):latest


### PR DESCRIPTION
### Description
Adding environment variable GODEBUG to make file with value x509ignoreCN=0 so that `/home/eranra/go/src/github.com/openshift/cluster-logging-operator/pkg/k8shandler/certificates_test.go` will work

/cc @jcantrill 
/assign @jcantrill 