### PR TITLE
Bug 1906641: Correctly extract master-certs to working directory

### DIFF
--- a/pkg/certificates/certificates.go
+++ b/pkg/certificates/certificates.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 
 	"github.com/openshift/cluster-logging-operator/pkg/logger"
+	"sigs.k8s.io/yaml"
 )
 
 func GenerateCertificates(namespace, scriptsDir, logStoreName, workDir string) (err error, updated bool) {
@@ -20,8 +21,21 @@ func RunCertificatesScript(namespace, logStoreName, workDir, script string) (err
 	logger.Tracef("Cert generation result %s / err: %v", result, err)
 	if result != "" {
 		updated = true
-		logger.Infof("cert_generation output: %s", result)
+		dumpLogs(result)
 	}
 	logger.Tracef("Returning err: %v , updated: %v", err, updated)
 	return err, updated
+}
+
+func dumpLogs(raw string) {
+	genLogs := []map[string]string{}
+	err := yaml.Unmarshal([]byte(raw), &genLogs)
+	if err == nil {
+		for _, eventlog := range genLogs {
+			logger.Infof("cert_generation output: %v", eventlog)
+		}
+		return
+	}
+	logger.Errorf("Unable to unmarshal cert_generation to structured output: %v", err)
+	logger.Infof("cert_generation output: %s", raw)
 }

--- a/pkg/k8shandler/certificates.go
+++ b/pkg/k8shandler/certificates.go
@@ -30,9 +30,10 @@ func (clusterRequest *ClusterLoggingRequest) extractMasterCerts() (extracted boo
 		}
 		return false, fmt.Errorf("Unable to get secret %s: %v", constants.MasterCASecretName, err)
 	}
-	workDir := utils.GetWorkingDir()
+
 	for name, value := range secret.Data {
-		if err != utils.WriteToWorkingDirFile(path.Join(workDir, name), value) {
+		if err = utils.WriteToWorkingDirFile(name, value); err != nil {
+			logger.Errorf("Error extracting cert from master-cert secret %q: %v", name, err)
 			return false, err
 		}
 	}
@@ -76,10 +77,10 @@ func loadFilesFromWorkingDir() (map[string][]byte, error) {
 
 //CreateOrUpdateCertificates for a cluster logging instance
 func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCertificates() (err error) {
-	return Syncronize(func() error {
+	return Synchronize(func() error {
 		var extracted bool
 		if extracted, err = clusterRequest.extractMasterCerts(); err != nil {
-			fmt.Printf("Error %v", err)
+			logger.Errorf("Error extracting master-cert: %v", err)
 			return err
 		}
 


### PR DESCRIPTION
### Description
This PR
* Corrects the cert extraction logic to extract all certs from the master-cert secret
* Reformats the cert gen script output to be parsable to allow explicit understandying of why certs were regenerated
* Adds a test to expose the issue
* Writing the secret when it changes or when it was not found initially

/cc @anpingli 
/assign @ewolinetz @vimalk78 

### Links
4.6 Backports for https://github.com/openshift/cluster-logging-operator/pull/819 and https://github.com/openshift/cluster-logging-operator/pull/847
https://bugzilla.redhat.com/show_bug.cgi?id=1906641
https://bugzilla.redhat.com/show_bug.cgi?id=1901869
