### PR TITLE
Add management workload annotations

### DIFF
--- a/bundle/manifests/cluster-logging.v5.1.0.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.v5.1.0.clusterserviceversion.yaml
@@ -298,6 +298,8 @@ spec:
               name: cluster-logging-operator
           template:
             metadata:
+              annotations:
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: cluster-logging-operator
             spec:

--- a/manifests/5.1/cluster-logging.v5.1.0.clusterserviceversion.yaml
+++ b/manifests/5.1/cluster-logging.v5.1.0.clusterserviceversion.yaml
@@ -298,6 +298,8 @@ spec:
               name: cluster-logging-operator
           template:
             metadata:
+              annotations:
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: cluster-logging-operator
             spec:

--- a/olm_deploy/operatorregistry/registry-deployment.yaml
+++ b/olm_deploy/operatorregistry/registry-deployment.yaml
@@ -9,6 +9,8 @@ spec:
       registry.operator.cluster-logging: "true"
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         registry.operator.cluster-logging: "true"
       name: cluster-logging-operator-registry

--- a/pkg/k8shandler/daemonset.go
+++ b/pkg/k8shandler/daemonset.go
@@ -37,6 +37,7 @@ func NewDaemonSet(daemonsetName, namespace, loggingComponent, component string, 
 					Labels: labels,
 					Annotations: map[string]string{
 						"scheduler.alpha.kubernetes.io/critical-pod": "",
+						"target.workload.openshift.io/management":           `{"effect": "PreferredDuringScheduling"}`,
 					},
 				},
 				Spec: podSpec,

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -44,6 +44,9 @@ func NewDeployment(deploymentName string, namespace string, loggingComponent str
 						"component":     component,
 						"logging-infra": loggingComponent,
 					},
+					Annotations: map[string]string{
+						"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+					},
 				},
 				Spec: podSpec,
 			},


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
