### PR TITLE
LOG-1201: Fixed zero minutes/days/etc. retention time

### DIFF
--- a/pkg/k8shandler/indexmanagement/index_management.go
+++ b/pkg/k8shandler/indexmanagement/index_management.go
@@ -137,13 +137,20 @@ func getHotPhaseAge(maxAge esapi.TimeUnit) (esapi.TimeUnit, error) {
 		hotphaseAge int
 	)
 	age, unit, err = toAgeAndUnit(maxAge)
-	if err == nil {
-		hotphaseAge, unit, err = toHotPhaseAge(age, unit)
-		if err == nil {
-			return esapi.TimeUnit(fmt.Sprintf("%d%c", hotphaseAge, unit)), nil
-		}
+	if err != nil {
+		return esapi.TimeUnit(""), err
 	}
-	return esapi.TimeUnit(""), err
+
+	if age == 0 {
+		return esapi.TimeUnit(fmt.Sprintf("0%c", unit)), nil
+	}
+
+	hotphaseAge, unit, err = toHotPhaseAge(age, unit)
+	if err != nil {
+		return esapi.TimeUnit(""), err
+	}
+
+	return esapi.TimeUnit(fmt.Sprintf("%d%c", hotphaseAge, unit)), nil
 }
 
 func toAgeAndUnit(timeunit esapi.TimeUnit) (int, byte, error) {

--- a/pkg/k8shandler/indexmanagement/indexmanagement_test.go
+++ b/pkg/k8shandler/indexmanagement/indexmanagement_test.go
@@ -27,6 +27,104 @@ var _ = Describe("Indexmanagement", func() {
 		}
 	})
 
+	Describe("IndexManagemet Policy with 0 minutes, hours, days, weeks, months", func() {
+		It("should correctly parse 0m", func() {
+			retentionPolicy = &logging.RetentionPoliciesSpec{
+				App: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0m"),
+				},
+				Infra: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0m"),
+				},
+				Audit: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0m"),
+				},
+			}
+			spec := NewSpec(retentionPolicy)
+			Expect(len(spec.Policies)).To(Equal(3))
+			Expect(len(spec.Mappings)).To(Equal(3))
+			Expect(spec.Policies[0].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0m")))
+			Expect(spec.Policies[1].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0m")))
+			Expect(spec.Policies[2].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0m")))
+		})
+		It("should correctly parse 0h", func() {
+			retentionPolicy = &logging.RetentionPoliciesSpec{
+				App: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0h"),
+				},
+				Infra: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0h"),
+				},
+				Audit: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0h"),
+				},
+			}
+			spec := NewSpec(retentionPolicy)
+			Expect(len(spec.Policies)).To(Equal(3))
+			Expect(len(spec.Mappings)).To(Equal(3))
+			Expect(spec.Policies[0].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0h")))
+			Expect(spec.Policies[1].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0h")))
+			Expect(spec.Policies[2].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0h")))
+		})
+		It("should correctly parse 0d", func() {
+			retentionPolicy = &logging.RetentionPoliciesSpec{
+				App: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0d"),
+				},
+				Infra: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0d"),
+				},
+				Audit: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0d"),
+				},
+			}
+			spec := NewSpec(retentionPolicy)
+			Expect(len(spec.Policies)).To(Equal(3))
+			Expect(len(spec.Mappings)).To(Equal(3))
+			Expect(spec.Policies[0].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0d")))
+			Expect(spec.Policies[1].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0d")))
+			Expect(spec.Policies[2].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0d")))
+		})
+		It("should correctly parse 0w", func() {
+			retentionPolicy = &logging.RetentionPoliciesSpec{
+				App: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0w"),
+				},
+				Infra: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0w"),
+				},
+				Audit: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0w"),
+				},
+			}
+			spec := NewSpec(retentionPolicy)
+			Expect(len(spec.Policies)).To(Equal(3))
+			Expect(len(spec.Mappings)).To(Equal(3))
+			Expect(spec.Policies[0].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0w")))
+			Expect(spec.Policies[1].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0w")))
+			Expect(spec.Policies[2].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0w")))
+		})
+		It("should correctly parse 0M", func() {
+			retentionPolicy = &logging.RetentionPoliciesSpec{
+				App: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0M"),
+				},
+				Infra: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0M"),
+				},
+				Audit: &logging.RetentionPolicySpec{
+					MaxAge: esapi.TimeUnit("0M"),
+				},
+			}
+			spec := NewSpec(retentionPolicy)
+			Expect(len(spec.Policies)).To(Equal(3))
+			Expect(len(spec.Mappings)).To(Equal(3))
+			Expect(spec.Policies[0].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0M")))
+			Expect(spec.Policies[1].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0M")))
+			Expect(spec.Policies[2].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0M")))
+		})
+	})
+
 	Describe("IndexManagement Policy creation failure", func() {
 		Context("when retention policy is not defined", func() {
 			BeforeEach(func() {


### PR DESCRIPTION
### Description
This PR fixes CLO behaviour when retention time (`RetentionPolicy.MaxAge`) is set to `0(m | h | d | w | M | Y)`

/cc @jcantrill @vimalk78 @vparfonov 
/assign @jcantrill 

### Links
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1936998
- JIRA: https://issues.redhat.com/browse/LOG-1201
