### PR TITLE
Bug 1906479: Set forward heartbeat to none

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -1014,20 +1014,21 @@ var _ = Describe("Generating fluentd config", func() {
 				<match **>
 					# https://docs.fluentd.org/v1.0/articles/in_forward
 				@type forward
+				heartbeat_type none
 
 				<buffer>
 					@type file
 					path '/var/lib/fluentd/secureforward_receiver'
 					queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
-          flush_mode interval
+					total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+					chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+					flush_mode interval
 					flush_interval 5s
 					flush_at_shutdown true
 					flush_thread_count 2
-          retry_type exponential_backoff
-          retry_wait 1s
-          retry_max_interval 60s
+					retry_type exponential_backoff
+					retry_wait 1s
+					retry_max_interval 60s
 					retry_forever true
 					# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 					# queue limit is hit - 'block' will halt further reads and keep retrying to flush the

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -42,44 +42,45 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			Expect(results[0]).To(EqualTrimLines(`<label @SECUREFORWARD_RECEIVER>
 	<match **>
 		# https://docs.fluentd.org/v1.0/articles/in_forward
-	   @type forward
-	   <security>
-	     self_hostname "#{ENV['NODE_NAME']}" 
-	     shared_key "#{File.open('/var/run/ocp-collector/secrets/my-infra-secret/shared_key') do |f| f.readline end.rstrip}"
-	   </security>
+		@type forward
+		heartbeat_type none
+		<security>
+			self_hostname "#{ENV['NODE_NAME']}" 
+			shared_key "#{File.open('/var/run/ocp-collector/secrets/my-infra-secret/shared_key') do |f| f.readline end.rstrip}"
+		</security>
 
-	   transport tls
-	   tls_verify_hostname false
-	   tls_version 'TLSv1_2'
-	
-	   #tls_client_private_key_path /var/run/ocp-collector/secrets/my-infra-secret/tls.key
-	   tls_client_cert_path /var/run/ocp-collector/secrets/my-infra-secret/tls.crt
-	   tls_cert_path /var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt
+		transport tls
+		tls_verify_hostname false
+		tls_version 'TLSv1_2'
+		
+		#tls_client_private_key_path /var/run/ocp-collector/secrets/my-infra-secret/tls.key
+		tls_client_cert_path /var/run/ocp-collector/secrets/my-infra-secret/tls.crt
+		tls_cert_path /var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt
 
-	   <buffer>
-	     @type file
-	     path '/var/lib/fluentd/secureforward_receiver'
-	     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-	     total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-	     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
-       flush_mode interval
-	     flush_interval 5s       
-	     flush_at_shutdown true
-	     flush_thread_count 2
-       retry_type exponential_backoff
-       retry_wait 1s
-	     retry_max_interval 60s
-	     retry_forever true
-	     # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-	     # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-	     # buffer to the remote - default is 'block' because in_tail handles that case
-	     overflow_action block
-	   </buffer>
+		<buffer>
+			@type file
+			path '/var/lib/fluentd/secureforward_receiver'
+			queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+			total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+			chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+			flush_mode interval
+			flush_interval 5s       
+			flush_at_shutdown true
+			flush_thread_count 2
+			retry_type exponential_backoff
+			retry_wait 1s
+			retry_max_interval 60s
+			retry_forever true
+			# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+			# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+			# buffer to the remote - default is 'block' because in_tail handles that case
+			overflow_action block
+		</buffer>
 
-	   <server>
-	     host es.svc.messaging.cluster.local
-	     port 9654
-	   </server>
+		<server>
+			host es.svc.messaging.cluster.local
+			port 9654
+		</server>
 	</match>
 </label>`))
 		})
@@ -102,33 +103,34 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			Expect(results[0]).To(EqualTrimLines(`<label @SECUREFORWARD_RECEIVER>
 			<match **>
 				# https://docs.fluentd.org/v1.0/articles/in_forward
-			  @type forward
+				@type forward
+				heartbeat_type none
 
-			  <buffer>
-				@type file
-				path '/var/lib/fluentd/secureforward_receiver'
-				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-        total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
-        flush_mode interval
-				flush_interval 5s
-				flush_at_shutdown true
-				flush_thread_count 2
-        retry_type exponential_backoff
-        retry_wait 1s
-				retry_max_interval 60s
-				retry_forever true
-				# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-				# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-				# buffer to the remote - default is 'block' because in_tail handles that case
-				overflow_action block
-			  </buffer>
-	   
-			  <server>
-				host es.svc.messaging.cluster.local
-				port 9654
-			  </server>
-		   </match>
+				<buffer>
+					@type file
+					path '/var/lib/fluentd/secureforward_receiver'
+					queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+					total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+					chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+					flush_mode interval
+					flush_interval 5s
+					flush_at_shutdown true
+					flush_thread_count 2
+					retry_type exponential_backoff
+					retry_wait 1s
+					retry_max_interval 60s
+					retry_forever true
+					# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+					# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+					# buffer to the remote - default is 'block' because in_tail handles that case
+					overflow_action block
+				</buffer>
+		
+				<server>
+					host es.svc.messaging.cluster.local
+					port 9654
+				</server>
+			</match>
 </label>`))
 		})
 	})

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -385,6 +385,7 @@ var _ = Describe("Generating fluentd config", func() {
           <match **>
             # https://docs.fluentd.org/v1.0/articles/in_forward
             @type forward
+            heartbeat_type none
 
             <buffer>
             @type file
@@ -421,37 +422,38 @@ var _ = Describe("Generating fluentd config", func() {
 
 		It("should override buffer configuration for given tuning parameters", func() {
 			fluentdForwardConf := `
-        <label @SECUREFORWARD_RECEIVER>
-          <match **>
-            # https://docs.fluentd.org/v1.0/articles/in_forward
-            @type forward
+      <label @SECUREFORWARD_RECEIVER>
+        <match **>
+          # https://docs.fluentd.org/v1.0/articles/in_forward
+          @type forward
+          heartbeat_type none
 
-            <buffer>
-            @type file
-            path '/var/lib/fluentd/secureforward_receiver'
-            queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-            total_limit_size 512m
-            chunk_limit_size 256m
-            flush_mode immediate
-            flush_interval 2s
-            flush_at_shutdown true
-            flush_thread_count 4
-            retry_type periodic
-            retry_wait 2s
-            retry_max_interval 600s
-            retry_forever true
-            # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-            # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-            # buffer to the remote - default is 'block' because in_tail handles that case
-            overflow_action drop_oldest_chunk
-            </buffer>
+          <buffer>
+          @type file
+          path '/var/lib/fluentd/secureforward_receiver'
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+          total_limit_size 512m
+          chunk_limit_size 256m
+          flush_mode immediate
+          flush_interval 2s
+          flush_at_shutdown true
+          flush_thread_count 4
+          retry_type periodic
+          retry_wait 2s
+          retry_max_interval 600s
+          retry_forever true
+          # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+          # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+          # buffer to the remote - default is 'block' because in_tail handles that case
+          overflow_action drop_oldest_chunk
+          </buffer>
 
-            <server>
-            host es.svc.messaging.cluster.local
-            port 9654
-            </server>
-           </match>
-         </label>`
+          <server>
+          host es.svc.messaging.cluster.local
+          port 9654
+          </server>
+        </match>
+      </label>`
 
 			results, err := generator.generateOutputLabelBlocks(outputs, customForwarderSpec)
 			Expect(err).To(BeNil())

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -632,6 +632,7 @@ const outputLabelConfJsonParseNoretryTemplate = `{{- define "outputLabelConfJson
 const forwardTemplate = `{{- define "forward" -}}
 # https://docs.fluentd.org/v1.0/articles/in_forward
 @type forward
+heartbeat_type none
 {{ if .Target.Secret }}
 <security>
   self_hostname "#{ENV['NODE_NAME']}"


### PR DESCRIPTION
(cherry picked from commit 0aa032a3a9f193fb754bca2ca7526b33ba33dcb1)

### Description 
This PR
*  sets the fluentd forward heartbeat to "none" to avoid dns resolution issues from stopping the pod from starting
* Expands the functional framework to add visitors in order to test this issue
```
2020-11-23 20:26:38 +0000 [error]: unexpected error error_class=SocketError error="getaddrinfo: Name or service not known"
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:680:in `getaddrinfo'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:680:in `resolve_dns!'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:666:in `resolved_host'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:516:in `validate_host_resolution!'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:237:in `block in configure'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:227:in `each'
  2020-11-23 20:26:38 +0000 [error]: /usr/local/share/gems/gems/fluentd-1.7.4/lib/fluent/plugin/out_forward.rb:227:in `configure'
```

/assign @igor-karpukhin @vimalk78 

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1906479
* Backport of https://github.com/openshift/cluster-logging-operator/pull/813