### PR TITLE
Fix built-in application behavior to collect all of logs

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -496,7 +496,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @_APPLICATION>
     <match **>
       @type label_router
-      default_route @_APPLICATION_DEFAULT
       <route>
         @label @APPS_PIPELINE
         <match>
@@ -509,9 +508,14 @@ var _ = Describe("Generating fluentd config", func() {
           namespaces dev-apple,project2-namespace
         </match>
       </route>
+      <route>
+        @label @_APPLICATION_ALL
+        <match>
+        </match>
+      </route>
     </match>
   </label>
-  <label @_APPLICATION_DEFAULT>
+  <label @_APPLICATION_ALL>
     <match **>
       @type copy
       <store>
@@ -1212,7 +1216,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @_APPLICATION>
     <match **>
       @type label_router
-      default_route @_APPLICATION_DEFAULT
       <route>
         @label @APPS_PROD_PIPELINE
         <match>
@@ -1225,9 +1228,14 @@ var _ = Describe("Generating fluentd config", func() {
           labels app:nginx,environment:dev
         </match>
       </route>
+      <route>
+        @label @_APPLICATION_ALL
+        <match>
+        </match>
+      </route>
     </match>
   </label>
-  <label @_APPLICATION_DEFAULT>
+  <label @_APPLICATION_ALL>
     <match **>
       @type copy
       <store>
@@ -1909,7 +1917,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @_APPLICATION>
     <match **>
       @type label_router
-      default_route @_APPLICATION_DEFAULT
       <route>
         @label @APPS_PROD_PIPELINE
         <match>
@@ -1924,9 +1931,14 @@ var _ = Describe("Generating fluentd config", func() {
           labels app:nginx,environment:dev
         </match>
       </route>
+      <route>
+        @label @_APPLICATION_ALL
+        <match>
+        </match>
+      </route>
     </match>
   </label>
-  <label @_APPLICATION_DEFAULT>
+  <label @_APPLICATION_ALL>
     <match **>
       @type copy
       <store>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -540,16 +540,20 @@ const inputSelectorToPipelineTemplate = `{{- define "inputSelectorToPipelineTemp
 <label {{sourceTypelabelName .Source}}>
   <match **>
     @type label_router
-{{- if .PipelineNames }}
-    default_route {{sourceTypelabelName .Source}}_DEFAULT
-{{- end }}
     {{- range .InputSelectors }}
     {{ . }}
     {{- end}}
+{{- if .PipelineNames }}
+    <route>
+      @label {{sourceTypelabelName .Source}}_ALL
+      <match>
+      </match>
+    </route>
+{{- end }}
   </match>
 </label>
 {{ if .PipelineNames -}}
-<label {{sourceTypelabelName .Source}}_DEFAULT>
+<label {{sourceTypelabelName .Source}}_ALL>
   <match **>
     @type copy
 {{- range $index, $pipelineLabel := .PipelineNames }}


### PR DESCRIPTION
# Overview
This PR changes the default input behavior to collect  records from all namespaces and pods.
The current log filtering by pod labels and namespaces only collects non matching records("anything left over").

For example, 
```
apiVersion: logging.openshift.io/v1
kind: ClusterLogForwarder
metadata:
  name: instance
  namespace: openshift-logging
spec:
  inputs:
   - name: application-logs1
     application:
       namespaces:
       - my-project
  outputs:
   - name: syslog1
     ...
  pipelines:
   - name: syslog-app-logs1
     inputRefs:
     - application-logs1
     outputRefs:
     - syslog1
   - name: app-default
     inputRefs:
     - application
     outputRefs:
     - default
```
The "app-default" pipeline won't collect logs from "my-project" namespace in the customized input.

The concept of "application" was discussed in https://github.com/openshift/cluster-logging-operator/pull/955/files#r600738769. But I would like to confirm it again.

/cc @alanconway @jcantrill

### Links
- Enhancement proposal: https://github.com/openshift/enhancements/pull/457
- JIRA: https://issues.redhat.com/browse/LOG-660