### PR TITLE
LOG-1354: No datapoints found on Elastic Query/Fetch Latency dashboard

### DIFF
--- a/files/dashboards/openshift-logging-dashboard.json
+++ b/files/dashboards/openshift-logging-dashboard.json
@@ -746,13 +746,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by()(rate(es_indices_search_query_time_seconds[5m])) / sum by()(irate(es_indices_search_query_count{context='total'}[5m]))",
+              "expr": "sum by()(rate(es_indices_search_query_time_seconds[5m])) / sum by()(rate(es_indices_search_query_count[5m]))",
               "hide": false,
               "legendFormat": "query time",
               "refId": "A"
             },
             {
-              "expr": "sum by()(rate(es_indices_search_fetch_time_seconds[5m])) / sum by()(irate(es_indices_search_fetch_count{context='total'}[5m]))",
+              "expr": "sum by()(rate(es_indices_search_fetch_time_seconds[5m])) / sum by()(rate(es_indices_search_fetch_count[5m]))",
               "hide": false,
               "legendFormat": "fetch time",
               "refId": "B"


### PR DESCRIPTION
### Description

There was a slight change to indices statistics metrics. We also need
to get rid of label filter (it does not make sense now).

Additional change was done to Prometheus metric calculation itself.
We changed "rate()/irate()" to "rate()/rate()".

Context – useful resource about rate and irate metrics: <https://www.robustperception.io/irate-graphs-are-better-graphs>

/cc @blockloop 
/assign @ewolinetz 

### Links

- JIRA: https://issues.redhat.com/browse/LOG-1354
