### PR TITLE
LOG-1446: kibana-proxy CrashLoopBackoff with error Invalid configuration cookie_secret must be 16, 24, or 32 bytes to create an AES cipher

### DIFF
--- a/scripts/cert_generation.sh
+++ b/scripts/cert_generation.sh
@@ -331,7 +331,7 @@ generate_certs 'logging-es' "$(generate_extensions false true $LOG_STORE{,.${NAM
 
 if [ ! -s "${WORKING_DIR}/kibana-session-secret" ] ; then
   info "Generating kibana session secret"
-  dd if=/dev/urandom count=1 ibs=16 status=none | hexdump -e '"%02X"' >  "${WORKING_DIR}/kibana-session-secret"
+  head -c 16 < /dev/urandom | hexdump -v -e '1/1 "%02X"' > "${WORKING_DIR}/kibana-session-secret"
 fi
 
 if [ -f ${WORKING_DIR}/action.log ] ; then


### PR DESCRIPTION
### Description
Corrected how Kibana session secret is generated. Prior to the fix, `hexdump` parameters allowed for deviation from the "1 byte -> 2 hex nibbles" scheme for some byte sequences.
Specifically, without `-v`, `hexdump` abbreviated repeating bytes with * and without `1/1`, it defaulted to processing bytes in groups of 2 and dropping leading zeros in the process.

### Test:
`while [ $(head -c 16 < /dev/urandom | tee bin | hexdump -e '"%02X"' | tee hex | wc -c) -eq 32 ]; do echo; done`

### Example of *
Sequence `70 70 70` becomes `70*\n`, length of `hex` is 30:
```
$ od -v -A n -t x1  bin
 75 70 93 8e 4b 67 aa 2a 70 70 70 86 52 29 42 31
$ cat hex 
7570938E4B67AA2A70*
8652294231
$ 
```

### Example of 1/1
length of `hex` is 31:
```
$ od -v -A n -t x1  bin
 db 03 0e be cd ea 53 ba 33 b4 9a 75 2d be 5a 05
$ cat hex
BE 0E 03 DB
BA 53 EA CD
75 9A B4 33
 5 5A BE 2D
$
^ missing 0 
```

Also, `dd` is replaced with `head` as unreliable in the face of partial reads.

### References:
https://www.suse.com/c/making-sense-hexdump/
https://unix.stackexchange.com/questions/32988/why-does-dd-from-dev-random-give-different-file-sizes

/cc @jcantrill 
/assign @alanconway 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1446