### PR TITLE
Update references to CI build images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(APP_NAME):latest
 export LOGGING_VERSION=$(shell basename $(shell ls -d manifests/[0-9]*))
 export NAMESPACE?=openshift-logging
 
-IMAGE_LOGGING_FLUENTD?=quay.io/openshift/origin-logging-fluentd:latest
+IMAGE_LOGGING_FLUENTD?=quay.io/openshift-logging/fluentd:latest
 REPLICAS?=0
 export E2E_TEST_INCLUDES?=
 export CLF_TEST_INCLUDES?=
@@ -75,7 +75,6 @@ RUN_CMD?=go run
 run:
 	@ls $(MANIFESTS)/*crd.yaml | xargs -n1 oc apply -f
 	@mkdir -p $(CURDIR)/tmp
-	CURATOR_IMAGE=quay.io/openshift/origin-logging-curator:latest \
 	FLUENTD_IMAGE=$(IMAGE_LOGGING_FLUENTD) \
 	OPERATOR_NAME=cluster-logging-operator \
 	WATCH_NAMESPACE=$(NAMESPACE) \
@@ -173,7 +172,6 @@ test-functional-benchmarker: bin/functional-benchmarker
 .PHONY: test-functional-benchmarker
 
 test-unit: test-forwarder-generator
-	CURATOR_IMAGE=quay.io/openshift/origin-logging-curator:latest \
 	FLUENTD_IMAGE=$(IMAGE_LOGGING_FLUENTD) \
 	go test -cover -race ./pkg/...
 

--- a/bundle/manifests/cluster-logging.v5.2.0.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.v5.2.0.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     certified: "false"
     description: |-
       The Cluster Logging Operator for OCP provides a means for configuring and managing your aggregated logging stack.
-    containerImage: quay.io/openshift/origin-cluster-logging-operator:latest
+    containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
     createdAt: 2018-08-01T08:00:00Z
     support: AOS Logging
     # The version value is substituted by the ART pipeline
@@ -308,7 +308,7 @@ spec:
               serviceAccountName: cluster-logging-operator
               containers:
               - name: cluster-logging-operator
-                image: quay.io/openshift/origin-cluster-logging-operator:latest
+                image: quay.io/openshift-logging/cluster-logging-operator:latest
                 imagePullPolicy: IfNotPresent
                 command:
                 - cluster-logging-operator
@@ -324,9 +324,7 @@ spec:
                   - name: OPERATOR_NAME
                     value: "cluster-logging-operator"
                   - name: FLUENTD_IMAGE
-                    value: "quay.io/openshift/origin-logging-fluentd:latest"
-                  - name: CURATOR_IMAGE
-                    value: "quay.io/openshift/origin-logging-curator5:latest"
+                    value: "quay.io/openshift-logging/fluentd:latest"
   customresourcedefinitions:
     owned:
     - name: clusterloggings.logging.openshift.io

--- a/docs/deploy-event-router.md
+++ b/docs/deploy-event-router.md
@@ -90,7 +90,7 @@ objects:
 parameters:
   - name: IMAGE
     displayName: Image
-    value: "quay.io/openshift/origin-logging-eventrouter:latest"
+    value: "quay.io/openshift-logging/eventrouter:latest"
   - name: MEMORY
     displayName: Memory
     value: "20Mi"

--- a/hack/eventrouter-template.yaml
+++ b/hack/eventrouter-template.yaml
@@ -83,7 +83,7 @@ objects:
 parameters:
   - name: IMAGE
     displayName: Image
-    value: "quay.io/openshift/origin-logging-eventrouter:latest"
+    value: "quay.io/openshift-logging/eventrouter:latest"
   - name: CPU
     displayName: CPU
     value: "100m"

--- a/hack/testing-olm/utils
+++ b/hack/testing-olm/utils
@@ -13,6 +13,6 @@ gather_logging_resources() {
   local runtime=${3:-$(date +%s)}
   outdir=$outdir/$runtime
   mkdir -p $outdir ||:
-  oc adm must-gather --image=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift/origin-cluster-logging-operator:latest} --dest-dir=$outdir -- /usr/bin/gather > $outdir/must-gather.log 2>&1
+  oc adm must-gather --image=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift-logging/cluster-logging-operator:latest} --dest-dir=$outdir -- /usr/bin/gather > $outdir/must-gather.log 2>&1
   set -e
 }

--- a/internal/cmd/functional-benchmarker/main.go
+++ b/internal/cmd/functional-benchmarker/main.go
@@ -23,7 +23,7 @@ import (
 // HACK - This command is for development use only
 func main() {
 
-	image := flag.String("image", "quay.io/openshift/origin-logging-fluentd:latest", "The image to use to run the benchmark")
+	image := flag.String("image", "quay.io/openshift-logging/fluentd:latest", "The image to use to run the benchmark")
 	totalMessages := flag.Uint64("totMessages", 10000, "The number of messages to write")
 	msgSize := flag.Uint64("size", 1024, "The message size in bytes")
 	verbosity := flag.Int("verbosity", 0, "")

--- a/manifests/5.2/cluster-logging.v5.2.0.clusterserviceversion.yaml
+++ b/manifests/5.2/cluster-logging.v5.2.0.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     certified: "false"
     description: |-
       The Cluster Logging Operator for OCP provides a means for configuring and managing your aggregated logging stack.
-    containerImage: quay.io/openshift/origin-cluster-logging-operator:latest
+    containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
     createdAt: 2018-08-01T08:00:00Z
     support: AOS Logging
     # The version value is substituted by the ART pipeline
@@ -308,7 +308,7 @@ spec:
               serviceAccountName: cluster-logging-operator
               containers:
               - name: cluster-logging-operator
-                image: quay.io/openshift/origin-cluster-logging-operator:latest
+                image: quay.io/openshift-logging/cluster-logging-operator:latest
                 imagePullPolicy: IfNotPresent
                 command:
                 - cluster-logging-operator
@@ -324,7 +324,7 @@ spec:
                   - name: OPERATOR_NAME
                     value: "cluster-logging-operator"
                   - name: FLUENTD_IMAGE
-                    value: "quay.io/openshift/origin-logging-fluentd:latest"
+                    value: "quay.io/openshift-logging/fluentd:latest"
   customresourcedefinitions:
     owned:
     - name: clusterloggings.logging.openshift.io

--- a/manifests/5.2/image-references
+++ b/manifests/5.2/image-references
@@ -5,8 +5,8 @@ spec:
   - name: cluster-logging-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-cluster-logging-operator:latest
+      name: quay.io/openshift-logging/cluster-logging-operator:latest
   - name: logging-fluentd
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-logging-fluentd:latest
+      name: quay.io/openshift-logging/fluentd:latest

--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -6,7 +6,7 @@ that expands its capabilities to gather Openshift Cluster Logging information.
 
 ### Usage
 ```sh
-oc adm must-gather --image=quay.io/openshift/origin-cluster-logging-operator -- /usr/bin/gather
+oc adm must-gather --image=quay.io/openshift-logging/cluster-logging-operator:latest -- /usr/bin/gather
 ```
 
 The command above will create a local directory with a dump of the cluster-logging state.

--- a/olm_deploy/scripts/registry-init.sh
+++ b/olm_deploy/scripts/registry-init.sh
@@ -7,20 +7,18 @@ env | grep IMAGE
 echo -e "\n\n"
 
 
-IMAGE_CLUSTER_LOGGING_OPERATOR=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift/origin-cluster-logging-operator:latest}
+IMAGE_CLUSTER_LOGGING_OPERATOR=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift-logging/cluster-logging-operator:5.2}
 IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-quay.io/openshift/origin-oauth-proxy:latest}
-IMAGE_LOGGING_CURATOR5=${IMAGE_LOGGING_CURATOR5:-quay.io/openshift/origin-logging-curator5:latest}
-IMAGE_LOGGING_FLUENTD=${IMAGE_LOGGING_FLUENTD:-quay.io/openshift/origin-logging-fluentd:latest}
-IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-quay.io/openshift/origin-logging-elasticsearch6:latest}
-IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-quay.io/openshift/origin-logging-kibana6:latest}
+IMAGE_LOGGING_FLUENTD=${IMAGE_LOGGING_FLUENTD:-quay.io/openshift-logging/fluentd:5.2}
+IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-quay.io/openshift-logging/elasticsearch6:5.2}
+IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-quay.io/openshift-logging/kibana6:5.2}
 
 # update the manifest with the image built by ci
-sed -i "s,quay.io/openshift/origin-cluster-logging-operator:latest,${IMAGE_CLUSTER_LOGGING_OPERATOR}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift-logging/cluster-logging-operator:latest,${IMAGE_CLUSTER_LOGGING_OPERATOR}," /manifests/*/*clusterserviceversion.yaml
 sed -i "s,quay.io/openshift/origin-oauth-proxy:latest,${IMAGE_OAUTH_PROXY}," /manifests/*/*clusterserviceversion.yaml
-sed -i "s,quay.io/openshift/origin-logging-curator5:latest,${IMAGE_LOGGING_CURATOR5}," /manifests/*/*clusterserviceversion.yaml
-sed -i "s,quay.io/openshift/origin-logging-fluentd:latest,${IMAGE_LOGGING_FLUENTD}," /manifests/*/*clusterserviceversion.yaml
-sed -i "s,quay.io/openshift/origin-logging-elasticsearch6:latest,${IMAGE_ELASTICSEARCH6}," /manifests/*/*clusterserviceversion.yaml
-sed -i "s,quay.io/openshift/origin-logging-kibana6:latest,${IMAGE_LOGGING_KIBANA6}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift-logging/fluentd:latest,${IMAGE_LOGGING_FLUENTD}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift-logging/elasticsearch6:latest,${IMAGE_ELASTICSEARCH6}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift-logging/kibana6:latest,${IMAGE_LOGGING_KIBANA6}," /manifests/*/*clusterserviceversion.yaml
 
 # update the manifest to pull always the operator image for non-CI environments
 if [ "${OPENSHIFT_CI:-false}" == "false" ] ; then

--- a/test/helpers/fluentd.go
+++ b/test/helpers/fluentd.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -273,7 +274,7 @@ func (tc *E2ETestFramework) DeployFluentdReceiver(rootDir string, secure bool) (
 	}
 	container := corev1.Container{
 		Name:            receiverName,
-		Image:           "quay.io/openshift/origin-logging-fluentd:latest",
+		Image:           "quay.io/openshift-logging/fluentd:latest",
 		ImagePullPolicy: corev1.PullAlways,
 		Args:            []string{"fluentd", "-c", "/fluentd/etc/fluent.conf"},
 		VolumeMounts: []corev1.VolumeMount{

--- a/test/helpers/fluentd/receiver.go
+++ b/test/helpers/fluentd/receiver.go
@@ -94,7 +94,7 @@ func NewReceiver(ns, name string) *Receiver {
 	runtime.Labels(r.Pod)[appName] = name
 	r.Pod.Spec.Containers = []corev1.Container{{
 		Name:  name,
-		Image: "quay.io/openshift/origin-logging-fluentd:latest",
+		Image: "quay.io/openshift-logging/fluentd:latest",
 		Args:  []string{"fluentd", "-c", filepath.Join(configDir, "fluent.conf")},
 		VolumeMounts: []corev1.VolumeMount{
 			{


### PR DESCRIPTION
### Description
Logging images are being mirrored to logging's own namespace in Quay, `quay.io/openshift-logging`. 
This PR attempts to update the CI built logging image references in the repo.


/cc 
/assign @jcantrill 


