### PR TITLE
Revert "LOG-1143: fix using spec'd secret in config instead of output…

### DIFF
--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -272,11 +272,7 @@ func (engine *ConfigGenerator) generateOutputLabelBlocks(outputs []logging.Outpu
 		default:
 			return nil, fmt.Errorf("Unknown output type: %v", output.Type)
 		}
-		var secret *corev1.Secret
-		if output.Secret != nil {
-			secret = secrets[output.Secret.Name]
-		}
-		conf, err := newOutputLabelConf(engine.Template, engine.storeTemplate, output, secret, outputConf)
+		conf, err := newOutputLabelConf(engine.Template, engine.storeTemplate, output, secrets[output.Name], outputConf)
 		if err != nil {
 			return nil, fmt.Errorf("generating fluentd output label: %v", err)
 		}

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 				},
 			}
 			secrets = map[string]*corev1.Secret{
-				outputs[0].Secret.Name: {
+				"secureforward-receiver": {
 					Data: map[string][]byte{
 						"shared_key":    []byte("my-key"),
 						"tls.crt":       []byte("my-tls"),
@@ -48,7 +48,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 		})
 
 		It("should skip missing secrets in the config", func() {
-			data := secrets["my-infra-secret"].Data
+			data := secrets["secureforward-receiver"].Data
 			delete(data, "shared_key")
 			delete(data, "tls.key")
 			results, err := generator.generateOutputLabelBlocks(outputs, secrets, nil)


### PR DESCRIPTION
Description
This PR reverts the original PR #895 because the original issue did not exist as it was mis-identifed.

Links
https://issues.redhat.com/browse/LOG-1143

cc @anpingli @alanconway @vimalk78