### PR TITLE
Removed references to OCP_VERSION env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export GODEBUG=x509ignoreCN=0
 export APP_NAME=cluster-logging-operator
 export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(APP_NAME):latest
 
-export LOGGING_VERSION=$(shell basename $(shell ls -d manifests/[0-9]*))
+export LOGGING_VERSION?=$(shell basename $(shell ls -d manifests/[0-9]*))
 export NAMESPACE?=openshift-logging
 
 IMAGE_LOGGING_FLUENTD?=quay.io/openshift/origin-logging-fluentd:latest


### PR DESCRIPTION
### Description

Fix for pulling non-existent registry.ci.openshift.org/ocp/5.1:oauth-proxy. OCP_VERSION is used for OpenShift version in ES olm_deploy scripts.

/cc @jcantrill 
/assign @ewolinetz 