### PR TITLE
Removing logic to control replicas for kibana CR

### DIFF
--- a/pkg/apis/logging/v1/clusterlogging_types.go
+++ b/pkg/apis/logging/v1/clusterlogging_types.go
@@ -90,7 +90,7 @@ type KibanaSpec struct {
 	Tolerations  []v1.Toleration   `json:"tolerations,omitempty"`
 
 	// Number of instances to deploy for a Kibana deployment
-	Replicas int32 `json:"replicas"`
+	Replicas *int32 `json:"replicas"`
 
 	// Specification of the Kibana Proxy component
 	ProxySpec `json:"proxy,omitempty"`

--- a/pkg/k8shandler/visualization_test.go
+++ b/pkg/k8shandler/visualization_test.go
@@ -14,6 +14,11 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
+var (
+	zeroInt = int32(0)
+	twoInt  = int32(2)
+)
+
 func TestNewKibanaCR(t *testing.T) {
 	tests := []struct {
 		desc string
@@ -63,7 +68,7 @@ func TestNewKibanaCR(t *testing.T) {
 			},
 		},
 		{
-			desc: "no kibana replica",
+			desc: "no kibana replica no elasticsearch",
 			cl: &logging.ClusterLogging{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "instance",
@@ -87,6 +92,94 @@ func TestNewKibanaCR(t *testing.T) {
 				Spec: es.KibanaSpec{
 					ManagementState: es.ManagementStateManaged,
 					Replicas:        0,
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: defaultKibanaMemory,
+						},
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: defaultKibanaMemory,
+							v1.ResourceCPU:    defaultKibanaCpuRequest,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "no kibana replica with elasticsearch",
+			cl: &logging.ClusterLogging{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instance",
+					Namespace: "openshift-logging",
+				},
+				Spec: logging.ClusterLoggingSpec{
+					Visualization: &logging.VisualizationSpec{
+						KibanaSpec: logging.KibanaSpec{
+							Replicas: &zeroInt,
+						},
+					},
+					LogStore: &logging.LogStoreSpec{
+						ElasticsearchSpec: logging.ElasticsearchSpec{
+							NodeCount: 1,
+						},
+					},
+				},
+			},
+			want: es.Kibana{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Kibana",
+					APIVersion: es.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kibana",
+					Namespace: "openshift-logging",
+				},
+				Spec: es.KibanaSpec{
+					ManagementState: es.ManagementStateManaged,
+					Replicas:        0,
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceMemory: defaultKibanaMemory,
+						},
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: defaultKibanaMemory,
+							v1.ResourceCPU:    defaultKibanaCpuRequest,
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "two kibana replica with elasticsearch",
+			cl: &logging.ClusterLogging{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "instance",
+					Namespace: "openshift-logging",
+				},
+				Spec: logging.ClusterLoggingSpec{
+					Visualization: &logging.VisualizationSpec{
+						KibanaSpec: logging.KibanaSpec{
+							Replicas: &twoInt,
+						},
+					},
+					LogStore: &logging.LogStoreSpec{
+						ElasticsearchSpec: logging.ElasticsearchSpec{
+							NodeCount: 1,
+						},
+					},
+				},
+			},
+			want: es.Kibana{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Kibana",
+					APIVersion: es.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kibana",
+					Namespace: "openshift-logging",
+				},
+				Spec: es.KibanaSpec{
+					ManagementState: es.ManagementStateManaged,
+					Replicas:        2,
 					Resources: &v1.ResourceRequirements{
 						Limits: v1.ResourceList{
 							v1.ResourceMemory: defaultKibanaMemory,


### PR DESCRIPTION
### Description
Addresses issue seen in https://bugzilla.redhat.com/show_bug.cgi?id=1942609 where the operator is changing the replica count for the Kibana CR which is unexpected for users.

/cc @igor-karpukhin 

Will link the bz to the 4.6.z cherry pick of this.