### PR TITLE
Cleanup of make check

### DIFF
--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -42,8 +42,8 @@ func Generate(clfYaml string, includeDefaultLogStore, includeLegacyForward bool)
 		Cluster: &logging.ClusterLogging{
 			Spec: logging.ClusterLoggingSpec{},
 		},
-		FnIncludeLegacyForward:  func()bool { return includeLegacyForward},
-		FnIncludeLegacySyslog:  func()bool { return includeLegacySyslog},
+		FnIncludeLegacyForward: func() bool { return includeLegacyForward },
+		FnIncludeLegacySyslog:  func() bool { return includeLegacySyslog },
 	}
 	if includeDefaultLogStore {
 		clRequest.Cluster.Spec.LogStore = &logging.LogStoreSpec{

--- a/pkg/k8shandler/collection_test.go
+++ b/pkg/k8shandler/collection_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Reconciling", func() {
                 `,
 			},
 		}
- 	)
+	)
 
 	Describe("Collection", func() {
 		var (

--- a/test/functional/framework.go
+++ b/test/functional/framework.go
@@ -117,7 +117,7 @@ func (f *FluentdFunctionalFramework) RunCommand(container string, cmd ...string)
 //Deploy the objects needed to functional Test
 func (f *FluentdFunctionalFramework) Deploy() (err error) {
 	visitors := []runtime.PodBuilderVisitor{
-		func(b *runtime.PodBuilder)error{
+		func(b *runtime.PodBuilder) error {
 			return f.addOutputContainers(b, f.Forwarder.Spec.Outputs)
 		},
 	}
@@ -129,6 +129,7 @@ func (f *FluentdFunctionalFramework) DeployWithVisitor(visitor runtime.PodBuilde
 	}
 	return f.DeployWithVisitors(visitors)
 }
+
 //Deploy the objects needed to functional Test
 func (f *FluentdFunctionalFramework) DeployWithVisitors(visitors []runtime.PodBuilderVisitor) (err error) {
 	log.V(2).Info("Generating config", "forwarder", f.Forwarder)

--- a/test/functional/message_templates.go
+++ b/test/functional/message_templates.go
@@ -24,13 +24,13 @@ var (
 	}
 )
 
-func NewApplicationLogTempate() types.ApplicationLog{
+func NewApplicationLogTempate() types.ApplicationLog {
 	return types.ApplicationLog{
-		Timestamp:    time.Time{},
-		Message:       "*",
-		ViaqIndexName: "app-write",
-		Level:         "unknown",
-		ViaqMsgID:     "*",
+		Timestamp:        time.Time{},
+		Message:          "*",
+		ViaqIndexName:    "app-write",
+		Level:            "unknown",
+		ViaqMsgID:        "*",
 		PipelineMetadata: templateForAnyPipelineMetadata,
 		Docker: types.Docker{
 			ContainerID: "*",

--- a/test/functional/normalization/eventrouter_test.go
+++ b/test/functional/normalization/eventrouter_test.go
@@ -56,10 +56,11 @@ var _ = Describe("[Normalization] Fluentd normalization for EventRouter messages
 	})
 
 	for _, verb := range []string{"ADDED", "UPDATED"} {
-		It(fmt.Sprintf("Should parse EventRouter %s message and check values", verb), func() {
+		v := verb // Make a local copy to avoid the "Using the variable on range scope `verb` in function literal" scopelint error
+		It(fmt.Sprintf("Should parse EventRouter %s message and check values", v), func() {
 			podRef, err := reference.GetReference(scheme.Scheme, pod)
 			Expect(err).To(BeNil())
-			newEventData := NewEventDataBuilder(verb, podRef)
+			newEventData := NewEventDataBuilder(v, podRef)
 			jsonBytes, _ := json.Marshal(newEventData)
 			jsonStr := string(jsonBytes)
 			msg := strings.ReplaceAll(fmt.Sprintf("%s stdout F %s", timestamp, jsonStr), "\"", "\\\"")

--- a/test/functional/output_forward.go
+++ b/test/functional/output_forward.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-
 	unsecureFluentConf = `
 <system>
 	log_level trace
@@ -80,4 +79,3 @@ func (f *FluentdFunctionalFramework) addForwardOutput(b *runtime.PodBuilder, out
 		AddConfigMapVolume(config.Name, config.Name)
 	return nil
 }
-

--- a/test/functional/outputs/forward_to_logstash_test.go
+++ b/test/functional/outputs/forward_to_logstash_test.go
@@ -18,14 +18,13 @@ var _ = Describe("[Functional][Outputs][Logstash] FluentdForward Output to Logst
 	//Logstash over fluentd forward protocol
 	type LogstashApplicationLog struct {
 		types.ApplicationLog
-		Tags []string `json:"tags"`
-		Version string `json:"@version"`
-		Host string `json:"host"`
-		Port int `json:"port"`
+		Tags    []string `json:"tags"`
+		Version string   `json:"@version"`
+		Host    string   `json:"host"`
+		Port    int      `json:"port"`
 	}
 
 	const (
-
 		logStashImage        = "logstash:7.10.1"
 		logstashConfFileName = "logstash.yml"
 		logstashConf         = `xpack.monitoring.enabled: false`
@@ -78,10 +77,10 @@ output {
 		// Template expected as output Log
 		outputLogTemplate = LogstashApplicationLog{
 			ApplicationLog: functional.NewApplicationLogTempate(),
-			Tags: []string{},
-			Version: "1",
-			Host: "*",
-			Port: 0,
+			Tags:           []string{},
+			Version:        "1",
+			Host:           "*",
+			Port:           0,
 		}
 	)
 


### PR DESCRIPTION
### Description

Code fixes for the "check" make target to run cleanly.
Fixes "go fmt" issues and 
```
test/functional/normalization/eventrouter_test.go:63:40: Using the variable on range scope `verb` in function literal (scopelint)
			newEventData := NewEventDataBuilder(verb, podRef)
```

/cc @jcantrill 
/assign @alanconway 