### PR TITLE
Revert "Bug 1915454: Enable deployment on OCP v4.6"

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -11,7 +11,7 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.6-v4.7"
+LABEL com.redhat.openshift.versions="v4.7"
 
 LABEL \
     com.redhat.component="cluster-logging-operator" \


### PR DESCRIPTION
This reverts commit 46dd7a6b0f888b79cd39f37c415272897f20c2d2.


cc @vimalk78 

ref https://bugzilla.redhat.com/show_bug.cgi?id=1915454