### PR TITLE
LOG-1123: fix routing of app logs per namespace

### DIFF
--- a/pkg/apis/logging/v1/cluster_log_forwarder.go
+++ b/pkg/apis/logging/v1/cluster_log_forwarder.go
@@ -64,6 +64,14 @@ func (m RouteMap) Insert(k, v string) {
 	m[k].Insert(v)
 }
 
+func (m RouteMap) Keys() []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // Routes maps connected input and output names.
 type Routes struct {
 	ByInput, ByOutput RouteMap
@@ -94,19 +102,19 @@ func (spec *ClusterLogForwarderSpec) OutputMap() map[string]*OutputSpec {
 	return m
 }
 
-// InputMap returns a map of names to outputs.
+// True if spec has a default output.
+func (spec *ClusterLogForwarderSpec) HasDefaultOutput() bool {
+	_, ok := spec.OutputMap()[OutputNameDefault]
+	return ok
+}
+
+// InputMap returns a map of input names to InputSpec.
 func (spec *ClusterLogForwarderSpec) InputMap() map[string]*InputSpec {
 	m := map[string]*InputSpec{}
 	for i := range spec.Inputs {
 		m[spec.Inputs[i].Name] = &spec.Inputs[i]
 	}
 	return m
-}
-
-// True if spec has a default output.
-func (spec *ClusterLogForwarderSpec) HasDefaultOutput() bool {
-	_, ok := spec.OutputMap()[OutputNameDefault]
-	return ok
 }
 
 // Types returns the set of input types that are used to by the input spec.

--- a/pkg/generators/forwarding/fluentd/fluent_conf.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf.go
@@ -109,14 +109,6 @@ func (conf *outputLabelConf) LabelName() string {
 	return labelName(conf.Name)
 }
 
-func labelName(name string) string {
-	return strings.ToUpper(fmt.Sprintf("@%s", replacer.Replace(name)))
-}
-
-func sourceTypeLabelName(name string) string {
-	return strings.ToUpper(fmt.Sprintf("@_%s", replacer.Replace(name)))
-}
-
 func (conf *outputLabelConf) StoreID() string {
 	prefix := ""
 	if conf.Hints().Has("prefix_as_retry") {

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -71,13 +71,21 @@ var _ = Describe("Generating fluentd config", func() {
 		}
 	})
 
-	It("should generate fluent config for sending given namespaces logs only to output", func() {
+	It("should generate fluent config for sending specific namespace logs to separate pipelines", func() {
 		forwarder = &logging.ClusterLogForwarderSpec{
 			Outputs: []logging.OutputSpec{
 				{
 					Type: logging.OutputTypeElasticsearch,
 					Name: "apps-es-1",
 					URL:  "https://es.svc.messaging.cluster.local:9654",
+					Secret: &logging.OutputSecretSpec{
+						Name: "my-es-secret",
+					},
+				},
+				{
+					Type: logging.OutputTypeElasticsearch,
+					Name: "apps-es-2",
+					URL:  "https://es2.svc.messaging.cluster.local:9654",
 					Secret: &logging.OutputSecretSpec{
 						Name: "my-es-secret",
 					},
@@ -90,12 +98,28 @@ var _ = Describe("Generating fluentd config", func() {
 						Namespaces: []string{"project1-namespace", "project2-namespace"},
 					},
 				},
+				{
+					Name: "myInput2",
+					Application: &logging.Application{
+						Namespaces: []string{"dev-apple", "project2-namespace"},
+					},
+				},
 			},
 			Pipelines: []logging.PipelineSpec{
+				{
+					Name:       "my-default-pipeline",
+					InputRefs:  []string{"application"},
+					OutputRefs: []string{"apps-es-2"},
+				},
 				{
 					Name:       "apps-pipeline",
 					InputRefs:  []string{"myInput"},
 					OutputRefs: []string{"apps-es-1", "apps-es-2"},
+				},
+				{
+					Name:       "apps-pipeline2",
+					InputRefs:  []string{"myInput2"},
+					OutputRefs: []string{"apps-es-2"},
 				},
 			},
 		}
@@ -463,12 +487,9 @@ var _ = Describe("Generating fluentd config", func() {
     <match **_default_** **_kube-*_** **_openshift-*_** **_openshift_** journal.** system.var.log**>
       @type null
     </match>
-    <match kubernetes.**_project1-namespace_** kubernetes.**_project2-namespace_** >
+    <match kubernetes.**>
       @type relabel
       @label @_APPLICATION
-    </match>
-    <match kubernetes.** >
-      @type null
     </match>
     <match linux-audit.log** k8s-audit.log** openshift-audit.log**>
       @type null
@@ -482,28 +503,66 @@ var _ = Describe("Generating fluentd config", func() {
 
   # Relabel specific sources (e.g. logs.apps) to multiple pipelines
   <label @_APPLICATION>
+     <match kubernetes.**_dev-apple_**>
+      @type copy
+      <store>
+	    @type relabel
+	    @label @APPS_PIPELINE2
+      </store>
+    </match>
+    <match kubernetes.**_project1-namespace_**>
+      @type copy
+      <store>
+		@type relabel
+		@label @APPS_PIPELINE
+      </store>
+    </match>
+    <match kubernetes.**_project2-namespace_**>
+      @type copy
+      <store>
+		@type relabel
+		@label @APPS_PIPELINE
+      </store>
+      <store>
+		@type relabel
+		@label @APPS_PIPELINE2
+      </store>
+    </match>
     <match **>
       @type copy
-
       <store>
-        @type relabel
-        @label @APPS_PIPELINE
+	    @type relabel
+	    @label @MY_DEFAULT_PIPELINE
       </store>
-
-
     </match>
   </label>
-
 
   # Relabel specific pipelines to multiple, outputs (e.g. ES, kafka stores)
   <label @APPS_PIPELINE>
     <match **>
       @type copy
-
       <store>
         @type relabel
         @label @APPS_ES_1
       </store>
+      <store>
+        @type relabel
+        @label @APPS_ES_2
+     </store>
+    </match>
+  </label>
+  <label @APPS_PIPELINE2>
+    <match **>
+      @type copy
+      <store>
+        @type relabel
+        @label @APPS_ES_2
+      </store>
+    </match>
+  </label>
+  <label @MY_DEFAULT_PIPELINE>
+    <match **>
+      @type copy
       <store>
         @type relabel
         @label @APPS_ES_2
@@ -593,6 +652,107 @@ var _ = Describe("Generating fluentd config", func() {
         <buffer>
           @type file
           path '/var/lib/fluentd/apps_es_1'
+          flush_mode interval
+          flush_interval 1s
+          flush_thread_count 2
+          flush_at_shutdown true
+          retry_type exponential_backoff
+          retry_wait 1s
+          retry_max_interval 60s
+          retry_forever true
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+
+          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+
+
+          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+
+          overflow_action block
+        </buffer>
+      </store>
+    </match>
+  </label>
+  <label @APPS_ES_2>
+    <match retry_apps_es_2>
+      @type copy
+      <store>
+        @type elasticsearch
+        @id retry_apps_es_2
+        host es2.svc.messaging.cluster.local
+        port 9654
+        verify_es_version_at_startup false
+        scheme https
+        ssl_version TLSv1_2
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
+        client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+        client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+        ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        type_name _doc
+        http_backend typhoeus
+        write_operation create
+        reload_connections 'true'
+        # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+        reload_after '200'
+        # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+        reload_on_failure false
+        # 2 ^ 31
+        request_timeout 2147483648
+        <buffer>
+          @type file
+          path '/var/lib/fluentd/retry_apps_es_2'
+          flush_mode interval
+          flush_interval 1s
+          flush_thread_count 2
+          flush_at_shutdown true
+          retry_type exponential_backoff
+          retry_wait 1s
+          retry_max_interval 60s
+          retry_forever true
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+
+          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+
+
+          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+
+          overflow_action block
+        </buffer>
+      </store>
+    </match>
+    <match **>
+      @type copy
+      <store>
+        @type elasticsearch
+        @id apps_es_2
+        host es2.svc.messaging.cluster.local
+        port 9654
+        verify_es_version_at_startup false
+        scheme https
+        ssl_version TLSv1_2
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
+        client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+        client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+        ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        type_name _doc
+        retry_tag retry_apps_es_2
+        http_backend typhoeus
+        write_operation create
+        reload_connections 'true'
+        # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+        reload_after '200'
+        # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+        sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+        reload_on_failure false
+        # 2 ^ 31
+        request_timeout 2147483648
+        <buffer>
+          @type file
+          path '/var/lib/fluentd/apps_es_2'
           flush_mode interval
           flush_interval 1s
           flush_thread_count 2
@@ -1517,15 +1677,6 @@ var _ = Describe("Generating fluentd config", func() {
 			</label>
 
 			# Relabel specific pipelines to multiple, outputs (e.g. ES, kafka stores)
-			<label @INFRA_PIPELINE>
-				<match **>
-					@type copy
-					<store>
-						@type relabel
-						@label @INFRA_ES
-					</store>
-				</match>
-			</label>
 			<label @APPS_PIPELINE>
 				<match **>
 					@type copy
@@ -1545,6 +1696,15 @@ var _ = Describe("Generating fluentd config", func() {
 					<store>
 						@type relabel
 						@label @AUDIT_ES
+					</store>
+				</match>
+			</label>
+			<label @INFRA_PIPELINE>
+				<match **>
+					@type copy
+					<store>
+						@type relabel
+						@label @INFRA_ES
 					</store>
 				</match>
 			</label>
@@ -2008,7 +2168,7 @@ var _ = Describe("Generating fluentd config", func() {
 			Expect(yaml.Unmarshal([]byte(yamlSpec), &spec)).To(Succeed())
 			gotFluentdConf, err := generator.Generate(&spec, nil, nil)
 			Expect(err).To(Succeed())
-			Expect(wantFluentdConf).To(EqualTrimLines(gotFluentdConf))
+			Expect(gotFluentdConf).To(EqualTrimLines(wantFluentdConf))
 		},
 		Entry("namespaces", `
   pipelines:
@@ -2386,14 +2546,11 @@ var _ = Describe("Generating fluentd config", func() {
         @type null
       </match>
 
-      <match kubernetes.**_project1_** kubernetes.**_project2_** >
+      <match kubernetes.**>
         @type relabel
         @label @_APPLICATION
       </match>
-      <match kubernetes.** >
-        @type null
-      </match>
-
+ 
       <match linux-audit.log** k8s-audit.log** openshift-audit.log**>
         @type null
       </match>
@@ -2406,18 +2563,21 @@ var _ = Describe("Generating fluentd config", func() {
 
     # Relabel specific sources (e.g. logs.apps) to multiple pipelines
     <label @_APPLICATION>
-      <match **>
+      <match kubernetes.**_project1_**>
         @type copy
-
         <store>
           @type relabel
           @label @TEST_APP
         </store>
-
-
+      </match>
+      <match kubernetes.**_project2_**>
+        @type copy
+        <store>
+          @type relabel
+          @label @TEST_APP
+        </store>
       </match>
     </label>
-
 
     # Relabel specific pipelines to multiple, outputs (e.g. ES, kafka stores)
     <label @TEST_APP>

--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -3,10 +3,8 @@ package fluentd
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
-	"text/template"
-
 	"github.com/openshift/cluster-logging-operator/pkg/constants"
+	"sort"
 
 	"github.com/ViaQ/logerr/log"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
@@ -27,10 +25,7 @@ type ConfigGenerator struct {
 //NewConfigGenerator creates an instance of FluentdConfigGenerator
 func NewConfigGenerator(includeLegacyForwardConfig, includeLegacySyslogConfig, useOldRemoteSyslogPlugin bool) (*ConfigGenerator, error) {
 	engine, err := generators.New("OutputLabelConf",
-		&template.FuncMap{
-			"labelName":           labelName,
-			"sourceTypelabelName": sourceTypeLabelName,
-		},
+		helperRegistry,
 		templateRegistry...)
 	if err != nil {
 		return nil, err
@@ -60,6 +55,7 @@ func (engine *ConfigGenerator) Generate(clfSpec *logging.ClusterLogForwarderSpec
 
 	inputs, namespaces = gatherSources(clfSpec)
 	routeMap = inputsToPipelines(clfSpec)
+	appNSToPipelines := mapAppNamespacesToPipelines(clfSpec)
 	// Provide inputs and inputsPipelines for legacy forwarding protocols
 	// w/o a user-provided ClusterLogFowarder instance to enable inputs and
 	// inputs-to-pipelines a.k.a. route map template generation.
@@ -72,9 +68,15 @@ func (engine *ConfigGenerator) Generate(clfSpec *logging.ClusterLogForwarderSpec
 		for _, logType := range inputs.List() {
 			if engine.includeLegacySyslogConfig {
 				routeMap.Insert(logType, constants.LegacySyslog)
+				if logType == logging.InputNameApplication {
+					appNSToPipelines.Insert("", constants.LegacySyslog)
+				}
 			}
 			if engine.includeLegacyForwardConfig {
 				routeMap.Insert(logType, constants.LegacySecureforward)
+				if logType == logging.InputNameApplication {
+					appNSToPipelines.Insert("", constants.LegacySecureforward)
+				}
 			}
 		}
 	}
@@ -86,7 +88,7 @@ func (engine *ConfigGenerator) Generate(clfSpec *logging.ClusterLogForwarderSpec
 		return "", err
 	}
 
-	sourceToPipelineLabels, err = engine.generateSourceToPipelineLabels(routeMap)
+	sourceToPipelineLabels, err = engine.generateSourceToPipelineLabels(routeMap, appNSToPipelines)
 	if err != nil {
 		log.V(3).Error(err, "Error generating source to pipeline blocks")
 		return "", err
@@ -143,6 +145,7 @@ func (engine *ConfigGenerator) Generate(clfSpec *logging.ClusterLogForwarderSpec
 	return result, nil
 }
 
+//gatherSources collects the set of unique source types and namespaces
 func gatherSources(forwarder *logging.ClusterLogForwarderSpec) (types sets.String, namespaces sets.String) {
 	types, namespaces = sets.NewString(), sets.NewString()
 	specs := forwarder.InputMap()
@@ -184,24 +187,64 @@ func inputsToPipelines(fwdspec *logging.ClusterLogForwarderSpec) logging.RouteMa
 	return result
 }
 
+func mapAppNamespacesToPipelines(fwdspec *logging.ClusterLogForwarderSpec) logging.RouteMap {
+	result := logging.RouteMap{}
+	inputs := fwdspec.InputMap()
+	for _, pipeline := range fwdspec.Pipelines {
+		for _, inRef := range pipeline.InputRefs {
+			if input, ok := inputs[inRef]; ok {
+				if input.Types().Has(logging.InputNameApplication) {
+					if len(input.Application.Namespaces) > 0 {
+						for _, ns := range input.Application.Namespaces {
+							result.Insert(ns, pipeline.Name)
+						}
+					} else {
+						result.Insert("", pipeline.Name)
+					}
+
+				}
+			} else if inRef == logging.InputNameApplication {
+				// Not a user defined type, insert direct.
+				result.Insert("", pipeline.Name)
+			}
+		}
+	}
+	return result
+}
+
 //generateSourceToPipelineLabels generates fluentd label stanzas to fan source types to multiple pipelines
-func (engine *ConfigGenerator) generateSourceToPipelineLabels(sourcesToPipelines logging.RouteMap) ([]string, error) {
+func (engine *ConfigGenerator) generateSourceToPipelineLabels(sourcesToPipelines, appNSToPipelines logging.RouteMap) ([]string, error) {
 	configs := []string{}
 	for sourceType, pipelineNames := range sourcesToPipelines {
+		templateName := "sourceToPipelineCopyTemplate"
+		namespaces := []string{}
+		if sourceType == logging.InputNameApplication {
+			templateName = "namespaceToPipelineTemplate"
+			namespaces = appNSToPipelines.Keys()
+			sort.Strings(namespaces)
+			// empty means ALL which MUST come last
+			if len(namespaces) >= 2 && namespaces[0] == "" {
+				namespaces = append(namespaces[1:], "")
+			}
+		}
 		data := struct {
 			IncludeLegacySecureForward bool
 			IncludeLegacySyslog        bool
 			Source                     string
 			PipelineNames              []string
+			AppNamespaces              []string
+			PipeLines                  logging.RouteMap
 		}{
 			engine.includeLegacyForwardConfig,
 			engine.includeLegacySyslogConfig,
 			sourceType,
 			pipelineNames.List(),
+			namespaces,
+			appNSToPipelines,
 		}
-		result, err := engine.Execute("sourceToPipelineCopyTemplate", data)
+		result, err := engine.Execute(templateName, data)
 		if err != nil {
-			return nil, fmt.Errorf("Error processing sourceToPipelineCopyTemplate template: %v", err)
+			return nil, fmt.Errorf("Error processing %s template: %v", templateName, err)
 		}
 		configs = append(configs, result)
 	}
@@ -210,6 +253,9 @@ func (engine *ConfigGenerator) generateSourceToPipelineLabels(sourcesToPipelines
 
 func (engine *ConfigGenerator) generatePipelineToOutputLabels(pipelines []logging.PipelineSpec) ([]string, error) {
 	configs := []string{}
+	sort.Slice(pipelines, func(i,j int) bool{
+		return pipelines[i].Name < pipelines[j].Name
+	})
 	for _, pipeline := range pipelines {
 		var jsonLabels string
 

--- a/pkg/generators/forwarding/fluentd/helpers.go
+++ b/pkg/generators/forwarding/fluentd/helpers.go
@@ -1,0 +1,39 @@
+package fluentd
+
+import (
+	"fmt"
+	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	"strings"
+	"text/template"
+)
+
+var (
+	helperRegistry = &template.FuncMap{
+		"applicationTag":      applicationTag,
+		"labelName":           labelName,
+		"sourceTypelabelName": sourceTypeLabelName,
+		"routeMapValues":      routeMapValues,
+	}
+)
+
+func applicationTag(namespace string) string {
+	if "" == namespace {
+		return "**"
+	}
+	return strings.ToLower(fmt.Sprintf("kubernetes.**_%s_**", namespace))
+}
+
+func labelName(name string) string {
+	return strings.ToUpper(fmt.Sprintf("@%s", replacer.Replace(name)))
+}
+
+func sourceTypeLabelName(name string) string {
+	return strings.ToUpper(fmt.Sprintf("@_%s", replacer.Replace(name)))
+}
+
+func routeMapValues(routeMap logging.RouteMap, key string) []string {
+	if values, found := routeMap[key]; found {
+		return values.List()
+	}
+	return []string{}
+}

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -471,37 +471,28 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @_APPLICATION>
           <match **>
             @type copy
-
-
             <store>
               @type relabel
               @label @_LEGACY_SECUREFORWARD
             </store>
-
           </match>
         </label>
         <label @_AUDIT>
           <match **>
             @type copy
-
-
             <store>
               @type relabel
               @label @_LEGACY_SECUREFORWARD
             </store>
-
           </match>
         </label>
         <label @_INFRASTRUCTURE>
           <match **>
             @type copy
-
-
             <store>
               @type relabel
               @label @_LEGACY_SECUREFORWARD
             </store>
-
           </match>
         </label>
 


### PR DESCRIPTION
### Description
This PR
* fixes routing of application messages by namespace so they end up at the desired outputs

/cc @alanconway @vimalk78 

/cherrypick release-5.0

### Links
https://issues.redhat.com/browse/LOG-1223