### PR TITLE
Added labeler github action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+dockerfile:
+  - '**/Dockerfile*'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,17 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: DockerfileWatcher
+on: 
+  pull_request:
+jobs:
+  WatchDockerfileChange:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Description
This PR attempts to label PRs which change Dockerfile.
For productization purposes, we need a solution to identify/track changes we make to upstream Dockerfiles. In cpaas/midstreams solution, we dont sync Dockerfiles from upstream github to downstream dist-git repos.  This PR will add `dockerfile` label to PRs which add/modify/delete Dockerfiles.
This is a first step in seamless sync of Dockerfiles to downstream.

/cc @syedriko @jcantrill 
/assign @jcantrill 
