### PR TITLE
Replace fmt.Print with log.Error

### DIFF
--- a/pkg/k8shandler/reconciler.go
+++ b/pkg/k8shandler/reconciler.go
@@ -171,7 +171,7 @@ func (clusterRequest *ClusterLoggingRequest) getClusterLogging() *logging.Cluste
 
 	if err := clusterRequest.Client.Get(context.TODO(), clusterLoggingNamespacedName, clusterLogging); err != nil {
 		if !apierrors.IsNotFound(err) {
-			fmt.Printf("Encountered unexpected error getting %v", clusterLoggingNamespacedName)
+			log.Error(err, "Encountered unexpected error getting", "NamespacedName", clusterLoggingNamespacedName)
 		}
 		return nil
 	}
@@ -186,7 +186,7 @@ func (clusterRequest *ClusterLoggingRequest) getProxyConfig() *configv1.Proxy {
 	proxyConfig := &configv1.Proxy{}
 	if err := clusterRequest.Client.Get(context.TODO(), proxyNamespacedName, proxyConfig); err != nil {
 		if !apierrors.IsNotFound(err) {
-			fmt.Printf("Encountered unexpected error getting %v", proxyNamespacedName)
+			log.Error(err, "Encountered unexpected error getting ", "proxyConfig", proxyNamespacedName)
 		}
 	}
 
@@ -198,7 +198,7 @@ func (clusterRequest *ClusterLoggingRequest) getLogForwarder() *logging.ClusterL
 	forwarder := &logging.ClusterLogForwarder{}
 	if err := clusterRequest.Client.Get(context.TODO(), nsname, forwarder); err != nil {
 		if !apierrors.IsNotFound(err) {
-			fmt.Printf("Encountered unexpected error getting %v", nsname)
+			log.Error(err, "Encountered unexpected error getting", "forwarder", nsname)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Replace fmt.Printf() with log.Error() or log.Info() 

/cc @jcantrill <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->
