### PR TITLE
fluentd instance not getting created in CRC error fix

### DIFF
--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -72,7 +72,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection(proxyConfi
 		}
 
 		if err = clusterRequest.createOrUpdateFluentdPrometheusRule(); err != nil {
-			return
+			log.Error(err, "unable to create or update fluentd prometheus rule")
 		}
 
 		if err = clusterRequest.createOrUpdateFluentdConfigMap(collectorConfig); err != nil {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
CRC does not start monitoring by default, so this was causing fluentd instance to not start on CRC.
Not creating prometheus rules should not block deployment, but only mark the operator as "degraded"

This PR:
- Removes the error caused by Fluentd Prometheus Rule.
- The fluentd instance will be up and running successfully.

/cc @vimalk78  <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->
