### PR TITLE
Updated Dockerfile.in to not use ART images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### This is a generated file from Dockerfile.in ###
-#@follow_tag(openshift-golang-builder:1.14)
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.15)
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
@@ -28,10 +28,10 @@ COPY ${REMOTE_SOURCE}/pkg ./pkg
 RUN make build
 
 
-#@follow_tag(openshift-ose-cli:v4.6)
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.7)
 FROM registry.ci.openshift.org/ocp/4.7:cli AS origincli
 
-#@follow_tag(openshift-ose-base:ubi8)
+#@follow_tag(registry.redhat.io/ubi8:latest)
 FROM registry.ci.openshift.org/ocp/4.7:base
 RUN INSTALL_PKGS=" \
       openssl \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,5 +1,5 @@
-#@follow_tag(openshift-golang-builder:1.14)
-FROM openshift-golang-builder:v1.14.4-9 AS builder
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.15)
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.15.7-202103192003.el7 AS builder
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
 ENV OS_GIT_MINOR=${CI_Y_VERSION}
@@ -30,11 +30,11 @@ COPY ${REMOTE_SOURCE}/pkg ./pkg
 RUN make build
 
 
-#@follow_tag(openshift-ose-cli:v4.6)
-FROM openshift-ose-cli:v4.6.0-202009152100.p0 AS origincli
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.7)
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.7.0-202104250659.p0 AS origincli
 
-#@follow_tag(openshift-ose-base:ubi8)
-FROM openshift-ose-base:v4.0-202009120053.11408
+#@follow_tag(registry.redhat.io/ubi8:latest)
+FROM registry.redhat.io/ubi8:8.3-297.1618432833
 RUN INSTALL_PKGS=" \
       openssl \
       rsync \
@@ -75,3 +75,6 @@ LABEL \
         io.openshift.build.commit.url=${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_URL}/commit/${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_COMMIT} \
         version=${CI_CONTAINER_VERSION}
 
+## EXCLUDE BEGIN ##
+LABEL name="openshift-logging/cluster-logging-rhel8-operator"
+## EXCLUDE END ##

--- a/origin-meta.yaml
+++ b/origin-meta.yaml
@@ -1,7 +1,7 @@
 from:
-- source: openshift-golang-builder\:v(?:[\.0-9\-]*).*
-  target: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
-- source: openshift-ose-cli\:v(?:[\.0-9\-p]*)
-  target: registry.ci.openshift.org/ocp/4.7:cli
-- source: openshift-ose-base\:v(?:[\.0-9\-]*)
-  target: registry.ci.openshift.org/ocp/4.7:base
+  - source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder\:v(?:[\.0-9\-]*).*
+    target: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
+  - source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.7.0-([0-9]*).*
+    target: registry.ci.openshift.org/ocp/4.7:cli AS origincli
+  - source: registry.redhat.io/ubi8:8.(\d)-([\.0-9])*
+    target: registry.ci.openshift.org/ocp/4.7:base


### PR DESCRIPTION
### Description
Since downstream builds do not use ART images anymore, need to update base images in Dockerfile.in to match the images used in CPaaS.
 Also added an extra LABEL step in Dockerfile to update the name LABEL as per downstream requirements

 - updated Dockerfile.in
 - updated origin-meta.yaml
 - updated generated Dockerfile


/cc 
/assign @jcantrill 

/cherry-pick release-5.1

