### PR TITLE
Bug 1891738: Make operator not depend on elasticsearch-operator

### DIFF
--- a/hack/logforwarder.yaml
+++ b/hack/logforwarder.yaml
@@ -1,0 +1,12 @@
+apiVersion: "logging.openshift.io/v1"
+kind: ClusterLogForwarder
+metadata:
+  name: instance 
+  namespace: openshift-logging 
+spec:
+  pipelines:
+   - name: application-logs 
+     inputRefs: 
+     - application
+     outputRefs:
+     - default 

--- a/pkg/k8shandler/clusterloggingrequest.go
+++ b/pkg/k8shandler/clusterloggingrequest.go
@@ -23,6 +23,10 @@ type ClusterLoggingRequest struct {
 	ForwarderSpec logging.ClusterLogForwarderSpec
 }
 
+func (clusterRequest *ClusterLoggingRequest) IncludesManagedStorage() bool {
+	return clusterRequest.Cluster != nil && clusterRequest.Cluster.Spec.LogStore != nil
+}
+
 // TODO: determine if this is even necessary
 func (clusterRequest *ClusterLoggingRequest) isManaged() bool {
 	return clusterRequest.Cluster.Spec.ManagementState == logging.ManagementStateManaged

--- a/pkg/k8shandler/clusterloggingrequest_test.go
+++ b/pkg/k8shandler/clusterloggingrequest_test.go
@@ -1,0 +1,40 @@
+package k8shandler
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+)
+
+var _ = Describe("ClusterLoggingRequest", func() {
+
+	var (
+		clr *ClusterLoggingRequest
+	)
+	BeforeEach(func() {
+		clr = &ClusterLoggingRequest{
+			Cluster: &logging.ClusterLogging{
+				Spec: logging.ClusterLoggingSpec{},
+			},
+		}
+
+	})
+	Describe("#IncludesManagedStorage", func() {
+		Context("when logstore", func() {
+			Context("is defined", func() {
+
+				It("should return true because we are writing to the managed store", func() {
+					clr.Cluster.Spec.LogStore = &logging.LogStoreSpec{}
+					Expect(clr.IncludesManagedStorage()).To(BeTrue())
+				})
+
+			})
+			Context("is not defined", func() {
+				It("should return false because there is nowhere to write logs", func() {
+					Expect(clr.IncludesManagedStorage()).To(BeFalse())
+				})
+			})
+
+		})
+	})
+})

--- a/pkg/k8shandler/curation.go
+++ b/pkg/k8shandler/curation.go
@@ -26,9 +26,6 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCuration() (err error
 
 	cluster := clusterRequest.Cluster
 	if cluster.Spec.Curation == nil || cluster.Spec.Curation.Type == "" {
-		if err = clusterRequest.removeCurator(); err != nil {
-			return
-		}
 		return nil
 	}
 	if cluster.Spec.Curation.Type == logging.CurationTypeCurator {

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -3,9 +3,10 @@ package k8shandler
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/pkg/utils/comparators/servicemonitor"
 	"reflect"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/pkg/utils/comparators/servicemonitor"
 
 	"github.com/ViaQ/logerr/log"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -430,7 +431,7 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, proxyConfig *configv1.Pr
 			{Name: "syslogconfig", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: syslogName}, Optional: utils.GetBool(true)}}},
 			{Name: "syslogcerts", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: syslogName, Optional: utils.GetBool(true)}}},
 			{Name: "entrypoint", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "fluentd"}}}},
-			{Name: "certs", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "fluentd"}}},
+			{Name: "certs", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "fluentd", Optional: utils.GetBool(true)}}},
 			{Name: "localtime", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/localtime"}}},
 			{Name: "dockercfg", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/sysconfig/docker"}}},
 			{Name: "dockerdaemoncfg", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/docker"}}},

--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -24,9 +24,6 @@ const (
 
 func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateLogStore() (err error) {
 	if clusterRequest.Cluster.Spec.LogStore == nil || clusterRequest.Cluster.Spec.LogStore.Type == "" {
-		if err = clusterRequest.removeElasticsearch(); err != nil {
-			return
-		}
 		return nil
 	}
 	if clusterRequest.Cluster.Spec.LogStore.Type == logging.LogStoreTypeElasticsearch {

--- a/pkg/k8shandler/reconciler.go
+++ b/pkg/k8shandler/reconciler.go
@@ -29,24 +29,28 @@ func Reconcile(requestCluster *logging.ClusterLogging, requestClient client.Clie
 
 	proxyConfig := clusterLoggingRequest.getProxyConfig()
 
-	// Reconcile certs
-	if err = clusterLoggingRequest.CreateOrUpdateCertificates(); err != nil {
-		return fmt.Errorf("Unable to create or update certificates for %q: %v", clusterLoggingRequest.Cluster.Name, err)
-	}
+	if clusterLoggingRequest.IncludesManagedStorage() {
+		// Reconcile certs
+		if err = clusterLoggingRequest.CreateOrUpdateCertificates(); err != nil {
+			return fmt.Errorf("Unable to create or update certificates for %q: %v", clusterLoggingRequest.Cluster.Name, err)
+		}
 
-	// Reconcile Log Store
-	if err = clusterLoggingRequest.CreateOrUpdateLogStore(); err != nil {
-		return fmt.Errorf("Unable to create or update logstore for %q: %v", clusterLoggingRequest.Cluster.Name, err)
-	}
+		// Reconcile Log Store
+		if err = clusterLoggingRequest.CreateOrUpdateLogStore(); err != nil {
+			return fmt.Errorf("Unable to create or update logstore for %q: %v", clusterLoggingRequest.Cluster.Name, err)
+		}
 
-	// Reconcile Visualization
-	if err = clusterLoggingRequest.CreateOrUpdateVisualization(proxyConfig); err != nil {
-		return fmt.Errorf("Unable to create or update visualization for %q: %v", clusterLoggingRequest.Cluster.Name, err)
-	}
+		// Reconcile Visualization
+		if err = clusterLoggingRequest.CreateOrUpdateVisualization(proxyConfig); err != nil {
+			return fmt.Errorf("Unable to create or update visualization for %q: %v", clusterLoggingRequest.Cluster.Name, err)
+		}
 
-	// Reconcile Curation
-	if err = clusterLoggingRequest.CreateOrUpdateCuration(); err != nil {
-		return fmt.Errorf("Unable to create or update curation for %q: %v", clusterLoggingRequest.Cluster.Name, err)
+		// Reconcile Curation
+		if err = clusterLoggingRequest.CreateOrUpdateCuration(); err != nil {
+			return fmt.Errorf("Unable to create or update curation for %q: %v", clusterLoggingRequest.Cluster.Name, err)
+		}
+	} else {
+		removeManagedStorage(clusterLoggingRequest)
 	}
 
 	// Reconcile Collection
@@ -60,6 +64,15 @@ func Reconcile(requestCluster *logging.ClusterLogging, requestClient client.Clie
 	}
 
 	return nil
+}
+
+func removeManagedStorage(clusterRequest ClusterLoggingRequest) {
+	log.V(1).Info("Removing managed store components...")
+	for _, remove := range []func() error{clusterRequest.removeElasticsearch, clusterRequest.removeKibana, clusterRequest.removeCurator} {
+		if err := remove(); err != nil {
+			log.V(1).Error(err, "Error removing component")
+		}
+	}
 }
 
 func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, requestClient client.Client) (err error) {

--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -23,9 +23,6 @@ import (
 // CreateOrUpdateVisualization reconciles visualization component for cluster logging
 func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateVisualization(proxyConfig *configv1.Proxy) (err error) {
 	if clusterRequest.Cluster.Spec.Visualization == nil || clusterRequest.Cluster.Spec.Visualization.Type == "" {
-		if err = clusterRequest.removeKibana(); err != nil {
-			return
-		}
 		return nil
 	}
 


### PR DESCRIPTION
### Description
This PR modifies the reconciliation loop to:
* skip reconciliation of storage, visualization and curation if the managed store is not defined

*Note*: while testing it was observed
* storage et al will fail (as expected) to deploy if the EO is not deployed
* It is possible to see the following error message in the logs if you deploy eo, logging, and then remove eo, logging, and delete the CRD
```
E1123 19:13:13.053559       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:224: Failed to list *v1.Elasticsearch: the server could not find the requested resource (get elasticsearches.logging.openshift.io)
```
Deleting the CRD is a manual step which is unlikely to be done unless a user explicitly does so

/cc @igor-karpukhin 
/assign @alanconway @vimalk78 

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1891738
