### PR TITLE
Fix Makefile for Go 1.15 legacy certificate incompatibility.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ include .bingo/Variables.mk
 export GOROOT=$(shell go env GOROOT)
 export GOFLAGS=-mod=vendor
 export GO111MODULE=on
+# Needed to process legacy certificates, see https://golang.org/doc/go1.15#commonname
+export GODEBUG=x509ignoreCN=0
 
 export APP_NAME=cluster-logging-operator
 export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(APP_NAME):latest

--- a/test/functional/framework.go
+++ b/test/functional/framework.go
@@ -50,12 +50,12 @@ func NewFluentdFunctionalFramework() *FluentdFunctionalFramework {
 	verbosity := 9
 	if level, found := os.LookupEnv("LOG_LEVEL"); found {
 		if i, err := strconv.Atoi(level); err == nil {
-			verbosity = int(i)
+			verbosity = i
 		}
 	}
 
 	log.MustInit("fluent-ftf")
- 	log.SetLogLevel(verbosity)
+	log.SetLogLevel(verbosity)
 	t := client.NewTest()
 	testName := fmt.Sprintf("test-fluent-%d", rand.Intn(1000))
 	framework := &FluentdFunctionalFramework{


### PR DESCRIPTION
Building and running tests with Go 1.15 causes certificate parsing errors.  The
issue is described https://golang.org/doc/go1.15#commonname The fix in Makefile
is: export GODEBUG=x509ignoreCN=0

We should sanitize our certs to avoid the deprecated practice but for now we can
disable the new check in Go.

Also fixed minor gofmt/lint issues in test/functional/framework.go

/approve @jcantril
/cc @ewolinetz