### PR TITLE
LOG-974: Fixed username and password feature for ES and Kafka

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -583,12 +583,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -632,12 +632,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_1
         http_backend typhoeus
@@ -693,12 +693,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -742,12 +742,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_2
         http_backend typhoeus
@@ -1298,12 +1298,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -1343,12 +1343,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_1
         http_backend typhoeus
@@ -1400,12 +1400,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -1445,12 +1445,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
 	scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_2
         http_backend typhoeus
@@ -2001,12 +2001,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -2046,12 +2046,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_1
         http_backend typhoeus
@@ -2103,12 +2103,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         http_backend typhoeus
         write_operation create
@@ -2148,12 +2148,12 @@ var _ = Describe("Generating fluentd config", func() {
         verify_es_version_at_startup false
         scheme https
         ssl_version TLSv1_2
-        target_index_key viaq_index_name
-        id_key viaq_msg_id
-        remove_keys viaq_index_name
         client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
         client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
         ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
+        target_index_key viaq_index_name
+        id_key viaq_msg_id
+        remove_keys viaq_index_name
         type_name _doc
         retry_tag retry_apps_es_2
         http_backend typhoeus
@@ -3124,13 +3124,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
 						type_name _doc
                         http_backend typhoeus
 						write_operation create
@@ -3170,13 +3170,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_infra_es
                         http_backend typhoeus
@@ -3228,13 +3228,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 						type_name _doc
                         http_backend typhoeus
 						write_operation create
@@ -3274,13 +3274,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_apps_es_1
                         http_backend typhoeus
@@ -3332,13 +3332,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
 						type_name _doc
                         http_backend typhoeus
 						write_operation create
@@ -3378,13 +3378,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_apps_es_2
                         http_backend typhoeus
@@ -3436,13 +3436,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
 						type_name _doc
                         http_backend typhoeus
 						write_operation create
@@ -3482,13 +3482,13 @@ var _ = Describe("Generating fluentd config", func() {
 						verify_es_version_at_startup false
 						scheme https
 						ssl_version TLSv1_2
+						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
+						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
+						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
 						target_index_key viaq_index_name
 						id_key viaq_msg_id
 						remove_keys viaq_index_name
 
-						client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
-						client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
-						ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
 						type_name _doc
 						retry_tag retry_audit_es
                         http_backend typhoeus

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -84,13 +84,13 @@ var _ = Describe("Generating fluentd config blocks", func() {
             verify_es_version_at_startup false
 			scheme https
 			ssl_version TLSv1_2
+			client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+			client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+			ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 			target_index_key viaq_index_name
 			id_key viaq_msg_id
 			remove_keys viaq_index_name
 
-			client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
-			client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
-			ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 			type_name _doc
             http_backend typhoeus
 			write_operation create
@@ -130,13 +130,13 @@ var _ = Describe("Generating fluentd config blocks", func() {
             verify_es_version_at_startup false
 			scheme https
 			ssl_version TLSv1_2
+			client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+			client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+			ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 			target_index_key viaq_index_name
 			id_key viaq_msg_id
 			remove_keys viaq_index_name
 
-			client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
-			client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
-			ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
 			type_name _doc
 			retry_tag retry_oncluster_elasticsearch
             http_backend typhoeus
@@ -202,7 +202,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			@id retry_other_elasticsearch
 			host es.svc.messaging.cluster.local
 			port 9654
-            verify_es_version_at_startup false
+            		verify_es_version_at_startup false
 			scheme http
 			target_index_key viaq_index_name
 			id_key viaq_msg_id
@@ -244,7 +244,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			@id other_elasticsearch
 			host es.svc.messaging.cluster.local
 			port 9654
-            verify_es_version_at_startup false
+            		verify_es_version_at_startup false
 			scheme http
 			target_index_key viaq_index_name
 			id_key viaq_msg_id

--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 
 	v1 "github.com/openshift/cluster-logging-operator/pkg/apis/logging/v1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("Generating external kafka server output store config block", func() {
@@ -88,9 +87,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 	       brokers broker1-kafka.svc.messaging.cluster.local:9092
 	       default_topic topic
 	       use_event_time true
-	       ssl_ca_cert '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
-	       ssl_client_cert "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.crt') ? '/var/run/ocp-collector/secrets/some-secret/tls.crt' : nil}"
-	       ssl_client_cert_key "#{File.exist?('/var/run/ocp-collector/secrets/some-secret/tls.key') ? '/var/run/ocp-collector/secrets/some-secret/tls.key' : nil}"
+	       sasl_over_ssl false
 	       <format>
 	           @type json
 	       </format>
@@ -234,65 +231,6 @@ var _ = Describe("Generating external kafka server output store config block", f
 			}
 			_, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).Should(HaveOccurred())
-		})
-	})
-
-	Context("for basic username/password auth", func() {
-		It("should return a valid configuration", func() {
-			kafkaConf := `<label @KAFKA_RECEIVER>
-			<match **>
-			   @type kafka2
-			   brokers broker1-kafka.svc.messaging.cluster.local:9092
-			   default_topic topic
-			   use_event_time true
-			   ssl_ca_cert '/var/run/ocp-collector/secrets/my-secret/ca-bundle.crt'
-			   ssl_client_cert "#{File.exist?('/var/run/ocp-collector/secrets/my-secret/tls.crt') ? '/var/run/ocp-collector/secrets/my-secret/tls.crt' : nil}"
-			   ssl_client_cert_key "#{File.exist?('/var/run/ocp-collector/secrets/my-secret/tls.key') ? '/var/run/ocp-collector/secrets/my-secret/tls.key' : nil}"
-		   
-			   <format>
-				   @type json
-			   </format>
-			   <buffer topic>
-				   @type file
-				   path '/var/lib/fluentd/kafka_receiver'
-				   flush_mode interval
-				   flush_interval 1s
-				   flush_thread_count 2
-				   flush_at_shutdown true
-				   retry_type exponential_backoff
-				   retry_wait 1s
-				   retry_max_interval 60s
-				   retry_forever true
-				   queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
-				   total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-				   chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
-				   overflow_action block
-			   </buffer>
-			</match>
-			</label>`
-
-			outputs = []v1.OutputSpec{
-				{
-					Type: v1.OutputTypeKafka,
-					Name: "kafka-receiver",
-					URL:  "tls://broker1-kafka.svc.messaging.cluster.local:9092/topic",
-					Secret: &v1.OutputSecretSpec{
-						Name: "my-secret",
-					},
-				},
-			}
-
-			results, err := generator.generateOutputLabelBlocks(outputs, map[string]*corev1.Secret{
-				"my-secret": {
-					Data: map[string][]byte{
-						"username": []byte("test"),
-						"password": []byte("test"),
-					},
-				},
-			}, forwarderSpec)
-			Expect(err).To(BeNil())
-			Expect(len(results)).To(Equal(1))
-			Expect(results[0]).To(EqualTrimLines(kafkaConf))
 		})
 	})
 })


### PR DESCRIPTION
### Description
This PR fixes the [LOG-974](https://issues.redhat.com/browse/LOG-974) feature of a username and password auth for Kafka and ES:

* Elasticsearch supports HTTP with username/password OR HTTPS with tls.key and tls.cert
* Kafka supports username/password with sasl_plain/sasl_over_ssl (put sasl_over_ssl into the secret to enable ssl) OR with tls.key and tls.cert
### Links
https://issues.redhat.com/browse/LOG-1372
https://issues.redhat.com/browse/LOG-1373