### PR TITLE
[Release-4.8] LOG-1442: Add mgmt workload annotations, OLM bug workaround

### DIFF
--- a/bundle/manifests/cluster-logging.v5.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.v5.0.0.clusterserviceversion.yaml
@@ -23,6 +23,10 @@ metadata:
     support: AOS Logging
     # The version value is substituted by the ART pipeline
     olm.skipRange: ">=4.6.0-0 <5.0.0"
+    # This annotation injection is a workaround for BZ-1950047, since the associated
+    # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
+    # TODO: remove the next line after BZ-1950047 is resolved.
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     alm-examples: |-
         [
           {
@@ -304,6 +308,8 @@ spec:
               name: cluster-logging-operator
           template:
             metadata:
+              annotations:
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: cluster-logging-operator
             spec:

--- a/manifests/5.0/cluster-logging.v5.0.0.clusterserviceversion.yaml
+++ b/manifests/5.0/cluster-logging.v5.0.0.clusterserviceversion.yaml
@@ -23,6 +23,10 @@ metadata:
     support: AOS Logging
     # The version value is substituted by the ART pipeline
     olm.skipRange: ">=4.6.0-0 <5.0.0"
+    # This annotation injection is a workaround for BZ-1950047, since the associated
+    # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
+    # TODO: remove the next line after BZ-1950047 is resolved.
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     alm-examples: |-
         [
           {
@@ -304,6 +308,8 @@ spec:
               name: cluster-logging-operator
           template:
             metadata:
+              annotations:
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: cluster-logging-operator
             spec:

--- a/olm_deploy/operatorregistry/registry-deployment.yaml
+++ b/olm_deploy/operatorregistry/registry-deployment.yaml
@@ -9,6 +9,8 @@ spec:
       registry.operator.cluster-logging: "true"
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         registry.operator.cluster-logging: "true"
       name: cluster-logging-operator-registry

--- a/pkg/k8shandler/daemonset.go
+++ b/pkg/k8shandler/daemonset.go
@@ -37,6 +37,7 @@ func NewDaemonSet(daemonsetName, namespace, loggingComponent, component string, 
 					Labels: labels,
 					Annotations: map[string]string{
 						"scheduler.alpha.kubernetes.io/critical-pod": "",
+						"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
 					},
 				},
 				Spec: podSpec,

--- a/pkg/k8shandler/deployment.go
+++ b/pkg/k8shandler/deployment.go
@@ -44,6 +44,9 @@ func NewDeployment(deploymentName string, namespace string, loggingComponent str
 						"component":     component,
 						"logging-infra": loggingComponent,
 					},
+					Annotations: map[string]string{
+						"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+					},
 				},
 				Spec: podSpec,
 			},


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.
In addition:
This PR provides a workaround necessary to release the workload
partitioning in OCP 4.8 ([LOG-1442](https://issues.redhat.com/browse/LOG-1442))
/cc @lack @imiller0 
/assign @jcantrill 

### Links
https://github.com/openshift/cluster-logging-operator/pull/1042
https://github.com/openshift/cluster-logging-operator/pull/973

