### PR TITLE
Bug 1905819: Bubble up errors from logstore reconciliation

### DIFF
--- a/pkg/controller/clusterlogging/clusterlogging_controller.go
+++ b/pkg/controller/clusterlogging/clusterlogging_controller.go
@@ -87,7 +87,9 @@ func (r *ReconcileClusterLogging) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, nil
 	}
 
-	err = k8shandler.Reconcile(instance, r.client)
+	if err = k8shandler.Reconcile(instance, r.client); err != nil {
+		logrus.Error(err, "Error reconciling clusterlogging instance")
+	}
 
 	if result, err := r.updateStatus(instance); err != nil {
 		return result, err

--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -34,11 +34,11 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateLogStore() (err error
 		cluster := clusterRequest.Cluster
 
 		if err = clusterRequest.createOrUpdateElasticsearchSecret(); err != nil {
-			return nil
+			return err
 		}
 
 		if err = clusterRequest.createOrUpdateElasticsearchCR(); err != nil {
-			return nil
+			return err
 		}
 
 		elasticsearchStatus, err := clusterRequest.getElasticsearchStatus()


### PR DESCRIPTION
(cherry picked from commit 86ecc8970b36696781ae41d3766278e60701d712)

### Description
This PR bubbles up errors from reconciling the logstore that were lost in a prior commit in order to expose more information to admins

/cc @igor-karpukhin @vimalk78 
/assign @alanconway 
### Links
This PR replaces https://github.com/openshift/cluster-logging-operator/pull/833 because of test errors and is a manual cherrypick of 1905819

https://bugzilla.redhat.com/show_bug.cgi?id=1905819
