### PR TITLE
Bug 1901424: Skip setting kibana replicas to 1 with zero es node

### DIFF
--- a/pkg/k8shandler/visualization.go
+++ b/pkg/k8shandler/visualization.go
@@ -196,7 +196,7 @@ func newKibanaCustomResource(cluster *logging.ClusterLogging, kibanaName string)
 	}
 
 	replicas := visSpec.Replicas
-	if replicas == 0 {
+	if replicas == 0 && (cluster.Spec.LogStore != nil && cluster.Spec.LogStore.ElasticsearchSpec.NodeCount > 0) {
 		replicas = 1
 	}
 


### PR DESCRIPTION
- test cases updated

### Description
This PR adds an additional condition check of the elasticsearch nodecount before setting the kibana replica to 1.

/cc @lukas-vlcek 
/assign @jcantrill

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1901424
