### PR TITLE
Bug 1901096: Set forward heartbeat to none

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -1014,20 +1014,21 @@ var _ = Describe("Generating fluentd config", func() {
 				<match **>
 					# https://docs.fluentd.org/v1.0/articles/in_forward
 				@type forward
+				heartbeat_type none
 
 				<buffer>
 					@type file
 					path '/var/lib/fluentd/secureforward_receiver'
 					queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
-          flush_mode interval
+					total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+					chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+					flush_mode interval
 					flush_interval 5s
 					flush_at_shutdown true
 					flush_thread_count 2
-          retry_type exponential_backoff
-          retry_wait 1s
-          retry_max_interval 60s
+					retry_type exponential_backoff
+					retry_wait 1s
+					retry_max_interval 60s
 					retry_forever true
 					# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 					# queue limit is hit - 'block' will halt further reads and keep retrying to flush the

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -42,44 +42,45 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			Expect(results[0]).To(EqualTrimLines(`<label @SECUREFORWARD_RECEIVER>
 	<match **>
 		# https://docs.fluentd.org/v1.0/articles/in_forward
-	   @type forward
-	   <security>
-	     self_hostname "#{ENV['NODE_NAME']}" 
-	     shared_key "#{File.open('/var/run/ocp-collector/secrets/my-infra-secret/shared_key') do |f| f.readline end.rstrip}"
-	   </security>
+		@type forward
+		heartbeat_type none
+		<security>
+			self_hostname "#{ENV['NODE_NAME']}" 
+			shared_key "#{File.open('/var/run/ocp-collector/secrets/my-infra-secret/shared_key') do |f| f.readline end.rstrip}"
+		</security>
 
-	   transport tls
-	   tls_verify_hostname false
-	   tls_version 'TLSv1_2'
-	
-	   #tls_client_private_key_path /var/run/ocp-collector/secrets/my-infra-secret/tls.key
-	   tls_client_cert_path /var/run/ocp-collector/secrets/my-infra-secret/tls.crt
-	   tls_cert_path /var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt
+		transport tls
+		tls_verify_hostname false
+		tls_version 'TLSv1_2'
+		
+		#tls_client_private_key_path /var/run/ocp-collector/secrets/my-infra-secret/tls.key
+		tls_client_cert_path /var/run/ocp-collector/secrets/my-infra-secret/tls.crt
+		tls_cert_path /var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt
 
-	   <buffer>
-	     @type file
-	     path '/var/lib/fluentd/secureforward_receiver'
-	     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-	     total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-	     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
-       flush_mode interval
-	     flush_interval 5s       
-	     flush_at_shutdown true
-	     flush_thread_count 2
-       retry_type exponential_backoff
-       retry_wait 1s
-	     retry_max_interval 60s
-	     retry_forever true
-	     # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-	     # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-	     # buffer to the remote - default is 'block' because in_tail handles that case
-	     overflow_action block
-	   </buffer>
+		<buffer>
+			@type file
+			path '/var/lib/fluentd/secureforward_receiver'
+			queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+			total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+			chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+			flush_mode interval
+			flush_interval 5s       
+			flush_at_shutdown true
+			flush_thread_count 2
+			retry_type exponential_backoff
+			retry_wait 1s
+			retry_max_interval 60s
+			retry_forever true
+			# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+			# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+			# buffer to the remote - default is 'block' because in_tail handles that case
+			overflow_action block
+		</buffer>
 
-	   <server>
-	     host es.svc.messaging.cluster.local
-	     port 9654
-	   </server>
+		<server>
+			host es.svc.messaging.cluster.local
+			port 9654
+		</server>
 	</match>
 </label>`))
 		})
@@ -102,33 +103,34 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			Expect(results[0]).To(EqualTrimLines(`<label @SECUREFORWARD_RECEIVER>
 			<match **>
 				# https://docs.fluentd.org/v1.0/articles/in_forward
-			  @type forward
+				@type forward
+				heartbeat_type none
 
-			  <buffer>
-				@type file
-				path '/var/lib/fluentd/secureforward_receiver'
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-        total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
-        flush_mode interval
-				flush_interval 5s
-				flush_at_shutdown true
-				flush_thread_count 2
-        retry_type exponential_backoff
-        retry_wait 1s
-				retry_max_interval 60s
-				retry_forever true
-				# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-				# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-				# buffer to the remote - default is 'block' because in_tail handles that case
-				overflow_action block
-			  </buffer>
-	   
-			  <server>
-				host es.svc.messaging.cluster.local
-				port 9654
-			  </server>
-		   </match>
+				<buffer>
+					@type file
+					path '/var/lib/fluentd/secureforward_receiver'
+					queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+					total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+					chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+					flush_mode interval
+					flush_interval 5s
+					flush_at_shutdown true
+					flush_thread_count 2
+					retry_type exponential_backoff
+					retry_wait 1s
+					retry_max_interval 60s
+					retry_forever true
+					# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+					# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+					# buffer to the remote - default is 'block' because in_tail handles that case
+					overflow_action block
+				</buffer>
+		
+				<server>
+					host es.svc.messaging.cluster.local
+					port 9654
+				</server>
+			</match>
 </label>`))
 		})
 	})

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -385,6 +385,7 @@ var _ = Describe("Generating fluentd config", func() {
           <match **>
             # https://docs.fluentd.org/v1.0/articles/in_forward
             @type forward
+            heartbeat_type none
 
             <buffer>
             @type file
@@ -421,37 +422,38 @@ var _ = Describe("Generating fluentd config", func() {
 
 		It("should override buffer configuration for given tuning parameters", func() {
 			fluentdForwardConf := `
-        <label @SECUREFORWARD_RECEIVER>
-          <match **>
-            # https://docs.fluentd.org/v1.0/articles/in_forward
-            @type forward
+      <label @SECUREFORWARD_RECEIVER>
+        <match **>
+          # https://docs.fluentd.org/v1.0/articles/in_forward
+          @type forward
+          heartbeat_type none
 
-            <buffer>
-            @type file
-            path '/var/lib/fluentd/secureforward_receiver'
-            queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-            total_limit_size 512m
-            chunk_limit_size 256m
-            flush_mode immediate
-            flush_interval 2s
-            flush_at_shutdown true
-            flush_thread_count 4
-            retry_type periodic
-            retry_wait 2s
-            retry_max_interval 600s
-            retry_forever true
-            # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-            # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-            # buffer to the remote - default is 'block' because in_tail handles that case
-            overflow_action drop_oldest_chunk
-            </buffer>
+          <buffer>
+          @type file
+          path '/var/lib/fluentd/secureforward_receiver'
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+          total_limit_size 512m
+          chunk_limit_size 256m
+          flush_mode immediate
+          flush_interval 2s
+          flush_at_shutdown true
+          flush_thread_count 4
+          retry_type periodic
+          retry_wait 2s
+          retry_max_interval 600s
+          retry_forever true
+          # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+          # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+          # buffer to the remote - default is 'block' because in_tail handles that case
+          overflow_action drop_oldest_chunk
+          </buffer>
 
-            <server>
-            host es.svc.messaging.cluster.local
-            port 9654
-            </server>
-           </match>
-         </label>`
+          <server>
+          host es.svc.messaging.cluster.local
+          port 9654
+          </server>
+        </match>
+      </label>`
 
 			results, err := generator.generateOutputLabelBlocks(outputs, customForwarderSpec)
 			Expect(err).To(BeNil())

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -632,6 +632,7 @@ const outputLabelConfJsonParseNoretryTemplate = `{{- define "outputLabelConfJson
 const forwardTemplate = `{{- define "forward" -}}
 # https://docs.fluentd.org/v1.0/articles/in_forward
 @type forward
+heartbeat_type none
 {{ if .Target.Secret }}
 <security>
   self_hostname "#{ENV['NODE_NAME']}"

--- a/test/functional/cluster_log_forwarder.go
+++ b/test/functional/cluster_log_forwarder.go
@@ -18,6 +18,8 @@ type PipelineBuilder struct {
 	inputName string
 }
 
+type OutputSpecVisiter func(spec *logging.OutputSpec)
+
 func NewClusterLogForwarderBuilder(clf *logging.ClusterLogForwarder) *ClusterLogForwarderBuilder {
 	return &ClusterLogForwarderBuilder{
 		Forwarder: clf,
@@ -33,6 +35,10 @@ func (b *ClusterLogForwarderBuilder) FromInput(inputName string) *PipelineBuilde
 }
 
 func (p *PipelineBuilder) ToFluentForwardOutput() *ClusterLogForwarderBuilder {
+	return p.ToFluentForwardOutputWithVisitor(func(output *logging.OutputSpec) {})
+}
+
+func (p *PipelineBuilder) ToFluentForwardOutputWithVisitor(visit OutputSpecVisiter) *ClusterLogForwarderBuilder {
 	clf := p.clfb.Forwarder
 	outputs := clf.Spec.OutputMap()
 	var output *logging.OutputSpec
@@ -43,6 +49,7 @@ func (p *PipelineBuilder) ToFluentForwardOutput() *ClusterLogForwarderBuilder {
 			Type: logging.OutputTypeFluentdForward,
 			URL:  "tcp://0.0.0.0:24224",
 		}
+		visit(output)
 		clf.Spec.Outputs = append(clf.Spec.Outputs, *output)
 	}
 	added := false

--- a/test/functional/framework.go
+++ b/test/functional/framework.go
@@ -55,7 +55,7 @@ func NewFluentdFunctionalFramework() *FluentdFunctionalFramework {
 	}
 
 	log.MustInit("fluent-ftf")
- 	log.SetLogLevel(verbosity)
+	log.SetLogLevel(verbosity)
 	t := client.NewTest()
 	testName := fmt.Sprintf("test-fluent-%d", rand.Intn(1000))
 	framework := &FluentdFunctionalFramework{
@@ -85,6 +85,14 @@ func (f *FluentdFunctionalFramework) RunCommand(container string, cmd ...string)
 
 //Deploy the objects needed to functional test
 func (f *FluentdFunctionalFramework) Deploy() (err error) {
+	visiter := func(b *runtime.PodBuilder) error {
+		return f.addOutputContainers(b, f.Forwarder.Spec.Outputs)
+	}
+	return f.DeployWithVisitor(visiter)
+}
+
+//Deploy the objects needed to functional test
+func (f *FluentdFunctionalFramework) DeployWithVisitor(visit runtime.PodBuilderVisitor) (err error) {
 	log.V(2).Info("Generating config", "forwarder", f.Forwarder)
 	yaml, _ := yaml.Marshal(f.Forwarder)
 	if f.Conf, err = forwarder.Generate(string(yaml), false); err != nil {
@@ -139,7 +147,7 @@ func (f *FluentdFunctionalFramework) Deploy() (err error) {
 		AddVolumeMount("entrypoint", "/opt/app-root/src/run.sh", "run.sh", true).
 		AddVolumeMount("certs", "/etc/fluent/metrics", "", true).
 		End()
-	if err = f.addOutputContainers(b, f.Forwarder.Spec.Outputs); err != nil {
+	if err = visit(b); err != nil {
 		return err
 	}
 	log.V(2).Info("Creating pod", "pod", f.pod)
@@ -188,6 +196,10 @@ func (f *FluentdFunctionalFramework) addOutputContainers(b *runtime.PodBuilder, 
 		}
 	}
 	return nil
+}
+
+func (f *FluentdFunctionalFramework) WaitForPodToBeReady() error {
+	return oc.Literal().From(fmt.Sprintf("oc wait -n %s pod/%s --timeout=60s --for=condition=Ready", f.test.NS.Name, f.Name)).Output()
 }
 
 func (f *FluentdFunctionalFramework) WritesApplicationLogs(numOfLogs int) error {

--- a/test/functional/outputs/suite_test.go
+++ b/test/functional/outputs/suite_test.go
@@ -1,0 +1,17 @@
+package outputs
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+)
+
+func TestFunctionalOutputs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	tc := "ClusterLogging Functional Output Suite"
+	jr := reporters.NewJUnitReporter("/tmp/artifacts/junit/junit-functional-output.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, tc, []Reporter{jr})
+}

--- a/test/functional/outputs/unavailable_forward_output_test.go
+++ b/test/functional/outputs/unavailable_forward_output_test.go
@@ -1,0 +1,49 @@
+package outputs
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"fmt"
+	"time"
+
+	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/test/functional"
+	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
+	"github.com/openshift/cluster-logging-operator/test/runtime"
+)
+
+var _ = Describe("[Functional][Outputs] FluentdForward Output", func() {
+
+	var (
+		framework *functional.FluentdFunctionalFramework
+	)
+
+	BeforeEach(func() {
+		visitor := func(spec *logging.OutputSpec) {
+			spec.URL = "tcp://foo.somenamespace.svc"
+		}
+		framework = functional.NewFluentdFunctionalFramework()
+		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+			FromInput(logging.InputNameApplication).
+			ToFluentForwardOutputWithVisitor(visitor)
+	})
+	AfterEach(func() {
+		framework.Cleanup()
+	})
+
+	Context("when the output is unavailable", func() {
+		It("should not cause the collector/normalizer to restart", func() {
+			skipAddingOutput := func(b *runtime.PodBuilder) error {
+				return nil
+			}
+			Expect(framework.DeployWithVisitor(skipAddingOutput)).To(BeNil())
+			//allow fluent process to load config
+			time.Sleep(8 * time.Second)
+			Expect(oc.Literal().
+				From(fmt.Sprintf("oc -n %s get pod %s -o jsonpath={.status.containerStatuses[0].restartCount}", framework.Namespace, framework.Name)).
+				Run()).
+				To(Equal("0"), "Exp. the pod to boot without restarting")
+		})
+	})
+})

--- a/test/runtime/pod.go
+++ b/test/runtime/pod.go
@@ -10,6 +10,10 @@ type PodBuilder struct {
 	Pod *corev1.Pod
 }
 
+//PodBuilderVisitor provides the ability to manipulate the PodBuilder with
+//custom logic
+type PodBuilderVisitor func(builder *PodBuilder) error
+
 func NewPodBuilder(pod *corev1.Pod) *PodBuilder {
 
 	return &PodBuilder{


### PR DESCRIPTION
### Description
This PR
*  sets the fluentd forward heartbeat to "none" to avoid dns resolution issues from stopping the pod from starting
* Expands the functional framework to add visitors in order to test this issue
```
2020-11-23 20:26:38 +0000 [error]: unexpected error error_class=SocketError error="getaddrinfo: Name or service not known"
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:680:in `getaddrinfo'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:680:in `resolve_dns!'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:666:in `resolved_host'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:516:in `validate_host_resolution!'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:237:in `block in configure'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:227:in `each'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:227:in `configure'
```


/cc @vimalk78 @igor-karpukhin 
/assign @alanconway 

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1901096