### PR TITLE
Bug 1945168: Remove hardcoded cluster local domain

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -16,7 +16,7 @@ const (
 	FluentdTrustedCAName       = "fluentd-trusted-ca-bundle"
 	KibanaTrustedCAName        = "kibana-trusted-ca-bundle"
 	// internal elasticsearch FQDN to prevent to connect to the global proxy
-	ElasticsearchFQDN   = "elasticsearch.openshift-logging.svc.cluster.local"
+	ElasticsearchFQDN   = "elasticsearch.openshift-logging.svc"
 	ElasticsearchName   = "elasticsearch"
 	ElasticsearchPort   = "9200"
 	FluentdName         = "fluentd"

--- a/pkg/k8shandler/certificates.go
+++ b/pkg/k8shandler/certificates.go
@@ -2,10 +2,11 @@ package k8shandler
 
 import (
 	"fmt"
-	"github.com/openshift/elasticsearch-operator/pkg/logger"
 	"io/ioutil"
 	"path"
 	"sync"
+
+	"github.com/openshift/elasticsearch-operator/pkg/logger"
 
 	"github.com/ViaQ/logerr/log"
 	"github.com/openshift/cluster-logging-operator/pkg/certificates"

--- a/pkg/k8shandler/certificates_test.go
+++ b/pkg/k8shandler/certificates_test.go
@@ -163,7 +163,6 @@ var _ = Describe("Reconciling", func() {
 				san := []string{
 					"elasticsearch-cluster",
 					"elasticsearch.openshift-logging.svc",
-					"elasticsearch.cluster.local",
 				}
 				Expect(secret).Should(ContainKeys("elasticsearch.key",
 					"elasticsearch.crt",
@@ -183,7 +182,6 @@ var _ = Describe("Reconciling", func() {
 
 				san := []string{
 					"elasticsearch.openshift-logging.svc",
-					"elasticsearch.cluster.local",
 				}
 				Expect(secret).Should(ContainKeys("elasticsearch.key",
 					"elasticsearch.crt",

--- a/pkg/k8shandler/forwarding_test.go
+++ b/pkg/k8shandler/forwarding_test.go
@@ -344,7 +344,7 @@ outputs:
 	secret:
 		name: fluentd
 	type: elasticsearch
-	url: https://elasticsearch.openshift-logging.svc.cluster.local:9200
+	url: https://elasticsearch.openshift-logging.svc:9200
 pipelines:
 - inputRefs:
 	- application
@@ -375,7 +375,7 @@ pipelines:
 			spec, status := request.NormalizeForwarder()
 			Expect(spec.Outputs).To(HaveLen(1))
 			Expect(spec.Outputs[0].Name).To(Equal("default"))
-			Expect(spec.Outputs[0].URL).To(Equal("https://elasticsearch.openshift-logging.svc.cluster.local:9200"))
+			Expect(spec.Outputs[0].URL).To(Equal("https://elasticsearch.openshift-logging.svc:9200"))
 			Expect(spec.Outputs[0].Secret.Name).To(Equal("fluentd"))
 			Expect(spec.Outputs[0].Type).To(Equal("elasticsearch"))
 

--- a/scripts/cert_generation.sh
+++ b/scripts/cert_generation.sh
@@ -327,8 +327,8 @@ generate_certs 'system.admin'
 
 # TODO: get es SAN DNS, IP values from es service names
 generate_certs 'kibana-internal' "$(generate_extensions false false kibana)"
-generate_certs 'elasticsearch' "$(generate_extensions true true $LOG_STORE{,-cluster}{,.${NAMESPACE}.svc}{,.cluster.local})"
-generate_certs 'logging-es' "$(generate_extensions false true $LOG_STORE{,.${NAMESPACE}.svc}{,.cluster.local})"
+generate_certs 'elasticsearch' "$(generate_extensions true true $LOG_STORE{,-cluster}{,.${NAMESPACE}.svc})"
+generate_certs 'logging-es' "$(generate_extensions false true $LOG_STORE{,.${NAMESPACE}.svc})"
 
 if [ ! -s "${WORKING_DIR}/kibana-session-secret" ] ; then
   info "Generating kibana session secret"


### PR DESCRIPTION
### Description
This PR provides a small fix for OCP environments with custom internal DNS, where using `cluster.local` for accessing Elasticsearch from Fluentd is not valid.

/cc @blockloop 
/assign @ewolinetz 

**Note:** Needs porting to 5.0.x and 5.1.x

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1945168
