### PR TITLE
Fix catalog-deploy script

### DIFF
--- a/olm_deploy/scripts/catalog-deploy.sh
+++ b/olm_deploy/scripts/catalog-deploy.sh
@@ -1,13 +1,13 @@
 #!/bin/sh 
 set -eou pipefail
-OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-4.7}
-export IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=${IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:cluster-logging-operator-registry}
-export IMAGE_CLUSTER_LOGGING_OPERATOR=${IMAGE_CLUSTER_LOGGING_OPERATOR:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:cluster-logging-operator}
-export IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:elasticsearch-proxy}
-export IMAGE_LOGGING_CURATOR5=${IMAGE_LOGGING_CURATOR5:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:logging-curator5}
-export IMAGE_LOGGING_FLUENTD=${IMAGE_LOGGING_FLUENTD:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:logging-fluentd}
-export IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:logging-elasticsearch6}
-export IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-registry.svc.ci.openshift.org/ocp/${OPENSHIFT_VERSION}:logging-kibana6}
+LOGGING_VERSION=${LOGGING_VERSION:-5.0}
+export IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=${IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:cluster-logging-operator-registry}
+export IMAGE_CLUSTER_LOGGING_OPERATOR=${IMAGE_CLUSTER_LOGGING_OPERATOR:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:cluster-logging-operator}
+export IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:elasticsearch-proxy}
+export IMAGE_LOGGING_CURATOR5=${IMAGE_LOGGING_CURATOR5:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:logging-curator5}
+export IMAGE_LOGGING_FLUENTD=${IMAGE_LOGGING_FLUENTD:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:logging-fluentd}
+export IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:logging-elasticsearch6}
+export IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:logging-kibana6}
 
 CLUSTER_LOGGING_OPERATOR_NAMESPACE=${CLUSTER_LOGGING_OPERATOR_NAMESPACE:-openshift-logging}
 


### PR DESCRIPTION

### Description
  From 5.0 onwards, the logging CI images changed pull spec to
    registry.ci.openshift.org/logging/5.0:cluster-logging-operator etc
  The script is changed to reflect this.


/cc @pmoogi-redhat 
/assign @jcantrill 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->


