### PR TITLE
Extend timeout waiting for eventrouter to deploy

### DIFF
--- a/hack/eventrouter-template.yaml
+++ b/hack/eventrouter-template.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   name: eventrouter-template
   annotations:


### PR DESCRIPTION
### Description
This PR
* Extend the wait time for the eventrouter to deploy.
* Update how CI provides IMAGE_FORMAT
* Update non CI registry to pull variables

Various CI failures demonstrate via logs the pod is not crashing but test times out waiting for the pod deploy.

Crashes should be resolved by https://github.com/openshift/origin-aggregated-logging/pull/2059

cc @syedriko 