### PR TITLE
BUG 1918920: keep the ES cluster status if the cluster is to be redep…

### DIFF
--- a/pkg/k8shandler/logstore.go
+++ b/pkg/k8shandler/logstore.go
@@ -257,7 +257,7 @@ func (cr *ClusterLoggingRequest) newElasticsearchCR(elasticsearchName string, ex
 	var es *elasticsearch.Elasticsearch
 	if existing != nil && existing.Name != "" {
 		// using existing es if a valid one exists
-		es = existing
+		es = existing.DeepCopy()
 	} else {
 		es = cr.emptyElasticsearchCR(elasticsearchName)
 	}


### PR DESCRIPTION
…loyed

### Description
When a cluster is set to be redeployed due to a secret change with the changes to the ES setting (e.g., CPU requirement in the logstore), current implementation will recreate the es type which overwrites the certRedeploy status. This PR fixes the issue by keeping the status if the cluster is set to be redeployed.

/cc @ewolinetz 
/assign @jcantrill 

/cherry-pick release-5.0

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1918920
- JIRA: https://issues.redhat.com/browse/LOG-1205