### PR TITLE
Bug 1889595: Fix regex for correct formatting if log message contains 'stderr|stdout'

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Generating fluentd config", func() {
       </pattern>
       <pattern>
         format regexp
-        expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+        expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
         time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
         keep_time_key true
       </pattern>
@@ -699,7 +699,7 @@ var _ = Describe("Generating fluentd config", func() {
 				</pattern>
 				<pattern>
 					format regexp
-					expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+					expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
 					time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
 					keep_time_key true
 				</pattern>
@@ -1142,7 +1142,7 @@ var _ = Describe("Generating fluentd config", func() {
 				</pattern>
 				<pattern>
 					format regexp
-					expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+					expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
 					time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
 					keep_time_key true
 				</pattern>
@@ -2033,7 +2033,7 @@ var _ = Describe("Generating fluentd config", func() {
         </pattern>
         <pattern>
           format regexp
-          expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+          expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
           time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
           keep_time_key true
         </pattern>

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             </pattern>
             <pattern>
               format regexp
-              expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+              expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
               time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
               keep_time_key true
             </pattern>
@@ -610,7 +610,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             </pattern>
             <pattern>
               format regexp
-              expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+              expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
               time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
               keep_time_key true
             </pattern>
@@ -1116,7 +1116,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             </pattern>
             <pattern>
               format regexp
-              expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+              expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
               time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
               keep_time_key true
             </pattern>

--- a/pkg/generators/forwarding/fluentd/source_test.go
+++ b/pkg/generators/forwarding/fluentd/source_test.go
@@ -50,7 +50,7 @@ var _ = Describe("generating source", func() {
 			  </pattern>
 			  <pattern>
 				format regexp
-				expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+				expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
 				time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
 				keep_time_key true
 			  </pattern>
@@ -117,7 +117,7 @@ var _ = Describe("generating source", func() {
 				</pattern>
 				<pattern>
 				  format regexp
-				  expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+				  expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
 				  time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
 				  keep_time_key true
 				</pattern>
@@ -243,7 +243,7 @@ var _ = Describe("generating source", func() {
 				  </pattern>
 				  <pattern>
 					format regexp
-					expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+					expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
 					time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
 					keep_time_key true
 				  </pattern>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -481,7 +481,7 @@ const inputSourceContainerTemplate = `{{- define "inputSourceContainerTemplate" 
     </pattern>
     <pattern>
       format regexp
-      expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+      expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
       time_format '%Y-%m-%dT%H:%M:%S.%N%:z'
       keep_time_key true
     </pattern>

--- a/test/functional/logforwarding/message_format_test.go
+++ b/test/functional/logforwarding/message_format_test.go
@@ -144,4 +144,39 @@ var _ = Describe("[LogForwarding] Functional tests for message format", func() {
 		Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 	})
 
+	It("should parse application log format correctly if log message contains 'stdout','stderr' (Bug 1889595)", func() {
+
+		// Log message data
+		message := "Functional test stdout stderr message "
+		timestamp := "2020-11-04T18:13:59.061892+00:00"
+		nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+
+		// Template expected as output Log
+		var outputLogTemplate = types.ApplicationLog{
+			Timestamp:        nanoTime,
+			Message:          fmt.Sprintf("regex:^%s.*$", message),
+			ViaqIndexName:    "app-write",
+			Level:            "unknown",
+			ViaqMsgID:        "*",
+			PipelineMetadata: templateForAnyCollector,
+			Docker: types.Docker{
+				ContainerID: "*"},
+			Kubernetes: templateForAnyKubernetes,
+		}
+
+		// Write log line as input to fluentd
+		applicationLogLine := fmt.Sprintf("%s stdout F %s $n", timestamp, message)
+		Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 1)).To(BeNil())
+		// Read line from Log Forward output
+		raw, err := framework.ReadApplicationLogsFrom("fluentforward")
+		Expect(err).To(BeNil(), "Expected no errors reading the logs")
+		// Parse log line
+		var logs []types.ApplicationLog
+		err = types.StrictlyParseLogs(raw, &logs)
+		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+		// Compare to expected template
+		outputTestLog := logs[0]
+		Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+	})
+
 })


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Fix regex for correct formatting if log message contains 'stderr|stdout'
Add test for checking 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @jcantrill
/assign @jcantrill 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1889595
