### PR TITLE
Bug 1903912: Deploy fluent init container when logstore.nodecount > 0

### DIFF
--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -503,7 +503,7 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, proxyConfig *configv1.Pr
 	// for collection config generation. If first is provided without the latter a
 	// ClusterLogFowarder with default fields is assumed.
 	// (See ClusterLoggingRequest#getLogForwarder)
-	if pipelineSpec.HasDefaultOutput() && cluster.Spec.LogStore != nil {
+	if pipelineSpec.HasDefaultOutput() && cluster.Spec.LogStore != nil && cluster.Spec.LogStore.ElasticsearchSpec.NodeCount > 0 {
 		fluentdPodSpec.InitContainers = []v1.Container{
 			newFluentdInitContainer(cluster),
 		}

--- a/pkg/k8shandler/fluentd_test.go
+++ b/pkg/k8shandler/fluentd_test.go
@@ -287,6 +287,9 @@ func TestFluentdPodInitContainerWithDefaultForwarding(t *testing.T) {
 			},
 			LogStore: &logging.LogStoreSpec{
 				Type: "elasticsearch",
+				ElasticsearchSpec: logging.ElasticsearchSpec{
+					NodeCount: 1,
+				},
 			},
 		},
 	}
@@ -299,6 +302,32 @@ func TestFluentdPodInitContainerWithDefaultForwarding(t *testing.T) {
 
 	if len(podSpec.InitContainers) == 0 {
 		t.Error("Expected pod to have defined init container")
+	}
+}
+
+func TestFluentdPodInitContainerWithZeroESCount(t *testing.T) {
+	cluster := &logging.ClusterLogging{
+		Spec: logging.ClusterLoggingSpec{
+			Collection: &logging.CollectionSpec{
+				Logs: logging.LogCollectionSpec{
+					Type:        "fluentd",
+					FluentdSpec: logging.FluentdSpec{},
+				},
+			},
+			LogStore: &logging.LogStoreSpec{
+				Type: "elasticsearch",
+			},
+		},
+	}
+
+	spec := logging.ClusterLogForwarderSpec{
+		Outputs: []logging.OutputSpec{{Name: "default"}},
+	}
+
+	podSpec := newFluentdPodSpec(cluster, nil, nil, spec)
+
+	if len(podSpec.InitContainers) > 0 {
+		t.Error("Expected pod not define init container")
 	}
 }
 


### PR DESCRIPTION
### Description
This PR only deploys an init container for fluentd if the logstore has a node count greater then 0

/cc @igor-karpukhin @vimalk78 
/assign @alanconway 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1903912
