### PR TITLE
Renaming Metric names and adding namespace label

### DIFF
--- a/files/dashboards/openshift-logging-dashboard.json
+++ b/files/dashboards/openshift-logging-dashboard.json
@@ -1748,9 +1748,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(10, round(rate(fluentd_input_status_total_bytes_logged[5m])))",
+          "expr": "topk(10, round(rate(log_logged_bytes_total[5m])))",
           "interval": "",
-          "legendFormat": "{{path}}",
+          "legendFormat": "{{path}} namespace:{{namespace}}",
           "refId": "A"
         }
       ],
@@ -1758,7 +1758,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Logs emitted (top 10 containers) - Bytes/Second",
+      "title": "Logs produced (top 10 containers) - Bytes/Second",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
### Description
In #954  PR we have added OCP dashboard chart which shows top 10 log producing  containers. In the chart label `namespace` is also added to identify container. 
 Also based on https://github.com/openshift/cluster-logging-operator/pull/979#issuecomment-820427833  metric name also changed from `fluentd_input_status_total_bytes_logged` to `log_logged_bytes_total`

/cc @alanconway 
/assign @jcantrill 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s): 
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-1271
- Enhancement proposal:
