### PR TITLE
Bug 1894634: lower default max_retry_wait

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -543,7 +543,7 @@ var _ = Describe("Generating fluentd config", func() {
           flush_at_shutdown true
           retry_type exponential_backoff
           retry_wait 1s
-          retry_max_interval 300s
+          retry_max_interval 60s
           retry_forever true
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           
@@ -593,7 +593,7 @@ var _ = Describe("Generating fluentd config", func() {
           flush_at_shutdown true
           retry_type exponential_backoff
           retry_wait 1s
-          retry_max_interval 300s
+          retry_max_interval 60s
           retry_forever true
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           
@@ -1027,7 +1027,7 @@ var _ = Describe("Generating fluentd config", func() {
 					flush_thread_count 2
           retry_type exponential_backoff
           retry_wait 1s
-          retry_max_interval 300s
+          retry_max_interval 60s
 					retry_forever true
 					# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 					# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
@@ -1569,7 +1569,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
               queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 						  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1616,7 +1616,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
- 							retry_max_interval 300s
+ 							retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1664,7 +1664,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1711,7 +1711,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1759,7 +1759,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1806,7 +1806,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1854,7 +1854,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1901,7 +1901,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-				retry_max_interval 300s
+				retry_max_interval 60s
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -149,7 +149,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-				retry_max_interval 300s
+				retry_max_interval 60s
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -210,7 +210,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-				retry_max_interval 300s
+				retry_max_interval 60s
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -253,7 +253,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-				retry_max_interval 300s
+				retry_max_interval 60s
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 	     flush_thread_count 2
        retry_type exponential_backoff
        retry_wait 1s
-	     retry_max_interval 300s
+	     retry_max_interval 60s
 	     retry_forever true
 	     # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 	     # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
@@ -116,7 +116,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 				flush_thread_count 2
         retry_type exponential_backoff
         retry_wait 1s
-				retry_max_interval 300s
+				retry_max_interval 60s
 				retry_forever true
 				# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 				# queue limit is hit - 'block' will halt further reads and keep retrying to flush the

--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Generating external kafka server output store config block", f
                flush_at_shutdown true
                retry_type exponential_backoff
                retry_wait 1s
-               retry_max_interval 300s
+               retry_max_interval 60s
                retry_forever true
                queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -102,7 +102,7 @@ var _ = Describe("Generating external kafka server output store config block", f
                flush_at_shutdown true
                retry_type exponential_backoff
                retry_wait 1s
-               retry_max_interval 300s
+               retry_max_interval 60s
                retry_forever true
                queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -150,7 +150,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 	           flush_at_shutdown true
              retry_type exponential_backoff
              retry_wait 1s
-	           retry_max_interval 300s
+	           retry_max_interval 60s
 	           retry_forever true
              queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 	           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-        retry_max_interval 300s
+        retry_max_interval 60s
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -196,7 +196,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-        retry_max_interval 300s
+        retry_max_interval 60s
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -243,7 +243,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-        retry_max_interval 300s
+        retry_max_interval 60s
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -284,7 +284,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-        retry_max_interval 300s
+        retry_max_interval 60s
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer.go
@@ -18,7 +18,7 @@ const (
 	// Retry buffer to output defaults
 	defaultRetryWait        = "1s"
 	defaultRetryType        = "exponential_backoff"
-	defaultRetryMaxInterval = "300s"
+	defaultRetryMaxInterval = "60s"
 
 	// Output fluentdForward default
 	fluentdForwardOverflowAction = "block"

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Generating fluentd config", func() {
                 flush_at_shutdown true
                 retry_type exponential_backoff
                 retry_wait 1s
-                retry_max_interval 300s
+                retry_max_interval 60s
                 retry_forever true
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -136,7 +136,7 @@ var _ = Describe("Generating fluentd config", func() {
                 flush_at_shutdown true
                 retry_type exponential_backoff
                 retry_wait 1s
-                retry_max_interval 300s
+                retry_max_interval 60s
                 retry_forever true
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -206,7 +206,7 @@ var _ = Describe("Generating fluentd config", func() {
                 flush_at_shutdown true
                 retry_type exponential_backoff
                 retry_wait 1s
-                retry_max_interval 300s
+                retry_max_interval 60s
                 retry_forever true
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -249,7 +249,7 @@ var _ = Describe("Generating fluentd config", func() {
                 flush_at_shutdown true
                 retry_type exponential_backoff
                 retry_wait 1s
-                retry_max_interval 300s
+                retry_max_interval 60s
                 retry_forever true
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -398,7 +398,7 @@ var _ = Describe("Generating fluentd config", func() {
             flush_thread_count 2
             retry_type exponential_backoff
             retry_wait 1s
-            retry_max_interval 300s
+            retry_max_interval 60s
             retry_forever true
             # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
             # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
@@ -512,7 +512,7 @@ var _ = Describe("Generating fluentd config", func() {
                 flush_at_shutdown true
                 retry_type exponential_backoff
                 retry_wait 1s
-                retry_max_interval 300s
+                retry_max_interval 60s
                 retry_forever true
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -618,7 +618,7 @@ var _ = Describe("Generating fluentd config", func() {
                flush_at_shutdown true
                retry_type exponential_backoff
                retry_wait 1s
-               retry_max_interval 300s
+               retry_max_interval 60s
                retry_forever true
                queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G


### PR DESCRIPTION
### Description
This PR lowers the default max_retry_wait to resolve cases where it appears fluent is functional but not pushing messages.  The current retry algo is an exponential backoff that will cause fluent to not retry try soon enough

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1894634

/assign @vimalk78 @alanconway 

backport of https://github.com/openshift/cluster-logging-operator/pull/799