### PR TITLE
LOG-1034: Allow selectively running e2e tests for EO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ export NAMESPACE?=openshift-logging
 
 FLUENTD_IMAGE?=quay.io/openshift/origin-logging-fluentd:latest
 REPLICAS?=0
+export E2E_TEST_INCLUDES?=
+export CLF_TEST_INCLUDES?=
 
 .PHONY: force all build clean fmt generate regenerate deploy-setup deploy-image image deploy deploy-example test-functional test-unit test-e2e test-sec undeploy run
 
@@ -170,9 +172,11 @@ generate-bundle: regenerate $(OPM)
 
 # NOTE: This is the CI e2e entry point.
 test-e2e-olm: $(JUNITREPORT)
-	hack/test-e2e-olm.sh
+	INCLUDES=$(E2E_TEST_INCLUDES) CLF_INCLUDES=$(CLF_TEST_INCLUDES) hack/test-e2e-olm.sh
 
 test-e2e-local: $(JUNITREPORT) deploy-image
+    CLF_INCLUDES=$(CLF_TEST_INCLUDES) \
+    INCLUDES=$(E2E_TEST_INCLUDES) \
 	IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc:5000/openshift/origin-cluster-logging-operator:latest \
 	IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=image-registry.openshift-image-registry.svc:5000/openshift/cluster-logging-operator-registry:latest \
 	hack/test-e2e-olm.sh

--- a/hack/test-e2e-olm.sh
+++ b/hack/test-e2e-olm.sh
@@ -12,6 +12,7 @@ test_artifactdir="${ARTIFACT_DIR}/$(basename ${BASH_SOURCE[0]})"
 if [ ! -d $test_artifactdir ] ; then
   mkdir -p $test_artifactdir
 fi
+INCLUDES=${INCLUDES:-}
 cleanup(){
   local return_code="$?"
   
@@ -36,6 +37,14 @@ popd
 get_setup_artifacts=false
 export JUNIT_REPORT_OUTPUT="/tmp/artifacts/junit/test-e2e-olm"
 for test in $( find "${current_dir}/testing-olm" -type f -name 'test-*.sh' | sort); do
+  if [ -n $INCLUDES ] ; then
+    if ! echo $test | grep -P -q "$INCLUDES" ; then
+      os::log::info "==============================================================="
+	    os::log::info "excluding e2e $test "
+	    os::log::info "==============================================================="
+      continue
+    fi
+  fi
 	os::log::info "==============================================================="
 	os::log::info "running e2e $test "
 	os::log::info "==============================================================="

--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -15,6 +15,7 @@ ARTIFACT_DIR=${ARTIFACT_DIR:-"$repo_dir/_output"}
 if [ ! -d $ARTIFACT_DIR ] ; then
   mkdir -p $ARTIFACT_DIR
 fi
+CLF_INCLUDES=${CLF_INCLUDES:-}
 
 cleanup(){
   local return_code="$?"
@@ -38,6 +39,14 @@ trap cleanup exit
 
 failed=0
 for dir in $(ls -d $TEST_DIR); do
+  if [ -n "${CLF_INCLUDES}" ] ; then
+    if ! echo $dir | grep -P -q "${CLF_INCLUDES}" ; then
+      os::log::info "==============================================================="
+	    os::log::info "excluding logforwarding $dir "
+	    os::log::info "==============================================================="
+      continue
+    fi
+  fi
   os::log::info "=========================================================="
   os::log::info "Starting test of logforwarding $dir"
   os::log::info "=========================================================="


### PR DESCRIPTION
### Description
This PR modifies Makefile and e2e scripts to allow selectively running tests for cases like the EO that only needs to be gated on the managed ES test

### Links
https://issues.redhat.com/browse/LOG-1034

cc @ewolinetz 