### PR TITLE
[release-4.5] Bug 1927537: LOG-965: remove username and password from fluentd conf

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -945,8 +945,6 @@ var _ = Describe("Generating fluentd config", func() {
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
-						user fluentd
-						password changeme
 
 						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
@@ -990,8 +988,6 @@ var _ = Describe("Generating fluentd config", func() {
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
-						user fluentd
-						password changeme
 
 						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
@@ -1038,8 +1034,6 @@ var _ = Describe("Generating fluentd config", func() {
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
-						user fluentd
-						password changeme
 
 						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
@@ -1083,8 +1077,6 @@ var _ = Describe("Generating fluentd config", func() {
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
-						user fluentd
-						password changeme
 
 						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
@@ -1131,8 +1123,6 @@ var _ = Describe("Generating fluentd config", func() {
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
-						user fluentd
-						password changeme
 
 						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
@@ -1176,8 +1166,6 @@ var _ = Describe("Generating fluentd config", func() {
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
-						user fluentd
-						password changeme
 
 						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
@@ -1224,8 +1212,6 @@ var _ = Describe("Generating fluentd config", func() {
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
-						user fluentd
-						password changeme
 
 						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
@@ -1269,8 +1255,6 @@ var _ = Describe("Generating fluentd config", func() {
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
-						user fluentd
-						password changeme
 
 						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
 						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -77,8 +77,6 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			target_index_key viaq_index_name
 			id_key viaq_msg_id
 			remove_keys viaq_index_name
-			user fluentd
-			password changeme
 
 			client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
 			client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
@@ -122,8 +120,6 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			target_index_key viaq_index_name
 			id_key viaq_msg_id
 			remove_keys viaq_index_name
-			user fluentd
-			password changeme
 
 			client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
 			client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
@@ -186,8 +182,6 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			target_index_key viaq_index_name
 			id_key viaq_msg_id
 			remove_keys viaq_index_name
-			user fluentd
-			password changeme
 
 			type_name _doc
             http_backend typhoeus
@@ -227,8 +221,6 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			target_index_key viaq_index_name
 			id_key viaq_msg_id
 			remove_keys viaq_index_name
-			user fluentd
-			password changeme
 
 			type_name _doc
 			retry_tag retry_other_elasticsearch

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -594,8 +594,6 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
   target_index_key viaq_index_name
   id_key viaq_msg_id
   remove_keys viaq_index_name
-  user fluentd
-  password changeme
 {{- if .Target.Secret }}
   client_key '{{ .SecretPath "tls.key"}}'
   client_cert '{{ .SecretPath "tls.crt"}}'


### PR DESCRIPTION
### Description
Remove from fluentd configuration the default username and password

/cc @vparfonov 
/assign @jcantrill 

### Links
- Depending on PR(s): https://github.com/openshift/cluster-logging-operator/pull/802
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1927537
- JIRA: https://issues.redhat.com/browse/LOG-965