### PR TITLE
Test improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ test-unit:
 	CURATOR_IMAGE=quay.io/openshift/origin-logging-curator:latest \
 	FLUENTD_IMAGE=$(FLUENTD_IMAGE) \
 	go test -cover -race ./pkg/...
+	go test -cover -race ./test/helpers/
 
 test-cluster:
 	go test  -cover -race ./test/... -- -root=$(CURDIR)

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -13,6 +13,13 @@ resources+=(ns/openshift-operators-redhat)
 
 # cluster-scoped resources
 resources+=(nodes)
+resources+=(pods)
+resources+=(roles)
+resources+=(rolebindings)
+resources+=(clusterroles)
+resources+=(clusterrolebindings)
+resources+=(configmaps)
+resources+=(serviceaccounts)
 resources+=(events)
 resources+=(persistentvolumes)
 

--- a/test/e2e/logforwarding/cleanup.sh
+++ b/test/e2e/logforwarding/cleanup.sh
@@ -13,4 +13,7 @@ oc -n "$GENERATOR_NS" get pods -o yaml > "$artifact_dir/$runtime/log-generator.p
 
 oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- tail -n 20000 /var/log/infra.log > "$artifact_dir/$runtime/syslog-receiver.log" ||:
 oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- cat /rsyslog/etc/rsyslog.conf > "$artifact_dir/$runtime/syslog-receiver.conf" ||:
-oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=kafka-consumer-clo-topic -o name| sed 's/pod\///') -- tail -n 5000 /shared/consumed.logs > "$artifact_dir/$runtime/kafka-consumer-clo-topic.log" ||:
+for pod in $(oc -n openshift-logging get pods -llogging-infra=kafka -oname| sed 's/pod\///')
+do
+    oc -n openshift-logging exec $pod -- tail -n 5000 /shared/consumed.logs > "$artifact_dir/$runtime/$pod.logs" ||:
+done

--- a/test/functional/framework.go
+++ b/test/functional/framework.go
@@ -50,12 +50,12 @@ func NewFluentdFunctionalFramework() *FluentdFunctionalFramework {
 	verbosity := 9
 	if level, found := os.LookupEnv("LOG_LEVEL"); found {
 		if i, err := strconv.Atoi(level); err == nil {
-			verbosity = int(i)
+			verbosity = i
 		}
 	}
 
 	log.MustInit("fluent-ftf")
- 	log.SetLogLevel(verbosity)
+	log.SetLogLevel(verbosity)
 	t := client.NewTest()
 	testName := fmt.Sprintf("test-fluent-%d", rand.Intn(1000))
 	framework := &FluentdFunctionalFramework{
@@ -78,7 +78,8 @@ func (f *FluentdFunctionalFramework) Cleanup() {
 
 func (f *FluentdFunctionalFramework) RunCommand(container string, cmd ...string) (string, error) {
 	log.V(2).Info("Running", "container", container, "cmd", cmd)
-	out, err := runtime.ExecContainer(f.pod, container, cmd[0], cmd[1:]...).CombinedOutput()
+	//out, err := runtime.ExecContainer(f.pod, container, cmd[0], cmd[1:]...).Output()
+	out, err := runtime.ExecOc(f.pod, container, cmd[0], cmd[1:]...)
 	log.V(2).Info("Exec'd", "out", string(out), "err", err)
 	return string(out), err
 }
@@ -148,7 +149,7 @@ func (f *FluentdFunctionalFramework) Deploy() (err error) {
 	}
 
 	log.V(2).Info("waiting for pod to be ready")
-	if err = oc.Literal().From(fmt.Sprintf("oc wait -n %s pod/%s --timeout=60s --for=condition=Ready", f.test.NS.Name, f.Name)).Output(); err != nil {
+	if err = oc.Literal().From(fmt.Sprintf("oc wait -n %s pod/%s --timeout=120s --for=condition=Ready", f.test.NS.Name, f.Name)).Output(); err != nil {
 		return err
 	}
 	if err = f.test.Client.Get(f.pod); err != nil {

--- a/test/helpers/oc/runner.go
+++ b/test/helpers/oc/runner.go
@@ -60,14 +60,14 @@ func (r *runner) runCmd() (string, error) {
 		r.Cmd.Stderr = &errbuf
 	}
 	r.Cmd.Env = []string{fmt.Sprintf("%s=%s", "KUBECONFIG", os.Getenv("KUBECONFIG"))}
-	log.Info("running: ", "command", r, "arguments", strings.Join(r.args, " "))
+	cmdargs := strings.Join(r.args, " ")
 	err := r.Cmd.Run()
 	if err != nil {
 		if r.tostdout {
 			return "", err
 		}
 		errout := strings.TrimSpace(errbuf.String())
-		log.Info("command result", "output", errout, "error", err)
+		log.Info("command result", "arguments", cmdargs, "output", errout, "error", err)
 		return errout, err
 	}
 	if r.tostdout {
@@ -75,9 +75,9 @@ func (r *runner) runCmd() (string, error) {
 	}
 	out := strings.TrimSpace(outbuf.String())
 	if len(out) > 500 {
-		log.Info("output(truncated 500/length)", "length", len(out), "result", truncateString(out, 500))
+		log.Info("output(truncated 500/length)", "arguments", cmdargs, "length", len(out), "result", truncateString(out, 500))
 	} else {
-		log.Info("output", out)
+		log.Info("command output", "arguments", cmdargs, "output", out)
 	}
 	return out, nil
 }

--- a/test/helpers/types.go
+++ b/test/helpers/types.go
@@ -2,62 +2,281 @@ package helpers
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
-
-	logger "github.com/ViaQ/logerr/log"
+	"time"
 )
 
-type logs []log
+var ErrParse = errors.New("logs could not be parsed")
 
-type docker struct {
+// ContainerLog
+type ContainerLog struct {
+	Docker           Docker           `json:"docker"`
+	Kubernetes       Kubernetes       `json:"kubernetes"`
+	Message          string           `json:"message"`
+	Level            string           `json:"level"`
+	Hostname         string           `json:"hostname"`
+	PipelineMetadata PipelineMetadata `json:"pipeline_metadata"`
+	Timestamp        time.Time        `json:"@timestamp"`
+	ViaqIndexName    string           `json:"viaq_index_name"`
+	ViaqMsgID        string           `json:"viaq_msg_id"`
+	OpenshiftLabels  OpenshiftMeta    `json:"openshift"`
+}
+
+type Docker struct {
 	ContainerID string `json:"container_id"`
 }
 
-type k8s struct {
+type Kubernetes struct {
 	ContainerName    string            `json:"container_name"`
+	NamespaceName    string            `json:"namespace_name"`
+	PodName          string            `json:"pod_name"`
 	ContainerImage   string            `json:"container_image"`
 	ContainerImageID string            `json:"container_image_id"`
-	PodName          string            `json:"pod_name"`
 	PodID            string            `json:"pod_id"`
 	Host             string            `json:"host"`
-	Labels           map[string]string `json:"labels"`
-	FlatLabels       []string          `json:"flat_labels"`
 	MasterURL        string            `json:"master_url"`
-	NamespaceName    string            `json:"namespace_name"`
 	NamespaceID      string            `json:"namespace_id"`
+	FlatLabels       []string          `json:"flat_labels"`
+	Labels           map[string]string `json:"labels"`
 }
 
-type pipelineMetadata struct {
-	Collector *struct {
-		IPaddr4    string `json:"ipaddr4"`
-		IPaddr6    string `json:"ipaddr6"`
-		InputName  string `json:"inputname"`
-		Name       string `json:"name"`
-		ReceivedAt string `json:"received_at"`
-		Version    string `json:"version"`
-	} `json:"collector"`
+type Collector struct {
+	Ipaddr4    string    `json:"ipaddr4"`
+	Inputname  string    `json:"inputname"`
+	Name       string    `json:"name"`
+	ReceivedAt time.Time `json:"received_at"`
+	Version    string    `json:"version"`
 }
 
-type log struct {
-	Docker           *docker           `json:"docker"`
-	Kubernetes       *k8s              `json:"kubernetes"`
-	Message          string            `json:"message"`
-	Level            string            `json:"level"`
-	Hostname         string            `json:"hostname"`
-	PipelineMetadata *pipelineMetadata `json:"pipeline_metadata"`
-	Timestamp        string            `json:"@timestamp"`
-	IndexName        string            `json:"viaq_index_name"`
-	MessageID        string            `json:"viaq_msg_id"`
-	OpenshiftLabels  openshiftMeta     `json:"openshift"`
+type PipelineMetadata struct {
+	Collector Collector `json:"collector"`
 }
 
-type openshiftMeta struct {
+type OpenshiftMeta struct {
 	Labels map[string]string `json:"labels"`
 }
 
+// Application Logs are container logs from all namespaces except "openshift" and "openshift-*" namespaces
+type ApplicationLog ContainerLog
+
+// Infrastructure logs are
+// - Journal logs
+// - logs from "openshift" and "openshift-*" namespaces
+
+// InfraContainerLog
+// InfraContainerLog logs are container logs from "openshift" and "openshift-*" namespaces
+type InfraContainerLog ContainerLog
+
+// JournalLog is linux journal logs
+type JournalLog struct {
+	STREAMID            string           `json:"_STREAM_ID"`
+	SYSTEMDINVOCATIONID string           `json:"_SYSTEMD_INVOCATION_ID"`
+	Systemd             Systemd          `json:"systemd"`
+	Level               string           `json:"level"`
+	Message             string           `json:"message"`
+	Hostname            string           `json:"hostname"`
+	PipelineMetadata    PipelineMetadata `json:"pipeline_metadata"`
+	Timestamp           time.Time        `json:"@timestamp"`
+	ViaqIndexName       string           `json:"viaq_index_name"`
+	ViaqMsgID           string           `json:"viaq_msg_id"`
+	Kubernetes          Kubernetes       `json:"kubernetes"`
+}
+
+type T struct {
+	BOOTID              string `json:"BOOT_ID"`
+	CAPEFFECTIVE        string `json:"CAP_EFFECTIVE"`
+	CMDLINE             string `json:"CMDLINE"`
+	COMM                string `json:"COMM"`
+	EXE                 string `json:"EXE"`
+	GID                 string `json:"GID"`
+	MACHINEID           string `json:"MACHINE_ID"`
+	PID                 string `json:"PID"`
+	SELINUXCONTEXT      string `json:"SELINUX_CONTEXT"`
+	STREAMID            string `json:"STREAM_ID"`
+	SYSTEMDCGROUP       string `json:"SYSTEMD_CGROUP"`
+	SYSTEMDINVOCATIONID string `json:"SYSTEMD_INVOCATION_ID"`
+	SYSTEMDSLICE        string `json:"SYSTEMD_SLICE"`
+	SYSTEMDUNIT         string `json:"SYSTEMD_UNIT"`
+	TRANSPORT           string `json:"TRANSPORT"`
+	UID                 string `json:"UID"`
+}
+
+type U struct {
+	SYSLOGIDENTIFIER string `json:"SYSLOG_IDENTIFIER"`
+}
+
+type Systemd struct {
+	T T `json:"t"`
+	U U `json:"u"`
+}
+
+// InfraLog is union of JournalLog and InfraContainerLog
+type InfraLog struct {
+	Docker              Docker           `json:"docker,omitempty"`
+	Kubernetes          Kubernetes       `json:"kubernetes,omitempty"`
+	Message             string           `json:"message"`
+	Level               string           `json:"level"`
+	Hostname            string           `json:"hostname"`
+	PipelineMetadata    PipelineMetadata `json:"pipeline_metadata"`
+	Timestamp           time.Time        `json:"@timestamp"`
+	ViaqIndexName       string           `json:"viaq_index_name"`
+	ViaqMsgID           string           `json:"viaq_msg_id"`
+	STREAMID            string           `json:"_STREAM_ID,omitempty"`
+	SYSTEMDINVOCATIONID string           `json:"_SYSTEMD_INVOCATION_ID,omitempty"`
+	Systemd             Systemd          `json:"systemd,omitempty"`
+	OpenshiftLabels     OpenshiftMeta    `json:"openshift"`
+}
+
+/*
+Audit logs are
+ - Audit logs generated by linux
+ - Audit logs generated by kubernetes
+ - Audit logs generated by openshift
+*/
+
+// LinuxAuditLog is generated by linux operating system
+type LinuxAuditLog struct {
+	Hostname         string           `json:"hostname"`
+	AuditLinux       AuditLinux       `json:"audit.linux"`
+	Message          string           `json:"message"`
+	PipelineMetadata PipelineMetadata `json:"pipeline_metadata"`
+	Timestamp        time.Time        `json:"@timestamp"`
+	ViaqIndexName    string           `json:"viaq_index_name"`
+	ViaqMsgID        string           `json:"viaq_msg_id"`
+	Kubernetes       Kubernetes       `json:"kubernetes"`
+}
+
+type AuditLinux struct {
+	Type     string `json:"type"`
+	RecordID string `json:"record_id"`
+}
+
+// AuditLogCommon is common to k8s and openshift auditlogs
+type AuditLogCommon struct {
+	Kind                     string           `json:"kind"`
+	APIVersion               string           `json:"apiVersion"`
+	Level                    string           `json:"level"`
+	AuditID                  string           `json:"auditID"`
+	Stage                    string           `json:"stage"`
+	RequestURI               string           `json:"requestURI"`
+	Verb                     string           `json:"verb"`
+	User                     User             `json:"user"`
+	SourceIPs                []string         `json:"sourceIPs"`
+	UserAgent                string           `json:"userAgent"`
+	ObjectRef                ObjectRef        `json:"objectRef"`
+	ResponseStatus           ResponseStatus   `json:"responseStatus"`
+	RequestReceivedTimestamp time.Time        `json:"requestReceivedTimestamp"`
+	StageTimestamp           time.Time        `json:"stageTimestamp"`
+	Annotations              Annotations      `json:"annotations"`
+	Message                  interface{}      `json:"message"`
+	Hostname                 string           `json:"hostname"`
+	PipelineMetadata         PipelineMetadata `json:"pipeline_metadata"`
+	Timestamp                time.Time        `json:"@timestamp"`
+	ViaqIndexName            string           `json:"viaq_index_name"`
+	ViaqMsgID                string           `json:"viaq_msg_id"`
+	Kubernetes               Kubernetes       `json:"kubernetes"`
+	OpenshiftLabels          OpenshiftMeta    `json:"openshift"`
+}
+type User struct {
+	Username string   `json:"username"`
+	UID      string   `json:"uid"`
+	Groups   []string `json:"groups"`
+}
+type ObjectRef struct {
+	Resource        string `json:"resource"`
+	ResourceVersion string `json:"resourceVersion"`
+	Name            string `json:"name"`
+	Namespace       string `json:"namespace"`
+	APIGroup        string `json:"apiGroup"`
+	APIVersion      string `json:"apiVersion"`
+	UID             string `json:"uid"`
+}
+type ResponseStatus struct {
+	Code int `json:"code"`
+}
+type Annotations struct {
+	AuthorizationK8SIoDecision string `json:"authorization.k8s.io/decision"`
+	AuthorizationK8SIoReason   string `json:"authorization.k8s.io/reason"`
+}
+
+// OpenshiftAuditLog is audit log generated by openshift-apiserver
+type OpenshiftAuditLog struct {
+	AuditLogCommon
+	OpenshiftAuditLevel string `json:"openshift_audit_level"`
+}
+
+// K8sAuditLog is audit logs generated by kube-apiserver
+type K8sAuditLog struct {
+	AuditLogCommon
+	K8SAuditLevel string `json:"k8s_audit_level"`
+}
+
+// AuditLog is a union of LinuxAudit, K8sAudit, OpenshiftAudit logs
+type AuditLog struct {
+	Hostname                 string           `json:"hostname"`
+	AuditLinux               AuditLinux       `json:"audit.linux"`
+	Message                  string           `json:"message"`
+	PipelineMetadata         PipelineMetadata `json:"pipeline_metadata"`
+	Timestamp                time.Time        `json:"@timestamp"`
+	ViaqIndexName            string           `json:"viaq_index_name"`
+	ViaqMsgID                string           `json:"viaq_msg_id"`
+	Kubernetes               Kubernetes       `json:"kubernetes"`
+	Kind                     string           `json:"kind"`
+	APIVersion               string           `json:"apiVersion"`
+	Level                    string           `json:"level"`
+	AuditID                  string           `json:"auditID"`
+	Stage                    string           `json:"stage"`
+	RequestURI               string           `json:"requestURI"`
+	Verb                     string           `json:"verb"`
+	User                     User             `json:"user"`
+	SourceIPs                []string         `json:"sourceIPs"`
+	UserAgent                string           `json:"userAgent"`
+	ObjectRef                ObjectRef        `json:"objectRef"`
+	ResponseStatus           ResponseStatus   `json:"responseStatus"`
+	RequestReceivedTimestamp time.Time        `json:"requestReceivedTimestamp"`
+	StageTimestamp           time.Time        `json:"stageTimestamp"`
+	Annotations              Annotations      `json:"annotations"`
+	K8SAuditLevel            string           `json:"k8s_audit_level"`
+	OpenshiftAuditLevel      string           `json:"openshift_audit_level"`
+}
+
+// AllLog is a union of all log types
+type AllLog struct {
+	Docker                   Docker           `json:"docker"`
+	Kubernetes               Kubernetes       `json:"kubernetes"`
+	Message                  string           `json:"message"`
+	Level                    string           `json:"level"`
+	Hostname                 string           `json:"hostname"`
+	PipelineMetadata         PipelineMetadata `json:"pipeline_metadata"`
+	Timestamp                time.Time        `json:"@timestamp"`
+	ViaqIndexName            string           `json:"viaq_index_name"`
+	ViaqMsgID                string           `json:"viaq_msg_id"`
+	STREAMID                 string           `json:"_STREAM_ID"`
+	SYSTEMDINVOCATIONID      string           `json:"_SYSTEMD_INVOCATION_ID"`
+	Systemd                  Systemd          `json:"systemd"`
+	AuditLinux               AuditLinux       `json:"audit.linux"`
+	Kind                     string           `json:"kind"`
+	APIVersion               string           `json:"apiVersion"`
+	AuditID                  string           `json:"auditID"`
+	Stage                    string           `json:"stage"`
+	RequestURI               string           `json:"requestURI"`
+	Verb                     string           `json:"verb"`
+	User                     User             `json:"user"`
+	SourceIPs                []string         `json:"sourceIPs"`
+	UserAgent                string           `json:"userAgent"`
+	ObjectRef                ObjectRef        `json:"objectRef"`
+	ResponseStatus           ResponseStatus   `json:"responseStatus"`
+	RequestReceivedTimestamp time.Time        `json:"requestReceivedTimestamp"`
+	StageTimestamp           time.Time        `json:"stageTimestamp"`
+	Annotations              Annotations      `json:"annotations"`
+	K8SAuditLevel            string           `json:"k8s_audit_level"`
+	OpenshiftAuditLevel      string           `json:"openshift_audit_level"`
+}
+type logs []AllLog
+
 func ParseLogs(in string) (logs, error) {
-	logger.V(3).Info("ParseLogs", "content", in)
-	logs := []log{}
+	logs := logs{}
 	if in == "" {
 		return logs, nil
 	}
@@ -71,9 +290,9 @@ func ParseLogs(in string) (logs, error) {
 }
 
 func (l logs) ByIndex(prefix string) logs {
-	filtered := []log{}
+	filtered := logs{}
 	for _, entry := range l {
-		if strings.HasPrefix(entry.IndexName, prefix) {
+		if strings.HasPrefix(entry.ViaqIndexName, prefix) {
 			filtered = append(filtered, entry)
 		}
 	}
@@ -81,11 +300,8 @@ func (l logs) ByIndex(prefix string) logs {
 }
 
 func (l logs) ByPod(name string) logs {
-	filtered := []log{}
+	filtered := logs{}
 	for _, entry := range l {
-		if entry.Kubernetes == nil {
-			continue
-		}
 		if entry.Kubernetes.PodName == name {
 			filtered = append(filtered, entry)
 		}

--- a/test/helpers/types_test.go
+++ b/test/helpers/types_test.go
@@ -1,0 +1,401 @@
+package helpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const (
+	ApplicationContainerLogStr = `
+{
+  "docker": {
+    "container_id": "9694d9dcde514f37fe865bb4752114939490f28080f630231223953eb18fff57"
+  },
+  "kubernetes": {
+    "container_name": "log-generator",
+    "namespace_name": "clo-test-21151",
+    "pod_name": "log-generator-595c967f99-59v44",
+    "container_image": "docker.io/library/busybox:latest",
+    "container_image_id": "docker.io/library/busybox@sha256:9f1c79411e054199210b4d489ae600a061595967adb643cd923f8515ad8123d2",
+    "pod_id": "b902950c-90df-4ca0-b296-614471c38fd0",
+    "host": "crc-j55b9-master-0",
+    "master_url": "https://kubernetes.default.svc",
+    "namespace_id": "86e19672-1671-472e-9b2e-6ca8c304f32b",
+    "flat_labels": [
+      "component=test",
+      "logging-infra=log-generator",
+      "pod-template-hash=595c967f99",
+      "provider=openshift"
+    ]
+  },
+  "message": "8316: My life is my message",
+  "level": "unknown",
+  "hostname": "crc-j55b9-master-0",
+  "pipeline_metadata": {
+    "collector": {
+      "ipaddr4": "192.168.126.11",
+      "inputname": "fluent-plugin-systemd",
+      "name": "fluentd",
+      "received_at": "2020-11-27T19:55:52.158588+00:00",
+      "version": "1.7.4 1.6.0"
+    }
+  },
+  "@timestamp": "2020-11-27T18:32:57.600159+00:00",
+  "viaq_index_name": "app-write",
+  "viaq_msg_id": "M2QxNzM0MmQtMmVmMy00NjM1LWE1YzAtYjE1MWMxOWE5MTM2"
+}
+	`
+
+	InfraContainerLogStr = `
+{
+  "docker": {
+    "container_id": "0b25616ba52ca96f0230779a72ea6abf541a7a06b586f93799052a7186dcb5c8"
+  },
+  "kubernetes": {
+    "container_name": "download-server",
+    "namespace_name": "openshift-console",
+    "pod_name": "downloads-55f4ff79-gnrsw",
+    "pod_id": "90831bef-2045-48d6-9d69-bb5156de67ff",
+    "host": "crc-j55b9-master-0",
+    "master_url": "https://kubernetes.default.svc",
+    "namespace_id": "213a73f1-1b3d-4d32-9f68-ff6b7010dcfe",
+    "flat_labels": [
+      "app=console",
+      "component=downloads",
+      "pod-template-hash=55f4ff79"
+    ]
+  },
+  "message": "::ffff:10.116.0.1 - - [29/Nov/2020 13:27:47] \"GET / HTTP/1.1\" 200 -",
+  "level": "unknown",
+  "hostname": "crc-j55b9-master-0",
+  "pipeline_metadata": {
+    "collector": {
+      "ipaddr4": "192.168.126.11",
+      "inputname": "fluent-plugin-systemd",
+      "name": "fluentd",
+      "received_at": "2020-11-29T13:27:48.886552+00:00",
+      "version": "1.7.4 1.6.0"
+    }
+  },
+  "@timestamp": "2020-11-29T13:27:47.955953+00:00",
+  "viaq_index_name": "infra-write",
+  "viaq_msg_id": "MjFlMWIxNGItMTljMi00NjA2LWFhNzUtNDg2OTYzYjQxYzUx"
+}
+	`
+	JournalLogStr = `
+{
+  "_STREAM_ID": "827e6000d4cb4e72ba99af117275cffb",
+  "_SYSTEMD_INVOCATION_ID": "1d6941944a444c199fbfa8497bbfcff1",
+  "systemd": {
+    "t": {
+      "BOOT_ID": "c5b940038cdf487d9661b1aef19d26dc",
+      "CAP_EFFECTIVE": "3fffffffff",
+      "CMDLINE": "kubelet --node-ip=192.168.126.11 --config=/etc/kubernetes/kubelet.conf --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig --kubeconfig=/var/lib/kubelet/kubeconfig --container-runtime=remote --container-runtime-endpoint=/var/run/crio/crio.sock --runtime-cgroups=/system.slice/crio.service --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=rhcos --minimum-container-ttl-duration=6m0s --cloud-provider= --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec --register-with-taints=node-role.kubernetes.io/master=:NoSchedule --pod-infra-container-image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cc0eb0534a361cffb7c392bf889ef061fc5390a7b21f6c92710f7a53ac4edd85 --v=4",
+      "COMM": "kubelet",
+      "EXE": "/usr/bin/kubelet",
+      "GID": "0",
+      "MACHINE_ID": "2b2d5b75dec04ce889fb7ae3690bdca7",
+      "PID": "2612",
+      "SELINUX_CONTEXT": "system_u:system_r:unconfined_service_t:s0",
+      "STREAM_ID": "827e6000d4cb4e72ba99af117275cffb",
+      "SYSTEMD_CGROUP": "/system.slice/kubelet.service",
+      "SYSTEMD_INVOCATION_ID": "1d6941944a444c199fbfa8497bbfcff1",
+      "SYSTEMD_SLICE": "system.slice",
+      "SYSTEMD_UNIT": "kubelet.service",
+      "TRANSPORT": "stdout",
+      "UID": "0"
+    },
+    "u": {
+      "SYSLOG_IDENTIFIER": "hyperkube"
+    }
+  },
+  "level": "info",
+  "message": "I1128 18:18:17.286513    2612 desired_state_of_world_populator.go:344] Added volume \"cluster-samples-operator-token-rz7g2\" (volSpec=\"cluster-samples-operator-token-rz7g2\") for pod \"efe875e1-05bf-4169-b7d4-0891e856d4eb\" to desired state.",
+  "hostname": "crc-j55b9-master-0",
+  "pipeline_metadata": {
+    "collector": {
+      "ipaddr4": "192.168.126.11",
+      "inputname": "fluent-plugin-systemd",
+      "name": "fluentd",
+      "received_at": "2020-11-28T18:18:17.845698+00:00",
+      "version": "1.7.4 1.6.0"
+    }
+  },
+  "@timestamp": "2020-11-28T18:18:17.286517+00:00",
+  "viaq_index_name": "infra-write",
+  "viaq_msg_id": "ZDY0ZjE4NTAtNGU3ZC00YmQ4LWJjYjctNzVjMTEwMzdlYWIz",
+  "kubernetes": {}
+}
+	`
+	LinuxAuditLogStr = `
+{
+  "hostname": "crc-j55b9-master-0",
+  "audit.linux": {
+    "type": "ANOM_PROMISCUOUS",
+    "record_id": "5964"
+  },
+  "message": "type=ANOM_PROMISCUOUS msg=audit(1606655808.785:5964): dev=veth823df183 prom=256 old_prom=0 auid=4294967295 uid=998 gid=996 ses=4294967295\u001dAUID=\"unset\" UID=\"etcd\" GID=\"cgred\"",
+  "pipeline_metadata": {
+    "collector": {
+      "ipaddr4": "192.168.126.11",
+      "inputname": "fluent-plugin-systemd",
+      "name": "fluentd",
+      "received_at": "2020-11-29T13:16:49.021493+00:00",
+      "version": "1.7.4 1.6.0"
+    }
+  },
+  "@timestamp": "2020-11-29T13:16:48.785000+00:00",
+  "viaq_index_name": "audit-write",
+  "viaq_msg_id": "Y2M1NThmYzUtODYxYS00MzY5LWJmZDQtN2FkYjk4ZDlmYjE3",
+  "kubernetes": {}
+}
+   `
+	K8sAuditLogStr = `
+{
+  "kind": "Event",
+  "apiVersion": "audit.k8s.io/v1",
+  "level": "info",
+  "auditID": "e7b84ee2-04c0-4b3f-bf8a-51290816680e",
+  "stage": "ResponseComplete",
+  "requestURI": "/api/v1/namespaces/openshift-sdn/configmaps/openshift-network-controller",
+  "verb": "update",
+  "user": {
+    "username": "system:serviceaccount:openshift-sdn:sdn-controller",
+    "uid": "abcb0401-1236-4dce-ab7c-ba1d2948da46",
+    "groups": [
+      "system:serviceaccounts",
+      "system:serviceaccounts:openshift-sdn",
+      "system:authenticated"
+    ]
+  },
+  "sourceIPs": [
+    "192.168.130.11"
+  ],
+  "userAgent": "openshift-sdn-controller/v0.0.0 (linux/amd64) kubernetes/$Format",
+  "objectRef": {
+    "resource": "configmaps",
+    "namespace": "openshift-sdn",
+    "name": "openshift-network-controller",
+    "uid": "a07dbbb1-8b53-4241-9153-c935c93c25b7",
+    "apiVersion": "v1",
+    "resourceVersion": "558761"
+  },
+  "responseStatus": {
+    "code": 200
+  },
+  "requestReceivedTimestamp": "2020-11-27T19:55:01.798728Z",
+  "stageTimestamp": "2020-11-27T19:55:01.801820Z",
+  "annotations": {
+    "authorization.k8s.io/decision": "allow",
+    "authorization.k8s.io/reason": "RBAC: allowed by RoleBinding \"openshift-sdn-controller-leaderelection/openshift-sdn\" of Role \"openshift-sdn-controller-leaderelection\" to ServiceAccount \"sdn-controller/openshift-sdn\""
+  },
+  "k8s_audit_level": "Metadata",
+  "message": null,
+  "hostname": "crc-j55b9-master-0",
+  "pipeline_metadata": {
+    "collector": {
+      "ipaddr4": "192.168.126.11",
+      "inputname": "fluent-plugin-systemd",
+      "name": "fluentd",
+      "received_at": "2020-11-27T19:55:17.529590+00:00",
+      "version": "1.7.4 1.6.0"
+    }
+  },
+  "@timestamp": "2020-11-27T19:55:01.798728+00:00",
+  "viaq_index_name": "audit-write",
+  "viaq_msg_id": "OWU1OGU0MzYtOGQ4YS00MTBhLWIwZGQtMzM1ZDc3ZmIzOTc4",
+  "kubernetes": {}
+}
+	`
+	OpenshiftAuditLogStr = `
+{
+  "kind": "Event",
+  "apiVersion": "audit.k8s.io/v1",
+  "level": "info",
+  "auditID": "e1c9ce68-dcde-4465-89f2-c9dd65da8139",
+  "stage": "ResponseComplete",
+  "requestURI": "/apis/security.openshift.io/v1/rangeallocations/scc-uid",
+  "verb": "update",
+  "user": {
+    "username": "system:serviceaccount:openshift-infra:namespace-security-allocation-controller",
+    "groups": [
+      "system:serviceaccounts",
+      "system:serviceaccounts:openshift-infra",
+      "system:authenticated"
+    ]
+  },
+  "sourceIPs": [
+    "192.168.130.11",
+    "10.116.0.1"
+  ],
+  "userAgent": "cluster-policy-controller/v0.0.0 (linux/amd64) kubernetes/$Format/system:serviceaccount:openshift-infra:namespace-security-allocation-controller",
+  "objectRef": {
+    "resource": "rangeallocations",
+    "name": "scc-uid",
+    "uid": "c51f9ef8-f6ac-4e14-be47-6322a37c6070",
+    "apiGroup": "security.openshift.io",
+    "apiVersion": "v1",
+    "resourceVersion": "440262"
+  },
+  "responseStatus": {
+    "code": 200
+  },
+  "requestReceivedTimestamp": "2020-11-29T13:26:56.978921Z",
+  "stageTimestamp": "2020-11-29T13:26:56.992462Z",
+  "annotations": {
+    "authorization.k8s.io/decision": "allow",
+    "authorization.k8s.io/reason": "RBAC: allowed by ClusterRoleBinding \"system:openshift:controller:namespace-security-allocation-controller\" of ClusterRole \"system:openshift:controller:namespace-security-allocation-controller\" to ServiceAccount \"namespace-security-allocation-controller/openshift-infra\""
+  },
+  "openshift_audit_level": "Metadata",
+  "message": null,
+  "hostname": "crc-j55b9-master-0",
+  "pipeline_metadata": {
+    "collector": {
+      "ipaddr4": "192.168.126.11",
+      "inputname": "fluent-plugin-systemd",
+      "name": "fluentd",
+      "received_at": "2020-11-29T13:26:57.026736+00:00",
+      "version": "1.7.4 1.6.0"
+    }
+  },
+  "@timestamp": "2020-11-29T13:26:56.978921+00:00",
+  "viaq_index_name": "audit-write",
+  "viaq_msg_id": "ZTRjMDQ4ZWEtMmVkMy00YTJmLTk0NTUtYTk4YzNjNDFlYjM5",
+  "kubernetes": {}
+}
+`
+)
+
+func join(log ...string) string {
+	return "[" + strings.Join(log, ",") + "]"
+}
+
+func TestDecodeApplicationLogs(t *testing.T) {
+	logs := []ApplicationLog{}
+	in := join(ApplicationContainerLogStr)
+	dec := json.NewDecoder(strings.NewReader(in))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&logs)
+	if err != nil {
+		fmt.Printf("%#v", err)
+		t.Fail()
+	}
+}
+
+func TestDecodeInfraContainerLogs(t *testing.T) {
+	logs := []InfraContainerLog{}
+	in := join(InfraContainerLogStr)
+	dec := json.NewDecoder(strings.NewReader(in))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&logs)
+	if err != nil {
+		fmt.Printf("%#v", err)
+		t.Fail()
+	}
+}
+
+func TestDecodeJournalLogs(t *testing.T) {
+	logs := []JournalLog{}
+	in := join(JournalLogStr)
+	dec := json.NewDecoder(strings.NewReader(in))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&logs)
+	if err != nil {
+		fmt.Printf("%#v", err)
+		t.Fail()
+	}
+}
+
+// decode Infra Container and Journal logs together
+func TestDecodeInfraLogs(t *testing.T) {
+	logs := []InfraLog{}
+	in := join(InfraContainerLogStr, JournalLogStr)
+	dec := json.NewDecoder(strings.NewReader(in))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&logs)
+	if err != nil {
+		fmt.Printf("%#v", err)
+		t.Fail()
+	}
+	if len(logs) != 2 {
+		t.Fail()
+	}
+}
+
+func TestDecodeLinuxAuditLogs(t *testing.T) {
+	logs := []LinuxAuditLog{}
+	in := join(LinuxAuditLogStr)
+	dec := json.NewDecoder(strings.NewReader(in))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&logs)
+	if err != nil {
+		fmt.Printf("%#v", err)
+		t.Fail()
+	}
+}
+
+func TestDecodeK8sAuditLogs(t *testing.T) {
+	logs := []K8sAuditLog{}
+	in := join(K8sAuditLogStr)
+	dec := json.NewDecoder(strings.NewReader(in))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&logs)
+	if err != nil {
+		fmt.Printf("%#v", err)
+		t.Fail()
+	}
+}
+
+func TestDecodeOpenshiftAuditLogs(t *testing.T) {
+	logs := []OpenshiftAuditLog{}
+	in := join(OpenshiftAuditLogStr)
+	dec := json.NewDecoder(strings.NewReader(in))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&logs)
+	if err != nil {
+		fmt.Printf("%#v", err)
+		t.Fail()
+	}
+}
+
+// decode Linux, K8s, Openshift Audit logs together
+func TestDecodeAuditLogs(t *testing.T) {
+	logs := []AuditLog{}
+	in := join(
+		LinuxAuditLogStr,
+		K8sAuditLogStr,
+		OpenshiftAuditLogStr)
+	dec := json.NewDecoder(strings.NewReader(in))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&logs)
+	if err != nil {
+		fmt.Printf("%#v", err)
+		t.Fail()
+	}
+	if len(logs) != 3 {
+		t.Fail()
+	}
+}
+
+func TestDecodeAllLogs(t *testing.T) {
+	logs := []AllLog{}
+	in := join(
+		ApplicationContainerLogStr,
+		JournalLogStr,
+		InfraContainerLogStr,
+		LinuxAuditLogStr,
+		K8sAuditLogStr,
+		OpenshiftAuditLogStr)
+	dec := json.NewDecoder(strings.NewReader(in))
+	dec.DisallowUnknownFields()
+	err := dec.Decode(&logs)
+	if err != nil {
+		fmt.Printf("%#v", err)
+		t.Fail()
+	}
+	if len(logs) != 6 {
+		t.Fail()
+	}
+}

--- a/test/runtime/runtime.go
+++ b/test/runtime/runtime.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -106,6 +107,11 @@ func Exec(o runtime.Object, cmd string, args ...string) *exec.Cmd {
 	}, args...)
 
 	return exec.Command("oc", ocCmd...)
+}
+
+func ExecOc(o runtime.Object, container, cmd string, args ...string) (string, error) {
+	m := Meta(o)
+	return oc.Exec().WithNamespace(m.GetNamespace()).Pod(m.GetName()).Container(container).WithCmd(cmd, args...).Run()
 }
 
 // ExecContainer returns an `oc exec` Cmd to run cmd on o.


### PR DESCRIPTION
 ### Description
 - We have 6 type of logs. (AppContainer, InfraContainer, Journal, LinuxAudit, K8sAudit, Openshift Audit)
 - Added Go struct for each type of logs
 - Added tests to decode each type of log with example for each log
 - Kafka test improvement: all logs in same topic test assertion improved
 - Fixed log statements after structured logging changes (depends on ViaQ/logerr library changes)
 - Test Cleanup also cleans the fluentd POS files, so that next testcase has higher chances of receiving logs
 - captured more resources in must-gather
 - modified functional tests RunCommand to use oc helper utility

/cc @eranra @alanconway 
/assign @jcantrill @igor-karpukhin 

