### PR TITLE
Bug 1901869: Recreate master-certs if deleted

### DIFF
--- a/pkg/k8shandler/certificates.go
+++ b/pkg/k8shandler/certificates.go
@@ -22,22 +22,22 @@ func Syncronize(action func() error) error {
 	return action()
 }
 
-func (clusterRequest *ClusterLoggingRequest) extractMasterCerts() (err error) {
+func (clusterRequest *ClusterLoggingRequest) extractMasterCerts() (extracted bool, err error) {
 	secret, err := clusterRequest.GetSecret(constants.MasterCASecretName)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("Unable to get secret %s: %v", constants.MasterCASecretName, err)
+		return false, fmt.Errorf("Unable to get secret %s: %v", constants.MasterCASecretName, err)
 	}
 	workDir := utils.GetWorkingDir()
 	for name, value := range secret.Data {
 		if err != utils.WriteToWorkingDirFile(path.Join(workDir, name), value) {
-			return err
+			return false, err
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 func (clusterRequest *ClusterLoggingRequest) writeSecret() (err error) {
@@ -77,7 +77,8 @@ func loadFilesFromWorkingDir() (map[string][]byte, error) {
 //CreateOrUpdateCertificates for a cluster logging instance
 func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCertificates() (err error) {
 	return Syncronize(func() error {
-		if err = clusterRequest.extractMasterCerts(); err != nil {
+		var extracted bool
+		if extracted, err = clusterRequest.extractMasterCerts(); err != nil {
 			fmt.Printf("Error %v", err)
 			return err
 		}
@@ -88,7 +89,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCertificates() (err e
 			return fmt.Errorf("Error running script: %v", err)
 		}
 		log.V(3).Info("Writing secret", "updated", updated)
-		if updated {
+		if !extracted || updated {
 			if err = clusterRequest.writeSecret(); err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description
This PR resolves the issue where the master-certs are not re-created when deleted by:
* Writing the secret when it changes or when it was not found initially

/cc @syedriko 
/assign @vimalk78 @igor-karpukhin 

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1901869
