### PR TITLE
Bug 1888943:  ClusterLogForwarder with Output.Secret causes fluentd crash loop

### DIFF
--- a/hack/update-pull-secret.sh
+++ b/hack/update-pull-secret.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+PULL_SECRET=$1
+test -n "$PULL_SECRET" || { echo "Specify a pull secret file"; exit 1; }
+BASE64=$(cat $PULL_SECRET | tr -d '[:space:]' | base64 -w0)
+
+secret_yaml() {
+    cat <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pull-secret
+  namespace: openshift-config
+data:
+  .dockerconfigjson: $BASE64
+EOF
+}
+
+secret_yaml | oc delete --ignore-not-found -f -
+secret_yaml | oc create -f -

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -52,7 +52,7 @@ func Generate(clfYaml string, includeDefaultLogStore, includeLegacyForward bool)
 	log.V(2).Info("Normalization", "status", status)
 	tunings := &logging.ForwarderSpec{}
 
-	generatedConfig, err := generator.Generate(spec, tunings)
+	generatedConfig, err := generator.Generate(spec, nil, tunings)
 	if err != nil {
 		return "", fmt.Errorf("Unable to generate log configuration: %v", err)
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,6 +6,8 @@ const (
 	// global proxy / trusted ca bundle consts
 	ProxyName                  = "cluster"
 	TrustedCABundleKey         = "ca-bundle.crt"
+	ClientCertKey              = "tls.crt"
+	ClientPrivateKey           = "tls.key"
 	InjectTrustedCABundleLabel = "config.openshift.io/inject-trusted-cabundle"
 	TrustedCABundleMountFile   = "tls-ca-bundle.pem"
 	TrustedCABundleMountDir    = "/etc/pki/ca-trust/extracted/pem/"
@@ -25,8 +27,9 @@ const (
 	MasterCASecretName  = "master-certs"
 	CollectorSecretName = "fluentd"
 
-	/* #nosec - suppressing rule G101 */
-	KibanaSessionSecretName = "kibana-session-secret"
+	// Disable gosec linter, complains "possible hard-coded secret"
+	CollectorSecretsDir     = "/var/run/ocp-collector/secrets" //nolint:gosec
+	KibanaSessionSecretName = "kibana-session-secret"          //nolint:gosec
 )
 
 var ReconcileForGlobalProxyList = []string{FluentdTrustedCAName}

--- a/pkg/generators/factory.go
+++ b/pkg/generators/factory.go
@@ -3,6 +3,7 @@ package generators
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 )
 
@@ -18,7 +19,13 @@ func New(name string, addFunctions *template.FuncMap, templates ...string) (*Gen
 	for i, s := range templates {
 		tmpl, err = tmpl.Parse(s)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing %q template %v: %s", name, i, err)
+			// Include the first line containing the template name in the error message.
+			templateName := "unknown"
+			lines := strings.SplitN(s, "\n", 2)
+			if len(lines) > 0 {
+				templateName = lines[0]
+			}
+			return nil, fmt.Errorf("Error parsing %v template %v %q: %s", name, i, templateName, err)
 		}
 	}
 	return &Generator{tmpl}, nil

--- a/pkg/generators/forwarding/factory.go
+++ b/pkg/generators/forwarding/factory.go
@@ -5,6 +5,7 @@ import (
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/pkg/generators/forwarding/fluentd"
+	corev1 "k8s.io/api/core/v1"
 )
 
 //NewConfigGenerator create a config generator for a given collector type
@@ -21,5 +22,5 @@ func NewConfigGenerator(collector logging.LogCollectionType, includeLegacyForwar
 type ConfigGenerator interface {
 
 	//Generate the config
-	Generate(clfSpec *logging.ClusterLogForwarderSpec, fwSpec *logging.ForwarderSpec) (string, error)
+	Generate(clfSpec *logging.ClusterLogForwarderSpec, secrets map[string]*corev1.Secret, fwSpec *logging.ForwarderSpec) (string, error)
 }

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 		})
 
 		It("should produce well formed output label config", func() {
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(results[0]).To(EqualTrimLines(`<label @ONCLUSTER_ELASTICSEARCH>
 	<match retry_oncluster_elasticsearch>
@@ -89,7 +89,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 			reload_after '200'
 			# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-			sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'	
+			sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
 			reload_on_failure false
 			# 2 ^ 31
 			request_timeout 2147483648
@@ -174,7 +174,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			}
 		})
 		It("should produce well formed output label config", func() {
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(results[0]).To(EqualTrimLines(`<label @OTHER_ELASTICSEARCH>
 	<match retry_other_elasticsearch>
@@ -197,7 +197,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 			reload_after '200'
 			# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-		        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'	
+		        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
 			reload_on_failure false
 			# 2 ^ 31
 			request_timeout 2147483648
@@ -240,7 +240,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			# https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 			reload_after '200'
 			# https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-		        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'	
+		        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
 			reload_on_failure false
 			# 2 ^ 31
 			request_timeout 2147483648

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -3,6 +3,7 @@ package fluentd
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
@@ -11,10 +12,9 @@ import (
 var _ = Describe("Generating fluentd secure forward output store config blocks", func() {
 
 	var (
-		err           error
-		outputs       []logging.OutputSpec
-		forwarderSpec *logging.ForwarderSpec
-		generator     *ConfigGenerator
+		err       error
+		outputs   []logging.OutputSpec
+		generator *ConfigGenerator
 	)
 	BeforeEach(func() {
 		generator, err = NewConfigGenerator(false, false, true)
@@ -22,6 +22,8 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 	})
 
 	Context("for a secure endpoint", func() {
+		var secrets map[string]*corev1.Secret
+
 		BeforeEach(func() {
 			outputs = []logging.OutputSpec{
 				{
@@ -33,49 +35,150 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 					},
 				},
 			}
+			secrets = map[string]*corev1.Secret{
+				"secureforward-receiver": {
+					Data: map[string][]byte{
+						"shared_key":    []byte("my-key"),
+						"tls.crt":       []byte("my-tls"),
+						"tls.key":       []byte("my-tls-key"),
+						"ca-bundle.crt": []byte("my-bundle"),
+					},
+				},
+			}
+		})
+
+		It("should skip missing secrets in the config", func() {
+			data := secrets["secureforward-receiver"].Data
+			delete(data, "shared_key")
+			delete(data, "tls.key")
+			results, err := generator.generateOutputLabelBlocks(outputs, secrets, nil)
+			Expect(err).To(BeNil())
+			Expect(len(results)).To(Equal(1))
+			Expect(results[0]).To(EqualTrimLines(`    <label @SECUREFORWARD_RECEIVER>
+      <match **>
+        # https://docs.fluentd.org/v1.0/articles/in_forward
+        @type forward
+    		heartbeat_type none
+        transport tls
+        tls_verify_hostname false
+        tls_version 'TLSv1_2'
+        tls_client_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.crt"
+        tls_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt"
+
+        <buffer>
+          @type file
+          path '/var/lib/fluentd/secureforward_receiver'
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+          flush_mode interval
+          flush_interval 5s
+          flush_at_shutdown true
+          flush_thread_count 2
+          retry_type exponential_backoff
+          retry_wait 1s
+          retry_max_interval 60s
+          retry_forever true
+          # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+          # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+          # buffer to the remote - default is 'block' because in_tail handles that case
+          overflow_action block
+        </buffer>
+
+        <server>
+          host es.svc.messaging.cluster.local
+          port 9654
+        </server>
+      </match>
+    </label>
+`))
+		})
+
+		It("should use insecure mode if no secret", func() {
+			outputs[0].Secret = nil
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, nil)
+			Expect(err).To(BeNil())
+			Expect(len(results)).To(Equal(1))
+			Expect(results[0]).To(EqualTrimLines(`    <label @SECUREFORWARD_RECEIVER>
+      <match **>
+        # https://docs.fluentd.org/v1.0/articles/in_forward
+        @type forward
+    		heartbeat_type none
+        transport tls
+        tls_verify_hostname false
+        tls_version 'TLSv1_2'
+        tls_insecure_mode true
+
+        <buffer>
+          @type file
+          path '/var/lib/fluentd/secureforward_receiver'
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+          flush_mode interval
+          flush_interval 5s
+          flush_at_shutdown true
+          flush_thread_count 2
+          retry_type exponential_backoff
+          retry_wait 1s
+          retry_max_interval 60s
+          retry_forever true
+          # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+          # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+          # buffer to the remote - default is 'block' because in_tail handles that case
+          overflow_action block
+        </buffer>
+
+        <server>
+          host es.svc.messaging.cluster.local
+          port 9654
+        </server>
+      </match>
+    </label>
+`))
 		})
 
 		It("should produce well formed output label config", func() {
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, secrets, nil)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(`<label @SECUREFORWARD_RECEIVER>
-	<match **>
-		# https://docs.fluentd.org/v1.0/articles/in_forward
-		@type forward
-		heartbeat_type none
-		<security>
-			self_hostname "#{ENV['NODE_NAME']}" 
-			shared_key "#{File.open('/var/run/ocp-collector/secrets/my-infra-secret/shared_key') do |f| f.readline end.rstrip}"
-		</security>
+  <match **>
+    # https://docs.fluentd.org/v1.0/articles/in_forward
+     @type forward
+     heartbeat_type none
+     <security>
+       self_hostname "#{ENV['NODE_NAME']}"
+       shared_key "my-key"
+     </security>
 
-		transport tls
-		tls_verify_hostname false
-		tls_version 'TLSv1_2'
-		
-		#tls_client_private_key_path /var/run/ocp-collector/secrets/my-infra-secret/tls.key
-		tls_client_cert_path /var/run/ocp-collector/secrets/my-infra-secret/tls.crt
-		tls_cert_path /var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt
+		 transport tls
+		 tls_verify_hostname false
+		 tls_version 'TLSv1_2'
 
-		<buffer>
-			@type file
-			path '/var/lib/fluentd/secureforward_receiver'
-			queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-			total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-			chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
-			flush_mode interval
-			flush_interval 5s       
-			flush_at_shutdown true
-			flush_thread_count 2
-			retry_type exponential_backoff
-			retry_wait 1s
-			retry_max_interval 60s
-			retry_forever true
-			# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-			# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-			# buffer to the remote - default is 'block' because in_tail handles that case
-			overflow_action block
-		</buffer>
+		 tls_client_private_key_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.key"
+		 tls_client_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.crt"
+		 tls_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt"
+
+     <buffer>
+       @type file
+       path '/var/lib/fluentd/secureforward_receiver'
+       queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+       flush_mode interval
+	     flush_interval 5s
+	     flush_at_shutdown true
+	     flush_thread_count 2
+       retry_type exponential_backoff
+       retry_wait 1s
+	     retry_max_interval 60s
+	     retry_forever true
+	     # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+	     # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+	     # buffer to the remote - default is 'block' because in_tail handles that case
+	     overflow_action block
+	   </buffer>
 
 		<server>
 			host es.svc.messaging.cluster.local
@@ -97,7 +200,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			}
 		})
 		It("should produce well formed output label config", func() {
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, nil)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(`<label @SECUREFORWARD_RECEIVER>
@@ -125,7 +228,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 					# buffer to the remote - default is 'block' because in_tail handles that case
 					overflow_action block
 				</buffer>
-		
+
 				<server>
 					host es.svc.messaging.cluster.local
 					port 9654

--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 				},
 			}
 
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -73,7 +73,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 				},
 			}
 
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -124,7 +124,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 				},
 			}
 
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -177,7 +177,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 				},
 			}
 
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -199,7 +199,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 				},
 			}
 
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -219,7 +219,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 					},
 				},
 			}
-			_, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			_, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).Should(HaveOccurred())
 		})
 
@@ -231,7 +231,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 					URL:  "not-a-valid-URL",
 				},
 			}
-			_, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			_, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).Should(HaveOccurred())
 		})
 	})

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -516,7 +516,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         </label>
       `
 
-			results, err := generator.Generate(clfSpec, fwSpec)
+			results, err := generator.Generate(clfSpec, nil, fwSpec)
 			Expect(err).Should(Succeed())
 			Expect(results).To(EqualTrimLines(legacyConf))
 		})
@@ -1022,7 +1022,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         </label>
       `
 
-			results, err := generator.Generate(clfSpec, fwSpec)
+			results, err := generator.Generate(clfSpec, nil, fwSpec)
 			Expect(err).Should(Succeed())
 			Expect(results).To(EqualTrimLines(legacyConf))
 		})
@@ -1547,7 +1547,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         </label>
       `
 
-			results, err := generator.Generate(clfSpec, fwSpec)
+			results, err := generator.Generate(clfSpec, nil, fwSpec)
 			Expect(err).Should(Succeed())
 			Expect(results).To(EqualTrimLines(legacyConf))
 		})

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 				}
 			})
 			It("should produce well formed output label config", func() {
-				results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+				results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 				Expect(err).To(BeNil())
 				Expect(len(results)).To(Equal(1))
 				Expect(results[0]).To(EqualTrimLines(tcpConf))
@@ -93,7 +93,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 				}
 			})
 			It("should produce well formed output label config", func() {
-				results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+				results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 				Expect(err).To(BeNil())
 				Expect(len(results)).To(Equal(1))
 				Expect(results[0]).To(EqualTrimLines(tcpConf))
@@ -111,7 +111,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 				}
 			})
 			It("should produce well formed output label config", func() {
-				results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+				results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 				Expect(err).To(BeNil())
 				Expect(len(results)).To(Equal(1))
 				Expect(results[0]).To(EqualTrimLines(udpConf))
@@ -307,7 +307,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					}
 				})
 				It("should produce well formed output label config", func() {
-					results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 					Expect(err).To(BeNil())
 					Expect(len(results)).To(Equal(1))
 					Expect(results[0]).To(EqualTrimLines(tcpConf))
@@ -327,7 +327,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					}
 				})
 				It("should produce well formed output label config", func() {
-					results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 					Expect(err).To(BeNil())
 					Expect(len(results)).To(Equal(1))
 					Expect(results[0]).To(EqualTrimLines(tcpWithTLSConf))
@@ -347,7 +347,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					}
 				})
 				It("should produce well formed output label config", func() {
-					results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 					Expect(err).To(BeNil())
 					Expect(len(results)).To(Equal(1))
 					Expect(results[0]).To(EqualTrimLines(udpConf))
@@ -367,7 +367,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					}
 				})
 				It("should produce well formed output label config", func() {
-					results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 					Expect(err).To(BeNil())
 					Expect(len(results)).To(Equal(1))
 					Expect(results[0]).To(EqualTrimLines(udpWithTLSConf))

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Generating fluentd config", func() {
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
               # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer' 
+              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
               reload_on_failure false
               # 2 ^ 31
               request_timeout 2147483648
@@ -123,7 +123,7 @@ var _ = Describe("Generating fluentd config", func() {
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
               # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'              
+              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
               reload_on_failure false
               # 2 ^ 31
               request_timeout 2147483648
@@ -147,7 +147,7 @@ var _ = Describe("Generating fluentd config", func() {
           </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, defaultForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, defaultForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(esConf))
@@ -193,7 +193,7 @@ var _ = Describe("Generating fluentd config", func() {
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
               # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer' 
+              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
               reload_on_failure false
               # 2 ^ 31
               request_timeout 2147483648
@@ -236,7 +236,7 @@ var _ = Describe("Generating fluentd config", func() {
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
               # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'              
+              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
               reload_on_failure false
               # 2 ^ 31
               request_timeout 2147483648
@@ -260,7 +260,7 @@ var _ = Describe("Generating fluentd config", func() {
           </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, defaultForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, defaultForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(esConf))
@@ -289,7 +289,7 @@ var _ = Describe("Generating fluentd config", func() {
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
               # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'              
+              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
               reload_on_failure false
               # 2 ^ 31
               request_timeout 2147483648
@@ -332,7 +332,7 @@ var _ = Describe("Generating fluentd config", func() {
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
               # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
-              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'              
+              sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
               reload_on_failure false
               # 2 ^ 31
               request_timeout 2147483648
@@ -356,7 +356,7 @@ var _ = Describe("Generating fluentd config", func() {
           </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, customForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, customForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(esConf))
@@ -414,7 +414,7 @@ var _ = Describe("Generating fluentd config", func() {
            </match>
          </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, defaultForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, defaultForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(fluentdForwardConf))
@@ -455,7 +455,7 @@ var _ = Describe("Generating fluentd config", func() {
         </match>
       </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, customForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, customForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(fluentdForwardConf))
@@ -525,7 +525,7 @@ var _ = Describe("Generating fluentd config", func() {
           </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, defaultForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, defaultForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(syslogConf))
@@ -578,7 +578,7 @@ var _ = Describe("Generating fluentd config", func() {
           </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, customForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, customForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(syslogConf))
@@ -630,7 +630,7 @@ var _ = Describe("Generating fluentd config", func() {
         </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, defaultForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, defaultForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -665,7 +665,7 @@ var _ = Describe("Generating fluentd config", func() {
         </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, customForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, customForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -639,20 +639,33 @@ const forwardTemplate = `{{- define "forward" -}}
 # https://docs.fluentd.org/v1.0/articles/in_forward
 @type forward
 heartbeat_type none
-{{ if .Target.Secret }}
+{{- with $sharedKey := .GetSecret "shared_key" }}
 <security>
   self_hostname "#{ENV['NODE_NAME']}"
-  shared_key "#{File.open('{{ .SecretPath "shared_key" }}') do |f| f.readline end.rstrip}"
+  shared_key "{{$sharedKey}}"
 </security>
+{{- end}}
+{{- if .IsTLS }}
 
 transport tls
 tls_verify_hostname false
 tls_version 'TLSv1_2'
 
-#tls_client_private_key_path {{ .SecretPath "tls.key"}}
-tls_client_cert_path {{ .SecretPath "tls.crt"}}
-tls_cert_path {{ .SecretPath "ca-bundle.crt"}}
-{{ end -}}
+{{- if not .Secret}}
+tls_insecure_mode true
+{{- end}}
+
+{{- with $path := .SecretPathIfFound "tls.key"}}
+tls_client_private_key_path "{{$path}}"
+{{- end}}
+{{- with $path := .SecretPathIfFound "tls.crt"}}
+tls_client_cert_path "{{$path}}"
+{{- end}}
+{{- with $path := .SecretPathIfFound "ca-bundle.crt"}}
+tls_cert_path "{{$path}}"
+{{- end}}
+
+{{- end}}
 
 <buffer>
   @type file

--- a/pkg/k8shandler/certificates_test.go
+++ b/pkg/k8shandler/certificates_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Reconciling", func() {
 			Expect(client.Get(context.TODO(), key, secret)).Should(Succeed())
 
 			Expect(os.RemoveAll(utils.GetWorkingDir())).To(Succeed())
-			clusterRequest.CreateOrUpdateCertificates()
+			_ = clusterRequest.CreateOrUpdateCertificates()
 
 			updatedsecret := &corev1.Secret{}
 			Expect(client.Get(context.TODO(), key, updatedsecret)).Should(Succeed())

--- a/pkg/k8shandler/clusterloggingrequest.go
+++ b/pkg/k8shandler/clusterloggingrequest.go
@@ -3,6 +3,7 @@ package k8shandler
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,13 +22,15 @@ type ClusterLoggingRequest struct {
 
 	// ForwarderSpec is the normalized and sanitized logforwarder spec
 	ForwarderSpec logging.ClusterLogForwarderSpec
+
+	// OutputSecrets are retrieved during validation and used for generation.
+	OutputSecrets map[string]*corev1.Secret
 }
 
 func (clusterRequest *ClusterLoggingRequest) IncludesManagedStorage() bool {
 	return clusterRequest.Cluster != nil && clusterRequest.Cluster.Spec.LogStore != nil
 }
 
-// TODO: determine if this is even necessary
 func (clusterRequest *ClusterLoggingRequest) isManaged() bool {
 	return clusterRequest.Cluster.Spec.ManagementState == logging.ManagementStateManaged
 }

--- a/pkg/k8shandler/forwarding.go
+++ b/pkg/k8shandler/forwarding.go
@@ -56,7 +56,7 @@ func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config s
 
 	clfSpec := &clusterRequest.ForwarderSpec
 	fwSpec := clusterRequest.Cluster.Spec.Forwarder
-	generatedConfig, err := generator.Generate(clfSpec, fwSpec)
+	generatedConfig, err := generator.Generate(clfSpec, clusterRequest.OutputSecrets, fwSpec)
 
 	if err != nil {
 		log.Error(err, "Unable to generate log configuration")
@@ -147,6 +147,10 @@ func condDegraded(r status.ConditionReason, format string, args ...interface{}) 
 
 func condInvalid(format string, args ...interface{}) status.Condition {
 	return condNotReady(logging.ReasonInvalid, format, args...)
+}
+
+func condMissing(format string, args ...interface{}) status.Condition {
+	return condNotReady(logging.ReasonMissingResource, format, args...)
 }
 
 var condReady = status.Condition{Type: logging.ConditionReady, Status: corev1.ConditionTrue}
@@ -240,16 +244,13 @@ func (clusterRequest *ClusterLoggingRequest) verifyInputs(spec *logging.ClusterL
 
 func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.ClusterLogForwarderSpec, status *logging.ClusterLogForwarderStatus) {
 	status.Outputs = logging.NamedConditions{}
+	clusterRequest.OutputSecrets = make(map[string]*corev1.Secret, len(clusterRequest.ForwarderSpec.Outputs))
 	names := sets.NewString() // Collect pipeline names
 	for i, output := range clusterRequest.ForwarderSpec.Outputs {
 		i, output := i, output // Don't bind range variable.
 		badName := func(format string, args ...interface{}) {
 			output.Name = fmt.Sprintf("output_%v_", i)
 			status.Outputs.Set(output.Name, condInvalid(format, args...))
-		}
-		var urlErr error
-		if output.URL != "" { // Allow missing URL
-			_, urlErr = url.ParseAbsolute(output.URL)
 		}
 		log.V(3).Info("Verifying", "outputs", output)
 		switch {
@@ -261,8 +262,6 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.Cluster
 			badName("duplicate name: %q", output.Name)
 		case !logging.IsOutputTypeName(output.Type):
 			status.Outputs.Set(output.Name, condInvalid("output %q: unknown output type %q", output.Name, output.Type))
-		case urlErr != nil:
-			status.Outputs.Set(output.Name, condInvalid("%v", urlErr))
 		case !clusterRequest.verifyOutputURL(&output, status.Outputs):
 			break
 		case !clusterRequest.verifyOutputSecret(&output, status.Outputs):
@@ -279,7 +278,7 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.Cluster
 	name := logging.OutputNameDefault
 	if _, ok := routes.ByOutput[name]; ok {
 		if clusterRequest.Cluster.Spec.LogStore == nil {
-			status.Outputs.Set(name, condNotReady(logging.ReasonMissingResource, "no default log store specified"))
+			status.Outputs.Set(name, condMissing("no default log store specified"))
 		} else {
 			spec.Outputs = append(spec.Outputs, logging.OutputSpec{
 				Name:   logging.OutputNameDefault,
@@ -293,23 +292,34 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.Cluster
 }
 
 func (clusterRequest *ClusterLoggingRequest) verifyOutputURL(output *logging.OutputSpec, conds logging.NamedConditions) bool {
-	switch strings.ToLower(output.Type) {
-	case "fluentdforward", "elasticsearch", "syslog":
-		if strings.TrimSpace(output.URL) == "" {
-			conds.Set(output.Name, condNotReady(logging.ReasonMissingResource, "output %q: URL not set for output type %q",
-				output.Name, output.Type))
-			return false
-		}
-		return true
-	case "kafka":
-		//TODO add kafka brokers verification here
-		return true
-	default:
-		return true
+	fail := func(c status.Condition) bool {
+		conds.Set(output.Name, c)
+		return false
 	}
+	if output.URL == "" {
+		// Some output types (currently just kafka) allow a missing URL
+		// TODO (alanconway) move output-specific valiation to the output implementation.
+		if output.Type == "kafka" {
+			return true
+		} else {
+			return fail(condInvalid("URL is required for output type %v", output.Type))
+		}
+	}
+	u, err := url.Parse(output.URL)
+	if err != nil {
+		return fail(condInvalid("invalid URL: %v", err))
+	}
+	if err := url.CheckAbsolute(u); err != nil {
+		return fail(condInvalid("invalid URL: %v", err))
+	}
+	return true
 }
 
 func (clusterRequest *ClusterLoggingRequest) verifyOutputSecret(output *logging.OutputSpec, conds logging.NamedConditions) bool {
+	fail := func(c status.Condition) bool {
+		conds.Set(output.Name, c)
+		return false
+	}
 	if output.Secret == nil {
 		return true
 	}
@@ -317,9 +327,20 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputSecret(output *logging.
 		conds.Set(output.Name, condInvalid("secret has empty name"))
 		return false
 	}
-	if _, err := clusterRequest.GetSecret(output.Secret.Name); err != nil {
-		conds.Set(output.Name, condNotReady(logging.ReasonMissingResource, "output %q: secret %q not found", output.Name, output.Secret.Name))
-		return false
+	log.V(3).Info("getting output secret", "output", output.Name, "secret", output.Secret.Name)
+	secret, err := clusterRequest.GetSecret(output.Secret.Name)
+	if err != nil {
+		return fail(condMissing("secret %q not found", output.Secret.Name))
 	}
+	// Make sure we have secrets for a valid TLS configuration.
+	haveCert := len(secret.Data[constants.ClientCertKey]) > 0
+	haveKey := len(secret.Data[constants.ClientPrivateKey]) > 0
+	switch {
+	case haveCert && !haveKey:
+		return fail(condMissing("cannot have %v without %v", constants.ClientCertKey, constants.ClientPrivateKey))
+	case !haveCert && haveKey:
+		return fail(condMissing("cannot have %v without %v", constants.ClientPrivateKey, constants.ClientCertKey))
+	}
+	clusterRequest.OutputSecrets[output.Name] = secret
 	return true
 }

--- a/pkg/k8shandler/forwarding_test.go
+++ b/pkg/k8shandler/forwarding_test.go
@@ -3,8 +3,6 @@ package k8shandler
 import (
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -17,8 +15,8 @@ import (
 	core "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 )
@@ -409,6 +407,7 @@ pipelines:
 		}
 		spec, status := request.NormalizeForwarder()
 		Expect(status.Conditions).To(HaveCondition("Ready", true, "", ""), "unexpected "+YAMLString(status))
+		Expect(status.Conditions).NotTo(HaveCondition("Degraded", true, "", ""), "unexpected "+YAMLString(status))
 		Expect(*spec).To(EqualDiff(request.ForwarderSpec))
 	})
 })

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -7,43 +7,39 @@ import (
 	"strings"
 )
 
-// ParseAbsolute parses an absolute URL - one with non-empty Scheme and Host.
-// Returned errors include the string s.
-func ParseAbsolute(s string) (*URL, error) {
-	if s == "" {
-		return nil, fmt.Errorf("empty")
-	}
-	u, err := url.Parse(s)
+// CheckAbsolute returns an error if Scheme or Host is empty.
+func CheckAbsolute(u *URL) error {
 	switch {
-	case err != nil:
-		return nil, err
+	case u == nil:
+		return fmt.Errorf("empty")
 	case u.Scheme == "":
-		return nil, fmt.Errorf("no scheme: %v", u)
+		return fmt.Errorf("no scheme: %q", u)
 	case u.Host == "":
-		return nil, fmt.Errorf("no host: %v", u)
+		return fmt.Errorf("no host: %q", u)
 	}
-	return u, nil
+	return nil
 }
 
-// ParseAbsoluteOrEmpty is like ParseAbsolute but returns an empty
-// URL rather than an error if s == "".
-func ParseAbsoluteOrEmpty(s string) (*URL, error) {
-	if s == "" {
-		return &url.URL{}, nil
-	} else {
-		return ParseAbsolute(s)
-	}
+var secureSchemes = map[string]string{
+	"https": "http",
+	"udps":  "udp",
+	"tls":   "tcp",
 }
 
 // IsTLSScheme returns true if scheme is recognized as needing TLS security,
-// for example "https", "tls" or "udps"
+// for example "https", "tls"
 func IsTLSScheme(scheme string) bool {
-	switch strings.ToLower(scheme) {
-	case "https", "tls", "udps":
-		return true
-	default:
-		return false
+	return secureSchemes[strings.ToLower(scheme)] != ""
+}
+
+// PlainScheme returns the plain, non-TLS, version of scheme.
+// Example: PlainScheme("https") == "http"
+func PlainScheme(scheme string) string {
+	scheme = strings.ToLower(scheme)
+	if base, ok := secureSchemes[scheme]; ok {
+		return base
 	}
+	return scheme
 }
 
 // Stubs for net/url types/functions so it's not necessary to import it as well.

--- a/test/client/clf.go
+++ b/test/client/clf.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"fmt"
+
+	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/test"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func ClusterLogForwarderReady(e watch.Event) (bool, error) {
+	clf := e.Object.(*loggingv1.ClusterLogForwarder)
+	cond := clf.Status.Conditions
+	switch {
+	case cond.IsTrueFor(loggingv1.ConditionReady):
+		return true, nil
+	case cond.IsFalseFor(loggingv1.ConditionReady), cond.IsTrueFor(loggingv1.ConditionDegraded):
+		return false, fmt.Errorf("ClusterLogForwarder unexpected condition: %v", test.YAMLString(clf.Status))
+	default:
+		return false, nil
+	}
+}

--- a/test/client/watch.go
+++ b/test/client/watch.go
@@ -91,7 +91,7 @@ func (c *Client) waitFor(o runtime.Object, condition Condition, w watch.Interfac
 		select {
 		case e, ok := <-w.ResultChan():
 			if !ok {
-				return ErrWatchClosed
+				return fmt.Errorf("%w: %v: %v", ErrWatchClosed, msg, runtime.ID(o))
 			}
 			log.V(3).Info("event: "+msg,
 				"object", runtime.ID(e.Object),

--- a/test/client/watch.go
+++ b/test/client/watch.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ViaQ/logerr/log"
 	"github.com/openshift/cluster-logging-operator/test/runtime"
-	testrt "github.com/openshift/cluster-logging-operator/test/runtime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -33,18 +33,19 @@ func (w *watcher) Stop() { w.Interface.Stop(); w.cancel() }
 
 // Watch for changes in namespace to objects with the given GroupVersionResource,
 // apply the given list options to the watch.
-func (c *Client) Watch(namespace string, gvr schema.GroupVersionResource, opts metav1.ListOptions) (watch.Interface, error) {
+func (c *Client) Watch(gvr schema.GroupVersionResource, opts ...ListOption) (w watch.Interface, err error) {
 	restClient, err := c.rest(gvr.GroupVersion())
 	if err != nil {
 		return nil, err
 	}
 	ctx, cancel := context.WithTimeout(c.ctx, c.timeout)
-	opts.Watch = true
-	w, err := restClient.Get().
+	listOpts := ListOptions{Raw: &metav1.ListOptions{Watch: true}}
+	listOpts.ApplyOptions(opts)
+	w, err = restClient.Get().
 		Timeout(c.timeout).
-		Namespace(namespace).
+		NamespaceIfScoped(listOpts.Namespace, listOpts.Namespace != "").
 		Resource(gvr.Resource).
-		VersionedParams(&opts, scheme.ParameterCodec).
+		VersionedParams(listOpts.AsListOptions(), scheme.ParameterCodec).
 		Watch(ctx)
 	if err != nil {
 		cancel()
@@ -53,17 +54,23 @@ func (c *Client) Watch(namespace string, gvr schema.GroupVersionResource, opts m
 	return &watcher{Interface: w, cancel: cancel}, nil
 }
 
-// WatchObject returns a watch for changes to a single named object.
-// Note: it is not an error if no such object exists, the watcher will wait for creation.
-func (c *Client) WatchObject(o runtime.Object) (w watch.Interface, err error) {
-	gvr, err := c.GetGroupVersionResource(o)
+// WatchTypeOf returns a watch using the GroupVersionResource of object o.
+func (c *Client) WatchTypeOf(o runtime.Object, opts ...ListOption) (w watch.Interface, err error) {
+	gvr, err := c.GroupVersionResource(o)
 	if err != nil {
 		return nil, err
 	}
-	m := runtime.Meta(o)
-	opts := metav1.ListOptions{FieldSelector: "metadata.name=" + m.GetName()}
-	w, err = c.Watch(m.GetNamespace(), gvr, opts)
-	return w, err
+	return c.Watch(gvr, opts...)
+}
+
+// WatchObject returns a watch for changes to a single named object.
+// Note: it is not an error if no such object exists, the watcher will wait for creation.
+func (c *Client) WatchObject(o runtime.Object) (w watch.Interface, err error) {
+	mo := runtime.Meta(o)
+	return c.WatchTypeOf(o,
+		InNamespace(mo.GetNamespace()),
+		MatchingFields{"metadata.name": mo.GetName()},
+	)
 }
 
 // Condition returns true if an event meets the condition, error if something goes wrong.
@@ -76,39 +83,27 @@ func funcName(f interface{}) string {
 	return name[i+1:]
 }
 
-// WaitFor watches o until condition() returns true or error, or c.Timeout expires.
-// o is updated (replaced) by the latest state.
-func (c *Client) WaitFor(o runtime.Object, condition Condition) (err error) {
-	defer logBeginEnd(fmt.Sprintf("WaitFor(%v)", funcName(condition)), o, &err,
-		"resourceVersion", testrt.Meta(o).GetResourceVersion())()
+func (c *Client) waitFor(o runtime.Object, condition Condition, w watch.Interface, msg string) (err error) {
+	defer logBeginEnd(msg, o, &err)()
 	start := time.Now()
-	w, err := c.WatchObject(o)
-	if err != nil {
-		return err
-	}
 	defer w.Stop()
-	// Watch won't fail if the object doesn't exist, make sure it does or we'll wait forever.
-	if err = c.get(o); err != nil {
-		return err
-	}
 	for {
 		select {
 		case e, ok := <-w.ResultChan():
 			if !ok {
 				return ErrWatchClosed
 			}
-			trace.Info("Client.WaitFor event",
-				"object", runtime.ID(o),
-				"resourceVersion", testrt.Meta(o).GetResourceVersion(),
-				"event", e.Type,
-				"delay", time.Since(start),
+			log.V(3).Info("event: "+msg,
+				"object", runtime.ID(e.Object),
+				"type", e.Type,
+				"elapsed", time.Since(start).String(),
 			)
 			start = time.Now()
 			// Copy payload of event to the original object so it is up-to-date.
-			if rhs := reflect.Indirect(reflect.ValueOf(e.Object)); rhs.IsValid() {
-				if lhs := reflect.Indirect(reflect.ValueOf(o)); lhs.IsValid() {
-					lhs.Set(rhs)
-				}
+			rhs := reflect.Indirect(reflect.ValueOf(e.Object))
+			lhs := reflect.Indirect(reflect.ValueOf(o))
+			if rhs.IsValid() && lhs.IsValid() && rhs.Type().AssignableTo(lhs.Type()) {
+				lhs.Set(rhs)
 			}
 			if ok, err := condition(e); ok {
 				return nil
@@ -119,4 +114,30 @@ func (c *Client) WaitFor(o runtime.Object, condition Condition) (err error) {
 			return ErrTimeout
 		}
 	}
+}
+
+// WaitFor watches o until condition() returns true or error, or c.Timeout expires.
+// It is not an error if o does not exist, it will be waited for.
+// o is updated from the last object seen by the watch.
+func (c *Client) WaitFor(o runtime.Object, condition Condition) (err error) {
+	w, err := c.WatchObject(o)
+	if err != nil {
+		return err
+	}
+	defer w.Stop()
+	msg := fmt.Sprintf("WaitFor(%v)", funcName(condition))
+	return c.waitFor(o, condition, w, msg)
+}
+
+// WaitForType watches for events involving objects of the same type as o,
+// until condition() returns true or error, or c.Timeout expires.
+// o is updated from the last object seen by the watch.
+func (c *Client) WaitForType(o runtime.Object, condition Condition, opts ...ListOption) (err error) {
+	w, err := c.WatchTypeOf(o, opts...)
+	if err != nil {
+		return err
+	}
+	defer w.Stop()
+	msg := fmt.Sprintf("WaitForTypeOf(%v, %#v)", funcName(condition), opts)
+	return c.waitFor(o, condition, w, msg)
 }

--- a/test/client/watch_test.go
+++ b/test/client/watch_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Watch", func() {
 	BeforeEach(func() { t = NewTest() })
 	AfterEach(func() { t.Close() })
 
-	It("ForObject watches resources", func() {
+	It("WatchObject watches resources", func() {
 		o := runtime.NewConfigMap(t.NS.Name, "test", map[string]string{"a": "b"})
 		w, err := t.WatchObject(o)
 		ExpectOK(err)

--- a/test/client/watch_test.go
+++ b/test/client/watch_test.go
@@ -1,6 +1,8 @@
 package client_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/cluster-logging-operator/test"
@@ -66,6 +68,6 @@ var _ = Describe("Watch", func() {
 	})
 
 	It("times out waiting for non-existent pod", func() {
-		Expect(t.WithTimeout(test.FailureTimeout()).WaitFor(runtime.NewPod(t.NS.Name, "no-such-pod"), PodRunning)).To(HaveOccurred())
+		Expect(t.WithTimeout(time.Second/10).WaitFor(runtime.NewPod(t.NS.Name, "no-such-pod"), PodRunning)).To(HaveOccurred())
 	})
 })

--- a/test/e2e/logforwarding/fluent/fixture_test.go
+++ b/test/e2e/logforwarding/fluent/fixture_test.go
@@ -1,0 +1,51 @@
+package fluent_test
+
+import (
+	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/test"
+	"github.com/openshift/cluster-logging-operator/test/client"
+	"github.com/openshift/cluster-logging-operator/test/helpers/fluentd"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	"github.com/openshift/cluster-logging-operator/test/runtime"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Fixture struct {
+	ClusterLogging      *loggingv1.ClusterLogging
+	ClusterLogForwarder *loggingv1.ClusterLogForwarder
+	Receiver            *fluentd.Receiver
+	LogGenerator        *corev1.Pod
+}
+
+// NewTest returns a new test, the clf and receiver are not yet configured.
+func NewFixture(namespace, message string) *Fixture {
+	return &Fixture{
+		ClusterLogging:      runtime.NewClusterLogging(),
+		ClusterLogForwarder: runtime.NewClusterLogForwarder(),
+		Receiver:            fluentd.NewReceiver(namespace, "receiver"),
+		LogGenerator:        runtime.NewLogGenerator(namespace, "log-generator", 1000, 0, message),
+	}
+}
+
+// Create resources, wait for them to be ready.
+func (f *Fixture) Create(c *client.Client) {
+	g := test.FailGroup{}
+	// Recreate resources in shared openshift-logging namespace.
+	g.Go(func() { ExpectOK(c.Recreate(f.ClusterLogging)) })
+	g.Go(func() {
+		ExpectOK(c.Recreate(f.ClusterLogForwarder))
+		ExpectOK(c.WaitFor(f.ClusterLogForwarder, client.ClusterLogForwarderReady))
+	})
+	g.Go(func() {
+		ExpectOK(c.WaitForType(&corev1.Pod{}, client.PodRunning,
+			client.MatchingLabels{"component": "fluentd"},
+			client.InNamespace(f.ClusterLogging.Namespace)))
+	})
+	// Create resources in temporary test namespace.
+	g.Go(func() {
+		ExpectOK(c.Create(f.LogGenerator))
+		ExpectOK(c.WaitFor(f.LogGenerator, client.PodRunning))
+	})
+	g.Go(func() { ExpectOK(f.Receiver.Create(c)) })
+	g.Wait()
+}

--- a/test/e2e/logforwarding/fluent/fluent_secure_test.go
+++ b/test/e2e/logforwarding/fluent/fluent_secure_test.go
@@ -1,0 +1,182 @@
+package fluent_test
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/test"
+	"github.com/openshift/cluster-logging-operator/test/client"
+	"github.com/openshift/cluster-logging-operator/test/helpers/certificate"
+	"github.com/openshift/cluster-logging-operator/test/helpers/fluentd"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	"github.com/openshift/cluster-logging-operator/test/runtime"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const secureMessage = "My life is my top secret message."
+
+var _ = Describe("[ClusterLogForwarder]", func() {
+	var (
+		c                                 *client.Test
+		f                                 *Fixture
+		privateCA, serverCert, clientCert *certificate.CertKey
+		sharedKey                         string
+	)
+
+	BeforeEach(func() {
+		c = client.NewTest()
+		f = NewFixture(c.NS.Name, secureMessage)
+
+		// Receiver acts as TLS server.
+		privateCA = certificate.NewCA(nil)
+		serverCert = certificate.NewCert(privateCA, f.Receiver.Host()) // Receiver is server.
+		clientCert = certificate.NewCert(privateCA)
+		sharedKey = "top-secret"
+		// The Receiver Sources act as TLS servers.
+		for i, s := range []*fluentd.Source{
+			{Name: "no-auth", Type: "forward", Cert: serverCert},
+			{Name: "server-auth", Type: "forward", Cert: serverCert},
+			{Name: "server-auth-shared", Type: "forward", Cert: serverCert, SharedKey: sharedKey},
+			{Name: "mutual-auth", Type: "forward", Cert: serverCert, CA: privateCA},
+			{Name: "mutual-auth-shared", Type: "forward", Cert: serverCert, CA: privateCA, SharedKey: sharedKey},
+		} {
+			s.Port = 24230 + i
+			f.Receiver.AddSource(s)
+		}
+		clf := f.ClusterLogForwarder
+		secrets := []*corev1.Secret{
+			runtime.NewSecret(clf.Namespace, "no-auth", map[string][]byte{}),
+			runtime.NewSecret(clf.Namespace, "server-auth", map[string][]byte{
+				"ca-bundle.crt": privateCA.CertificatePEM(),
+				"ca.key":        privateCA.PrivateKeyPEM(),
+			}),
+			runtime.NewSecret(clf.Namespace, "server-auth-shared", map[string][]byte{
+				"ca-bundle.crt": privateCA.CertificatePEM(),
+				"ca.key":        privateCA.PrivateKeyPEM(),
+				"shared_key":    []byte(sharedKey),
+			}),
+			runtime.NewSecret(clf.Namespace, "mutual-auth", map[string][]byte{
+				"ca-bundle.crt": privateCA.CertificatePEM(),
+				"ca.key":        privateCA.PrivateKeyPEM(),
+				"tls.crt":       clientCert.CertificatePEM(),
+				"tls.key":       clientCert.PrivateKeyPEM(),
+			}),
+			runtime.NewSecret(clf.Namespace, "mutual-auth-shared", map[string][]byte{
+				"ca-bundle.crt": privateCA.CertificatePEM(),
+				"ca.key":        privateCA.PrivateKeyPEM(),
+				"tls.crt":       clientCert.CertificatePEM(),
+				"tls.key":       clientCert.PrivateKeyPEM(),
+				"shared_key":    []byte(sharedKey),
+			}),
+		}
+		g := test.FailGroup{}
+		for _, secret := range secrets {
+			secret := secret // Don't bind to range variable.
+			g.Go(func() { ExpectOK(c.Recreate(secret)) })
+		}
+		g.Wait() // Create secrets before creating CLF to pass validation first time
+	})
+
+	AfterEach(func() { c.Close() })
+
+	It("connects to secure destinations", func() {
+		// Set up the CLF, one output per receiver source.
+		clf := f.ClusterLogForwarder
+		clf.Spec.Pipelines = []loggingv1.PipelineSpec{{InputRefs: []string{loggingv1.InputNameApplication}}}
+		for _, s := range f.Receiver.Sources {
+			secret := &loggingv1.OutputSecretSpec{Name: s.Name}
+			if s.Name == "no-auth" {
+				secret = nil
+			}
+			clf.Spec.Outputs = append(clf.Spec.Outputs, loggingv1.OutputSpec{
+				Name:   s.Name,
+				Type:   "fluentdForward",
+				URL:    fmt.Sprintf("tls://%v:%v", s.Host(), s.Port),
+				Secret: secret,
+			})
+			clf.Spec.Pipelines[0].OutputRefs = append(clf.Spec.Pipelines[0].OutputRefs, s.Name)
+		}
+		f.Create(c.Client)
+		// Verify log lines at readers.
+		g := test.FailGroup{}
+		for _, s := range f.Receiver.Sources {
+			r := s.TailReader()
+			g.Go(func() {
+				for i := 0; i < 10; {
+					l, err := r.ReadLine()
+					ExpectOK(err)
+					Expect(l).To(ContainSubstring(`"viaq_index_name":"app`)) // Only app logs
+					if strings.Contains(l, secureMessage) {
+						i++ // Count our own app messages, ignore others.
+					}
+				}
+			})
+		}
+		g.Wait()
+	})
+
+	It("fails to send without permission", func() {
+		clf := f.ClusterLogForwarder
+		// Secure URL without secret is invalid - need CAr to authenticate server.
+		s := f.Receiver.Sources["server-auth"]
+		clf.Spec.Outputs = append(clf.Spec.Outputs, loggingv1.OutputSpec{
+			Name: s.Name,
+			Type: "fluentdForward",
+			URL:  fmt.Sprintf("tls://%v:%v", s.Host(), s.Port),
+		})
+
+		// shared-key server but no shared-key on Output.
+		s = f.Receiver.Sources["server-auth-shared"]
+		clf.Spec.Outputs = append(clf.Spec.Outputs, loggingv1.OutputSpec{
+			Name: s.Name,
+			Type: "fluentdForward",
+			URL:  fmt.Sprintf("tls://%v:%v", s.Host(), s.Port),
+			// Secret lacks sharedKey
+			Secret: &loggingv1.OutputSecretSpec{Name: "server-auth"},
+		})
+
+		// Mutual-auth server but no client certificate.
+		s = f.Receiver.Sources["mutual-auth"]
+		clf.Spec.Outputs = append(clf.Spec.Outputs, loggingv1.OutputSpec{
+			Name: s.Name,
+			Type: "fluentdForward",
+			URL:  fmt.Sprintf("tls://%v:%v", s.Host(), s.Port),
+			// Secret lacks client certificate
+			Secret: &loggingv1.OutputSecretSpec{Name: "server-auth"},
+		})
+		f.Create(c.Client)
+		for _, s := range f.Receiver.Sources {
+			Expect(s.HasOutput()).To(BeFalse(), s.Name)
+		}
+	})
+
+	It("works when multiple outputs use same Secret", func() {
+		clf := f.ClusterLogForwarder
+		clf.Spec.Pipelines = []loggingv1.PipelineSpec{{InputRefs: []string{loggingv1.InputNameApplication}}}
+		s := f.Receiver.Sources["server-auth"]
+		for i := 0; i < 2; i++ {
+			name := fmt.Sprintf("%v%v", s.Name, i)
+			clf.Spec.Outputs = append(clf.Spec.Outputs, loggingv1.OutputSpec{
+				Name:   name,
+				Type:   "fluentdForward",
+				URL:    fmt.Sprintf("tls://%v:%v", s.Host(), s.Port),
+				Secret: &loggingv1.OutputSecretSpec{Name: s.Name},
+			})
+			clf.Spec.Pipelines[0].OutputRefs = append(clf.Spec.Pipelines[0].OutputRefs, name)
+		}
+		f.Create(c.Client)
+		By("verify log lines received")
+		r := s.TailReader()
+		for i := 0; i < 10; {
+			l, err := r.ReadLine()
+			ExpectOK(err)
+			Expect(l).To(ContainSubstring(`"viaq_index_name":"app`)) // Only app logs
+			if strings.Contains(l, secureMessage) {
+				i++ // Count our own app messages, ignore others.
+			}
+		}
+	})
+})

--- a/test/e2e/logforwarding/fluent/fluent_suite_test.go
+++ b/test/e2e/logforwarding/fluent/fluent_suite_test.go
@@ -1,0 +1,13 @@
+package fluent_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFluent(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Fluent Suite")
+}

--- a/test/helpers/cmd/reader_test.go
+++ b/test/helpers/cmd/reader_test.go
@@ -48,6 +48,6 @@ var _ = Describe("Reader", func() {
 		ExpectOK(err)
 		_, err = r.ReadLine()
 		short := strings.Repeat("X", stderrLimit)
-		Expect(err).To(MatchError("EOF: exit status 1: " + short))
+		Expect(err.Error()).To(MatchRegexp(fmt.Sprintf(" %v$", short)))
 	})
 })

--- a/test/helpers/cmd/reader_test.go
+++ b/test/helpers/cmd/reader_test.go
@@ -3,18 +3,16 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io"
 	"os/exec"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/cluster-logging-operator/test"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
-var _ = Describe("CmdReader", func() {
+var _ = Describe("Reader", func() {
 	It("reads lines", func() {
 		cmd := exec.Command("echo", "a\nb\nc\n")
 		r, err := NewReader(cmd)
@@ -51,53 +49,5 @@ var _ = Describe("CmdReader", func() {
 		_, err = r.ReadLine()
 		short := strings.Repeat("X", stderrLimit)
 		Expect(err).To(MatchError("EOF: exit status 1: " + short))
-	})
-
-	It("ExpectEmpty passes on EOF", func() {
-		r, err := NewReader(exec.Command("true"))
-		ExpectOK(err)
-		defer r.Close()
-		ExpectOK(r.ExpectEmpty(context.Background()))
-	})
-
-	It("ExpectEmpty passes on timeout", func() {
-		r, err := NewReader(exec.Command("sleep", "1m"))
-		ExpectOK(err)
-		defer r.Close()
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second/10)
-		defer cancel()
-		ExpectOK(r.ExpectEmpty(ctx))
-	})
-
-	It("ExpectEmpty fails", func() {
-		r, err := NewReader(exec.Command("echo", "hello\n"))
-		ExpectOK(err)
-		defer r.Close()
-		ctx, cancel := context.WithTimeout(context.Background(), test.SuccessTimeout())
-		defer cancel()
-		Expect(r.ExpectEmpty(ctx)).To(MatchError(`expected empty, read line: "hello\n"`))
-	})
-
-	It("ExpectLines passes", func() {
-		r, err := NewReader(exec.Command("echo", "hello\nignoreme\nhello there\n"))
-		ExpectOK(err)
-		defer r.Close()
-		ExpectOK(r.ExpectLines(2, "hello", ""))
-	})
-
-	It("ExpectLines fails with bad lines", func() {
-		r, err := NewReader(exec.Command("echo", "hello\nwho's bad?\nhello there\n"))
-		ExpectOK(err)
-		defer r.Close()
-		Expect(r.ExpectLines(2, "hello", "bad")).To(MatchError(`bad line: "who's bad?\n"`))
-	})
-
-	It("ExpectLines fails with not enough lines", func() {
-		r, err := NewReader(exec.Command("echo", "hello\nignoreme\n"))
-		ExpectOK(err)
-		defer r.Close()
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second/10)
-		defer cancel()
-		Expect(r.ExpectLinesContext(ctx, 2, "hello", "bad")).To(MatchError(io.EOF))
 	})
 })

--- a/test/helpers/fluentd/receiver.go
+++ b/test/helpers/fluentd/receiver.go
@@ -211,8 +211,12 @@ func (r *Receiver) Create(c *client.Client) error {
 	g := errgroup.Group{}
 	g.Go(func() error { return c.Create(r.ConfigMap) })
 	g.Go(func() error { return c.Create(r.service) })
-	g.Go(func() error { return c.Create(r.Pod) })
-	g.Go(func() error { return c.WaitFor(r.Pod, client.PodRunning) })
+	g.Go(func() error {
+		if err := c.Create(r.Pod); err != nil {
+			return err
+		}
+		return c.WaitFor(r.Pod, client.PodRunning)
+	})
 	return g.Wait()
 }
 

--- a/test/helpers/fluentd/receiver.go
+++ b/test/helpers/fluentd/receiver.go
@@ -3,7 +3,6 @@ package fluentd
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -32,8 +31,7 @@ type Receiver struct {
 
 	service *corev1.Service
 	config  strings.Builder
-	done    chan struct{}
-	err     error
+	ready   chan struct{}
 }
 
 // Source represents a fluentd listening port and output file.
@@ -61,17 +59,27 @@ func (s *Source) Host() string { return s.receiver.Host() }
 func (s *Source) OutFile() string { return filepath.Join(dataDir, s.Name) }
 
 // TailReader returns a CmdReader that tails the source's log stream.
+// Will fail if called before Receiver.Create() has returned.
 //
 // It waits for the file to exist, and will tail the output file forever,
 // so it won't normally return io.EOF.
 func (s *Source) TailReader() *cmd.Reader {
-	test.Must(s.receiver.Wait()) // Make sure r.Pod is running before we exec.
 	r, err := cmd.TailReader(s.receiver.Pod, s.OutFile())
 	test.Must(err)
 	return r
 }
 
-// NewReceiver creates a receiver. Use AddSource() to add sources before calling Create().
+// HasOutput returns true if the source's output file exists and is non empty.
+func (s *Source) HasOutput() (bool, error) {
+	script := fmt.Sprintf("if test -s %q; then echo yes; fi", s.OutFile())
+	out, err := runtime.Exec(s.receiver.Pod, "sh", "-c", script).Output()
+	if err != nil {
+		return false, test.WrapError(err)
+	}
+	return len(out) > 0, nil
+}
+
+// NewReceiver returns a receiver with no sources. Use AddSource() before calling Create().
 func NewReceiver(ns, name string) *Receiver {
 	r := &Receiver{
 		Name:      name,
@@ -79,28 +87,26 @@ func NewReceiver(ns, name string) *Receiver {
 		ConfigMap: runtime.NewConfigMap(ns, name, nil),
 		Pod:       runtime.NewPod(ns, name),
 		service:   runtime.NewService(ns, name),
-		done:      make(chan struct{}),
+		ready:     make(chan struct{}),
 	}
 	r.Pod.Spec.RestartPolicy = corev1.RestartPolicyNever // Don't restart if fluentd fails.
 	runtime.Labels(r.Pod)[appName] = name
-	r.Pod.Spec.Containers = []corev1.Container{
-		{
-			Name:  name,
-			Image: "quay.io/openshift/origin-logging-fluentd:latest",
-			Args:  []string{"fluentd", "-c", filepath.Join(configDir, "fluent.conf")},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "config",
-					ReadOnly:  true,
-					MountPath: configDir,
-				},
-				{
-					Name:      "data",
-					MountPath: dataDir,
-				},
+	r.Pod.Spec.Containers = []corev1.Container{{
+		Name:  name,
+		Image: "quay.io/openshift/origin-logging-fluentd:latest",
+		Args:  []string{"fluentd", "-c", filepath.Join(configDir, "fluent.conf")},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "config",
+				ReadOnly:  true,
+				MountPath: configDir,
+			},
+			{
+				Name:      "data",
+				MountPath: dataDir,
 			},
 		},
-	}
+	}}
 	r.Pod.Spec.Volumes = []corev1.Volume{
 		{
 			Name: "config",
@@ -124,10 +130,6 @@ func NewReceiver(ns, name string) *Receiver {
 	}
 	// Start of fluent config: ignore fluent's internal events
 	r.config.WriteString(`
-<system>
-  log_level trace
-</system>
-
 <label @FLUENT_LOG>
   <match **>
     @type null
@@ -199,7 +201,7 @@ func (s *Source) config() {
 	test.Must(t.Execute(&s.receiver.config, s))
 }
 
-// Create the receiver's resources, wait for pod to be running.
+// Create the receiver's resources. Blocks till created.
 func (r *Receiver) Create(c *client.Client) error {
 	for _, s := range r.Sources {
 		s.config()
@@ -209,29 +211,10 @@ func (r *Receiver) Create(c *client.Client) error {
 	g := errgroup.Group{}
 	g.Go(func() error { return c.Create(r.ConfigMap) })
 	g.Go(func() error { return c.Create(r.service) })
-	g.Go(func() error {
-		if err := c.Create(r.Pod); err != nil {
-			return err
-		}
-		err := c.WaitFor(r.Pod, client.PodRunning)
-		return err
-	})
-	if err := g.Wait(); err != nil {
-		r.err = fmt.Errorf("%w\n%v", err, r.Logs())
-	}
-	close(r.done)
-	return r.err
+	g.Go(func() error { return c.Create(r.Pod) })
+	g.Go(func() error { return c.WaitFor(r.Pod, client.PodRunning) })
+	return g.Wait()
 }
-
-func (r *Receiver) Logs() string {
-	ns, name := r.Pod.Namespace, r.Pod.Name
-	cmd := exec.Command("oc", "logs", "-n", ns, name)
-	b, _ := cmd.CombinedOutput()
-	return string(b)
-}
-
-// Wait till r.Pod is running.
-func (r *Receiver) Wait() error { <-r.done; return r.err }
 
 // Host name for the receiver.
 func (r *Receiver) Host() string { return runtime.ServiceDomainName(r.service) }

--- a/test/helpers/fluentd/receiver_test.go
+++ b/test/helpers/fluentd/receiver_test.go
@@ -27,6 +27,8 @@ var _ = Describe("Receiver", func() {
 		r.Sources["bar"].Cert = certificate.NewCert(nil, r.Host())
 		ExpectOK(r.Create(t.Client))
 
+		Expect(r.Sources["foo"].HasOutput()).To(BeFalse())
+
 		var g test.FailGroup
 		defer g.Wait()
 		msg := `{"hello":"world"}`
@@ -51,12 +53,13 @@ var _ = Describe("Receiver", func() {
 
 		By("checking for data")
 		for _, s := range r.Sources {
-			r := s.TailReader()
+			tr := s.TailReader()
 			g.Go(func() {
-				defer r.Close()
-				line, err := r.ReadLine()
+				defer tr.Close()
+				line, err := tr.ReadLine()
 				ExpectOK(err)
 				Expect(strings.TrimSpace(line)).To(Equal(msg))
+				Expect(r.Sources["foo"].HasOutput()).To(BeTrue())
 			})
 		}
 	})

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"math/rand"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,30 +39,14 @@ const (
 	DefaultCleanUpTimeout  = 60.0 * 2
 )
 
-var (
-	defaultRetryInterval        time.Duration
-	defaultTimeout              time.Duration
-	DefaultWaitForLogsTimeout   time.Duration
-	DefaultWaitForNoLogsTimeout time.Duration
-	err                         error
-)
-
-func init() {
-	if defaultRetryInterval, err = time.ParseDuration("1s"); err != nil {
-		panic(err)
-	}
-	if defaultTimeout, err = time.ParseDuration("5m"); err != nil {
-		panic(err)
-	}
-	if DefaultWaitForLogsTimeout, err = time.ParseDuration("5m"); err != nil {
-		panic(err)
-	}
-	// Shorter timeout for when we are expecting that there will be no logs,
+const (
+	defaultRetryInterval      = 1 * time.Second
+	defaultTimeout            = 10 * time.Minute
+	DefaultWaitForLogsTimeout = 10 * time.Minute
+	// Shorter timeout for when we are expecting that there will be no logs
 	// since we will always go to the timeout in that case.a
-	if DefaultWaitForNoLogsTimeout, err = time.ParseDuration("1m"); err != nil {
-		panic(err)
-	}
-}
+	DefaultWaitForNoLogsTimeout = 1 * time.Minute
+)
 
 type LogStore interface {
 	//ApplicationLogs returns app logs for a given log store
@@ -587,11 +572,11 @@ func (tc *E2ETestFramework) CreatePipelineSecret(pwd, logStoreName, secretName s
 			return nil, err
 		}
 	}
-	if err = os.Setenv("WORKING_DIR", workingDir); err != nil {
+	if err := os.Setenv("WORKING_DIR", workingDir); err != nil {
 		return nil, err
 	}
 	scriptsDir := fmt.Sprintf("%s/scripts", pwd)
-	if err, _ = certificates.GenerateCertificates(OpenshiftLoggingNS, scriptsDir, logStoreName, workingDir); err != nil {
+	if err, _ := certificates.GenerateCertificates(OpenshiftLoggingNS, scriptsDir, logStoreName, workingDir); err != nil {
 		return nil, err
 	}
 	data := map[string][]byte{

--- a/test/helpers/kafka.go
+++ b/test/helpers/kafka.go
@@ -3,9 +3,10 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"strings"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 
 	clolog "github.com/ViaQ/logerr/log"
 	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
@@ -225,8 +226,7 @@ func (tc *E2ETestFramework) createKafkaConsumers(rcv *kafkaReceiver) error {
 			return err
 		}
 	}
-
-	return err
+	return nil
 }
 
 func (tc *E2ETestFramework) createKafkaBrokerStatefulSet() (*apps.StatefulSet, error) {

--- a/test/helpers/syslog.go
+++ b/test/helpers/syslog.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"math/rand"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -474,7 +475,7 @@ func (tc *E2ETestFramework) CreateSyslogReceiverSecrets(testDir, logStoreName, s
 			return nil, err
 		}
 	}
-	if err = os.Setenv("WORKING_DIR", workingDir); err != nil {
+	if err := os.Setenv("WORKING_DIR", workingDir); err != nil {
 		return nil, err
 	}
 	script := fmt.Sprintf("%s/syslog_cert_generation.sh", testDir)

--- a/test/matchers/diff.go
+++ b/test/matchers/diff.go
@@ -39,12 +39,12 @@ type lineMatcher struct {
 }
 
 func (m *lineMatcher) Match(actual interface{}) (success bool, err error) {
-	m.diff = cmp.Diff(m.normalize(m.expected.(string)), m.normalize(actual.(string)))
+	m.diff = cmp.Diff(m.normalize(actual.(string)), m.normalize(m.expected.(string)))
 	return m.diff == "", nil
 }
 
 func (m *lineMatcher) FailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected:\n%s\nTo Equal:\n%s\n\nDiff:\n%s", m.expected, actual, m.diff)
+	return fmt.Sprintf("Expected\n%s\nto equal\n%s\nDiff\n%s", actual, m.expected, m.diff)
 }
 
 func (m *lineMatcher) NegatedFailureMessage(actual interface{}) (message string) {

--- a/test/matchers/errors.go
+++ b/test/matchers/errors.go
@@ -1,21 +1,9 @@
 package matchers
 
 import (
-	"errors"
-	"fmt"
-	"os/exec"
-
 	"github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/test"
 )
-
-// WrapError wraps certain error types with additional information.
-func WrapError(err error) error {
-	exitErr := &exec.ExitError{}
-	if errors.As(err, &exitErr) && len(exitErr.Stderr) != 0 {
-		return fmt.Errorf("%w: %v", err, string(exitErr.Stderr))
-	}
-	return err
-}
 
 // ExpectOK is shorthand for these annoyingly long ginkgo forms:
 //    Expect(err).NotTo(HaveOccured()
@@ -26,5 +14,5 @@ func ExpectOK(err error, description ...interface{}) {
 }
 
 func ExpectOKWithOffset(skip int, err error, description ...interface{}) {
-	gomega.ExpectWithOffset(skip+1, WrapError(err)).To(gomega.Succeed(), description...)
+	gomega.ExpectWithOffset(skip+1, test.WrapError(err)).To(gomega.Succeed(), description...)
 }

--- a/test/matchers/log_format.go
+++ b/test/matchers/log_format.go
@@ -2,11 +2,12 @@ package matchers
 
 import (
 	"fmt"
-	logger "github.com/ViaQ/logerr/log"
-	"github.com/onsi/gomega/types"
 	"reflect"
 	"regexp"
 	"strings"
+
+	logger "github.com/ViaQ/logerr/log"
+	"github.com/onsi/gomega/types"
 )
 
 type LogMatcher struct {


### PR DESCRIPTION
Loads only secrets that are available in configuration.

- Additional validation of consistency between URL scheme and secrets.
- verifyOutputs loads secrets to do full validation
- Secrets are passed through to the generator
- Touched many test because of change to generator signature change

Fixes the following 2 bugs:

-   [1888943 – ClusterLogForwarder with Output.Secret causes fluentd crash loop](https://bugzilla.redhat.com/show_bug.cgi?id=1888943)
-   [1890072 – Log forwarding API with multiple outputs same secret cause issues](https://bugzilla.redhat.com/show_bug.cgi?id=1890072)
