### PR TITLE
Cleaned up pattern matching for selective running of logforwarding e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ generate-bundle: regenerate $(OPM)
 
 # NOTE: This is the CI e2e entry point.
 test-e2e-olm: $(JUNITREPORT)
-	INCLUDES=$(E2E_TEST_INCLUDES) CLF_INCLUDES=$(CLF_TEST_INCLUDES) hack/test-e2e-olm.sh
+	INCLUDES="$(E2E_TEST_INCLUDES)" CLF_INCLUDES="$(CLF_TEST_INCLUDES)" hack/test-e2e-olm.sh
 
 test-e2e-local: $(JUNITREPORT) deploy-image
 	CLF_INCLUDES=$(CLF_TEST_INCLUDES) \

--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -40,7 +40,7 @@ trap cleanup exit
 failed=0
 for dir in $(ls -d $TEST_DIR); do
   if [ -n "${CLF_INCLUDES}" ] ; then
-    if ! echo $dir | grep -P -q "${CLF_INCLUDES}" ; then
+    if ! basename $dir | grep -P -q "${CLF_INCLUDES}" ; then
       os::log::info "==============================================================="
 	    os::log::info "excluding logforwarding $dir "
 	    os::log::info "==============================================================="


### PR DESCRIPTION
### Description
Cleaned up pattern matching for the logforwarding e2e tests.
    The CLF_TEST_INCLUDES env variable takes a PCRE that directories in test/e2e/logforwarding are matched against. Examples:
    - CLF_TEST_INCLUDES=syslog matches syslog and sysloglegacy
    - CLF_TEST_INCLUDES=syslog|fluent matches syslog, sysloglegacy, fluent and fluentlegacy
    - CLF_TEST_INCLUDES=^syslog$ matches just syslog

/cc @jcantrill 
/assign @alanconway 