### PR TITLE
 LOG-1286: Pick daemon names when configuring addLogSource field

### DIFF
--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -210,10 +210,12 @@ spec:
                         type `syslog`
                       properties:
                         addLogSource:
-                          description: AddLogSource adds log's source information
+                          description: "AddLogSource adds log's source information
                             to the log message If the logs are collected from a process;
                             namespace_name, pod_name, container_name is added to the
-                            log
+                            log. \n In addition, it picks the originating process name
+                            and id(known as the `pid`) from the record and injects them
+                            into the header field."
                           type: boolean
                         appName:
                           description: "AppName is APP-NAME part of the syslog-msg

--- a/manifests/5.2/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/manifests/5.2/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -210,10 +210,12 @@ spec:
                         type `syslog`
                       properties:
                         addLogSource:
-                          description: AddLogSource adds log's source information
+                          description: "AddLogSource adds log's source information
                             to the log message If the logs are collected from a process;
                             namespace_name, pod_name, container_name is added to the
-                            log
+                            log. \n In addition, it picks the originating process name
+                            and id(known as the `pid`) from the record and injects them
+                            into the header field."
                           type: boolean
                         appName:
                           description: "AppName is APP-NAME part of the syslog-msg

--- a/pkg/apis/logging/v1/output_types.go
+++ b/pkg/apis/logging/v1/output_types.go
@@ -67,6 +67,8 @@ type Syslog struct {
 
 	// AddLogSource adds log's source information to the log message
 	// If the logs are collected from a process; namespace_name, pod_name, container_name is added to the log
+	// In addition, it picks the originating process name and id(known as the `pid`) from the record
+	// and injects them into the header field."
 	//
 	// +optional
 	AddLogSource bool `json:"addLogSource,omitempty"`

--- a/pkg/generators/forwarding/fluentd/fluent_conf.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf.go
@@ -145,10 +145,14 @@ func (conf *outputLabelConf) LabelName() string {
 
 func (conf *outputLabelConf) StoreID() string {
 	prefix := ""
+	suffix := ""
 	if conf.Hints().Has("prefix_as_retry") {
 		prefix = "retry_"
 	}
-	return strings.ToLower(fmt.Sprintf("%v%v", prefix, replacer.Replace(conf.Name)))
+	if conf.Hints().Has("journal_log") {
+		suffix = "_journal"
+	}
+	return strings.ToLower(fmt.Sprintf("%v%v%v", prefix, replacer.Replace(conf.Name), suffix))
 }
 
 func (conf *outputLabelConf) RetryTag() string {

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -355,9 +355,53 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					  msg_key         ${if record.has_key?('message') && record['message'] != nil; record['message']; else nil; end}
 					  msg_info        ${if record['msg_key'] != nil && record['msg_key'].is_a?(Hash); require 'json'; "message="+record['message'].to_json; elsif record['msg_key'] != nil; "message="+record['message']; else nil; end}
 					  message         ${if record['msg_key'] != nil && record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; record['namespace_info'] + ", " + record['container_info'] + ", " + record['pod_info'] + ", " + record['msg_info']; else record['message']; end}
+					  systemd_info    ${if record.has_key?('systemd') && record['systemd']['t'].has_key?('PID'); record['systemd']['u']['SYSLOG_IDENTIFIER'] += "[" + record['systemd']['t']['PID'] + "]"; else {}; end}
 					</record>
-					  remove_keys kubernetes_info, namespace_info, pod_info, container_info, msg_key, msg_info
+					  remove_keys kubernetes_info, namespace_info, pod_info, container_info, msg_key, msg_info, systemd_info
 				  </filter>
+				  # The "infrastructure" stream is splitted into the pod logs and the journal logs.
+				  # This match section is for the journal logs to inject the daemon name info into the journal logs only.
+				  <match journal.** system.var.log**>
+					@type copy
+					<store>
+					  @type remote_syslog
+					  @id syslog_receiver_journal
+					  host sl.svc.messaging.cluster.local
+					  port 9654
+					  rfc rfc5424
+					  facility user
+					  severity debug
+					  appname ${$.systemd.u.SYSLOG_IDENTIFIER}
+					  protocol tcp
+					  packet_size 4096
+					  hostname "#{ENV['NODE_NAME']}"
+					  tls true
+					  ca_file '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
+					  verify_mode true
+					  timeout 60
+					  timeout_exception true
+					  keep_alive true
+					  keep_alive_idle 75
+					  keep_alive_cnt 9
+					  keep_alive_intvl 7200
+					  <buffer $.systemd.u.SYSLOG_IDENTIFIER>
+						@type file
+						path '/var/lib/fluentd/syslog_receiver_journal'
+						flush_mode interval
+						flush_interval 1s
+						flush_thread_count 2
+						flush_at_shutdown true
+						retry_type exponential_backoff
+						retry_wait 1s
+						retry_max_interval 60s
+						retry_timeout 60m
+						queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+						total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+						chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+						overflow_action block
+					  </buffer>
+					</store>
+				  </match>
 				  <match **>
 					@type copy
 					<store>
@@ -412,6 +456,270 @@ var _ = Describe("Generating external syslog server output store config blocks",
 								Syslog: &logging.Syslog{
 									AddLogSource: true,
 									RFC:          "RFC5424",
+								},
+							},
+						},
+					}
+				})
+				It("should produce config to copy log source information to log message", func() {
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
+					Expect(err).To(BeNil())
+					Expect(len(results)).To(Equal(1))
+					Expect(results[0]).To(EqualTrimLines(syslogConfWithAddSource))
+				})
+			})
+			Context("with AddLogSource flag and AppName field", func() {
+				syslogConfWithAddSource := `<label @SYSLOG_RECEIVER>
+				  <filter **>
+					@type parse_json_field
+					json_fields  message
+					merge_json_log false
+					replace_json_log true
+				  </filter>
+				  <filter **>
+					@type record_modifier
+					<record>
+					  kubernetes_info ${if record.has_key?('kubernetes'); record['kubernetes']; else {}; end}
+					  namespace_info  ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "namespace_name=" + record['kubernetes_info']['namespace_name']; else nil; end}
+					  pod_info        ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "pod_name=" + record['kubernetes_info']['pod_name']; else nil; end}
+					  container_info  ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "container_name=" + record['kubernetes_info']['container_name']; else nil; end}
+					  msg_key         ${if record.has_key?('message') && record['message'] != nil; record['message']; else nil; end}
+					  msg_info        ${if record['msg_key'] != nil && record['msg_key'].is_a?(Hash); require 'json'; "message="+record['message'].to_json; elsif record['msg_key'] != nil; "message="+record['message']; else nil; end}
+					  message         ${if record['msg_key'] != nil && record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; record['namespace_info'] + ", " + record['container_info'] + ", " + record['pod_info'] + ", " + record['msg_info']; else record['message']; end}
+					  systemd_info    ${if record.has_key?('systemd') && record['systemd']['t'].has_key?('PID'); record['systemd']['u']['SYSLOG_IDENTIFIER'] += "[" + record['systemd']['t']['PID'] + "]"; else {}; end}
+					</record>
+					  remove_keys kubernetes_info, namespace_info, pod_info, container_info, msg_key, msg_info, systemd_info
+				  </filter>
+				  # The "infrastructure" stream is splitted into the pod logs and the journal logs.
+				  # This match section is for the journal logs to inject the daemon name info into the journal logs only.
+				  <match journal.** system.var.log**>
+					@type copy
+					<store>
+					  @type remote_syslog
+					  @id syslog_receiver_journal
+					  host sl.svc.messaging.cluster.local
+					  port 9654
+					  rfc rfc5424
+					  facility user
+					  severity debug
+					  appname ${$.systemd.u.SYSLOG_IDENTIFIER}
+					  protocol tcp
+					  packet_size 4096
+					  hostname "#{ENV['NODE_NAME']}"
+					  tls true
+					  ca_file '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
+					  verify_mode true
+					  timeout 60
+					  timeout_exception true
+					  keep_alive true
+					  keep_alive_idle 75
+					  keep_alive_cnt 9
+					  keep_alive_intvl 7200
+					  <buffer $.systemd.u.SYSLOG_IDENTIFIER>
+						@type file
+						path '/var/lib/fluentd/syslog_receiver_journal'
+						flush_mode interval
+						flush_interval 1s
+						flush_thread_count 2
+						flush_at_shutdown true
+						retry_type exponential_backoff
+						retry_wait 1s
+						retry_max_interval 60s
+						retry_timeout 60m
+						queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+						total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+						chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+						overflow_action block
+					  </buffer>
+					</store>
+				  </match>
+				  <match **>
+					@type copy
+					<store>
+					  @type remote_syslog
+					  @id syslog_receiver
+					  host sl.svc.messaging.cluster.local
+					  port 9654
+					  rfc rfc5424
+					  facility user
+					  severity debug
+					  appname app
+					  protocol tcp
+					  packet_size 4096
+					  hostname "#{ENV['NODE_NAME']}"
+					  tls true
+					  ca_file '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
+					  verify_mode true
+					  timeout 60
+					  timeout_exception true
+					  keep_alive true
+					  keep_alive_idle 75
+					  keep_alive_cnt 9
+					  keep_alive_intvl 7200
+					  <buffer >
+						@type file
+						path '/var/lib/fluentd/syslog_receiver'
+						flush_mode interval
+						flush_interval 1s
+						flush_thread_count 2
+						flush_at_shutdown true
+						retry_type exponential_backoff
+						retry_wait 1s
+						retry_max_interval 60s
+						retry_timeout 60m
+						queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+						total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+						chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+						overflow_action block
+					  </buffer>
+					</store>
+				  </match>
+				</label>`
+				BeforeEach(func() {
+					outputs = []logging.OutputSpec{
+						{
+							Type: "syslog",
+							Name: "syslog-receiver",
+							URL:  "tls://sl.svc.messaging.cluster.local:9654",
+							Secret: &logging.OutputSecretSpec{
+								Name: "some-secret",
+							},
+							OutputTypeSpec: logging.OutputTypeSpec{
+								Syslog: &logging.Syslog{
+									AddLogSource: true,
+									AppName:      "app",
+									RFC:          "RFC5424",
+								},
+							},
+						},
+					}
+				})
+				It("should produce config to copy log source information to log message", func() {
+					results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
+					Expect(err).To(BeNil())
+					Expect(len(results)).To(Equal(1))
+					Expect(results[0]).To(EqualTrimLines(syslogConfWithAddSource))
+				})
+			})
+			Context("with AddLogSource flag and rfc3164 flag", func() {
+				syslogConfWithAddSource := `<label @SYSLOG_RECEIVER>
+				  <filter **>
+					@type parse_json_field
+					json_fields  message
+					merge_json_log false
+					replace_json_log true
+				  </filter>
+				  <filter **>
+					@type record_modifier
+					<record>
+					  kubernetes_info ${if record.has_key?('kubernetes'); record['kubernetes']; else {}; end}
+					  namespace_info  ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "namespace_name=" + record['kubernetes_info']['namespace_name']; else nil; end}
+					  pod_info        ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "pod_name=" + record['kubernetes_info']['pod_name']; else nil; end}
+					  container_info  ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "container_name=" + record['kubernetes_info']['container_name']; else nil; end}
+					  msg_key         ${if record.has_key?('message') && record['message'] != nil; record['message']; else nil; end}
+					  msg_info        ${if record['msg_key'] != nil && record['msg_key'].is_a?(Hash); require 'json'; "message="+record['message'].to_json; elsif record['msg_key'] != nil; "message="+record['message']; else nil; end}
+					  message         ${if record['msg_key'] != nil && record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; record['namespace_info'] + ", " + record['container_info'] + ", " + record['pod_info'] + ", " + record['msg_info']; else record['message']; end}
+					  systemd_info    ${if record.has_key?('systemd') && record['systemd']['t'].has_key?('PID'); record['systemd']['u']['SYSLOG_IDENTIFIER'] += "[" + record['systemd']['t']['PID'] + "]"; else {}; end}
+					</record>
+					  remove_keys kubernetes_info, namespace_info, pod_info, container_info, msg_key, msg_info, systemd_info
+				  </filter>
+				  # The "infrastructure" stream is splitted into the pod logs and the journal logs.
+				  # This match section is for the journal logs to inject the daemon name info into the journal logs only.
+				  <match journal.** system.var.log**>
+					@type copy
+					<store>
+					  @type remote_syslog
+					  @id syslog_receiver_journal
+					  host sl.svc.messaging.cluster.local
+					  port 9654
+					  rfc rfc3164
+					  facility user
+					  severity debug
+					  program ${$.systemd.u.SYSLOG_IDENTIFIER}
+					  protocol tcp
+					  packet_size 4096
+					  hostname "#{ENV['NODE_NAME']}"
+					  tls true
+					  ca_file '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
+					  verify_mode true
+					  timeout 60
+					  timeout_exception true
+					  keep_alive true
+					  keep_alive_idle 75
+					  keep_alive_cnt 9
+					  keep_alive_intvl 7200
+					  <buffer $.systemd.u.SYSLOG_IDENTIFIER>
+						@type file
+						path '/var/lib/fluentd/syslog_receiver_journal'
+						flush_mode interval
+						flush_interval 1s
+						flush_thread_count 2
+						flush_at_shutdown true
+						retry_type exponential_backoff
+						retry_wait 1s
+						retry_max_interval 60s
+						retry_timeout 60m
+						queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+						total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+						chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+						overflow_action block
+					  </buffer>
+					</store>
+				  </match>
+				  <match **>
+					@type copy
+					<store>
+					  @type remote_syslog
+					  @id syslog_receiver
+					  host sl.svc.messaging.cluster.local
+					  port 9654
+					  rfc rfc3164
+					  facility user
+					  severity debug
+					  protocol tcp
+					  packet_size 4096
+					  hostname "#{ENV['NODE_NAME']}"
+					  tls true
+					  ca_file '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
+					  verify_mode true
+					  timeout 60
+					  timeout_exception true
+					  keep_alive true
+					  keep_alive_idle 75
+					  keep_alive_cnt 9
+					  keep_alive_intvl 7200
+					  <buffer >
+						@type file
+						path '/var/lib/fluentd/syslog_receiver'
+						flush_mode interval
+						flush_interval 1s
+						flush_thread_count 2
+						flush_at_shutdown true
+						retry_type exponential_backoff
+						retry_wait 1s
+						retry_max_interval 60s
+						retry_timeout 60m
+						queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
+						total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
+						chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+						overflow_action block
+					  </buffer>
+					</store>
+				  </match>
+				</label>`
+				BeforeEach(func() {
+					outputs = []logging.OutputSpec{
+						{
+							Type: "syslog",
+							Name: "syslog-receiver",
+							URL:  "tls://sl.svc.messaging.cluster.local:9654",
+							Secret: &logging.OutputSecretSpec{
+								Name: "some-secret",
+							},
+							OutputTypeSpec: logging.OutputTypeSpec{
+								Syslog: &logging.Syslog{
+									AddLogSource: true,
+									RFC:          "RFC3164",
 								},
 							},
 						},

--- a/pkg/generators/forwarding/fluentd/syslog_conf.go
+++ b/pkg/generators/forwarding/fluentd/syslog_conf.go
@@ -55,8 +55,19 @@ func (conf *outputLabelConf) TrimPrefix() string {
 	return conf.Target.Syslog.TrimPrefix
 }
 
+func (conf *outputLabelConf) HasTag() bool {
+	if conf.Target.Syslog.Tag != "" || conf.Hints().Has("journal_log") && conf.Rfc() == "rfc3164" {
+		return true
+	} else {
+		return false
+	}
+}
+
 func (conf *outputLabelConf) Tag() string {
 	tag := conf.Target.Syslog.Tag
+	if conf.Hints().Has("journal_log") {
+		return "${$.systemd.u.SYSLOG_IDENTIFIER}"
+	}
 	if tag == "" {
 		return "-"
 	}
@@ -80,8 +91,19 @@ func (conf *outputLabelConf) AddLogSource() bool {
 	return conf.Target.Syslog.AddLogSource
 }
 
+func (conf *outputLabelConf) HasAppName() bool {
+	if conf.Target.Syslog.AppName != "" || conf.Hints().Has("journal_log") && conf.Rfc() == "rfc5424" {
+		return true
+	} else {
+		return false
+	}
+}
+
 func (conf *outputLabelConf) AppName() string {
 	appname := conf.Target.Syslog.AppName
+	if conf.Hints().Has("journal_log") {
+		return "${$.systemd.u.SYSLOG_IDENTIFIER}"
+	}
 	if appname == "" {
 		return "-"
 	}
@@ -122,6 +144,9 @@ func (conf *outputLabelConf) ProcID() string {
 func (conf *outputLabelConf) ChunkKeys() string {
 	keys := []string{}
 	tagAdded := false
+	if conf.Hints().Has("journal_log") {
+		keys = append(keys, "$.systemd.u.SYSLOG_IDENTIFIER")
+	}
 	if conf.isTagKeyExpr() {
 		keys = append(keys, conf.Target.Syslog.Tag)
 	}

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -684,11 +684,18 @@ const outputLabelConfJsonParseNoretryTemplate = `{{- define "outputLabelConfJson
 	  pod_info        ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "pod_name=" + record['kubernetes_info']['pod_name']; else nil; end}
 	  container_info  ${if record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; "container_name=" + record['kubernetes_info']['container_name']; else nil; end}
 	  msg_key         ${if record.has_key?('message') && record['message'] != nil; record['message']; else nil; end}
-      msg_info        ${if record['msg_key'] != nil && record['msg_key'].is_a?(Hash); require 'json'; "message="+record['message'].to_json; elsif record['msg_key'] != nil; "message="+record['message']; else nil; end}
-      message         ${if record['msg_key'] != nil && record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; record['namespace_info'] + ", " + record['container_info'] + ", " + record['pod_info'] + ", " + record['msg_info']; else record['message']; end}
+	  msg_info        ${if record['msg_key'] != nil && record['msg_key'].is_a?(Hash); require 'json'; "message="+record['message'].to_json; elsif record['msg_key'] != nil; "message="+record['message']; else nil; end}
+	  message         ${if record['msg_key'] != nil && record['kubernetes_info'] != nil && record['kubernetes_info'] != {}; record['namespace_info'] + ", " + record['container_info'] + ", " + record['pod_info'] + ", " + record['msg_info']; else record['message']; end}
+	  systemd_info    ${if record.has_key?('systemd') && record['systemd']['t'].has_key?('PID'); record['systemd']['u']['SYSLOG_IDENTIFIER'] += "[" + record['systemd']['t']['PID'] + "]"; else {}; end}
 	</record>
-	remove_keys kubernetes_info, namespace_info, pod_info, container_info, msg_key, msg_info
+	remove_keys kubernetes_info, namespace_info, pod_info, container_info, msg_key, msg_info, systemd_info
   </filter>
+  # The "infrastructure" stream is splitted into the pod logs and the journal logs.
+  # This match section is for the journal logs to inject the daemon name info into the journal logs only.
+  <match journal.** system.var.log**>
+    @type copy
+{{include .StoreTemplate . "journal_log" | indent 4}}
+  </match>
 {{end -}}
   <match **>
     @type copy
@@ -864,7 +871,7 @@ const storeSyslogTemplate = `{{- define "storeSyslog" -}}
 	rfc {{.Rfc}}
 	facility {{.Facility}}
     severity {{.Severity}}
-	{{if .Target.Syslog.AppName -}}
+	{{if .HasAppName -}}
 	appname {{.AppName}}
 	{{end -}}
 	{{if .Target.Syslog.MsgID -}}
@@ -873,7 +880,7 @@ const storeSyslogTemplate = `{{- define "storeSyslog" -}}
 	{{if .Target.Syslog.ProcID -}}
 	procid {{.ProcID}}
 	{{end -}}
-	{{if .Target.Syslog.Tag -}}
+	{{if .HasTag -}}
 	program {{.Tag}}
 	{{end -}}
 	protocol {{.Protocol}}


### PR DESCRIPTION
### Description
The current syslog forwarding can not report who outputted logs in journal log when configuring addLogSource field.
To identify the daemon name, the "systemd.u.SYSLOG_IDENTIFIER" in journal log record is what information we want. 
So fluentd can pick their daemon names from journal log records.

This PR enhances the addLogSource field in Log Forwarding API by splitting  infrastructure stream into journal log and pod log and injecting daemon names into the journal log stream.
So this change is limited to the addLogSource field related code.

This PR picks the originating process name and id(known as the "pid") from the record and injects them into the header field.
There are three type messages in the journal log and the process information are injected like the following:

1. System messages stored in the journal log
"Tag" and "AppName" fields in CLF are ignored for the system messages when enabling the "AddLogSource" field.
```
<158>May 18 00:21:27 worker3.cluster.sub.nec.test crio[1738]: time="2021-05-18 00:21:25.958832751Z" level=info msg="About to del CNI network multus
-cni-network (type=multus)"
```
2. Kernel messages stored in the journal
Any daemon information are not injected to the kernel messages.
```
<158>May 18 00:21:27 worker3.cluster.sub.nec.test kernel: device vethc2d8643c left promiscuous mode
```
3. System pod messages not stored in the journal
Any daemon information are not injected to the pod messages.
The "fluentd:" is overwritten by specifying "Tag" and "AppName" fields.
```
<158>May 18 00:23:00 worker4.cluster.sub.nec.test fluentd: namespace_name=openshift-image-registry, container_name=node-ca, pod_name=node-ca-q5m
n5, message=image-registry.openshift-image-registry.svc:5000
```

/cc @vimalk78 @alanconway 

### Links
- Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1891886
- JIRA: https://issues.redhat.com/browse/LOG-1286
