### PR TITLE
Go implementation log file exporter jira ticket log 1188 - log 1357 with new service within fluentd container

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,8 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -1145,6 +1147,7 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191025021431-6c3a3bfe00ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,7 +28,6 @@ const (
 	LogStoreURL         = "https://" + ElasticsearchFQDN + ":" + ElasticsearchPort
 	MasterCASecretName  = "master-certs"
 	CollectorSecretName = "fluentd"
-
 	// Disable gosec linter, complains "possible hard-coded secret"
 	CollectorSecretsDir     = "/var/run/ocp-collector/secrets" //nolint:gosec
 	KibanaSessionSecretName = "kibana-session-secret"          //nolint:gosec

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -21,6 +21,8 @@ import (
 
 const (
 	clusterLoggingPriorityClassName = "cluster-logging"
+	exporterPort                    = int32(2112)
+	exporterPortName                = "logfile-metrics"
 	metricsPort                     = int32(24231)
 	metricsPortName                 = "metrics"
 	metricsVolumeName               = "collector-metrics"


### PR DESCRIPTION
### Description
Modify CLO to accommodate the log file exporter - 
JIRA Reference  -- OpenShift Logging/LOG-1188, Implement Go implementation log file exporter/LOG-1359
Task Name: Modify CLO to accommodate the log file exporter

/cc @jcantrill @alanconway @vimalk78
/assign @jcantrill 


### Links
- Depending on PR(s): new fluentd image that enables go based log-file-metric-exporter running as a background service
- Bugzilla: NA
- Github issue: NA
- JIRA: https://issues.redhat.com/browse/LOG-1359
- Enhancement proposal:  Currently Collector is found to have issue with tracking each and every file rotation. It misses out logs when log files are rotated at a faster pace (typically > 2 rotations per second as observed in performance simulations). There is a need for publishing new metrics on how much actually total bytes got written(logged) by conmon processes during log generation, how much of that is being collected by the collector (fluentd) process. This PR is to enable go based file watcher which publishes actual data logged (log_logged_bytes_total) metric via prometheus client service. 