### PR TITLE
Add forward keepalive

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -1184,10 +1184,11 @@ var _ = Describe("Generating fluentd config", func() {
 			# Ship logs to specific outputs
 			<label @SECUREFORWARD_RECEIVER>
 				<match **>
-					# https://docs.fluentd.org/v1.0/articles/in_forward
+				# https://docs.fluentd.org/v1.0/articles/in_forward
 				@type forward
 				heartbeat_type none
-
+				keepalive true
+				
 				<buffer>
 					@type file
 					path '/var/lib/fluentd/secureforward_receiver'

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -58,7 +58,8 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
       <match **>
         # https://docs.fluentd.org/v1.0/articles/in_forward
         @type forward
-    		heartbeat_type none
+        heartbeat_type none
+        keepalive true
         transport tls
         tls_verify_hostname false
         tls_version 'TLSv1_2'
@@ -103,7 +104,8 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
       <match **>
         # https://docs.fluentd.org/v1.0/articles/in_forward
         @type forward
-    		heartbeat_type none
+        heartbeat_type none
+        keepalive true
         transport tls
         tls_verify_hostname false
         tls_version 'TLSv1_2'
@@ -144,21 +146,22 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(`<label @SECUREFORWARD_RECEIVER>
   <match **>
-    # https://docs.fluentd.org/v1.0/articles/in_forward
+     # https://docs.fluentd.org/v1.0/articles/in_forward
      @type forward
      heartbeat_type none
+     keepalive true
      <security>
        self_hostname "#{ENV['NODE_NAME']}"
        shared_key "my-key"
      </security>
 
-		 transport tls
-		 tls_verify_hostname false
-		 tls_version 'TLSv1_2'
+     transport tls
+     tls_verify_hostname false
+     tls_version 'TLSv1_2'
 
-		 tls_client_private_key_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.key"
-		 tls_client_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.crt"
-		 tls_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt"
+     tls_client_private_key_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.key"
+     tls_client_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.crt"
+     tls_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt"
 
      <buffer>
        @type file
@@ -167,23 +170,23 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
        total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
        chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
        flush_mode interval
-	     flush_interval 5s
-	     flush_at_shutdown true
-	     flush_thread_count 2
+       flush_interval 5s
+       flush_at_shutdown true
+       flush_thread_count 2
        retry_type exponential_backoff
        retry_wait 1s
-	     retry_max_interval 60s
-	     retry_forever true
-	     # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
-	     # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
-	     # buffer to the remote - default is 'block' because in_tail handles that case
-	     overflow_action block
-	   </buffer>
+       retry_max_interval 60s
+       retry_forever true
+       # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+       # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+       # buffer to the remote - default is 'block' because in_tail handles that case
+       overflow_action block
+	 </buffer>
 
-		<server>
-			host es.svc.messaging.cluster.local
-			port 9654
-		</server>
+	 <server>
+	   host es.svc.messaging.cluster.local
+	   port 9654
+	 </server>
 	</match>
 </label>`))
 		})
@@ -208,6 +211,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 				# https://docs.fluentd.org/v1.0/articles/in_forward
 				@type forward
 				heartbeat_type none
+				keepalive true
 
 				<buffer>
 					@type file

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -386,6 +386,7 @@ var _ = Describe("Generating fluentd config", func() {
             # https://docs.fluentd.org/v1.0/articles/in_forward
             @type forward
             heartbeat_type none
+            keepalive true
 
             <buffer>
             @type file
@@ -427,6 +428,7 @@ var _ = Describe("Generating fluentd config", func() {
           # https://docs.fluentd.org/v1.0/articles/in_forward
           @type forward
           heartbeat_type none
+          keepalive true
 
           <buffer>
           @type file

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -660,6 +660,7 @@ const forwardTemplate = `{{- define "forward" -}}
 # https://docs.fluentd.org/v1.0/articles/in_forward
 @type forward
 heartbeat_type none
+keepalive true
 {{- with $sharedKey := .GetSecret "shared_key" }}
 <security>
   self_hostname "#{ENV['NODE_NAME']}"


### PR DESCRIPTION
This PR adds keepalive=true for all forward configurations.

Currently keepalive defaults to false which means a new socket is created for every chunk sent.  This change ensures connections are reused.

fixes #829 