### PR TITLE
LOG-974: Enable username and password for Kafka and Elasticsearch

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -8,6 +8,8 @@ const (
 	TrustedCABundleKey         = "ca-bundle.crt"
 	ClientCertKey              = "tls.crt"
 	ClientPrivateKey           = "tls.key"
+	ClientUsername             = "username"
+	ClientPassword             = "password"
 	InjectTrustedCABundleLabel = "config.openshift.io/inject-trusted-cabundle"
 	TrustedCABundleMountFile   = "tls-ca-bundle.pem"
 	TrustedCABundleMountDir    = "/etc/pki/ca-trust/extracted/pem/"

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -580,6 +580,8 @@ var _ = Describe("Generating fluentd config", func() {
         host es.svc.messaging.cluster.local
         port 9654
         verify_es_version_at_startup false
+		user "#{open('/var/run/ocp-collector/secrets/my-es-secret/username','r') do |f|f.read end}"
+		password "#{open('/var/run/ocp-collector/secrets/my-es-secret/password','r') do |f|f.read end}"
         scheme https
         ssl_version TLSv1_2
         target_index_key viaq_index_name
@@ -629,6 +631,8 @@ var _ = Describe("Generating fluentd config", func() {
         host es.svc.messaging.cluster.local
         port 9654
         verify_es_version_at_startup false
+		user "#{open('/var/run/ocp-collector/secrets/my-es-secret/username','r') do |f|f.read end}"
+		password "#{open('/var/run/ocp-collector/secrets/my-es-secret/password','r') do |f|f.read end}"
         scheme https
         ssl_version TLSv1_2
         target_index_key viaq_index_name
@@ -681,6 +685,8 @@ var _ = Describe("Generating fluentd config", func() {
         host es2.svc.messaging.cluster.local
         port 9654
         verify_es_version_at_startup false
+		user "#{open('/var/run/ocp-collector/secrets/my-es-secret/username','r') do |f|f.read end}"
+		password "#{open('/var/run/ocp-collector/secrets/my-es-secret/password','r') do |f|f.read end}"
         scheme https
         ssl_version TLSv1_2
         target_index_key viaq_index_name
@@ -730,6 +736,8 @@ var _ = Describe("Generating fluentd config", func() {
         host es2.svc.messaging.cluster.local
         port 9654
         verify_es_version_at_startup false
+		user "#{open('/var/run/ocp-collector/secrets/my-es-secret/username','r') do |f|f.read end}"
+		password "#{open('/var/run/ocp-collector/secrets/my-es-secret/password','r') do |f|f.read end}"
         scheme https
         ssl_version TLSv1_2
         target_index_key viaq_index_name
@@ -1720,6 +1728,8 @@ var _ = Describe("Generating fluentd config", func() {
 						host es.svc.infra.cluster
 						port 9999
 						verify_es_version_at_startup false
+						user "#{open('/var/run/ocp-collector/secrets/my-infra-secret/username','r') do |f|f.read end}"
+						password "#{open('/var/run/ocp-collector/secrets/my-infra-secret/password','r') do |f|f.read end}"
 						scheme https
 						ssl_version TLSv1_2
 						target_index_key viaq_index_name
@@ -1766,6 +1776,8 @@ var _ = Describe("Generating fluentd config", func() {
 						host es.svc.infra.cluster
 						port 9999
 						verify_es_version_at_startup false
+						user "#{open('/var/run/ocp-collector/secrets/my-infra-secret/username','r') do |f|f.read end}"
+						password "#{open('/var/run/ocp-collector/secrets/my-infra-secret/password','r') do |f|f.read end}"
 						scheme https
 						ssl_version TLSv1_2
 						target_index_key viaq_index_name
@@ -1815,6 +1827,8 @@ var _ = Describe("Generating fluentd config", func() {
 						host es.svc.messaging.cluster.local
 						port 9654
 						verify_es_version_at_startup false
+						user "#{open('/var/run/ocp-collector/secrets/my-es-secret/username','r') do |f|f.read end}"
+						password "#{open('/var/run/ocp-collector/secrets/my-es-secret/password','r') do |f|f.read end}"
 						scheme https
 						ssl_version TLSv1_2
 						target_index_key viaq_index_name
@@ -1861,6 +1875,8 @@ var _ = Describe("Generating fluentd config", func() {
 						host es.svc.messaging.cluster.local
 						port 9654
 						verify_es_version_at_startup false
+						user "#{open('/var/run/ocp-collector/secrets/my-es-secret/username','r') do |f|f.read end}"
+						password "#{open('/var/run/ocp-collector/secrets/my-es-secret/password','r') do |f|f.read end}"
 						scheme https
 						ssl_version TLSv1_2
 						target_index_key viaq_index_name
@@ -1910,6 +1926,8 @@ var _ = Describe("Generating fluentd config", func() {
 						host es.svc.messaging.cluster.local2
 						port 9654
 						verify_es_version_at_startup false
+						user "#{open('/var/run/ocp-collector/secrets/my-other-secret/username','r') do |f|f.read end}"
+						password "#{open('/var/run/ocp-collector/secrets/my-other-secret/password','r') do |f|f.read end}"
 						scheme https
 						ssl_version TLSv1_2
 						target_index_key viaq_index_name
@@ -1956,6 +1974,8 @@ var _ = Describe("Generating fluentd config", func() {
 						host es.svc.messaging.cluster.local2
 						port 9654
 						verify_es_version_at_startup false
+						user "#{open('/var/run/ocp-collector/secrets/my-other-secret/username','r') do |f|f.read end}"
+						password "#{open('/var/run/ocp-collector/secrets/my-other-secret/password','r') do |f|f.read end}"
 						scheme https
 						ssl_version TLSv1_2
 						target_index_key viaq_index_name
@@ -2005,6 +2025,8 @@ var _ = Describe("Generating fluentd config", func() {
 						host es.svc.audit.cluster
 						port 9654
 						verify_es_version_at_startup false
+						user "#{open('/var/run/ocp-collector/secrets/my-audit-secret/username','r') do |f|f.read end}"
+						password "#{open('/var/run/ocp-collector/secrets/my-audit-secret/password','r') do |f|f.read end}"
 						scheme https
 						ssl_version TLSv1_2
 						target_index_key viaq_index_name
@@ -2051,6 +2073,8 @@ var _ = Describe("Generating fluentd config", func() {
 						host es.svc.audit.cluster
 						port 9654
 						verify_es_version_at_startup false
+						user "#{open('/var/run/ocp-collector/secrets/my-audit-secret/username','r') do |f|f.read end}"
+						password "#{open('/var/run/ocp-collector/secrets/my-audit-secret/password','r') do |f|f.read end}"
 						scheme https
 						ssl_version TLSv1_2
 						target_index_key viaq_index_name

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -73,6 +73,8 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			host es.svc.messaging.cluster.local
 			port 9654
             verify_es_version_at_startup false
+			user "#{open('/var/run/ocp-collector/secrets/my-es-secret/username','r') do |f|f.read end}"
+			password "#{open('/var/run/ocp-collector/secrets/my-es-secret/password','r') do |f|f.read end}"
 			scheme https
 			ssl_version TLSv1_2
 			target_index_key viaq_index_name
@@ -119,6 +121,8 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			host es.svc.messaging.cluster.local
 			port 9654
             verify_es_version_at_startup false
+			user "#{open('/var/run/ocp-collector/secrets/my-es-secret/username','r') do |f|f.read end}"
+			password "#{open('/var/run/ocp-collector/secrets/my-es-secret/password','r') do |f|f.read end}"
 			scheme https
 			ssl_version TLSv1_2
 			target_index_key viaq_index_name

--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 
 	v1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("Generating external kafka server output store config block", func() {
@@ -22,32 +23,32 @@ var _ = Describe("Generating external kafka server output store config block", f
 
 	Context("for a single kafka default output target", func() {
 		kafkaConf := `<label @KAFKA_RECEIVER>
-        <match **>
-           @type kafka2
-           brokers broker1-kafka.svc.messaging.cluster.local:9092
-           default_topic topic
-           use_event_time true
-           <format>
-               @type json
-           </format>
-           <buffer topic>
-               @type file
-               path '/var/lib/fluentd/kafka_receiver'
-               flush_mode interval
-               flush_interval 1s
-               flush_thread_count 2
-               flush_at_shutdown true
-               retry_type exponential_backoff
-               retry_wait 1s
-               retry_max_interval 60s
-               retry_forever true
-               queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
-               total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-               chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
-               overflow_action block
-           </buffer>
-        </match>
-        </label>`
+	    <match **>
+	       @type kafka2
+	       brokers broker1-kafka.svc.messaging.cluster.local:9092
+	       default_topic topic
+	       use_event_time true
+	       <format>
+	           @type json
+	       </format>
+	       <buffer topic>
+	           @type file
+	           path '/var/lib/fluentd/kafka_receiver'
+	           flush_mode interval
+	           flush_interval 1s
+	           flush_thread_count 2
+	           flush_at_shutdown true
+	           retry_type exponential_backoff
+	           retry_wait 1s
+	           retry_max_interval 60s
+	           retry_forever true
+	           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+	           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+	           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+	           overflow_action block
+	       </buffer>
+	    </match>
+	    </label>`
 
 		It("should result in a valid kafka label config", func() {
 			outputs = []v1.OutputSpec{
@@ -82,35 +83,37 @@ var _ = Describe("Generating external kafka server output store config block", f
 
 	Context("for kafka output with secured communication and authentication", func() {
 		kafkaConf := `<label @KAFKA_RECEIVER>
-        <match **>
-           @type kafka2
-           brokers broker1-kafka.svc.messaging.cluster.local:9092
-           default_topic topic
-           use_event_time true
-           ssl_ca_cert '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
-           ssl_client_cert "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.crt') ? '/var/run/ocp-collector/secrets/some-secret/tls.crt' : nil}"
-           ssl_client_cert_key "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.key') ? '/var/run/ocp-collector/secrets/some-secret/tls.key' : nil}"
-           <format>
-               @type json
-           </format>
-           <buffer topic>
-               @type file
-               path '/var/lib/fluentd/kafka_receiver'
-               flush_mode interval
-               flush_interval 1s
-               flush_thread_count 2
-               flush_at_shutdown true
-               retry_type exponential_backoff
-               retry_wait 1s
-               retry_max_interval 60s
-               retry_forever true
-               queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
-               total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-               chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
-               overflow_action block
-           </buffer>
-        </match>
-        </label>`
+	    <match **>
+	       @type kafka2
+	       brokers broker1-kafka.svc.messaging.cluster.local:9092
+	       default_topic topic
+	       use_event_time true
+		   username "#{open('/var/run/ocp-collector/secrets/some-secret/username','r') do |f|f.read end}"
+		   password "#{open('/var/run/ocp-collector/secrets/some-secret/password','r') do |f|f.read end}"
+	       ssl_ca_cert '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
+	       ssl_client_cert "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.crt') ? '/var/run/ocp-collector/secrets/some-secret/tls.crt' : nil}"
+	       ssl_client_cert_key "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.key') ? '/var/run/ocp-collector/secrets/some-secret/tls.key' : nil}"
+	       <format>
+	           @type json
+	       </format>
+	       <buffer topic>
+	           @type file
+	           path '/var/lib/fluentd/kafka_receiver'
+	           flush_mode interval
+	           flush_interval 1s
+	           flush_thread_count 2
+	           flush_at_shutdown true
+	           retry_type exponential_backoff
+	           retry_wait 1s
+	           retry_max_interval 60s
+	           retry_forever true
+	           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+	           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+	           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+	           overflow_action block
+	       </buffer>
+	    </match>
+	    </label>`
 
 		It("should result in a valid kafka label config", func() {
 			outputs = []v1.OutputSpec{
@@ -137,22 +140,22 @@ var _ = Describe("Generating external kafka server output store config block", f
 	       @type kafka2
 	       brokers broker1-kafka.svc.messaging.cluster.local:9092,broker2-kafka.svc.messaging.cluster.local:9092
 	       default_topic topic
-         use_event_time true
+	     use_event_time true
 	       <format>
 	           @type json
 	       </format>
 	       <buffer topic>
 	           @type file
 	           path '/var/lib/fluentd/kafka_receiver'
-             flush_mode interval
+	         flush_mode interval
 	           flush_interval 1s
 	           flush_thread_count 2
 	           flush_at_shutdown true
-             retry_type exponential_backoff
-             retry_wait 1s
+	         retry_type exponential_backoff
+	         retry_wait 1s
 	           retry_max_interval 60s
 	           retry_forever true
-             queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+	         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 	           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 	           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
 	           overflow_action block
@@ -233,6 +236,67 @@ var _ = Describe("Generating external kafka server output store config block", f
 			}
 			_, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("for basic username/password auth", func() {
+		It("should return a valid configuration", func() {
+			kafkaConf := `<label @KAFKA_RECEIVER>
+			<match **>
+			   @type kafka2
+			   brokers broker1-kafka.svc.messaging.cluster.local:9092
+			   default_topic topic
+			   use_event_time true
+			   username "#{open('/var/run/ocp-collector/secrets/my-secret/username','r') do |f|f.read end}"
+			   password "#{open('/var/run/ocp-collector/secrets/my-secret/password','r') do |f|f.read end}"
+			   ssl_ca_cert '/var/run/ocp-collector/secrets/my-secret/ca-bundle.crt'
+			   ssl_client_cert "#{File.exist?('/var/run/ocp-collector/secrets/my-secret/tls.crt') ? '/var/run/ocp-collector/secrets/my-secret/tls.crt' : nil}"
+			   ssl_client_cert_key "#{File.exist?('/var/run/ocp-collector/secrets/my-secret/tls.key') ? '/var/run/ocp-collector/secrets/my-secret/tls.key' : nil}"
+		   
+			   <format>
+				   @type json
+			   </format>
+			   <buffer topic>
+				   @type file
+				   path '/var/lib/fluentd/kafka_receiver'
+				   flush_mode interval
+				   flush_interval 1s
+				   flush_thread_count 2
+				   flush_at_shutdown true
+				   retry_type exponential_backoff
+				   retry_wait 1s
+				   retry_max_interval 60s
+				   retry_forever true
+				   queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+				   total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+				   chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+				   overflow_action block
+			   </buffer>
+			</match>
+			</label>`
+
+			outputs = []v1.OutputSpec{
+				{
+					Type: v1.OutputTypeKafka,
+					Name: "kafka-receiver",
+					URL:  "tls://broker1-kafka.svc.messaging.cluster.local:9092/topic",
+					Secret: &v1.OutputSecretSpec{
+						Name: "my-secret",
+					},
+				},
+			}
+
+			results, err := generator.generateOutputLabelBlocks(outputs, map[string]*corev1.Secret{
+				"my-secret": {
+					Data: map[string][]byte{
+						"username": []byte("test"),
+						"password": []byte("test"),
+					},
+				},
+			}, forwarderSpec)
+			Expect(err).To(BeNil())
+			Expect(len(results)).To(Equal(1))
+			Expect(results[0]).To(EqualTrimLines(kafkaConf))
 		})
 	})
 })

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -731,6 +731,12 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
   port {{.Port}}
   verify_es_version_at_startup false
 {{- if .Target.Secret }}
+{{ with $path := .SecretPath "username" -}}
+  user "#{open('{{ $path }}','r') do |f|f.read end}"
+{{ end -}}
+{{ with $path := .SecretPath "password" -}}
+  password "#{open('{{ $path }}','r') do |f|f.read end}"
+{{ end -}}
   scheme https
   ssl_version TLSv1_2
 {{- else }}
@@ -875,6 +881,12 @@ brokers {{.Brokers}}
 default_topic {{.Topic}}
 use_event_time true
 {{ if .Target.Secret -}}
+{{ with $path := .SecretPath "username" -}}
+username "#{open('{{ $path }}','r') do |f|f.read end}"
+{{ end -}}
+{{ with $path := .SecretPath "password" -}}
+password "#{open('{{ $path }}','r') do |f|f.read end}"
+{{ end -}}
 {{ $tlsCert := .SecretPath "tls.crt" }}
 {{ $tlsKey := .SecretPath "tls.key" }}
 ssl_ca_cert '{{ .SecretPath "ca-bundle.crt"}}'

--- a/pkg/k8shandler/forwarding.go
+++ b/pkg/k8shandler/forwarding.go
@@ -346,11 +346,17 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputSecret(output *logging.
 	// Make sure we have secrets for a valid TLS configuration.
 	haveCert := len(secret.Data[constants.ClientCertKey]) > 0
 	haveKey := len(secret.Data[constants.ClientPrivateKey]) > 0
+	haveUsername := len(secret.Data[constants.ClientUsername]) > 0
+	havePassword := len(secret.Data[constants.ClientPassword]) > 0
 	switch {
 	case haveCert && !haveKey:
 		return fail(condMissing("cannot have %v without %v", constants.ClientCertKey, constants.ClientPrivateKey))
 	case !haveCert && haveKey:
 		return fail(condMissing("cannot have %v without %v", constants.ClientPrivateKey, constants.ClientCertKey))
+	case haveUsername && !havePassword:
+		return fail(condMissing("cannot have %v without %v", constants.ClientUsername, constants.ClientPassword))
+	case !haveUsername && havePassword:
+		return fail(condMissing("cannot have %v without %v", constants.ClientPassword, constants.ClientUsername))
 	}
 	clusterRequest.OutputSecrets[output.Name] = secret
 	return true


### PR DESCRIPTION
### Description
This PR enables the usage of `username` and `password` as part of the CLF secret. 

/cc @jcantrill 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-974
