### PR TITLE
Replace OCP_VERSION with LOGGING_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ export GODEBUG=x509ignoreCN=0
 export APP_NAME=cluster-logging-operator
 export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(APP_NAME):latest
 
-export OCP_VERSION?=4.7
 export LOGGING_VERSION=$(shell basename $(shell ls -d manifests/[0-9]*))
 export NAMESPACE?=openshift-logging
 
@@ -120,7 +119,7 @@ fmt:
 
 # Do all code/CRD generation at once, with timestamp file to check out-of-date.
 GEN_TIMESTAMP=.zz_generate_timestamp
-MANIFESTS=manifests/$(OCP_VERSION)
+MANIFESTS=manifests/$(LOGGING_VERSION)
 generate: $(GEN_TIMESTAMP)
 $(GEN_TIMESTAMP): $(shell find pkg/apis -name '*.go') $(OPERATOR_SDK)
 	@echo generating code
@@ -183,7 +182,7 @@ test-cluster:
 
 OPENSHIFT_VERSIONS?="v4.7"
 generate-bundle: regenerate $(OPM)
-	MANIFEST_VERSION=${OCP_VERSION} OPENSHIFT_VERSIONS=${OPENSHIFT_VERSIONS} hack/generate-bundle.sh
+	MANIFEST_VERSION=${LOGGING_VERSION} OPENSHIFT_VERSIONS=${OPENSHIFT_VERSIONS} hack/generate-bundle.sh
 .PHONY: generate-bundle
 
 # NOTE: This is the CI e2e entry point.

--- a/hack/generate-crd.sh
+++ b/hack/generate-crd.sh
@@ -4,7 +4,7 @@ source .bingo/variables.env
 
 set -euo pipefail
 
-MANIFESTS_DIR=${1:-"manifests/${OCP_VERSION}"}
+MANIFESTS_DIR=${1:-"manifests/${LOGGING_VERSION}"}
 CLF_CRD_FILE="logging.openshift.io_clusterlogforwarders_crd.yaml"
 CLO_CRD_FILE="logging.openshift.io_clusterloggings_crd.yaml"
 CLO_PATCH_FILE="crd-v1-clusterloggings-patches.yaml"


### PR DESCRIPTION
All versioned artifacts now go under manifests/$LOGGING_VERSION.  Redundant OCP_VERSION was removed.

/assign @jcantrill