### PR TITLE
Bug 1905910: Correctly extract master-certs to workind directory

### DIFF
--- a/pkg/k8shandler/certificates.go
+++ b/pkg/k8shandler/certificates.go
@@ -30,9 +30,12 @@ func (clusterRequest *ClusterLoggingRequest) extractMasterCerts() (extracted boo
 		}
 		return false, fmt.Errorf("Unable to get secret %s: %v", constants.MasterCASecretName, err)
 	}
-	workDir := utils.GetWorkingDir()
+
+	log.V(3).Info("Master cert", "size", len(secret.Data))
 	for name, value := range secret.Data {
-		if err != utils.WriteToWorkingDirFile(path.Join(workDir, name), value) {
+		log.V(3).Info("Master cert", "file", name)
+		if err = utils.WriteToWorkingDirFile(name, value); err != nil {
+			log.Error(err, "Error extracting cert from master-cert secret", "file", name)
 			return false, err
 		}
 	}
@@ -79,7 +82,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCertificates() (err e
 	return Syncronize(func() error {
 		var extracted bool
 		if extracted, err = clusterRequest.extractMasterCerts(); err != nil {
-			fmt.Printf("Error %v", err)
+			log.Error(err, "Error extracting master-cert")
 			return err
 		}
 


### PR DESCRIPTION
### Description
This PR
* Corrects the cert extraction logic to extract all certs from the master-cert secret
* Reformats the cert gen script output to be parsable to allow explicit understandying of why certs were regenerated
* Adds a test to expose the issue

/cc @anpingli 
/assign @ewolinetz @vimalk78 

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1905910
