### PR TITLE
Bug 1894640: Reduce the max retry rate to 60s

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -480,7 +480,7 @@ var _ = Describe("Generating fluentd config", func() {
 					flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 					flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 					flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
-					retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
+					retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || 60}"
 					retry_forever true
 					# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 					# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
@@ -968,7 +968,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 							flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -1014,7 +1014,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 							flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -1061,7 +1061,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 							flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -1107,7 +1107,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 							flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -1154,7 +1154,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 							flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -1200,7 +1200,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 							flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -1247,7 +1247,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 							flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -1293,7 +1293,7 @@ var _ = Describe("Generating fluentd config", func() {
 							flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 							flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 							flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+							retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 							retry_forever true
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 				flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -146,7 +146,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 				flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -206,7 +206,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 				flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -248,7 +248,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 				flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
 				flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+				retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
 				retry_forever true
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 	     flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 	     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 	     flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
-	     retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
+	     retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || 60}"
 	     retry_forever true
 	     # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 	     # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
@@ -109,7 +109,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 				flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
 				flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
 				flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
-				retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
+				retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || 60}"
 				retry_forever true
 				# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 				# queue limit is hit - 'block' will halt further reads and keep retrying to flush the

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
         flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-        retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+        retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -168,7 +168,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
         flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-        retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+        retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -207,7 +207,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
         flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-        retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+        retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -240,7 +240,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
         flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
         flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-        retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+        retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
         retry_forever true
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -564,7 +564,7 @@ tls_cert_path {{ .SecretPath "ca-bundle.crt"}}
   flush_interval "#{ENV['FORWARD_FLUSH_INTERVAL'] || '5s'}"
   flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
   flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
-  retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
+  retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || 60}"
   retry_forever true
   # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
   # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
@@ -621,7 +621,7 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
     flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
     flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-    retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+    retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
     retry_forever true
     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"
@@ -675,7 +675,7 @@ const storeSyslogTemplate = `{{- define "storeSyslog" -}}
     flush_interval "#{ENV['ES_FLUSH_INTERVAL'] || '1s'}"
     flush_thread_count "#{ENV['ES_FLUSH_THREAD_COUNT'] || 2}"
     flush_at_shutdown "#{ENV['FLUSH_AT_SHUTDOWN'] || 'false'}"
-    retry_max_interval "#{ENV['ES_RETRY_WAIT'] || '300'}"
+    retry_max_interval "#{ENV['ES_RETRY_WAIT'] || 60}"
     retry_forever true
     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
     chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m' }"


### PR DESCRIPTION
# Description
This PR lowers the default max_retry_wait to resolve cases where it appears fluent is functional but not pushing messages. The current retry algo is an exponential backoff that will cause fluent to not retry try soon enough

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1894640

/assign @vimalk78 @alanconway

backport of https://github.com/openshift/cluster-logging-operator/pull/799