### PR TITLE
Bug 1928949: Write to default logstore when legacy forwarding enabled

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -25,8 +25,12 @@ const (
 	MasterCASecretName  = "master-certs"
 	CollectorSecretName = "fluentd"
 
-	/* #nosec - suppressing rule G101 */
-	KibanaSessionSecretName = "kibana-session-secret"
+	// Disable gosec linter, complains "possible hard-coded secret"
+	CollectorSecretsDir     = "/var/run/ocp-collector/secrets" //nolint:gosec
+	KibanaSessionSecretName = "kibana-session-secret"          //nolint:gosec
+
+	LegacySecureforward = "_LEGACY_SECUREFORWARD"
+	LegacySyslog        = "_LEGACY_SYSLOG"
 )
 
 var ReconcileForGlobalProxyList = []string{FluentdTrustedCAName}

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -546,18 +546,6 @@ const sourceToPipelineCopyTemplate = `{{- define "sourceToPipelineCopyTemplate" 
       @label {{labelName $pipelineLabel}}
     </store>
 {{- end }}
-{{ if .IncludeLegacySecureForward }}
-    <store>
-      @type relabel
-      @label @_LEGACY_SECUREFORWARD
-    </store>
-{{- end }}
-{{ if .IncludeLegacySyslog }}
-    <store>
-      @type relabel
-      @label @_LEGACY_SYSLOG
-    </store>
-{{- end }}
   </match>
 </label>
 {{- end}}`

--- a/pkg/k8shandler/clusterloggingrequest.go
+++ b/pkg/k8shandler/clusterloggingrequest.go
@@ -21,6 +21,15 @@ type ClusterLoggingRequest struct {
 
 	// ForwarderSpec is the normalized and sanitized logforwarder spec
 	ForwarderSpec logging.ClusterLogForwarderSpec
+
+	// OutputSecrets are retrieved during validation and used for generation.
+	OutputSecrets map[string]*v1.Secret
+
+	//FnIncludeLegacyForward function to allow override for internal use
+	FnIncludeLegacyForward func() bool
+
+	//fnIncludeLegacySyslog function to allow override for internal use
+	FnIncludeLegacySyslog func() bool
 }
 
 func (clusterRequest *ClusterLoggingRequest) IncludesManagedStorage() bool {

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -181,6 +181,9 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateFluentdPrometheusRule
 // includeLegacyForwardConfig to address Bug 1782566.
 // To be removed when legacy forwarding is unsupported
 func (clusterRequest *ClusterLoggingRequest) includeLegacyForwardConfig() bool {
+	if clusterRequest.FnIncludeLegacyForward != nil {
+		return clusterRequest.FnIncludeLegacySyslog()
+	}
 	config := &v1.ConfigMap{
 		Data: map[string]string{},
 	}
@@ -197,6 +200,9 @@ func (clusterRequest *ClusterLoggingRequest) includeLegacyForwardConfig() bool {
 // includeLegacySyslogConfig to address Bug 1799024.
 // To be removed when legacy syslog is no longer supported.
 func (clusterRequest *ClusterLoggingRequest) includeLegacySyslogConfig() bool {
+	if clusterRequest.FnIncludeLegacySyslog != nil {
+		return clusterRequest.FnIncludeLegacySyslog()
+	}
 	config := &v1.ConfigMap{
 		Data: map[string]string{},
 	}

--- a/pkg/k8shandler/forwarding.go
+++ b/pkg/k8shandler/forwarding.go
@@ -86,11 +86,16 @@ func (clusterRequest *ClusterLoggingRequest) NormalizeForwarder() (*logging.Clus
 	if len(clusterRequest.ForwarderSpec.Pipelines) == 0 {
 		if clusterRequest.Cluster.Spec.LogStore != nil && clusterRequest.Cluster.Spec.LogStore.Type == logging.LogStoreTypeElasticsearch {
 			log.V(2).Info("ClusterLogForwarder forwarding to default store")
-			clusterRequest.ForwarderSpec.Pipelines = []logging.PipelineSpec{
-				{
-					InputRefs:  []string{logging.InputNameApplication, logging.InputNameInfrastructure},
-					OutputRefs: []string{logging.OutputNameDefault},
-				},
+			defaultPipeline := logging.PipelineSpec{
+				InputRefs:  []string{logging.InputNameApplication, logging.InputNameInfrastructure},
+				OutputRefs: []string{logging.OutputNameDefault},
+			}
+			clusterRequest.ForwarderSpec.Pipelines = []logging.PipelineSpec{defaultPipeline}
+			if clusterRequest.includeLegacySyslogConfig() {
+				defaultPipeline.OutputRefs = append(defaultPipeline.OutputRefs, constants.LegacySyslog)
+			}
+			if clusterRequest.includeLegacyForwardConfig() {
+				defaultPipeline.OutputRefs = append(defaultPipeline.OutputRefs, constants.LegacySecureforward)
 			}
 			// Continue with normalization to fill out spec and status.
 		} else {


### PR DESCRIPTION
(cherry picked from commit 1597789cd86de024c3cb50485a6d501c0e374ff3)

### Description
This PR fixes:

* forwarding logs to the managed store and legacy forwarding
* maintains writing to the legacy store when no managed store is defined

/cc @alanconway @igor-karpukhin @vimalk78 
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->
### Links
* 4.6 backport of https://github.com/openshift/cluster-logging-operator/pull/879
* https://bugzilla.redhat.com/show_bug.cgi?id=1928949
