### PR TITLE
Go implementation log file exporter jira ticket log 1188

### DIFF
--- a/bundle/manifests/cluster-logging.v5.2.0.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.v5.2.0.clusterserviceversion.yaml
@@ -330,6 +330,8 @@ spec:
                     value: "cluster-logging-operator"
                   - name: FLUENTD_IMAGE
                     value: "quay.io/openshift-logging/fluentd:latest"
+                  - name: LOGFILEMETRICEXPORTER_IMAGE
+                    value: "quay.io/openshift-logging/log-file-metric-exporter:latest"
   customresourcedefinitions:
     owned:
     - name: clusterloggings.logging.openshift.io

--- a/manifests/5.2/cluster-logging.v5.2.0.clusterserviceversion.yaml
+++ b/manifests/5.2/cluster-logging.v5.2.0.clusterserviceversion.yaml
@@ -328,6 +328,8 @@ spec:
                     value: "cluster-logging-operator"
                   - name: FLUENTD_IMAGE
                     value: "quay.io/openshift-logging/fluentd:latest"
+                  - name: LOGFILEMETRICEXPORTER_IMAGE
+                    value: "quay.io/openshift-logging/log-file-metric-exporter:latest"
   customresourcedefinitions:
     owned:
     - name: clusterloggings.logging.openshift.io

--- a/olm_deploy/operatorregistry/registry-deployment.yaml
+++ b/olm_deploy/operatorregistry/registry-deployment.yaml
@@ -41,6 +41,8 @@ spec:
           value: ${IMAGE_ELASTICSEARCH6}
         - name: IMAGE_LOGGING_KIBANA6
           value: ${IMAGE_LOGGING_KIBANA6}
+        - name: IMAGE_LOG_FILE_METRIC_EXPORTER
+          value: ${IMAGE_LOG_FILE_METRIC_EXPORTER}
 
       containers:
       - name: cluster-logging-operator-registry

--- a/olm_deploy/scripts/catalog-deploy.sh
+++ b/olm_deploy/scripts/catalog-deploy.sh
@@ -6,6 +6,7 @@ export IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=${IMAGE_CLUSTER_LOGGING_OPERATOR_
 export IMAGE_CLUSTER_LOGGING_OPERATOR=${IMAGE_CLUSTER_LOGGING_OPERATOR:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:cluster-logging-operator}
 export IMAGE_LOGGING_CURATOR5=${IMAGE_LOGGING_CURATOR5:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:logging-curator5}
 export IMAGE_LOGGING_FLUENTD=${IMAGE_LOGGING_FLUENTD:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:logging-fluentd}
+export IMAGE_LOG_FILE_METRIC_EXPORTER=${IMAGE_LOG_FILE_METRIC_EXPORTER:-registry.ci.openshift.org/${LOGGING_IS}/${LOGGING_VERSION}:log-file-metric-exporter}
 
 CLUSTER_LOGGING_OPERATOR_NAMESPACE=${CLUSTER_LOGGING_OPERATOR_NAMESPACE:-openshift-logging}
 
@@ -14,6 +15,7 @@ echo "cluster logging operator registry: ${IMAGE_CLUSTER_LOGGING_OPERATOR_REGIST
 echo "cluster logging operator: ${IMAGE_CLUSTER_LOGGING_OPERATOR}"
 echo "curator5: ${IMAGE_LOGGING_CURATOR5}"
 echo "fluentd: ${IMAGE_LOGGING_FLUENTD}"
+echo "log-file-metric-exporter: ${IMAGE_LOG_FILE_METRIC_EXPORTER}"
 
 echo "In namespace: ${CLUSTER_LOGGING_OPERATOR_NAMESPACE}"
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -18,16 +18,17 @@ const (
 	FluentdTrustedCAName       = "fluentd-trusted-ca-bundle"
 	KibanaTrustedCAName        = "kibana-trusted-ca-bundle"
 	// internal elasticsearch FQDN to prevent to connect to the global proxy
-	ElasticsearchFQDN   = "elasticsearch.openshift-logging.svc"
-	ElasticsearchName   = "elasticsearch"
-	ElasticsearchPort   = "9200"
-	FluentdName         = "fluentd"
-	KibanaName          = "kibana"
-	KibanaProxyName     = "kibana-proxy"
-	CuratorName         = "curator"
-	LogStoreURL         = "https://" + ElasticsearchFQDN + ":" + ElasticsearchPort
-	MasterCASecretName  = "master-certs"
-	CollectorSecretName = "fluentd"
+	ElasticsearchFQDN          = "elasticsearch.openshift-logging.svc"
+	ElasticsearchName          = "elasticsearch"
+	ElasticsearchPort          = "9200"
+	FluentdName                = "fluentd"
+	KibanaName                 = "kibana"
+	KibanaProxyName            = "kibana-proxy"
+	CuratorName                = "curator"
+	LogfilesmetricexporterName = "logfilesmetricexporter"
+	LogStoreURL                = "https://" + ElasticsearchFQDN + ":" + ElasticsearchPort
+	MasterCASecretName         = "master-certs"
+	CollectorSecretName        = "fluentd"
 	// Disable gosec linter, complains "possible hard-coded secret"
 	CollectorSecretsDir     = "/var/run/ocp-collector/secrets" //nolint:gosec
 	KibanaSessionSecretName = "kibana-session-secret"          //nolint:gosec
@@ -35,8 +36,9 @@ const (
 	LegacySecureforward = "_LEGACY_SECUREFORWARD"
 	LegacySyslog        = "_LEGACY_SYSLOG"
 
-	FluentdImageEnvVar = "FLUENTD_IMAGE"
-	CertEventName      = "cluster-logging-certs-generate"
+	FluentdImageEnvVar        = "FLUENTD_IMAGE"
+	LogfilesmetricImageEnvVar = "LOGFILEMETRICEXPORTER_IMAGE"
+	CertEventName             = "cluster-logging-certs-generate"
 )
 
 var ReconcileForGlobalProxyList = []string{FluentdTrustedCAName}

--- a/pkg/k8shandler/fluentd_test.go
+++ b/pkg/k8shandler/fluentd_test.go
@@ -45,8 +45,8 @@ func TestNewFluentdPodSpecWhenFieldsAreUndefined(t *testing.T) {
 	cluster := &logging.ClusterLogging{}
 	podSpec := newFluentdPodSpec(cluster, nil, logging.ClusterLogForwarderSpec{})
 
-	if len(podSpec.Containers) != 1 {
-		t.Error("Exp. there to be 1 fluentd container")
+	if len(podSpec.Containers) != 2 {
+		t.Error("Exp. there to be 2 fluentd container")
 	}
 
 	resources := podSpec.Containers[0].Resources
@@ -81,8 +81,8 @@ func TestNewFluentdPodSpecWhenResourcesAreDefined(t *testing.T) {
 	}
 	podSpec := newFluentdPodSpec(cluster, nil, logging.ClusterLogForwarderSpec{})
 
-	if len(podSpec.Containers) != 1 {
-		t.Error("Exp. there to be 1 fluentd container")
+	if len(podSpec.Containers) != 2 {
+		t.Error("Exp. there to be 2 fluentd container")
 	}
 
 	resources := podSpec.Containers[0].Resources
@@ -258,8 +258,8 @@ func TestNewFluentdPodSpecWhenProxyConfigExists(t *testing.T) {
 		},
 	}, logging.ClusterLogForwarderSpec{})
 
-	if len(podSpec.Containers) != 1 {
-		t.Error("Exp. there to be 1 fluentd container")
+	if len(podSpec.Containers) != 2 {
+		t.Error("Exp. there to be 2 fluentd container")
 	}
 
 	checkFluentdProxyEnvVar(t, podSpec, "HTTP_PROXY", httpproxy)
@@ -409,8 +409,8 @@ func TestNewFluentdPodWhenChunkLimitSizeExists(t *testing.T) {
 	}
 	podSpec := newFluentdPodSpec(cluster, nil, logging.ClusterLogForwarderSpec{})
 
-	if len(podSpec.Containers) != 1 {
-		t.Error("Exp. there to be 1 fluentd container")
+	if len(podSpec.Containers) != 2 {
+		t.Error("Exp. there to be 2 fluentd container")
 	}
 
 	checkFluentdForwarderEnvVar(t, podSpec, "BUFFER_SIZE_LIMIT", strconv.FormatInt(chunkLimitSize.Value(), 10))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -32,9 +32,10 @@ const (
 
 // COMPONENT_IMAGES are thee keys are based on the "container name" + "-{image,version}"
 var COMPONENT_IMAGES = map[string]string{
-	"curator":             "CURATOR_IMAGE",
-	constants.FluentdName: constants.FluentdImageEnvVar,
-	"kibana":              "KIBANA_IMAGE",
+	"curator":                            "CURATOR_IMAGE",
+	constants.FluentdName:                constants.FluentdImageEnvVar,
+	"kibana":                             "KIBANA_IMAGE",
+	constants.LogfilesmetricexporterName: constants.LogfilesmetricImageEnvVar,
 }
 
 // GetAnnotation returns the value of an annoation for a given key and true if the key was found


### PR DESCRIPTION
### Description
Summary
Implement an independent process to monitor CRIO container log file rotations that can be used to publish total_bytes_logged metrics in prometheus format. The motivation for moving away from a Ruby implementation is Ruby is not efficient in tracking file rotations. Also collectors can change over time so making metric computation outside of fluentd for logging total_bytes_logged is more preferred.

Exposes metric endpoint that is consumable by Prometheus at port :2112
Exposes metric of total_bytes_logged


/cc @alanconway @jcantrill 
/assign @jcantrill 


### Links

- Related PR(s): origin-aggregated-logging:Metric-for-inbound-log-data-loss-at-the-collector-JIRA-ticket-[LOG-1032](https://issues.redhat.com/browse/LOG-1032)
   Got in_tail and prometheus plugin changes which enable total_bytes_collected metric computed and published in prometheus plugin
- JIRA: https://issues.redhat.com/browse/LOG-1188

