### PR TITLE
Bug 1903784: Bubble up errors from logstore reconciliation

### DIFF
--- a/pkg/controller/clusterlogging/clusterlogging_controller.go
+++ b/pkg/controller/clusterlogging/clusterlogging_controller.go
@@ -86,7 +86,9 @@ func (r *ReconcileClusterLogging) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, nil
 	}
 
-	err = k8shandler.Reconcile(instance, r.client)
+	if err = k8shandler.Reconcile(instance, r.client); err != nil {
+		log.Error(err, "Error reconciling clusterlogging instance")
+	}
 
 	if result, err := r.updateStatus(instance); err != nil {
 		return result, err

--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -31,11 +31,11 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateLogStore() (err error
 		cluster := clusterRequest.Cluster
 
 		if err = clusterRequest.createOrUpdateElasticsearchSecret(); err != nil {
-			return nil
+			return err
 		}
 
 		if err = clusterRequest.createOrUpdateElasticsearchCR(); err != nil {
-			return nil
+			return err
 		}
 
 		elasticsearchStatus, err := clusterRequest.getElasticsearchStatus()


### PR DESCRIPTION
### Description
This PR bubbles up errors from reconciling the logstore that were lost in a prior commit in order to expose more information to admins

/cc @igor-karpukhin 
/assign @alanconway @vimalk78 

### Links
*https://bugzilla.redhat.com/show_bug.cgi?id=1903784