### PR TITLE
Add 'downstream' PR label for Dockerfile changes

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,11 +5,16 @@ approvers:
   - alanconway
 reviewers:
   - jcantrill
-  - ewolinetz
-  - lukas-vlcek
   - alanconway
   - igor-karpukhin
   - vimalk78
   - syedriko
-  - periklis
+  - vparfonov
+  - eranra
+  - pmoogi-redhat
+  - ajaygupta978
 component: "Logging"
+filters:
+  "Dockerfile":   # matches Dockerfile, Dockerfile.rhel8, bundle.Dockerfile
+    labels:
+      - downstream


### PR DESCRIPTION
### Description
Downstream images do not get built from upstream Dockerfiles. So we need a mechanism to trace changes to upstream Dockerfiles to decide if a corresponding change is needed in Downstream Dockerfile.
Any PR which changes a file matching the go regex `Dockerfile` will be added with label `downstream`.
If a change is required in downstream Dockerfile, the reviewer should ensure same change gets done in Downstream, either by putting a hold on the upstream PR, or by any other means.

/cc @jcantrill 
/assign @jcantrill 

/cherry-pick release-5.0
