### PR TITLE
Bug 1915454: Enable deployment on OCP v4.6

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -11,7 +11,7 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.7"
+LABEL com.redhat.openshift.versions="v4.6-v4.7"
 
 LABEL \
     com.redhat.component="cluster-logging-operator" \


### PR DESCRIPTION
### Description
This PR enables deployment of 4.7 logging on OCP 4.6

/cc @vimalk78 @igor-karpukhin 

### Links
https://bugzilla.redhat.com/show_bug.cgi?id=1915454

/cherrypick release-4.6
