### PR TITLE
Bug 1892511: Renamed level field in k8s/openshift audit logs

### DIFF
--- a/must-gather/collection-scripts/gather_collection_resources
+++ b/must-gather/collection-scripts/gather_collection_resources
@@ -50,14 +50,19 @@ echo "Gathering data for collection component"
 mkdir -p $collector_folder
 
 echo "-- Retrieving configmaps"
-oc -n $NAMESPACE extract configmap/fluentd --to=$collector_folder ||:
-oc -n $NAMESPACE extract configmap/secure-forward --to=$collector_folder ||:
+mkdir -p $collector_folder/cm/fluentd
+oc -n $NAMESPACE extract configmap/fluentd --to=$collector_folder/cm/fluentd
+mkdir -p $collector_folder/cm/secure-forward
+oc -n $NAMESPACE extract configmap/secure-forward --to=$collector_folder/cm/secure-forward
+mkdir -p $collector_folder/cm/syslog
+oc -n $NAMESPACE extract configmap/syslog --to=$collector_folder/cm/syslog
 
 echo "-- Checking Collector health"
 pods="$(oc -n $NAMESPACE get pods -l logging-infra=fluentd -o jsonpath={.items[*].metadata.name})"
 for pod in $pods
 do
     echo "---- Collector pod: $pod"
+    oc -n $NAMESPACE describe pod/$pod > $collector_folder/$pod.describe 2>&1
     get_env $pod $collector_folder "$NAMESPACE"
     check_collector_connectivity $pod
     check_collector_persistence $pod

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -362,14 +362,20 @@ var _ = Describe("Generating fluentd config", func() {
       remove_keys req,res,msg,name,level,v,pid,err
     </filter>
   
-    <filter k8s-audit.log**>
-      @type record_transformer
-      enable_ruby
-      <record>
-        k8s_audit_level ${record['level']}
-        level info
-      </record>
-    </filter>
+	<filter k8s-audit.log**>
+	  @type record_modifier
+	  <record>
+		k8s_audit_level ${record['level']}
+		level info
+	  </record>
+	</filter>
+	<filter openshift-audit.log**>
+	  @type record_modifier
+	  <record>
+		openshift_audit_level ${record['level']}
+		level info
+	  </record>
+	</filter>
   
     <filter **>
       @type viaq_data_model
@@ -879,11 +885,17 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 
 				<filter k8s-audit.log**>
-				  @type record_transformer
-				  enable_ruby
+     			  @type record_modifier
 				  <record>
 				    k8s_audit_level ${record['level']}
 				    level info
+				  </record>
+				</filter>
+				<filter openshift-audit.log**>
+				  @type record_modifier
+				  <record>
+                    openshift_audit_level ${record['level']}
+					level info
 				  </record>
 				</filter>
 
@@ -1363,11 +1375,17 @@ var _ = Describe("Generating fluentd config", func() {
 				</filter>
 
 				<filter k8s-audit.log**>
-				  @type record_transformer
-				  enable_ruby
+				  @type record_modifier
 				  <record>
-				    k8s_audit_level ${record['level']}
-				    level info
+					k8s_audit_level ${record['level']}
+					level info
+				  </record>
+				</filter>				  
+				<filter openshift-audit.log**>
+				  @type record_modifier
+				  <record>
+					openshift_audit_level ${record['level']}
+					level info
 				  </record>
 				</filter>
 
@@ -2213,14 +2231,20 @@ var _ = Describe("Generating fluentd config", func() {
         remove_keys req,res,msg,name,level,v,pid,err
       </filter>
     
-      <filter k8s-audit.log**>
-        @type record_transformer
-	enable_ruby
-        <record>
-          k8s_audit_level ${record['level']}
-          level info
-        </record>
-      </filter>
+	  <filter k8s-audit.log**>
+		@type record_modifier
+		<record>
+		  k8s_audit_level ${record['level']}
+		  level info
+		</record>
+	  </filter>
+	  <filter openshift-audit.log**>
+		@type record_modifier
+		<record>
+		  openshift_audit_level ${record['level']}
+		  level info
+		</record>
+	  </filter>
 
       <filter **>
         @type viaq_data_model

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -348,14 +348,20 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             remove_keys req,res,msg,name,level,v,pid,err
           </filter>
 
-          <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
-            <record>
-              k8s_audit_level ${record['level']}
-              level info
-            </record>
-          </filter>
+		  <filter k8s-audit.log**>
+			@type record_modifier
+			<record>
+			  k8s_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
+		  <filter openshift-audit.log**>
+			@type record_modifier
+			<record>
+			  openshift_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
 
           <filter **>
             @type viaq_data_model
@@ -847,14 +853,20 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             remove_keys req,res,msg,name,level,v,pid,err
           </filter>
 
-          <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
-            <record>
-              k8s_audit_level ${record['level']}
-              level info
-            </record>
-          </filter>
+		  <filter k8s-audit.log**>
+			@type record_modifier
+			<record>
+			  k8s_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
+		  <filter openshift-audit.log**>
+			@type record_modifier
+			<record>
+			  openshift_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
 
           <filter **>
             @type viaq_data_model
@@ -1348,14 +1360,20 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             remove_keys req,res,msg,name,level,v,pid,err
           </filter>
 
-          <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
-            <record>
-              k8s_audit_level ${record['level']}
-              level info
-            </record>
-          </filter>
+		  <filter k8s-audit.log**>
+			@type record_modifier
+			<record>
+			  k8s_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
+		  <filter openshift-audit.log**>
+			@type record_modifier
+			<record>
+			  openshift_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
 
           <filter **>
             @type viaq_data_model

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -262,10 +262,16 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
   </filter>
 
   <filter k8s-audit.log**>
-    @type record_transformer
-    enable_ruby
+    @type record_modifier
     <record>
       k8s_audit_level ${record['level']}
+      level info
+    </record>
+  </filter>
+  <filter openshift-audit.log**>
+    @type record_modifier
+    <record>
+      openshift_audit_level ${record['level']}
       level info
     </record>
   </filter>

--- a/pkg/k8shandler/certificates_test.go
+++ b/pkg/k8shandler/certificates_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Reconciling", func() {
 			Expect(client.Get(context.TODO(), key, secret)).Should(Succeed())
 
 			Expect(os.RemoveAll(utils.GetWorkingDir())).To(Succeed())
-			clusterRequest.CreateOrUpdateCertificates()
+			_ = clusterRequest.CreateOrUpdateCertificates()
 
 			updatedsecret := &corev1.Secret{}
 			Expect(client.Get(context.TODO(), key, updatedsecret)).Should(Succeed())

--- a/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
@@ -48,6 +48,24 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 	hostname ${hostname}
 	facility user
 	severity debug
+	use_record true
+	payload_key message
+	<buffer>
+	  @type file
+	  path '/var/lib/fluentd/syslogout'
+	  flush_mode interval
+	  flush_interval 1s
+	  flush_thread_count 2
+	  flush_at_shutdown true
+	  retry_type exponential_backoff
+	  retry_wait 1s
+	  retry_max_interval 300s
+	  retry_forever true
+	  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+	  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }"
+	  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+	  overflow_action block
+	</buffer>	
 </store>
 					`
 					//create configmap syslog/"syslog.conf"
@@ -88,6 +106,9 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 	hostname ${hostname}
 	facility user
 	severity debug
+	use_record true
+	payload_key message
+	#no <buffer> section because @syslog plugin does not support buffering	
 </store>
 					`
 					//create configmap syslog/"syslog.conf"
@@ -95,7 +116,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 						Fail(fmt.Sprintf("Unable to create legacy syslog.conf configmap: %v", err))
 					}
 
-					components := []helpers.LogComponentType{helpers.ComponentTypeCollector, helpers.ComponentTypeStore}
+					components := []helpers.LogComponentType{helpers.ComponentTypeCollector}
 					cr := helpers.NewClusterLogging(components...)
 					if err := e2e.CreateClusterLogging(cr); err != nil {
 						Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))


### PR DESCRIPTION
### Description

Cherry pick of 8d0b1af270c9852dae1438da3dafb656f86ae1f9  (PR https://github.com/openshift/cluster-logging-operator/pull/815) onto release-4.6


/cc @jcantrill @igor-karpukhin 
/assign @jcantrill 



### Links
- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1892511
