### PR TITLE
Bug 1929420: ClusterLogForwarder with Output.Secret causes fluentd crash loop

### DIFF
--- a/internal/cmd/forwarder-generator/main.go
+++ b/internal/cmd/forwarder-generator/main.go
@@ -64,7 +64,7 @@ func main() {
 	spec, _ := clRequest.NormalizeForwarder()
 	tunings := &logging.ForwarderSpec{}
 
-	generatedConfig, err := generator.Generate(spec, tunings)
+	generatedConfig, err := generator.Generate(spec, nil, tunings)
 	if err != nil {
 		log.Error(err, "Unable to generate log configuration")
 		os.Exit(1)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,6 +6,8 @@ const (
 	// global proxy / trusted ca bundle consts
 	ProxyName                  = "cluster"
 	TrustedCABundleKey         = "ca-bundle.crt"
+	ClientCertKey              = "tls.crt"
+	ClientPrivateKey           = "tls.key"
 	InjectTrustedCABundleLabel = "config.openshift.io/inject-trusted-cabundle"
 	TrustedCABundleMountFile   = "tls-ca-bundle.pem"
 	TrustedCABundleMountDir    = "/etc/pki/ca-trust/extracted/pem/"

--- a/pkg/generators/factory.go
+++ b/pkg/generators/factory.go
@@ -3,6 +3,7 @@ package generators
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 )
 
@@ -18,7 +19,13 @@ func New(name string, addFunctions *template.FuncMap, templates ...string) (*Gen
 	for i, s := range templates {
 		tmpl, err = tmpl.Parse(s)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing %q template %v: %s", name, i, err)
+			// Include the first line containing the template name in the error message.
+			templateName := "unknown"
+			lines := strings.SplitN(s, "\n", 2)
+			if len(lines) > 0 {
+				templateName = lines[0]
+			}
+			return nil, fmt.Errorf("Error parsing %v template %v %q: %s", name, i, templateName, err)
 		}
 	}
 	return &Generator{tmpl}, nil

--- a/pkg/generators/forwarding/factory.go
+++ b/pkg/generators/forwarding/factory.go
@@ -2,6 +2,7 @@ package forwarding
 
 import (
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/pkg/generators/forwarding/fluentd"
@@ -21,5 +22,5 @@ func NewConfigGenerator(collector logging.LogCollectionType, includeLegacyForwar
 type ConfigGenerator interface {
 
 	//Generate the config
-	Generate(clfSpec *logging.ClusterLogForwarderSpec, fwSpec *logging.ForwarderSpec) (string, error)
+	Generate(clfSpec *logging.ClusterLogForwarderSpec, secrets map[string]*corev1.Secret, fwSpec *logging.ForwarderSpec) (string, error)
 }

--- a/pkg/generators/forwarding/fluentd/fluent_conf.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf.go
@@ -2,6 +2,9 @@ package fluentd
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -23,10 +26,11 @@ type outputLabelConf struct {
 	hints           sets.String
 	storeTemplate   string
 	URL             *url.URL
+	Secret          *corev1.Secret
 }
 
-func newOutputLabelConf(t *template.Template, storeTemplate string, target logging.OutputSpec, config *logging.ForwarderSpec, fluentTags ...string) (*outputLabelConf, error) {
-	u, err := url.ParseAbsoluteOrEmpty(target.URL)
+func newOutputLabelConf(t *template.Template, storeTemplate string, target logging.OutputSpec, secret *corev1.Secret, config *logging.ForwarderSpec, fluentTags ...string) (*outputLabelConf, error) {
+	u, err := url.Parse(target.URL)
 	if err != nil {
 		return nil, fmt.Errorf("url field: %v", err)
 	}
@@ -41,6 +45,7 @@ func newOutputLabelConf(t *template.Template, storeTemplate string, target loggi
 		fluentTags:      sets.NewString(fluentTags...),
 		storeTemplate:   storeTemplate,
 		URL:             u,
+		Secret:          secret,
 	}, nil
 }
 
@@ -66,24 +71,38 @@ func (conf *outputLabelConf) Port() string {
 	return p
 }
 
-// Protocol returns the insecure base protocol name used in fluentd configuration.
-func (conf *outputLabelConf) Protocol() string {
-	protocol := strings.ToLower(conf.URL.Scheme)
-	switch protocol {
-	case "tls":
-		return "tcp" // Fluentd uses "tcp" for TLS connections, TLS is dealt with elsewhere.
-	case "udps":
-		return "udp"
-	default:
-		return protocol
-	}
-}
+// Protocol returns the insecure protocol name used in fluentd configuration.
+func (conf *outputLabelConf) Protocol() string { return url.PlainScheme(conf.URL.Scheme) }
 
 func (conf *outputLabelConf) BufferPath() string {
 	return fmt.Sprintf("/var/lib/fluentd/%s", conf.StoreID())
 }
+
+func (conf *outputLabelConf) IsTLS() bool {
+	return url.IsTLSScheme(conf.URL.Scheme) || conf.Secret != nil
+}
+
 func (conf *outputLabelConf) SecretPath(file string) string {
-	return fmt.Sprintf("/var/run/ocp-collector/secrets/%s/%s", conf.Target.Secret.Name, file)
+	if conf.Target.Secret != nil {
+		return filepath.Join(constants.CollectorSecretsDir, conf.Target.Secret.Name, file)
+	}
+	return ""
+}
+
+func (conf *outputLabelConf) SecretPathIfFound(file string) string {
+	if conf.Secret != nil {
+		if _, ok := conf.Secret.Data[file]; ok {
+			return conf.SecretPath(file)
+		}
+	}
+	return ""
+}
+
+func (conf *outputLabelConf) GetSecret(key string) string {
+	if conf.Secret != nil {
+		return string(conf.Secret.Data[key])
+	}
+	return ""
 }
 
 func (conf *outputLabelConf) LabelName() string {

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Generating fluentd config", func() {
 				},
 			},
 		}
-		results, err := generator.Generate(forwarder, forwarderSpec)
+		results, err := generator.Generate(forwarder, nil, forwarderSpec)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(`
   ## CLO GENERATED CONFIGURATION ###
@@ -627,7 +627,7 @@ var _ = Describe("Generating fluentd config", func() {
 				},
 			},
 		}
-		results, err := generator.Generate(forwarder, forwarderSpec)
+		results, err := generator.Generate(forwarder, nil, forwarderSpec)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(`
 			## CLO GENERATED CONFIGURATION ### 
@@ -1046,7 +1046,7 @@ var _ = Describe("Generating fluentd config", func() {
 	})
 
 	It("should produce well formed fluent.conf", func() {
-		results, err := generator.Generate(forwarder, forwarderSpec)
+		results, err := generator.Generate(forwarder, nil, forwarderSpec)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(`
 			## CLO GENERATED CONFIGURATION ### 
@@ -1935,7 +1935,7 @@ var _ = Describe("Generating fluentd config", func() {
 		func(yamlSpec, wantFluentdConf string) {
 			var spec logging.ClusterLogForwarderSpec
 			Expect(yaml.Unmarshal([]byte(yamlSpec), &spec)).To(Succeed())
-			gotFluentdConf, err := generator.Generate(&spec, nil)
+			gotFluentdConf, err := generator.Generate(&spec, nil, nil)
 			Expect(err).To(Succeed())
 			Expect(wantFluentdConf).To(EqualTrimLines(gotFluentdConf))
 		},

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 		})
 
 		It("should produce well formed output label config", func() {
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(results[0]).To(EqualTrimLines(`<label @ONCLUSTER_ELASTICSEARCH>
 	<match retry_oncluster_elasticsearch>
@@ -174,7 +174,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			}
 		})
 		It("should produce well formed output label config", func() {
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(results[0]).To(EqualTrimLines(`<label @OTHER_ELASTICSEARCH>
 	<match retry_other_elasticsearch>

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -3,6 +3,7 @@ package fluentd
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
@@ -11,10 +12,9 @@ import (
 var _ = Describe("Generating fluentd secure forward output store config blocks", func() {
 
 	var (
-		err           error
-		outputs       []logging.OutputSpec
-		forwarderSpec *logging.ForwarderSpec
-		generator     *ConfigGenerator
+		err       error
+		outputs   []logging.OutputSpec
+		generator *ConfigGenerator
 	)
 	BeforeEach(func() {
 		generator, err = NewConfigGenerator(false, false, true)
@@ -22,6 +22,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 	})
 
 	Context("for a secure endpoint", func() {
+		var secrets map[string]*corev1.Secret
 		BeforeEach(func() {
 			outputs = []logging.OutputSpec{
 				{
@@ -33,10 +34,106 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 					},
 				},
 			}
+			secrets = map[string]*corev1.Secret{
+				"secureforward-receiver": {
+					Data: map[string][]byte{
+						"shared_key":    []byte("my-key"),
+						"tls.crt":       []byte("my-tls"),
+						"tls.key":       []byte("my-tls-key"),
+						"ca-bundle.crt": []byte("my-bundle"),
+					},
+				},
+			}
+		})
+		It("should skip missing secrets in the config", func() {
+			data := secrets["secureforward-receiver"].Data
+			delete(data, "shared_key")
+			delete(data, "tls.key")
+			results, err := generator.generateOutputLabelBlocks(outputs, secrets, nil)
+			Expect(err).To(BeNil())
+			Expect(len(results)).To(Equal(1))
+			Expect(results[0]).To(EqualTrimLines(`    <label @SECUREFORWARD_RECEIVER>
+      <match **>
+        # https://docs.fluentd.org/v1.0/articles/in_forward
+        @type forward
+    		heartbeat_type none
+        transport tls
+        tls_verify_hostname false
+        tls_version 'TLSv1_2'
+        tls_client_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.crt"
+        tls_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt"
+        <buffer>
+          @type file
+          path '/var/lib/fluentd/secureforward_receiver'
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+          flush_mode interval
+          flush_interval 5s
+          flush_at_shutdown true
+          flush_thread_count 2
+          retry_type exponential_backoff
+          retry_wait 1s
+          retry_max_interval 60s
+          retry_forever true
+          # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+          # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+          # buffer to the remote - default is 'block' because in_tail handles that case
+          overflow_action block
+        </buffer>
+        <server>
+          host es.svc.messaging.cluster.local
+          port 9654
+        </server>
+      </match>
+    </label>
+		`))
+		})
+
+		It("should use insecure mode if no secret", func() {
+			outputs[0].Secret = nil
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, nil)
+			Expect(err).To(BeNil())
+			Expect(len(results)).To(Equal(1))
+			Expect(results[0]).To(EqualTrimLines(`    <label @SECUREFORWARD_RECEIVER>
+      <match **>
+        # https://docs.fluentd.org/v1.0/articles/in_forward
+        @type forward
+    		heartbeat_type none
+        transport tls
+        tls_verify_hostname false
+        tls_version 'TLSv1_2'
+        tls_insecure_mode true
+        <buffer>
+          @type file
+          path '/var/lib/fluentd/secureforward_receiver'
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
+          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
+          flush_mode interval
+          flush_interval 5s
+          flush_at_shutdown true
+          flush_thread_count 2
+          retry_type exponential_backoff
+          retry_wait 1s
+          retry_max_interval 60s
+          retry_forever true
+          # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
+          # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
+          # buffer to the remote - default is 'block' because in_tail handles that case
+          overflow_action block
+        </buffer>
+        <server>
+          host es.svc.messaging.cluster.local
+          port 9654
+        </server>
+      </match>
+    </label>
+		`))
 		})
 
 		It("should produce well formed output label config", func() {
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, secrets, nil)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(`<label @SECUREFORWARD_RECEIVER>
@@ -46,16 +143,16 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 		heartbeat_type none
 		<security>
 			self_hostname "#{ENV['NODE_NAME']}" 
-			shared_key "#{File.open('/var/run/ocp-collector/secrets/my-infra-secret/shared_key') do |f| f.readline end.rstrip}"
+			shared_key "my-key"
 		</security>
 
 		transport tls
 		tls_verify_hostname false
 		tls_version 'TLSv1_2'
 		
-		#tls_client_private_key_path /var/run/ocp-collector/secrets/my-infra-secret/tls.key
-		tls_client_cert_path /var/run/ocp-collector/secrets/my-infra-secret/tls.crt
-		tls_cert_path /var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt
+		tls_client_private_key_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.key"
+		tls_client_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.crt"
+		tls_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt"
 
 		<buffer>
 			@type file
@@ -97,7 +194,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			}
 		})
 		It("should produce well formed output label config", func() {
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, nil)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(`<label @SECUREFORWARD_RECEIVER>

--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 				},
 			}
 
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -73,7 +73,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 				},
 			}
 
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -124,7 +124,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 				},
 			}
 
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -177,7 +177,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 				},
 			}
 
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -199,7 +199,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 				},
 			}
 
-			results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -219,7 +219,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 					},
 				},
 			}
-			_, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			_, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).Should(HaveOccurred())
 		})
 
@@ -231,7 +231,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 					URL:  "not-a-valid-URL",
 				},
 			}
-			_, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+			_, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).Should(HaveOccurred())
 		})
 	})

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -510,7 +510,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         </label>
       `
 
-			results, err := generator.Generate(clfSpec, fwSpec)
+			results, err := generator.Generate(clfSpec, nil, fwSpec)
 			Expect(err).Should(Succeed())
 			Expect(results).To(EqualTrimLines(legacyConf))
 		})
@@ -1011,7 +1011,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         </label>
       `
 
-			results, err := generator.Generate(clfSpec, fwSpec)
+			results, err := generator.Generate(clfSpec, nil, fwSpec)
 			Expect(err).Should(Succeed())
 			Expect(results).To(EqualTrimLines(legacyConf))
 		})
@@ -1530,7 +1530,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         </label>
       `
 
-			results, err := generator.Generate(clfSpec, fwSpec)
+			results, err := generator.Generate(clfSpec, nil, fwSpec)
 			Expect(err).Should(Succeed())
 			Expect(results).To(EqualTrimLines(legacyConf))
 		})

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 				}
 			})
 			It("should produce well formed output label config", func() {
-				results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+				results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 				Expect(err).To(BeNil())
 				Expect(len(results)).To(Equal(1))
 				Expect(results[0]).To(EqualTrimLines(tcpConf))
@@ -93,7 +93,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 				}
 			})
 			It("should produce well formed output label config", func() {
-				results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+				results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 				Expect(err).To(BeNil())
 				Expect(len(results)).To(Equal(1))
 				Expect(results[0]).To(EqualTrimLines(tcpConf))
@@ -111,7 +111,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 				}
 			})
 			It("should produce well formed output label config", func() {
-				results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+				results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 				Expect(err).To(BeNil())
 				Expect(len(results)).To(Equal(1))
 				Expect(results[0]).To(EqualTrimLines(udpConf))
@@ -307,7 +307,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					}
 				})
 				It("should produce well formed output label config", func() {
-					results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 					Expect(err).To(BeNil())
 					Expect(len(results)).To(Equal(1))
 					Expect(results[0]).To(EqualTrimLines(tcpConf))
@@ -327,7 +327,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					}
 				})
 				It("should produce well formed output label config", func() {
-					results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 					Expect(err).To(BeNil())
 					Expect(len(results)).To(Equal(1))
 					Expect(results[0]).To(EqualTrimLines(tcpWithTLSConf))
@@ -347,7 +347,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					}
 				})
 				It("should produce well formed output label config", func() {
-					results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 					Expect(err).To(BeNil())
 					Expect(len(results)).To(Equal(1))
 					Expect(results[0]).To(EqualTrimLines(udpConf))
@@ -367,7 +367,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					}
 				})
 				It("should produce well formed output label config", func() {
-					results, err := generator.generateOutputLabelBlocks(outputs, forwarderSpec)
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 					Expect(err).To(BeNil())
 					Expect(len(results)).To(Equal(1))
 					Expect(results[0]).To(EqualTrimLines(udpWithTLSConf))

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Generating fluentd config", func() {
           </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, defaultForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, defaultForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(esConf))
@@ -260,7 +260,7 @@ var _ = Describe("Generating fluentd config", func() {
           </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, defaultForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, defaultForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(esConf))
@@ -356,7 +356,7 @@ var _ = Describe("Generating fluentd config", func() {
           </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, customForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, customForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(esConf))
@@ -414,7 +414,7 @@ var _ = Describe("Generating fluentd config", func() {
            </match>
          </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, defaultForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, defaultForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(fluentdForwardConf))
@@ -455,7 +455,7 @@ var _ = Describe("Generating fluentd config", func() {
         </match>
       </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, customForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, customForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(fluentdForwardConf))
@@ -525,7 +525,7 @@ var _ = Describe("Generating fluentd config", func() {
           </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, defaultForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, defaultForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(syslogConf))
@@ -578,7 +578,7 @@ var _ = Describe("Generating fluentd config", func() {
           </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, customForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, customForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(syslogConf))
@@ -630,7 +630,7 @@ var _ = Describe("Generating fluentd config", func() {
         </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, defaultForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, defaultForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))
@@ -665,7 +665,7 @@ var _ = Describe("Generating fluentd config", func() {
         </match>
         </label>`
 
-			results, err := generator.generateOutputLabelBlocks(outputs, customForwarderSpec)
+			results, err := generator.generateOutputLabelBlocks(outputs, nil, customForwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0]).To(EqualTrimLines(kafkaConf))

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -621,20 +621,31 @@ const forwardTemplate = `{{- define "forward" -}}
 # https://docs.fluentd.org/v1.0/articles/in_forward
 @type forward
 heartbeat_type none
-{{ if .Target.Secret }}
+{{- with $sharedKey := .GetSecret "shared_key" }}
 <security>
   self_hostname "#{ENV['NODE_NAME']}"
-  shared_key "#{File.open('{{ .SecretPath "shared_key" }}') do |f| f.readline end.rstrip}"
+  shared_key "{{$sharedKey}}"
 </security>
+{{- end}}
+{{- if .IsTLS }}
 
 transport tls
 tls_verify_hostname false
 tls_version 'TLSv1_2'
 
-#tls_client_private_key_path {{ .SecretPath "tls.key"}}
-tls_client_cert_path {{ .SecretPath "tls.crt"}}
-tls_cert_path {{ .SecretPath "ca-bundle.crt"}}
-{{ end -}}
+{{- if not .Secret}}
+tls_insecure_mode true
+{{- end}}
+{{- with $path := .SecretPathIfFound "tls.key"}}
+tls_client_private_key_path "{{$path}}"
+{{- end}}
+{{- with $path := .SecretPathIfFound "tls.crt"}}
+tls_client_cert_path "{{$path}}"
+{{- end}}
+{{- with $path := .SecretPathIfFound "ca-bundle.crt"}}
+tls_cert_path "{{$path}}"
+{{- end}}
+{{- end}}
 
 <buffer>
   @type file

--- a/pkg/k8shandler/forwarding_test.go
+++ b/pkg/k8shandler/forwarding_test.go
@@ -409,6 +409,7 @@ pipelines:
 		}
 		spec, status := request.NormalizeForwarder()
 		Expect(status.Conditions).To(HaveCondition("Ready", true, "", ""), "unexpected "+YAMLString(status))
+		Expect(status.Conditions).NotTo(HaveCondition("Degraded", true, "", ""), "unexpected "+YAMLString(status))
 		Expect(*spec).To(EqualDiff(request.ForwarderSpec))
 	})
 })

--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -7,43 +7,39 @@ import (
 	"strings"
 )
 
-// ParseAbsolute parses an absolute URL - one with non-empty Scheme and Host.
-// Returned errors include the string s.
-func ParseAbsolute(s string) (*URL, error) {
-	if s == "" {
-		return nil, fmt.Errorf("empty")
-	}
-	u, err := url.Parse(s)
+// CheckAbsolute returns an error if Scheme or Host is empty.
+func CheckAbsolute(u *URL) error {
 	switch {
-	case err != nil:
-		return nil, err
+	case u == nil:
+		return fmt.Errorf("empty")
 	case u.Scheme == "":
-		return nil, fmt.Errorf("no scheme: %v", u)
+		return fmt.Errorf("no scheme: %q", u)
 	case u.Host == "":
-		return nil, fmt.Errorf("no host: %v", u)
+		return fmt.Errorf("no host: %q", u)
 	}
-	return u, nil
+	return nil
 }
 
-// ParseAbsoluteOrEmpty is like ParseAbsolute but returns an empty
-// URL rather than an error if s == "".
-func ParseAbsoluteOrEmpty(s string) (*URL, error) {
-	if s == "" {
-		return &url.URL{}, nil
-	} else {
-		return ParseAbsolute(s)
-	}
+var secureSchemes = map[string]string{
+	"https": "http",
+	"udps":  "udp",
+	"tls":   "tcp",
 }
 
 // IsTLSScheme returns true if scheme is recognized as needing TLS security,
-// for example "https", "tls" or "udps"
+// for example "https", "tls"
 func IsTLSScheme(scheme string) bool {
-	switch strings.ToLower(scheme) {
-	case "https", "tls", "udps":
-		return true
-	default:
-		return false
+	return secureSchemes[strings.ToLower(scheme)] != ""
+}
+
+// PlainScheme returns the plain, non-TLS, version of scheme.
+// Example: PlainScheme("https") == "http"
+func PlainScheme(scheme string) string {
+	scheme = strings.ToLower(scheme)
+	if base, ok := secureSchemes[scheme]; ok {
+		return base
 	}
+	return scheme
 }
 
 // Stubs for net/url types/functions so it's not necessary to import it as well.

--- a/test/files/secure-forward.conf
+++ b/test/files/secure-forward.conf
@@ -6,8 +6,9 @@
   </security>
   transport tls
   tls_verify_hostname false           # Set false to ignore server cert hostname.
-
-  tls_cert_path '/etc/ocp-forward/ca-bundle.crt'
+  tls_client_private_key_path /etc/ocp-forward/system.admin.key
+  tls_client_cert_path /etc/ocp-forward/system.admin.crt
+  tls_cert_path /etc/ocp-forward/ca-bundle.crt
   <buffer>
     @type file
     path '/var/lib/fluentd/secureforwardlegacy'

--- a/test/helpers/elasticsearch.go
+++ b/test/helpers/elasticsearch.go
@@ -89,6 +89,10 @@ type ElasticLogStore struct {
 	Framework *E2ETestFramework
 }
 
+func (es *ElasticLogStore) Secret() *corev1.Secret {
+	panic("Method not implemented")
+}
+
 func (es *ElasticLogStore) ApplicationLogs(timeToWait time.Duration) (logs, error) {
 	panic("Method not implemented")
 }

--- a/test/helpers/kafka.go
+++ b/test/helpers/kafka.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"time"
 
@@ -19,7 +20,9 @@ type kafkaReceiver struct {
 	app    *apps.StatefulSet
 	topics []string
 }
-
+func (kr *kafkaReceiver) Secret() *corev1.Secret {
+	panic("Method not implemented")
+}
 func (kr *kafkaReceiver) ApplicationLogs(timeToWait time.Duration) (logs, error) {
 	logs, err := kr.tc.consumedLogs(kr.app.Name, loggingv1.InputNameApplication)
 	if err != nil {

--- a/test/helpers/syslog.go
+++ b/test/helpers/syslog.go
@@ -206,6 +206,10 @@ func (syslog *syslogReceiverLogStore) grepLogs(expr string, logfile string, time
 	return value, nil
 }
 
+func (syslog *syslogReceiverLogStore) Secret() *corev1.Secret {
+	panic("Method not implemented")
+}
+
 func (syslog *syslogReceiverLogStore) ApplicationLogs(timeToWait time.Duration) (logs, error) {
 	panic("Method not implemented")
 }


### PR DESCRIPTION
### Description
The fix adds secrets during validation, changes the generate signature
and so touches a lot of files.

/cc @alanconway @vimalk78 

### Links
* 4.6 backport of https://github.com/openshift/cluster-logging-operator/pull/823
* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1929420
* Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1929419