### PR TITLE
Cleanup of the eventrouter e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export GODEBUG=x509ignoreCN=0
 export APP_NAME=cluster-logging-operator
 export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(APP_NAME):latest
 
-export OCP_VERSION?=$(shell basename $(shell find manifests/  -maxdepth 1  -not -name manifests -not -name patches -type d))
+export OCP_VERSION?=$(shell basename $(shell ls -d manifests/[0-9]*))
 export NAMESPACE?=openshift-logging
 
 IMAGE_LOGGING_FLUENTD?=quay.io/openshift/origin-logging-fluentd:latest

--- a/hack/common
+++ b/hack/common
@@ -7,7 +7,7 @@ source "$repo_dir/hack/lib/init.sh"
 source "$repo_dir/hack/testing-olm/utils"
 source "$repo_dir/hack/testing-olm/assertions"
 
-VERSION=${VERSION:-$(basename $(find ${repo_dir}/manifests -type d | sort -r | head -n 1))}
+VERSION=${VERSION:-$(basename $(ls -d ${repo_dir}/manifests/[0-9]*))}
 ELASTICSEARCH_OP_REPO=${ELASTICSEARCH_OP_REPO:-${repo_dir}/../elasticsearch-operator}
 
 ADMIN_USER=${ADMIN_USER:-kubeadmin}

--- a/hack/testing-olm/test-040-eventrouter.sh
+++ b/hack/testing-olm/test-040-eventrouter.sh
@@ -14,8 +14,7 @@ if [ ! -d $test_artifactdir ] ; then
   mkdir -p $test_artifactdir
 fi
 LOGGING_NS=${LOGGING_NS:-openshift-logging}
-LOGGING_VERSION=${LOGGING_VERSION:-5.1}
-IMAGE_LOGGING_EVENTROUTER=${IMAGE_LOGGING_EVENTROUTER:-"registry.ci.openshift.org/logging/${LOGGING_VERSION}:\${component}"}
+IMAGE_LOGGING_EVENTROUTER=${IMAGE_LOGGING_EVENTROUTER:-"registry.ci.openshift.org/logging/${VERSION}:logging-eventrouter"}
 EVENT_ROUTER_TEMPLATE=${repo_dir}/hack/eventrouter-template.yaml
 MAX_DEPLOY_WAIT_SECONDS=${MAX_DEPLOY_WAIT_SECONDS:-120}
 mkdir -p /tmp/artifacts/junit
@@ -110,16 +109,13 @@ os::cmd::try_until_text "oc -n ${LOGGING_NS} get clusterloggings/instance -o jso
 deploy_eventrouter
 
 os::log::info "Checking deployment of elasticsearch..."
-oc -n $LOGGING_NS get all
 espod=$(oc -n $LOGGING_NS get pods -l component=elasticsearch -o jsonpath={.items[0].metadata.name})
 os::log::info "Testing Elasticsearch pod ${espod}..."
 os::cmd::try_until_text "oc -n $LOGGING_NS exec -c elasticsearch ${espod} -- es_util --query=/ --request HEAD --head --output /dev/null --write-out %{response_code}" "200" "$(( 1*$minute ))"
 
 warn_nonformatted 'infra'
 
-oc get events --all-namespaces
 evpod=$(oc -n $LOGGING_NS get pods -l component=eventrouter -o jsonpath={.items[0].metadata.name})
-oc logs -n $LOGGING_NS pod/$evpod
 
 os::log::info "Checking if 1) the doc _id is the same as the kube id 2) there's no duplicates"
 hit_count=10


### PR DESCRIPTION
### Description
- Fixed the eventrouter e2e test failure due to bad image name when running in dev env
- Removed noise from the output of the eventrouter e2e test. The events for debugging can be found in the artifacts dir.
- Simplified Logging version detection

/cc @jcantrill 
/assign @alanconway