### PR TITLE
LOG-1440: Add OLM bug workaround for workload partitioning

### DIFF
--- a/bundle/manifests/cluster-logging.v5.2.0.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.v5.2.0.clusterserviceversion.yaml
@@ -23,6 +23,10 @@ metadata:
     support: AOS Logging
     # The version value is substituted by the ART pipeline
     olm.skipRange: ">=4.6.0-0 <5.2.0"
+    # This annotation injection is a workaround for BZ-1950047, since the associated
+    # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
+    # TODO: remove the next line after BZ-1950047 is resolved.
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     alm-examples: |-
         [
           {

--- a/manifests/5.2/cluster-logging.v5.2.0.clusterserviceversion.yaml
+++ b/manifests/5.2/cluster-logging.v5.2.0.clusterserviceversion.yaml
@@ -23,6 +23,10 @@ metadata:
     support: AOS Logging
     # The version value is substituted by the ART pipeline
     olm.skipRange: ">=4.6.0-0 <5.2.0"
+    # This annotation injection is a workaround for BZ-1950047, since the associated
+    # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
+    # TODO: remove the next line after BZ-1950047 is resolved.
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     alm-examples: |-
         [
           {


### PR DESCRIPTION
### Description
PR #973 added annotations
required for supporting the workload partitioning feature for ocp 4.8.
However, OLM has a bug in processing the annotations (BZ 1950047).
This PR provides a workaround necessary to release the workload
partitioning in OCP 4.8.

/cc @lack @imiller0 
/assign @jcantrill

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this 
- Depending on PR(s): 973
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1950047
- https://issues.redhat.com/browse/LOG-1440
