### PR TITLE
Bug 1894639: lower default max_retry_wait

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -495,7 +495,7 @@ var _ = Describe("Generating fluentd config", func() {
           flush_at_shutdown true
           retry_type exponential_backoff
           retry_wait 1s
-          retry_max_interval 300s
+          retry_max_interval 60s
           retry_forever true
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           
@@ -546,7 +546,7 @@ var _ = Describe("Generating fluentd config", func() {
           flush_at_shutdown true
           retry_type exponential_backoff
           retry_wait 1s
-          retry_max_interval 300s
+          retry_max_interval 60s
           retry_forever true
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           
@@ -931,7 +931,7 @@ var _ = Describe("Generating fluentd config", func() {
 					flush_thread_count 2
           retry_type exponential_backoff
           retry_wait 1s
-          retry_max_interval 300s
+          retry_max_interval 60s
 					retry_forever true
 					# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 					# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
@@ -1425,7 +1425,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
               queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 						  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1473,7 +1473,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
- 							retry_max_interval 300s
+ 							retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1522,7 +1522,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1570,7 +1570,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1619,7 +1619,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1667,7 +1667,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1716,7 +1716,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1764,7 +1764,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_at_shutdown true
               retry_type exponential_backoff
               retry_wait 1s
-              retry_max_interval 300s
+              retry_max_interval 60s
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-				retry_max_interval 300s
+				retry_max_interval 60s
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -151,7 +151,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-				retry_max_interval 300s
+				retry_max_interval 60s
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -213,7 +213,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-				retry_max_interval 300s
+				retry_max_interval 60s
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -257,7 +257,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-				retry_max_interval 300s
+				retry_max_interval 60s
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 	     flush_thread_count 2
        retry_type exponential_backoff
        retry_wait 1s
-	     retry_max_interval 300s
+	     retry_max_interval 60s
 	     retry_forever true
 	     # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 	     # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
@@ -116,7 +116,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 				flush_thread_count 2
         retry_type exponential_backoff
         retry_wait 1s
-				retry_max_interval 300s
+				retry_max_interval 60s
 				retry_forever true
 				# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 				# queue limit is hit - 'block' will halt further reads and keep retrying to flush the

--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Generating external kafka server output store config block", f
                flush_at_shutdown true
                retry_type exponential_backoff
                retry_wait 1s
-               retry_max_interval 300s
+               retry_max_interval 60s
                retry_forever true
                queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -102,7 +102,7 @@ var _ = Describe("Generating external kafka server output store config block", f
                flush_at_shutdown true
                retry_type exponential_backoff
                retry_wait 1s
-               retry_max_interval 300s
+               retry_max_interval 60s
                retry_forever true
                queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -150,7 +150,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 	           flush_at_shutdown true
              retry_type exponential_backoff
              retry_wait 1s
-	           retry_max_interval 300s
+	           retry_max_interval 60s
 	           retry_forever true
              queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 	           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-        retry_max_interval 300s
+        retry_max_interval 60s
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -196,7 +196,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-        retry_max_interval 300s
+        retry_max_interval 60s
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -243,7 +243,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-        retry_max_interval 300s
+        retry_max_interval 60s
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -284,7 +284,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_at_shutdown true
         retry_type exponential_backoff
         retry_wait 1s
-        retry_max_interval 300s
+        retry_max_interval 60s
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer.go
@@ -18,7 +18,7 @@ const (
 	// Retry buffer to output defaults
 	defaultRetryWait        = "1s"
 	defaultRetryType        = "exponential_backoff"
-	defaultRetryMaxInterval = "300s"
+	defaultRetryMaxInterval = "60s"
 
 	// Output fluentdForward default
 	fluentdForwardOverflowAction = "block"

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Generating fluentd config", func() {
                 flush_at_shutdown true
                 retry_type exponential_backoff
                 retry_wait 1s
-                retry_max_interval 300s
+                retry_max_interval 60s
                 retry_forever true
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -138,7 +138,7 @@ var _ = Describe("Generating fluentd config", func() {
                 flush_at_shutdown true
                 retry_type exponential_backoff
                 retry_wait 1s
-                retry_max_interval 300s
+                retry_max_interval 60s
                 retry_forever true
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -209,7 +209,7 @@ var _ = Describe("Generating fluentd config", func() {
                 flush_at_shutdown true
                 retry_type exponential_backoff
                 retry_wait 1s
-                retry_max_interval 300s
+                retry_max_interval 60s
                 retry_forever true
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -253,7 +253,7 @@ var _ = Describe("Generating fluentd config", func() {
                 flush_at_shutdown true
                 retry_type exponential_backoff
                 retry_wait 1s
-                retry_max_interval 300s
+                retry_max_interval 60s
                 retry_forever true
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -404,7 +404,7 @@ var _ = Describe("Generating fluentd config", func() {
             flush_thread_count 2
             retry_type exponential_backoff
             retry_wait 1s
-            retry_max_interval 300s
+            retry_max_interval 60s
             retry_forever true
             # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
             # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
@@ -518,7 +518,7 @@ var _ = Describe("Generating fluentd config", func() {
                 flush_at_shutdown true
                 retry_type exponential_backoff
                 retry_wait 1s
-                retry_max_interval 300s
+                retry_max_interval 60s
                 retry_forever true
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -624,7 +624,7 @@ var _ = Describe("Generating fluentd config", func() {
                flush_at_shutdown true
                retry_type exponential_backoff
                retry_wait 1s
-               retry_max_interval 300s
+               retry_max_interval 60s
                retry_forever true
                queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G


### PR DESCRIPTION
# Description
This PR lowers the default max_retry_wait to resolve cases where it appears fluent is functional but not pushing messages. The current retry algo is an exponential backoff that will cause fluent to not retry try soon enough

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1894639

/assign @vimalk78 @alanconway