### PR TITLE
use image env vars instead of IMAGE_FORMAT

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -2,7 +2,7 @@
 # with the cluster logging operator source so we can use all the
 # test scripts to deploy the elasticsearch operator and then
 # test the clusterlogging operator
-FROM registry.svc.ci.openshift.org/ocp/4.7:elasticsearch-operator-src
+FROM registry.svc.ci.openshift.org/ocp/5.0:elasticsearch-operator-src
 ADD . /go/src/github.com/openshift/cluster-logging-operator
 WORKDIR /go/src/github.com/openshift/cluster-logging-operator
 RUN mkdir -p /go/src/github.com/openshift/cluster-logging-operator/bin/

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -3,7 +3,7 @@ BASE_COLLECTION_PATH="${1:-/must-gather}"
 mkdir -p "${BASE_COLLECTION_PATH}"
 
 # resource list
-resources=()
+resources=(ns/openshift-operator-lifecycle-manager)
 
 # cluster logging operator namespace
 resources+=(ns/openshift-logging)

--- a/olm_deploy/scripts/catalog-deploy.sh
+++ b/olm_deploy/scripts/catalog-deploy.sh
@@ -1,34 +1,19 @@
-#!/bin/sh 
+#!/bin/sh
 set -eou pipefail
 LOGGING_VERSION=${LOGGING_VERSION:-5.0}
-export IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=${IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:cluster-logging-operator-registry}
-export IMAGE_CLUSTER_LOGGING_OPERATOR=${IMAGE_CLUSTER_LOGGING_OPERATOR:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:cluster-logging-operator}
-export IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:elasticsearch-proxy}
-export IMAGE_LOGGING_CURATOR5=${IMAGE_LOGGING_CURATOR5:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:logging-curator5}
-export IMAGE_LOGGING_FLUENTD=${IMAGE_LOGGING_FLUENTD:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:logging-fluentd}
-export IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:logging-elasticsearch6}
-export IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-registry.ci.openshift.org/logging/${LOGGING_VERSION}:logging-kibana6}
+LOGGING_IS=${LOGGING_IS:-logging}
+export IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=${IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:cluster-logging-operator-registry}
+export IMAGE_CLUSTER_LOGGING_OPERATOR=${IMAGE_CLUSTER_LOGGING_OPERATOR:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:cluster-logging-operator}
+export IMAGE_LOGGING_CURATOR5=${IMAGE_LOGGING_CURATOR5:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:logging-curator5}
+export IMAGE_LOGGING_FLUENTD=${IMAGE_LOGGING_FLUENTD:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:logging-fluentd}
 
 CLUSTER_LOGGING_OPERATOR_NAMESPACE=${CLUSTER_LOGGING_OPERATOR_NAMESPACE:-openshift-logging}
-
-if [ -n "${IMAGE_FORMAT:-}" ] ; then
-  export IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=$(echo $IMAGE_FORMAT | sed -e "s,\${component},cluster-logging-operator-registry,")
-  export IMAGE_CLUSTER_LOGGING_OPERATOR=$(echo $IMAGE_FORMAT | sed -e "s,\${component},cluster-logging-operator,")
-  export IMAGE_OAUTH_PROXY=$(echo $IMAGE_FORMAT | sed -e "s,\${component},oauth-proxy,")
-  export IMAGE_LOGGING_CURATOR5=$(echo $IMAGE_FORMAT | sed -e "s,\${component},logging-curator5,")
-  export IMAGE_LOGGING_FLUENTD=$(echo $IMAGE_FORMAT | sed -e "s,\${component},logging-fluentd,")
-  export IMAGE_ELASTICSEARCH6=$(echo $IMAGE_FORMAT | sed -e "s,\${component},logging-elasticsearch6,")
-  export IMAGE_LOGGING_KIBANA6=$(echo $IMAGE_FORMAT | sed -e "s,\${component},logging-kibana6,")
-fi
 
 echo "Deploying operator catalog with bundle using images: "
 echo "cluster logging operator registry: ${IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY}"
 echo "cluster logging operator: ${IMAGE_CLUSTER_LOGGING_OPERATOR}"
-echo "oauth proxy: ${IMAGE_OAUTH_PROXY}"
 echo "curator5: ${IMAGE_LOGGING_CURATOR5}"
 echo "fluentd: ${IMAGE_LOGGING_FLUENTD}"
-echo "elastic6: ${IMAGE_ELASTICSEARCH6}"
-echo "kibana: ${IMAGE_LOGGING_KIBANA6}"
 
 echo "In namespace: ${CLUSTER_LOGGING_OPERATOR_NAMESPACE}"
 

--- a/olm_deploy/scripts/registry-init.sh
+++ b/olm_deploy/scripts/registry-init.sh
@@ -23,7 +23,7 @@ sed -i "s,quay.io/openshift/origin-logging-elasticsearch6:latest,${IMAGE_ELASTIC
 sed -i "s,quay.io/openshift/origin-logging-kibana6:latest,${IMAGE_LOGGING_KIBANA6}," /manifests/*/*clusterserviceversion.yaml
 
 # update the manifest to pull always the operator image for non-CI environments
-if [ -z "${IMAGE_FORMAT:-}" ] ; then
+if [ "${OPENSHIFT_CI:-false}" == "false" ] ; then
     echo -e "Set operator deployment's imagePullPolicy to 'Always'\n\n"
     sed -i 's,imagePullPolicy:\ IfNotPresent,imagePullPolicy:\ Always,' /manifests/*/*clusterserviceversion.yaml
 fi


### PR DESCRIPTION
### Description
This PR

removes IMAGE_FORMAT in deference to images defined via env vars
IMAGE_FORMAT has been deprecated for over a year
CI was modified to tag in image refs via "pipelines" that are consumable by env vars
update logging imagestream
remove unused images
/cc @vimalk78 @igor-karpukhin

backport of https://github.com/openshift/cluster-logging-operator/pull/919