### PR TITLE
Bug1891623: Change expression for Fluentd file buffer usage

### DIFF
--- a/files/fluentd/fluentd_prometheus_alerts.yaml
+++ b/files/fluentd/fluentd_prometheus_alerts.yaml
@@ -11,27 +11,16 @@
     "labels":
       "service": "fluentd"
       "severity": "critical"
-  - "alert": "FluentdQueueLengthBurst"
-    "annotations":
-      "message": "In the last minute, fluentd {{ $labels.instance }} buffer queue length increased more than 32. Current value is {{ $value }}."
-      "summary": "Fluentd is overwhelmed"
-    "expr": |
-      delta(fluentd_output_status_buffer_queue_length[1m]) > 32
-    "for": "1m"
-    "labels":
-      "service": "fluentd"
-      "severity": "warning"
   - "alert": "FluentdQueueLengthIncreasing"
     "annotations":
-      "message": "In the last 12h, fluentd {{ $labels.instance }} buffer queue length constantly increased more than 1. Current value is {{ $value }}."
-      "summary": "Fluentd file buffer usage issue"
+      "message": "For the last hour, fluentd {{ $labels.instance }} average buffer queue length has increased continuously."
+      "summary": "Fluentd unable to keep up with traffic over time."
     "expr": |
-      delta(fluentd_output_status_buffer_queue_length[1m]) > 1
-    "for": "12h"
+      deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1
+    "for": "1h"
     "labels":
       "service": "fluentd"
-      "severity": "critical"
-
+      "severity": "error"
   - alert: FluentDHighErrorRate
     annotations:
       message: |-


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description

1. Change `FluentdQueueLengthIncreasing` alert expression. Fluentd buffering logs when it can't push to an output. This can be happened at startup because logstore not ready yet or in case log spamming. To prevent firing alerts if this is not necessary and system works well need to tune expression for buffer usage. Going to use [deriv() function](https://prometheus.io/docs/prometheus/latest/querying/functions/#deriv) for buffer increase calculation

2. Remove `FluentdQueueLengthBurst` at all, because this alert was related to our internal store which do not seem to apply for now.


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @alanconway @blockloop <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill  <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1891623
