### PR TITLE
LOG-1572: Fix built-in application behavior to collect all of logs

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -503,36 +503,44 @@ var _ = Describe("Generating fluentd config", func() {
 
   # Relabel specific sources (e.g. logs.apps) to multiple pipelines
   <label @_APPLICATION>
-     <match kubernetes.**_dev-apple_**>
+    <match **>
       @type copy
       <store>
-	    @type relabel
-	    @label @APPS_PIPELINE2
+        @type relabel
+        @label @MY_DEFAULT_PIPELINE
+      </store>
+
+      <store>
+        @type relabel
+        @label @_APPLICATION_NAMESPACE_FILTERING
+      </store>
+    </match>
+  </label>
+
+  <label @_APPLICATION_NAMESPACE_FILTERING>
+    <match kubernetes.**_dev-apple_**>
+      @type copy
+      <store>
+        @type relabel
+        @label @APPS_PIPELINE2
       </store>
     </match>
     <match kubernetes.**_project1-namespace_**>
       @type copy
       <store>
-		@type relabel
-		@label @APPS_PIPELINE
+        @type relabel
+        @label @APPS_PIPELINE
       </store>
     </match>
     <match kubernetes.**_project2-namespace_**>
       @type copy
       <store>
-		@type relabel
-		@label @APPS_PIPELINE
+        @type relabel
+        @label @APPS_PIPELINE
       </store>
       <store>
-		@type relabel
-		@label @APPS_PIPELINE2
-      </store>
-    </match>
-    <match **>
-      @type copy
-      <store>
-	    @type relabel
-	    @label @MY_DEFAULT_PIPELINE
+        @type relabel
+        @label @APPS_PIPELINE2
       </store>
     </match>
   </label>
@@ -2510,6 +2518,17 @@ var _ = Describe("Generating fluentd config", func() {
 
     # Relabel specific sources (e.g. logs.apps) to multiple pipelines
     <label @_APPLICATION>
+      <match **>
+        @type copy
+
+        <store>
+          @type relabel
+          @label @_APPLICATION_NAMESPACE_FILTERING
+        </store>
+      </match>
+    </label>
+
+    <label @_APPLICATION_NAMESPACE_FILTERING>
       <match kubernetes.**_project1_**>
         @type copy
         <store>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -533,6 +533,24 @@ const inputSourceOpenShiftAuditTemplate = `{{- define "inputSourceOpenShiftAudit
 
 const namespaceToPipelineTemplate = `{{- define "namespaceToPipelineTemplate" -}}
 <label {{sourceTypelabelName .Source}}>
+  <match **>
+    @type copy
+  {{- range $index, $pipelineName := .AppAllPipelineNames }}
+    <store>
+      @type relabel
+      @label {{labelName $pipelineName}}
+    </store>
+  {{- end }}
+  {{ if .AppNamespaces }}
+    <store>
+      @type relabel
+      @label {{sourceTypelabelName .Source}}_NAMESPACE_FILTERING
+    </store>
+  {{- end }}
+  </match>
+</label>
+  {{ if .AppNamespaces }}
+<label {{sourceTypelabelName .Source}}_NAMESPACE_FILTERING>
   {{- $pipelines := $.PipeLines -}}
   {{- range $nsindex, $ns := .AppNamespaces }}
   <match {{applicationTag $ns}}>
@@ -546,6 +564,7 @@ const namespaceToPipelineTemplate = `{{- define "namespaceToPipelineTemplate" -}
   </match>
   {{- end }}
 </label>
+  {{- end }}
 {{- end}}`
 
 const sourceToPipelineCopyTemplate = `{{- define "sourceToPipelineCopyTemplate" -}}


### PR DESCRIPTION
### Description
This PR changes the built-in `application` behavior to collect all the applications logs.

As for release-5.1, the namespace filtering feature is changed based on label router plugin.
So we can not cherry-pick https://github.com/openshift/cluster-logging-operator/pull/999.

This PR suggests the following change without depending on https://github.com/openshift/cluster-logging-operator/pull/999:

### Example LF CR:
```
spec:
  inputs:
   - name: myInput
     application:
       namespaces: 
       - project1-namespace
  outputs:
   - name: apps-es-1
     ...
   - name: apps-es-2
     ...
  pipelines:
   - name: my-default-pipeline
     inputRefs:
     - application
     outputRefs:
     - app-es-1
   - name: apps-pipeline
     inputRefs:
     - myInput
     outputRefs:
     - app-es-2
```
### Current fluent.conf
```
  <label @_APPLICATION>
    <match kubernetes.**_project1-namespace_**>
      @type copy
      <store>
                @type relabel
                @label @APPS_PIPELINE
      </store>
    </match>
    <match **>
      @type copy
      <store>
            @type relabel
            @label @MY_DEFAULT_PIPELINE
      </store>
    </match>
  </label>
```

### Proposed fluent.conf
```
  <label @_APPLICATION>
    <match **>
      @type copy
      <store>
        @type relabel
        @label @MY_DEFAULT_PIPELINE
      </store>
      <store>
        @type relabel
        @label @_APPLICATION_NAMESPACE_FILTERING
      </store>
    </match>
  </label>
  <label @_APPLICATION_NAMESPAECE_FILTERING>
    <match kubernetes.**_project1-namespace_**>
      @type copy
      <store>
        @type relabel
        @label @APPS_PIPELINE
      </store>
    </match>
  </label>

```

/cc @alanconway @jcantrill

### Links
- Depending on PR(s): https://github.com/openshift/cluster-logging-operator/pull/999
