### PR TITLE
LOG-1385: priorityclasses.v1beta1.scheduling.k8s.io is removed in 1.22 and replaced by priorityclasses.v1.scheduling.k8s.io

### DIFF
--- a/pkg/k8shandler/priorityclass.go
+++ b/pkg/k8shandler/priorityclass.go
@@ -5,7 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	scheduling "k8s.io/api/scheduling/v1beta1"
+	scheduling "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 


### PR DESCRIPTION
### Description
`APIRemovedInNextReleaseInUse` alerts for priorityclasses because priorityclasses.v1beta1.scheduling.k8s.io is completely removed in 1.22. Replaced by priorityclasses.v1.scheduling.k8s.io.

/cc jcantrill
/assign ewolinetz

### Links
* https://issues.redhat.com/browse/LOG-1385
