### PR TITLE
LOG-974: Fixed username password

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf.go
@@ -95,7 +95,10 @@ func (conf *outputLabelConf) Hints() sets.String {
 func (conf *outputLabelConf) Template() *template.Template {
 	return conf.TemplateContext
 }
-func (conf *outputLabelConf) Host() string { return conf.URL.Hostname() }
+
+//Scheme returns the scheme defined in the URL for an output
+func (conf *outputLabelConf) Scheme() string { return conf.URL.Scheme }
+func (conf *outputLabelConf) Host() string   { return conf.URL.Hostname() }
 
 func (conf *outputLabelConf) Port() string {
 	p := conf.URL.Port()

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	yaml "sigs.k8s.io/yaml"
 )
@@ -15,12 +16,27 @@ var _ = Describe("Generating fluentd config", func() {
 		forwarder     *logging.ClusterLogForwarderSpec
 		forwarderSpec *logging.ForwarderSpec
 		generator     *ConfigGenerator
+		secrets       map[string]*corev1.Secret
 	)
 	BeforeEach(func() {
 		var err error
 		generator, err = NewConfigGenerator(false, false, true)
 		Expect(err).To(BeNil())
 		Expect(generator).ToNot(BeNil())
+		secret := &corev1.Secret{
+			Data: map[string][]byte{
+				"shared_key":    []byte("my-key"),
+				"tls.crt":       []byte("my-tls"),
+				"tls.key":       []byte("my-tls-key"),
+				"ca-bundle.crt": []byte("my-bundle"),
+			},
+		}
+		secrets = map[string]*corev1.Secret{
+			"infra-es":  secret,
+			"apps-es-1": secret,
+			"apps-es-2": secret,
+			"audit-es":  secret,
+		}
 		forwarder = &logging.ClusterLogForwarderSpec{
 			Outputs: []logging.OutputSpec{
 				{
@@ -124,7 +140,7 @@ var _ = Describe("Generating fluentd config", func() {
 				},
 			},
 		}
-		results, err := generator.Generate(forwarder, nil, forwarderSpec)
+		results, err := generator.Generate(forwarder, secrets, forwarderSpec)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(`
   ## CLO GENERATED CONFIGURATION ###
@@ -583,12 +599,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -632,12 +648,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_1
         http_backend typhoeus
@@ -693,12 +709,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -742,12 +758,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_2
         http_backend typhoeus
@@ -844,7 +860,7 @@ var _ = Describe("Generating fluentd config", func() {
 				},
 			},
 		}
-		results, err := generator.Generate(forwarder, nil, forwarderSpec)
+		results, err := generator.Generate(forwarder, secrets, forwarderSpec)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(`
   ## CLO GENERATED CONFIGURATION ###
@@ -1298,12 +1314,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -1343,12 +1359,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_1
         http_backend typhoeus
@@ -1400,12 +1416,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -1445,12 +1461,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
 	scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_2
         http_backend typhoeus
@@ -1545,7 +1561,7 @@ var _ = Describe("Generating fluentd config", func() {
 				},
 			},
 		}
-		results, err := generator.Generate(forwarder, nil, forwarderSpec)
+		results, err := generator.Generate(forwarder, secrets, forwarderSpec)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(`
   ## CLO GENERATED CONFIGURATION ###
@@ -2001,12 +2017,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -2046,12 +2062,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_1
         http_backend typhoeus
@@ -2103,12 +2119,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -2148,12 +2164,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_2
         http_backend typhoeus
@@ -2621,7 +2637,7 @@ var _ = Describe("Generating fluentd config", func() {
 	})
 
 	It("should produce well formed fluent.conf", func() {
-		results, err := generator.Generate(forwarder, nil, forwarderSpec)
+		results, err := generator.Generate(forwarder, secrets, forwarderSpec)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(`
 			## CLO GENERATED CONFIGURATION ###
@@ -3124,13 +3140,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
 						type_name _doc
                         http_backend typhoeus
 						write_operation create
@@ -3170,13 +3186,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_infra_es
                         http_backend typhoeus
@@ -3228,13 +3244,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 						type_name _doc
                         http_backend typhoeus
 						write_operation create
@@ -3274,13 +3290,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_apps_es_1
                         http_backend typhoeus
@@ -3332,13 +3348,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
 						type_name _doc
                         http_backend typhoeus
 						write_operation create
@@ -3378,13 +3394,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_apps_es_2
                         http_backend typhoeus
@@ -3436,13 +3452,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
 						type_name _doc
                         http_backend typhoeus
 						write_operation create
@@ -3482,13 +3498,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_audit_es
                         http_backend typhoeus

--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 
 	v1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("Generating external kafka server output store config block", func() {
@@ -88,9 +87,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 	       brokers broker1-kafka.svc.messaging.cluster.local:9092
 	       default_topic topic
 	       use_event_time true
-	       ssl_ca_cert '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
-	       ssl_client_cert "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.crt') ? '/var/run/ocp-collector/secrets/some-secret/tls.crt' : nil}"
-	       ssl_client_cert_key "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.key') ? '/var/run/ocp-collector/secrets/some-secret/tls.key' : nil}"
+	       sasl_over_ssl false
 	       <format>
 	           @type json
 	       </format>
@@ -234,65 +231,6 @@ var _ = Describe("Generating external kafka server output store config block", f
 			}
 			_, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).Should(HaveOccurred())
-		})
-	})
-
-	Context("for basic username/password auth", func() {
-		It("should return a valid configuration", func() {
-			kafkaConf := `<label @KAFKA_RECEIVER>
-			<match **>
-			   @type kafka2
-			   brokers broker1-kafka.svc.messaging.cluster.local:9092
-			   default_topic topic
-			   use_event_time true
-			   ssl_ca_cert '/var/run/ocp-collector/secrets/my-secret/ca-bundle.crt'
-			   ssl_client_cert "#{File.exist?('/var/run/ocp-collector/secrets/my-secret/tls.crt') ? '/var/run/ocp-collector/secrets/my-secret/tls.crt' : nil}"
-			   ssl_client_cert_key "#{File.exist?('/var/run/ocp-collector/secrets/my-secret/tls.key') ? '/var/run/ocp-collector/secrets/my-secret/tls.key' : nil}"
-		   
-			   <format>
-				   @type json
-			   </format>
-			   <buffer topic>
-				   @type file
-				   path '/var/lib/fluentd/kafka_receiver'
-				   flush_mode interval
-				   flush_interval 1s
-				   flush_thread_count 2
-				   flush_at_shutdown true
-				   retry_type exponential_backoff
-				   retry_wait 1s
-				   retry_max_interval 60s
-				   retry_forever true
-				   queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
-				   total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-				   chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
-				   overflow_action block
-			   </buffer>
-			</match>
-			</label>`
-
-			outputs = []v1.OutputSpec{
-				{
-					Type: v1.OutputTypeKafka,
-					Name: "kafka-receiver",
-					URL:  "tls://broker1-kafka.svc.messaging.cluster.local:9092/topic",
-					Secret: &v1.OutputSecretSpec{
-						Name: "my-secret",
-					},
-				},
-			}
-
-			results, err := generator.generateOutputLabelBlocks(outputs, map[string]*corev1.Secret{
-				"my-secret": {
-					Data: map[string][]byte{
-						"username": []byte("test"),
-						"password": []byte("test"),
-					},
-				},
-			}, forwarderSpec)
-			Expect(err).To(BeNil())
-			Expect(len(results)).To(Equal(1))
-			Expect(results[0]).To(EqualTrimLines(kafkaConf))
 		})
 	})
 })

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -771,30 +771,28 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
   host {{.Host}}
   port {{.Port}}
   verify_es_version_at_startup false
+  scheme {{.Scheme}}
+{{- if eq .Scheme "https" }}
+  ssl_version TLSv1_2
+{{- end }}
 {{- if .Target.Secret }}
-{{ if .SecretPathIfFound "username" -}}
+{{- if and (.SecretPathIfFound "username") (.SecretPathIfFound "password") }}
 {{ with $path := .SecretPath "username" -}}
   user "#{File.exists?('{{ $path }}') ? open('{{ $path }}','r') do |f|f.read end : ''}"
 {{ end -}}
-{{ end -}}
-{{ if .SecretPathIfFound "password" -}}
 {{ with $path := .SecretPath "password" -}}
   password "#{File.exists?('{{ $path }}') ? open('{{ $path }}','r') do |f|f.read end : ''}"
 {{ end -}}
 {{ end -}}
-  scheme https
-  ssl_version TLSv1_2
-{{- else }}
-  scheme http
-{{- end }}
-  target_index_key viaq_index_name
-  id_key viaq_msg_id
-  remove_keys viaq_index_name
-{{- if .Target.Secret }}
+{{- if and (.SecretPathIfFound "tls.key") (.SecretPathIfFound "tls.crt")}}
   client_key '{{ .SecretPath "tls.key"}}'
   client_cert '{{ .SecretPath "tls.crt"}}'
   ca_file '{{ .SecretPath "ca-bundle.crt"}}'
 {{- end }}
+{{- end }}
+  target_index_key viaq_index_name
+  id_key viaq_msg_id
+  remove_keys viaq_index_name
   type_name _doc
 {{- if .Hints.Has "include_retry_tag" }}
   retry_tag {{.RetryTag}}
@@ -926,21 +924,28 @@ brokers {{.Brokers}}
 default_topic {{.Topic}}
 use_event_time true
 {{ if .Target.Secret -}}
-{{ if .SecretPathIfFound "username" -}}
+{{ if and (.SecretPathIfFound "username") (.SecretPathIfFound "password") -}}
 {{ with $path := .SecretPath "username" -}}
-username "#{File.exists?('{{ $path }}') ? open('{{ $path }}','r') do |f|f.read end : ''}"
+sasl_plain_username "#{File.exists?('{{ $path }}') ? open('{{ $path }}','r') do |f|f.read end : ''}"
 {{ end -}}
-{{ end -}}
-{{ if .SecretPathIfFound "password" -}}
 {{ with $path := .SecretPath "password" -}}
-password "#{File.exists?('{{ $path }}') ? open('{{ $path }}','r') do |f|f.read end : ''}"
+sasl_plain_password "#{File.exists?('{{ $path }}') ? open('{{ $path }}','r') do |f|f.read end : ''}"
 {{ end -}}
 {{ end -}}
+{{ if not (.SecretPathIfFound "sasl_over_ssl") -}}
+sasl_over_ssl false
+{{ else }}
+sasl_over_ssl true
+{{ end -}}
+{{ if and (.SecretPathIfFound "tls.crt") (.SecretPathIfFound "tls.key") -}}
 {{ $tlsCert := .SecretPath "tls.crt" }}
 {{ $tlsKey := .SecretPath "tls.key" }}
-ssl_ca_cert '{{ .SecretPath "ca-bundle.crt"}}'
 ssl_client_cert "#{File.exist?('{{ $tlsCert }}') ? '{{ $tlsCert }}' : nil}"
 ssl_client_cert_key "#{File.exist?('{{ $tlsKey }}') ? '{{ $tlsKey }}' : nil}"
+{{ end -}}
+{{ if .SecretPathIfFound "ca-bundle.crt" -}}
+ssl_ca_cert '{{ .SecretPath "ca-bundle.crt"}}'
+{{ end -}}
 {{ end -}}
 <format>
   @type json

--- a/pkg/k8shandler/collection.go
+++ b/pkg/k8shandler/collection.go
@@ -53,15 +53,6 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 			return
 		}
 
-		if collectorConfig, err = clusterRequest.generateCollectorConfig(); err != nil {
-			return
-		}
-		log.V(3).Info("Generated collector config", "config", collectorConfig)
-		collectorConfHash, err = utils.CalculateMD5Hash(collectorConfig)
-		if err != nil {
-			log.Error(err, "unable to calculate MD5 hash")
-			return
-		}
 		if err = clusterRequest.reconcileFluentdService(); err != nil {
 			return
 		}
@@ -74,11 +65,21 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 			log.Error(err, "unable to create or update fluentd prometheus rule")
 		}
 
-		if err = clusterRequest.createOrUpdateFluentdConfigMap(collectorConfig); err != nil {
+		if err = clusterRequest.createOrUpdateFluentdSecret(); err != nil {
 			return
 		}
 
-		if err = clusterRequest.createOrUpdateFluentdSecret(); err != nil {
+		if collectorConfig, err = clusterRequest.generateCollectorConfig(); err != nil {
+			return
+		}
+		log.V(3).Info("Generated collector config", "config", collectorConfig)
+		collectorConfHash, err = utils.CalculateMD5Hash(collectorConfig)
+		if err != nil {
+			log.Error(err, "unable to calculate MD5 hash")
+			return
+		}
+
+		if err = clusterRequest.createOrUpdateFluentdConfigMap(collectorConfig); err != nil {
 			return
 		}
 


### PR DESCRIPTION
### Description
This PR fixes the [LOG-974](https://issues.redhat.com/browse/LOG-974) feature of a username and password auth for Kafka and ES:
* Elasticsearch supports HTTP with username/password OR HTTPS with tls.key and tls.cert
* Kafka supports username/password with sasl_plain/sasl_over_ssl (put sasl_over_ssl into the secret to enable ssl) OR with tls.key and tls.cert
### Links
https://issues.redhat.com/browse/LOG-1372
https://issues.redhat.com/browse/LOG-1373