### PR TITLE
Fix for forward_to_syslog test flake

### DIFF
--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -61,7 +61,7 @@ for dir in $(ls -d $TEST_DIR); do
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/logforwarding/cleanup.sh $artifact_dir $GENERATOR_NS" \
     artifact_dir=$artifact_dir \
     GENERATOR_NS=$GENERATOR_NS \
-    go test -count=1 -parallel=1 -timeout=60m "$dir" -ginkgo.noColor -ginkgo.trace | tee -a "$artifact_dir/test.log" ; then
+    go test -count=1 -parallel=1 -timeout=90m "$dir" -ginkgo.noColor -ginkgo.trace | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "Logforwarding $dir passed"
     os::log::info "======================================================="

--- a/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
@@ -307,6 +307,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 					}
 					logStore := e2e.LogStores[syslogDeployment.GetName()]
 					Expect(logStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+					_, _ = logStore.GrepLogs(waitlogs, helpers.DefaultWaitForLogsTimeout)
 					grepMsgContent := fmt.Sprintf(`grep %s %%s | tail -n 1 | awk -F' ' '{ s = ""; for (i = 8; i <= NF; i++) s = s $i " "; print s }'`, "rec_appname")
 					str, err := logStore.GrepLogs(grepMsgContent, helpers.DefaultWaitForLogsTimeout)
 					Expect(err).To(BeNil())
@@ -575,6 +576,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 						}
 						logStore := e2e.LogStores[syslogDeployment.GetName()]
 						Expect(logStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+						_, _ = logStore.GrepLogs(waitlogs, helpers.DefaultWaitForLogsTimeout)
 						grepMsgContent := fmt.Sprintf(`grep %s %%s | tail -n 1 | awk -F' ' '{ s = ""; for (i = 8; i <= NF; i++) s = s $i " "; print s }'`, "rec_tag")
 						str, err := logStore.GrepLogs(grepMsgContent, helpers.DefaultWaitForLogsTimeout)
 						Expect(err).To(BeNil())
@@ -610,6 +612,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 						}
 						logStore := e2e.LogStores[syslogDeployment.GetName()]
 						Expect(logStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+						_, _ = logStore.GrepLogs(waitlogs, helpers.DefaultWaitForLogsTimeout)
 						grepMsgContent := fmt.Sprintf(`grep %s %%s | tail -n 1 | awk -F' ' '{ s = ""; for (i = 8; i <= NF; i++) s = s $i " "; print s }'`, "namespace_name")
 						_, err := logStore.GrepLogs(grepMsgContent, helpers.DefaultWaitForLogsTimeout)
 						Expect(err).To(BeNil())
@@ -640,6 +643,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 							}
 							logStore := e2e.LogStores[syslogDeployment.GetName()]
 							Expect(logStore.HasInfraStructureLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored infrastructure logs")
+							_, _ = logStore.GrepLogs(waitlogs, helpers.DefaultWaitForLogsTimeout)
 							grepMsgContent := fmt.Sprintf(`grep %s %%s | tail -n 1 | awk -F' ' '{ s = ""; for (i = 8; i <= NF; i++) s = s $i " "; print s }'`, "rec_tag")
 							_, err := logStore.GrepLogs(grepMsgContent, helpers.DefaultWaitForLogsTimeout)
 							Expect(err).To(BeNil())

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -206,18 +206,21 @@ func (tc *E2ETestFramework) WaitFor(component LogComponentType) error {
 }
 
 func (tc *E2ETestFramework) waitForFluentDaemonSet(retryInterval, timeout time.Duration) error {
-	// daemonset should have non-zero number of instances for maxtimes consecutive retryInterval to detect a CrashLoopBackOff pod
+	// daemonset should have pods running and available on all the nodes for maxtimes * retryInterval
 	maxtimes := 5
 	times := 0
 	return wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
-		numReady, err := oc.Literal().From("oc -n openshift-logging get daemonset/fluentd -o jsonpath={.status.numberReady}").Run()
+		numUnavail, err := oc.Literal().From("oc -n openshift-logging get daemonset/fluentd -o jsonpath={.status.NumberUnavailable}").Run()
 		if err == nil {
-			value, err := strconv.Atoi(strings.TrimSpace(numReady))
+			if numUnavail == "" {
+				numUnavail = "0"
+			}
+			value, err := strconv.Atoi(strings.TrimSpace(numUnavail))
 			if err != nil {
 				times = 0
 				return false, err
 			}
-			if value > 0 {
+			if value == 0 {
 				times++
 			} else {
 				times = 0


### PR DESCRIPTION
### Description

This fixes the following flake:
```
{"_ts":"2021-03-18T19:52:14.094739921Z","_file:line":"forward_to_syslog_test.go:304","_level":"3","_component":"test","_message":"Waiting for ","component":"Collector"}
{"_ts":"2021-03-18T19:52:14.529118966Z","_level":"0","_component":"test","_message":"command output","arguments":"-n openshift-logging get daemonset/fluentd -o jsonpath={.status.numberReady}","output":"6"}
{"_ts":"2021-03-18T19:52:15.865822899Z","_level":"0","_component":"test","_message":"command output","arguments":"-n openshift-logging get daemonset/fluentd -o jsonpath={.status.numberReady}","output":"6"}
{"_ts":"2021-03-18T19:52:16.866539769Z","_level":"0","_component":"test","_message":"command output","arguments":"-n openshift-logging get daemonset/fluentd -o jsonpath={.status.numberReady}","output":"5"}
{"_ts":"2021-03-18T19:52:17.840117811Z","_level":"0","_component":"test","_message":"command output","arguments":"-n openshift-logging get daemonset/fluentd -o jsonpath={.status.numberReady}","output":"5"}
{"_ts":"2021-03-18T19:52:18.860622657Z","_level":"0","_component":"test","_message":"command output","arguments":"-n openshift-logging get daemonset/fluentd -o jsonpath={.status.numberReady}","output":"5"}
{"_ts":"2021-03-18T19:52:20.470182292Z","_level":"0","_component":"test","_message":"command output","arguments":"-n openshift-logging exec syslog-receiver-6d46c47964-mg88z -c syslog-receiver -- bash -c ls /var/log/infra.log | wc -l","output":"0"}
{"_ts":"2021-03-18T19:52:21.424923135Z","_level":"0","_component":"test","_message":"command output","arguments":"-n openshift-logging exec syslog-receiver-6d46c47964-mg88z -c syslog-receiver -- bash -c ls /var/log/infra.log | wc -l","output":"1"}
{"_ts":"2021-03-18T19:52:21.446097852Z","_file:line":"helpers/syslog.go:229","_level":"3","_component":"test","_message":"Pod","PodName":"syslog-receiver-6d46c47964-mg88z"}
{"_ts":"2021-03-18T19:52:21.446187215Z","_file:line":"helpers/syslog.go:229","_level":"3","_component":"test","_message":"running expression","expression":"grep rec_appname /var/log/infra.log | tail -n 1 | awk -F' ' '{ s = \"\"; for (i = 8; i \u003c= NF; i++) s = s $i \" \"; print s }'"}
{"_ts":"2021-03-18T19:52:22.966381828Z","_level":"0","_component":"test","_message":"command output","arguments":"-n openshift-logging exec syslog-receiver-6d46c47964-mg88z -c syslog-receiver -- bash -c grep rec_appname /var/log/infra.log | tail -n 1 | awk -F' ' '{ s = \"\"; for (i = 8; i \u003c= NF; i++) s = s $i \" \"; print s }'","output":""}
...
• Failure [107.741 seconds]
[ClusterLogForwarder] Forwards logs
/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/syslog/forward_to_syslog_test.go:29
  when the output is a third-party managed syslog
  /go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/syslog/forward_to_syslog_test.go:65
    with rfc5424
    /go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/syslog/forward_to_syslog_test.go:72
      syslog payload
      /go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/syslog/forward_to_syslog_test.go:284
        should take from payload_key [It]
        /go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/syslog/forward_to_syslog_test.go:288

        Expected
            <*json.SyntaxError | 0xc0005194e0>: {
                msg: "unexpected end of JSON input",
                Offset: 0,
            }
        to be nil

        /go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/syslog/forward_to_syslog_test.go:316
```

The root cause is twofold. One, in a few tests there was a step missing that waits for log entries from the log generator to appear in the syslog's log. That's what the added `_, _ = logStore.GrepLogs(waitlogs, helpers.DefaultWaitForLogsTimeout)` lines fix. Two, the waiting logic for the fluentd DS to be ready allowed for no fluentd pod on the node with the log generator. These two issues together allowed the tests to go look for log entries from the generator when there were none, hence the empty JSON above.

/cc @jcantrill 
/assign @alanconway 