### PR TITLE
Prevent adding manifests/5.0 to clo image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/files/
 
 COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/manifests /manifests
 RUN rm /manifests/art.yaml
+RUN rm -rf /manifests/5.0
 
 COPY --from=origincli /usr/bin/oc /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/must-gather/collection-scripts/* /usr/bin/


### PR DESCRIPTION
### Description
For productization purposes we had added a `manifests/5.0` folder in upstream. So the `cluster-logging-operator-registry` is loading both CSVs.

#### Observed logs in cluster-logging-operator-registry
```
time="2020-11-21T12:45:08Z" level=info msg=directory dir=/manifests file=manifests load=bundles
time="2020-11-21T12:45:08Z" level=info msg=directory dir=/manifests file=4.7 load=bundles
time="2020-11-21T12:45:08Z" level=info msg="found csv, loading bundle" dir=/manifests file=cluster-logging.v4.7.0.clusterserviceversion.yaml load=bundles
time="2020-11-21T12:45:08Z" level=info msg="loading bundle file" dir=/manifests/4.7 file=0100_clusterroles.yaml load=bundle name=clusterlogging.v4.7.0
time="2020-11-21T12:45:08Z" level=info msg="loading bundle file" dir=/manifests/4.7 file=0110_clusterrolebindings.yaml load=bundle name=clusterlogging.v4.7.0
time="2020-11-21T12:45:08Z" level=info msg="loading bundle file" dir=/manifests/4.7 file=cluster-logging.v4.7.0.clusterserviceversion.yaml load=bundle name=clusterlogging.v4.7.0
time="2020-11-21T12:45:08Z" level=info msg="loading bundle file" dir=/manifests/4.7 file=logging.openshift.io_clusterlogforwarders_crd.yaml load=bundle name=clusterlogging.v4.7.0
time="2020-11-21T12:45:08Z" level=info msg="loading bundle file" dir=/manifests/4.7 file=logging.openshift.io_clusterloggings_crd.yaml load=bundle name=clusterlogging.v4.7.0
time="2020-11-21T12:45:08Z" level=info msg=directory dir=/manifests file=5.0 load=bundles
time="2020-11-21T12:45:08Z" level=info msg="found csv, loading bundle" dir=/manifests file=cluster-logging.v5.0.0.clusterserviceversion.yaml load=bundles
time="2020-11-21T12:45:08Z" level=info msg="loading bundle file" dir=/manifests/5.0 file=0100_clusterroles.yaml load=bundle name=clusterlogging.v5.0.0
time="2020-11-21T12:45:08Z" level=info msg="loading bundle file" dir=/manifests/5.0 file=0110_clusterrolebindings.yaml load=bundle name=clusterlogging.v5.0.0
time="2020-11-21T12:45:08Z" level=info msg="loading bundle file" dir=/manifests/5.0 file=cluster-logging.v5.0.0.clusterserviceversion.yaml load=bundle name=clusterlogging.v5.0.0
time="2020-11-21T12:45:08Z" level=info msg="loading bundle file" dir=/manifests/5.0 file=logging.openshift.io_clusterlogforwarders_crd.yaml load=bundle name=clusterlogging.v5.0.0
time="2020-11-21T12:45:08Z" level=info msg="loading bundle file" dir=/manifests/5.0 file=logging.openshift.io_clusterloggings_crd.yaml load=bundle name=clusterlogging.v5.0.0
time="2020-11-21T12:45:08Z" level=info msg=directory dir=/manifests file=patches load=bundles
time="2020-11-21T12:45:08Z" level=info msg="loading Packages and Entries" dir=/manifests
time="2020-11-21T12:45:08Z" level=info msg=directory dir=/manifests file=manifests load=package
time="2020-11-21T12:45:08Z" level=info msg=directory dir=/manifests file=4.7 load=package
time="2020-11-21T12:45:08Z" level=info msg=directory dir=/manifests file=5.0 load=package
time="2020-11-21T12:45:08Z" level=info msg=directory dir=/manifests file=patches load=package
```
This folder is also present in ART image
```
vimalkum ~ $ podman run -it --rm --entrypoint /bin/bash registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-logging-operator:v4.7.0-202011210054.p0
[root@e6659b553b7f bin]# ls -al /manifests/
total 24
drwxr-xr-x. 5 root root 4096 Nov 21 01:28 .
drwxr-xr-x. 3 root root 4096 Nov 21 13:18 ..
drwxr-xr-x. 2 root root 4096 Nov 21 01:26 4.7
drwxr-xr-x. 2 root root 4096 Nov 21 01:26 5.0
-rw-r--r--. 1 root root  220 Nov 21 01:26 cluster-logging.package.yaml
drwxr-xr-x. 2 root root 4096 Nov 21 01:26 patches
```

To prevent both 4.7 and 5.0 being loaded, added a statement in Dockerfile to delete the `manifests/5.0` folder. This way 4.7 images will not have additional CSV.
Ideally this change should have been added in https://github.com/openshift/cluster-logging-operator/pull/791

/cc @syedriko 
/assign @jcantrill 


### Links
