### PR TITLE
LOG-1143: fix using spec'd secret in config instead of output name

### DIFF
--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -272,7 +272,11 @@ func (engine *ConfigGenerator) generateOutputLabelBlocks(outputs []logging.Outpu
 		default:
 			return nil, fmt.Errorf("Unknown output type: %v", output.Type)
 		}
-		conf, err := newOutputLabelConf(engine.Template, engine.storeTemplate, output, secrets[output.Name], outputConf)
+		var secret *corev1.Secret
+		if output.Secret != nil {
+			secret = secrets[output.Secret.Name]
+		}
+		conf, err := newOutputLabelConf(engine.Template, engine.storeTemplate, output, secret, outputConf)
 		if err != nil {
 			return nil, fmt.Errorf("generating fluentd output label: %v", err)
 		}

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 				},
 			}
 			secrets = map[string]*corev1.Secret{
-				"secureforward-receiver": {
+				outputs[0].Secret.Name: {
 					Data: map[string][]byte{
 						"shared_key":    []byte("my-key"),
 						"tls.crt":       []byte("my-tls"),
@@ -48,7 +48,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 		})
 
 		It("should skip missing secrets in the config", func() {
-			data := secrets["secureforward-receiver"].Data
+			data := secrets["my-infra-secret"].Data
 			delete(data, "shared_key")
 			delete(data, "tls.key")
 			results, err := generator.generateOutputLabelBlocks(outputs, secrets, nil)


### PR DESCRIPTION
### Description
fix using the CLF spec'd secret instead of assuming its the same as the output name

/cc @igor-karpukhin @vimalk78 
/assign @alanconway 


### Links
https://issues.redhat.com/browse/LOG-1143