### PR TITLE
E2E logforwarding fluent flake fixes

### DIFF
--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -61,6 +61,7 @@ for dir in $(ls -d $TEST_DIR); do
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/logforwarding/cleanup.sh $artifact_dir $GENERATOR_NS" \
     artifact_dir=$artifact_dir \
     GENERATOR_NS=$GENERATOR_NS \
+    SUCCESS_TIMEOUT=10m \
     go test -count=1 -parallel=1 -timeout=90m "$dir" -ginkgo.noColor -ginkgo.trace | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "Logforwarding $dir passed"

--- a/test/client/pod.go
+++ b/test/client/pod.go
@@ -1,9 +1,11 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/openshift/cluster-logging-operator/test/runtime"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -40,3 +42,13 @@ func PodFailed(e watch.Event) (bool, error) { return podInPhase(e.Object, corev1
 // PodRunning returns (true,nil) when e.Object is a Pod with phase PodRunning.
 // Returns an error if pod reaches any other long-lasting state	[failed, succeeded ,running]
 func PodRunning(e watch.Event) (bool, error) { return podInPhase(e.Object, corev1.PodRunning) }
+
+// DaemonSetIsReady returns (true, nil) when the pods of the set are ready on all nodes
+// in the cluster and (false, nil) otherwise.
+func IsDaemonSetReady(e watch.Event) (bool, error) {
+	ds, ok := e.Object.(*appsv1.DaemonSet)
+	if !ok {
+		return false, errors.New(fmt.Sprintf("event is not for a daemonset: %v", e))
+	}
+	return ds.Status.NumberUnavailable == 0, nil
+}

--- a/test/e2e/logforwarding/fluent/fixture_test.go
+++ b/test/e2e/logforwarding/fluent/fixture_test.go
@@ -2,12 +2,17 @@ package fluent_test
 
 import (
 	loggingv1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	"github.com/openshift/cluster-logging-operator/test"
 	"github.com/openshift/cluster-logging-operator/test/client"
 	"github.com/openshift/cluster-logging-operator/test/helpers/fluentd"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 	"github.com/openshift/cluster-logging-operator/test/runtime"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"time"
 )
 
 type Fixture struct {
@@ -29,23 +34,133 @@ func NewFixture(namespace, message string) *Fixture {
 
 // Create resources, wait for them to be ready.
 func (f *Fixture) Create(c *client.Client) {
-	g := test.FailGroup{}
-	// Recreate resources in shared openshift-logging namespace.
-	g.Go(func() { ExpectOK(c.Recreate(f.ClusterLogging)) })
-	g.Go(func() {
-		ExpectOK(c.Recreate(f.ClusterLogForwarder))
-		ExpectOK(c.WaitFor(f.ClusterLogForwarder, client.ClusterLogForwarderReady))
+	ExpectOK(c.Remove(f.ClusterLogging))
+	ExpectOK(c.Remove(f.ClusterLogForwarder))
+	ExpectOK(c.RemoveSync(&appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fluentd",
+			Namespace: f.ClusterLogging.Namespace,
+		},
+	}))
+	f.cleanFluentDBuffers(c)
+	ExpectOK(c.Recreate(f.ClusterLogging))
+	ExpectOK(c.Recreate(f.ClusterLogForwarder))
+	ExpectOK(c.WaitFor(f.ClusterLogForwarder, client.ClusterLogForwarderReady))
+	ExpectOK(c.WaitFor(
+		&appsv1.DaemonSet{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "DaemonSet",
+				APIVersion: "apps/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fluentd",
+				Namespace: f.ClusterLogging.Namespace,
+			},
+		},
+		func(e watch.Event) (bool, error) {
+			ds := e.Object.(*appsv1.DaemonSet)
+			return ds.Status.NumberUnavailable == 0 &&
+				ds.Status.CurrentNumberScheduled == ds.Status.DesiredNumberScheduled &&
+				ds.Status.CurrentNumberScheduled == ds.Status.NumberReady &&
+				ds.Status.CurrentNumberScheduled == ds.Status.NumberAvailable, nil
+		},
+	))
+	ExpectOK(c.Create(f.LogGenerator))
+	ExpectOK(c.WaitFor(f.LogGenerator, client.PodRunning))
+	ExpectOK(f.Receiver.Create(c))
+}
+
+func (f *Fixture) cleanFluentDBuffers(c *client.Client) {
+	h := corev1.HostPathDirectory
+	p := true
+	ds := &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "clean-fluentd-buffers",
+			Namespace: "default",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": "clean-fluentd-buffers",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"name": "clean-fluentd-buffers",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Tolerations: []corev1.Toleration{
+						{
+							Key:    "node-role.kubernetes.io/master",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:  "clean-fluentd-buffers",
+							Image: "docker.io/library/busybox:latest",
+							Args:  []string{"sh", "-c", "rm -rf /fluentd-buffers/** || rm /logs/audit/audit.log.pos || rm /logs/kube-apiserver/audit.log.pos || rm /logs/es-containers.log.pos"},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &p,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "fluentd-buffers",
+									MountPath: "/fluentd-buffers",
+								},
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "pause",
+							Image: "centos:centos7",
+							Args:  []string{"sh", "-c", "echo done!!!!"},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "fluentd-buffers",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/var/lib/fluentd",
+									Type: &h,
+								},
+							},
+						},
+						{
+							Name: "logs",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/var/log",
+									Type: &h,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ExpectOK(c.Recreate(ds))
+	_ = wait.PollImmediate(time.Second*10, time.Minute*5, func() (bool, error) {
+		ExpectOK(c.Get(ds))
+		return ds.Status.DesiredNumberScheduled == ds.Status.CurrentNumberScheduled, nil
 	})
-	g.Go(func() {
-		ExpectOK(c.WaitForType(&corev1.Pod{}, client.PodRunning,
-			client.MatchingLabels{"component": "fluentd"},
-			client.InNamespace(f.ClusterLogging.Namespace)))
-	})
-	// Create resources in temporary test namespace.
-	g.Go(func() {
-		ExpectOK(c.Create(f.LogGenerator))
-		ExpectOK(c.WaitFor(f.LogGenerator, client.PodRunning))
-	})
-	g.Go(func() { ExpectOK(f.Receiver.Create(c)) })
-	g.Wait()
+	ExpectOK(c.RemoveSync(ds))
 }


### PR DESCRIPTION
### Description
Fixes for the sporadic failures of the e2e logforwarding fluent test:
- serialized manipulations with the fluentd DS
- made fluentd ports for different tests unique to exclude cross-contamination
- added cleanup of fluentd on-disk buffers between tests

These are not final fixes for all the ills with this test, but they make it much more stable without altering its logic.

/cc @vimalk78 
/assign @ewolinetz