### PR TITLE
Bug 1892511: Renamed level field in k8s/openshift audit logs

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -347,13 +347,19 @@ var _ = Describe("Generating fluentd config", func() {
 					remove_keys req,res,msg,name,level,v,pid,err
 				</filter>
 				<filter k8s-audit.log**>
-					@type record_transformer
-					enable_ruby
-					<record>
-						k8s_audit_level ${record['level']}
-						level info
-					</record>
-			  </filter>
+				  @type record_modifier
+				  <record>
+					k8s_audit_level ${record['level']}
+					level info
+				  </record>
+				</filter>
+				<filter openshift-audit.log**>
+				  @type record_modifier
+				  <record>
+					openshift_audit_level ${record['level']}
+					level info
+				  </record>
+				</filter>				
 				<filter **>
 					@type viaq_data_model
 					elasticsearch_index_prefix_field 'viaq_index_name'
@@ -765,13 +771,19 @@ var _ = Describe("Generating fluentd config", func() {
 					remove_keys req,res,msg,name,level,v,pid,err
 				</filter>
 				<filter k8s-audit.log**>
-					@type record_transformer
-					enable_ruby
-					<record>
-						k8s_audit_level ${record['level']}
-						level info
-					</record>
+				  @type record_modifier
+				  <record>
+					k8s_audit_level ${record['level']}
+					level info
+				  </record>
 				</filter>
+				<filter openshift-audit.log**>
+				  @type record_modifier
+				  <record>
+					openshift_audit_level ${record['level']}
+					level info
+				  </record>
+				</filter>				
 				<filter **>
 					@type viaq_data_model
 					elasticsearch_index_prefix_field 'viaq_index_name'

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -296,14 +296,20 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             </record>
             remove_keys req,res,msg,name,level,v,pid,err
           </filter>
-          <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
-            <record>
-              k8s_audit_level ${record['level']}
-              level info
-            </record>
-          </filter>
+		  <filter k8s-audit.log**>
+			@type record_modifier
+			<record>
+			  k8s_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
+		  <filter openshift-audit.log**>
+			@type record_modifier
+			<record>
+			  openshift_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>		  
           <filter **>
             @type viaq_data_model
             elasticsearch_index_prefix_field 'viaq_index_name'
@@ -743,14 +749,20 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             </record>
             remove_keys req,res,msg,name,level,v,pid,err
           </filter>
-          <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
-            <record>
-              k8s_audit_level ${record['level']}
-              level info
-            </record>
-          </filter>
+		  <filter k8s-audit.log**>
+			@type record_modifier
+			<record>
+			  k8s_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
+		  <filter openshift-audit.log**>
+			@type record_modifier
+			<record>
+			  openshift_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>		  
           <filter **>
             @type viaq_data_model
             elasticsearch_index_prefix_field 'viaq_index_name'
@@ -1191,14 +1203,20 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             </record>
             remove_keys req,res,msg,name,level,v,pid,err
           </filter>
-          <filter k8s-audit.log**>
-            @type record_transformer
-            enable_ruby
-            <record>
-              k8s_audit_level ${record['level']}
-              level info
-            </record>
-          </filter>
+		  <filter k8s-audit.log**>
+			@type record_modifier
+			<record>
+			  k8s_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>
+		  <filter openshift-audit.log**>
+			@type record_modifier
+			<record>
+			  openshift_audit_level ${record['level']}
+			  level info
+			</record>
+		  </filter>		  
           <filter **>
             @type viaq_data_model
             elasticsearch_index_prefix_field 'viaq_index_name'

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -209,10 +209,16 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
   </filter>
 
   <filter k8s-audit.log**>
-    @type record_transformer
-    enable_ruby
+    @type record_modifier
     <record>
       k8s_audit_level ${record['level']}
+      level info
+    </record>
+  </filter>
+  <filter openshift-audit.log**>
+    @type record_modifier
+    <record>
+      openshift_audit_level ${record['level']}
       level info
     </record>
   </filter>

--- a/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
@@ -49,6 +49,24 @@ var _ = Describe("LogForwarding", func() {
 	hostname ${hostname}
 	facility user
 	severity debug
+	use_record true
+	payload_key message
+	<buffer>
+	  @type file
+	  path '/var/lib/fluentd/syslogout'
+	  flush_mode interval
+	  flush_interval 1s
+	  flush_thread_count 2
+	  flush_at_shutdown true
+	  retry_type exponential_backoff
+	  retry_wait 1s
+	  retry_max_interval 300s
+	  retry_forever true
+	  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+	  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }"
+	  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+	  overflow_action block
+	</buffer>
 </store>
 					`
 					//create configmap syslog/"syslog.conf"
@@ -89,6 +107,9 @@ var _ = Describe("LogForwarding", func() {
 	hostname ${hostname}
 	facility user
 	severity debug
+	use_record true
+	payload_key message
+	#no <buffer> section because @syslog plugin does not support buffering
 </store>
 					`
 					//create configmap syslog/"syslog.conf"
@@ -96,7 +117,7 @@ var _ = Describe("LogForwarding", func() {
 						Fail(fmt.Sprintf("Unable to create legacy syslog.conf configmap: %v", err))
 					}
 
-					components := []helpers.LogComponentType{helpers.ComponentTypeCollector, helpers.ComponentTypeStore}
+					components := []helpers.LogComponentType{helpers.ComponentTypeCollector}
 					cr := helpers.NewClusterLogging(components...)
 					cr.ObjectMeta.Annotations[k8shandler.ForwardingAnnotation] = "disabled"
 					if err := e2e.CreateClusterLogging(cr); err != nil {


### PR DESCRIPTION
### Description
Bug 1892511: Renamed level field in k8s/openshift audit logs


/cc 
/assign @jcantrill 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1892511
