### PR TITLE
Bug 1892511: Renamed `level' field in k8s/openshift audit logs

### DIFF
--- a/must-gather/collection-scripts/gather_collection_resources
+++ b/must-gather/collection-scripts/gather_collection_resources
@@ -50,14 +50,19 @@ echo "Gathering data for collection component"
 mkdir -p $collector_folder
 
 echo "-- Retrieving configmaps"
-oc -n $NAMESPACE extract configmap/fluentd --to=$collector_folder
-oc -n $NAMESPACE extract configmap/secure-forward --to=$collector_folder
+mkdir -p $collector_folder/cm/fluentd
+oc -n $NAMESPACE extract configmap/fluentd --to=$collector_folder/cm/fluentd
+mkdir -p $collector_folder/cm/secure-forward
+oc -n $NAMESPACE extract configmap/secure-forward --to=$collector_folder/cm/secure-forward
+mkdir -p $collector_folder/cm/syslog
+oc -n $NAMESPACE extract configmap/syslog --to=$collector_folder/cm/syslog
 
 echo "-- Checking Collector health"
 pods="$(oc -n $NAMESPACE get pods -l logging-infra=fluentd -o jsonpath='{.items[*].metadata.name}')"
 for pod in $pods
 do
     echo "---- Collector pod: $pod"
+    oc -n $NAMESPACE describe pod/$pod > $collector_folder/$pod.describe 2>&1
     get_env $pod $collector_folder "$NAMESPACE"
     check_collector_connectivity $pod
     check_collector_persistence $pod

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -362,15 +362,21 @@ var _ = Describe("Generating fluentd config", func() {
       remove_keys req,res,msg,name,level,v,pid,err
     </filter>
   
-    <filter k8s-audit.log**>
-      @type record_transformer
-      enable_ruby
-      <record>
-        k8s_audit_level ${record['level']}
-        level info
-      </record>
-    </filter>
-  
+	<filter k8s-audit.log**>
+	  @type record_modifier
+	  <record>
+		k8s_audit_level ${record['level']}
+		level info
+	  </record>
+	</filter>
+	<filter openshift-audit.log**>
+	  @type record_modifier
+	  <record>
+		openshift_audit_level ${record['level']}
+		level info
+	  </record>
+	</filter>
+
     <filter **>
       @type viaq_data_model
       elasticsearch_index_prefix_field 'viaq_index_name'
@@ -879,11 +885,17 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 
 				<filter k8s-audit.log**>
-				  @type record_transformer
-				  enable_ruby
+				  @type record_modifier
 				  <record>
-				    k8s_audit_level ${record['level']}
-				    level info
+					k8s_audit_level ${record['level']}
+					level info
+				  </record>
+				</filter>
+				<filter openshift-audit.log**>
+				  @type record_modifier
+				  <record>
+					openshift_audit_level ${record['level']}
+					level info
 				  </record>
 				</filter>
 
@@ -1362,11 +1374,17 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 
 				<filter k8s-audit.log**>
-				  @type record_transformer
-				  enable_ruby
+				  @type record_modifier
 				  <record>
-				    k8s_audit_level ${record['level']}
-				    level info
+					k8s_audit_level ${record['level']}
+					level info
+				  </record>
+				</filter>
+				<filter openshift-audit.log**>
+				  @type record_modifier
+				  <record>
+					openshift_audit_level ${record['level']}
+					level info
 				  </record>
 				</filter>
 
@@ -2202,7 +2220,7 @@ var _ = Describe("Generating fluentd config", func() {
         preserve_json_log true
         json_fields 'log,MESSAGE'
       </filter>
-    
+
       <filter **kibana**>
         @type record_transformer
         enable_ruby
@@ -2211,15 +2229,21 @@ var _ = Describe("Generating fluentd config", func() {
         </record>
         remove_keys req,res,msg,name,level,v,pid,err
       </filter>
-    
-      <filter k8s-audit.log**>
-        @type record_transformer
-	enable_ruby
-        <record>
-          k8s_audit_level ${record['level']}
-          level info
-        </record>
-      </filter>
+
+	  <filter k8s-audit.log**>
+		@type record_modifier
+		<record>
+		  k8s_audit_level ${record['level']}
+		  level info
+		</record>
+	  </filter>
+	  <filter openshift-audit.log**>
+		@type record_modifier
+		<record>
+		  openshift_audit_level ${record['level']}
+		  level info
+		</record>
+	  </filter>
 
       <filter **>
         @type viaq_data_model

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -348,14 +348,20 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             remove_keys req,res,msg,name,level,v,pid,err
           </filter>
 
-          <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
-            <record>
-              k8s_audit_level ${record['level']}
-              level info
-            </record>
-          </filter>
+		  <filter k8s-audit.log**>
+			@type record_modifier
+			<record>
+			  k8s_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
+		  <filter openshift-audit.log**>
+			@type record_modifier
+			<record>
+			  openshift_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
 
           <filter **>
             @type viaq_data_model
@@ -847,15 +853,20 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             remove_keys req,res,msg,name,level,v,pid,err
           </filter>
 
-          <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
-            <record>
-              k8s_audit_level ${record['level']}
-              level info
-            </record>
-          </filter>
-
+		  <filter k8s-audit.log**>
+			@type record_modifier
+			<record>
+			  k8s_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
+		  <filter openshift-audit.log**>
+			@type record_modifier
+			<record>
+			  openshift_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
           <filter **>
             @type viaq_data_model
             elasticsearch_index_prefix_field 'viaq_index_name'
@@ -1348,14 +1359,20 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             remove_keys req,res,msg,name,level,v,pid,err
           </filter>
 
-          <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
-            <record>
-              k8s_audit_level ${record['level']}
-              level info
-            </record>
-          </filter>
+		  <filter k8s-audit.log**>
+			@type record_modifier
+			<record>
+			  k8s_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
+		  <filter openshift-audit.log**>
+			@type record_modifier
+			<record>
+			  openshift_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
 
           <filter **>
             @type viaq_data_model

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -262,10 +262,16 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
   </filter>
 
   <filter k8s-audit.log**>
-    @type record_transformer
-    enable_ruby
+    @type record_modifier
     <record>
       k8s_audit_level ${record['level']}
+      level info
+    </record>
+  </filter>
+  <filter openshift-audit.log**>
+    @type record_modifier
+    <record>
+      openshift_audit_level ${record['level']}
       level info
     </record>
   </filter>

--- a/test/client/test.go
+++ b/test/client/test.go
@@ -31,5 +31,10 @@ func NewTest() *Test {
 func (t *Test) Close() {
 	if !ginkgo.CurrentGinkgoTestDescription().Failed {
 		_ = t.Remove(t.NS)
+	} else {
+		fmt.Printf("\n\n============\n")
+		fmt.Printf("Not removing functional test namespace since test failed. Run \"oc delete ns %s\" to delete namespace manually\n", t.NS.Name)
+		fmt.Printf("To delete all lingering functional test namespaces, run \"oc delete ns -ltest-client=true\"\n")
+		fmt.Printf("============\n\n")
 	}
 }

--- a/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
@@ -48,6 +48,24 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 	hostname ${hostname}
 	facility user
 	severity debug
+	use_record true
+	payload_key message
+	<buffer>
+	  @type file
+	  path '/var/lib/fluentd/syslogout'
+	  flush_mode interval
+	  flush_interval 1s
+	  flush_thread_count 2
+	  flush_at_shutdown true
+	  retry_type exponential_backoff
+	  retry_wait 1s
+	  retry_max_interval 300s
+	  retry_forever true
+	  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+	  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }"
+	  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+	  overflow_action block
+	</buffer>
 </store>
 					`
 					//create configmap syslog/"syslog.conf"
@@ -88,6 +106,9 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 	hostname ${hostname}
 	facility user
 	severity debug
+	use_record true
+	payload_key message
+	#no <buffer> section because @syslog plugin does not support buffering
 </store>
 					`
 					//create configmap syslog/"syslog.conf"
@@ -95,7 +116,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 						Fail(fmt.Sprintf("Unable to create legacy syslog.conf configmap: %v", err))
 					}
 
-					components := []helpers.LogComponentType{helpers.ComponentTypeCollector, helpers.ComponentTypeStore}
+					components := []helpers.LogComponentType{helpers.ComponentTypeCollector}
 					cr := helpers.NewClusterLogging(components...)
 					if err := e2e.CreateClusterLogging(cr); err != nil {
 						Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))

--- a/test/functional/framework.go
+++ b/test/functional/framework.go
@@ -55,7 +55,7 @@ func NewFluentdFunctionalFramework() *FluentdFunctionalFramework {
 	}
 
 	log.MustInit("fluent-ftf")
- 	log.SetLogLevel(verbosity)
+	log.SetLogLevel(verbosity)
 	t := client.NewTest()
 	testName := fmt.Sprintf("test-fluent-%d", rand.Intn(1000))
 	framework := &FluentdFunctionalFramework{
@@ -148,7 +148,7 @@ func (f *FluentdFunctionalFramework) Deploy() (err error) {
 	}
 
 	log.V(2).Info("waiting for pod to be ready")
-	if err = oc.Literal().From(fmt.Sprintf("oc wait -n %s pod/%s --timeout=60s --for=condition=Ready", f.test.NS.Name, f.Name)).Output(); err != nil {
+	if err = oc.Literal().From(fmt.Sprintf("oc wait -n %s pod/%s --timeout=120s --for=condition=Ready", f.test.NS.Name, f.Name)).Output(); err != nil {
 		return err
 	}
 	if err = f.test.Client.Get(f.pod); err != nil {


### PR DESCRIPTION
### Description
There are 3 types of audit logs:
 - linux audit logs generated by operating system
 - kubernetes audit logs generated by kube-api server
 - openshift audit logs generated by openshift-apiserver
see examples below.
The k8s and openshift audit logs are json structured, and contain a field called `level`

The presence of this field conflicts with the `use_record` feature of the legacy way of sending logs to syslog.
When `use_record` is enabled in legacy syslog, the value of `level` field is used as the SEVERITY fields of syslog. But audit logs have this fields for some other purpose than setting the value of syslog field. so the value of `level` when used as SEVERITY generates an UNRECOVERABLE error in fluentd and we get the logs reported in the BZ.

So as a solution, the `level` field is renamed to `k8s-audit-level` and `openshift-audit-level` respectively.

 - Added record_modifier plugins to rename 'level' to k8s-audit-level for k8s audit logs
 - Added record_modifier plugins to rename 'level' to openshift-audit-level for openshift audit logs
 - changed tests to align with the problem in the BZ
 - modifed gather scripts to collect legacy syslog configmap
 - minor changes to functional test framework

Example: kubernetes audit logs
```
{
  "kind": "Event",
  "apiVersion": "audit.k8s.io/v1",
  "level": "Metadata",
  "auditID": "0cbe8fc5-3dbd-42fc-bf6e-1256b72007d9",
  "stage": "ResponseComplete",
  "requestURI": "/api/v1/namespaces/openshift-kube-apiserver/pods?labelSelector=apiserver%3Dtrue",
  "verb": "list",
  "user": {
    "username": "system:serviceaccount:openshift-kube-apiserver-operator:kube-apiserver-operator",
    "uid": "91a12a06-11d5-4e18-a918-e5c1bbe65e50",
    "groups": [
      "system:serviceaccounts",
      "system:serviceaccounts:openshift-kube-apiserver-operator",
      "system:authenticated"
    ]
  },
  "sourceIPs": [
    "10.116.0.2"
  ],
  "userAgent": "cluster-kube-apiserver-operator/v0.0.0 (linux/amd64) kubernetes/$Format",
  "objectRef": {
    "resource": "pods",
    "namespace": "openshift-kube-apiserver",
    "apiVersion": "v1"
  },
  "responseStatus": {
    "metadata": {},
    "code": 200
  },
  "requestReceivedTimestamp": "2020-11-26T21:42:18.658410Z",
  "stageTimestamp": "2020-11-26T21:42:18.660791Z",
  "annotations": {
    "authorization.k8s.io/decision": "allow",
    "authorization.k8s.io/reason": "RBAC: allowed by ClusterRoleBinding \"system:openshift:operator:kube-apiserver-operator\" of ClusterRole \"cluster-admin\" to ServiceAccount \"kube-apiserver-operator/openshift-kube-apiserver-operator\""
  }
}
```

Example: openshift audit logs
```
{
  "kind": "Event",
  "apiVersion": "audit.k8s.io/v1",
  "level": "Metadata",
  "auditID": "d94ca30a-580a-4b7a-9939-c10edac0a708",
  "stage": "ResponseComplete",
  "requestURI": "/openapi/v2",
  "verb": "get",
  "user": {
    "username": "system:aggregator",
    "groups": [
      "system:authenticated"
    ]
  },
  "sourceIPs": [
    "10.116.0.1"
  ],
  "responseStatus": {
    "metadata": {},
    "code": 304
  },
  "requestReceivedTimestamp": "2020-11-26T21:43:36.470183Z",
  "stageTimestamp": "2020-11-26T21:43:36.470275Z",
  "annotations": {
    "authorization.k8s.io/decision": "allow",
    "authorization.k8s.io/reason": "RBAC: allowed by ClusterRoleBinding \"cluster-status-binding\" of ClusterRole \"cluster-status\" to Group \"system:authenticated\""
  }
}
```





/cc @igor-karpukhin @jcantrill 
/assign @jcantrill @alanconway 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1892511
