### PR TITLE
LOG-1355: Send logs to app-write if json parsing fails

### DIFF
--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -623,7 +623,7 @@ const outputLabelConfTemplate = `{{- define "outputLabelConf" -}}
 	<record>
 	  indexFromKey     ${record.dig({{.GetKeyVal .Target.OutputTypeSpec.Elasticsearch.StructuredIndexKey}})}
 	  hasStructuredIndexName     "{{.Target.OutputTypeSpec.Elasticsearch.StructuredIndexName}}"
-	  viaq_index_name  ${if !record['indexFromKey'].nil?; record['indexFromKey']; elsif record['hasStructuredIndexName'] != ""; record['hasStructuredIndexName']; else record['viaq_index_name']; end;}
+	  viaq_index_name  ${ if !record['structured'].nil? && record['structured'] != {}; if !record['indexFromKey'].nil?; record['indexFromKey']; elsif record['hasStructuredIndexName'] != ""; record['hasStructuredIndexName']; else record['viaq_index_name']; end; else record['viaq_index_name']; end;}
 	</record>
 	remove_keys indexFromKey, hasStructuredIndexName
   </filter>

--- a/test/functional/framework.go
+++ b/test/functional/framework.go
@@ -80,8 +80,8 @@ type FluentdFunctionalFramework struct {
 }
 
 func init() {
-	maxDuration, _ = time.ParseDuration("60*2m")
-	defaultRetryInterval, _ = time.ParseDuration("1ms")
+	maxDuration, _ = time.ParseDuration("10m")
+	defaultRetryInterval, _ = time.ParseDuration("10s")
 }
 
 func NewFluentdFunctionalFramework() *FluentdFunctionalFramework {


### PR DESCRIPTION
### Description
_Only valid JSON messages that have a structured index name go to a structured index. Invalid JSON always goes to app-index._
This PR  tries to fix a bug which sends invalid json to structuredIndex



/cc @alanconway @jcantrill  
/assign @jcantrill 



### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
