### PR TITLE
LOG-1500: Discard messages after 60m instead of retry forever

### DIFF
--- a/manifests/5.2/logging.openshift.io_clusterloggings_crd.yaml
+++ b/manifests/5.2/logging.openshift.io_clusterloggings_crd.yaml
@@ -296,6 +296,13 @@ spec:
                               exponential_backoff`.'
                             pattern: ^([0-9]+)([smhd]{0,1})$
                             type: string
+                          retryTimeout:
+                            description: RetryTimeout represents the maxixum time
+                              interval to attempt retries before giving up and the
+                              record is disguarded.  If unspecified, the default will
+                              be used
+                            pattern: ^([0-9]+)([smhd]{0,1})$
+                            type: string
                           retryType:
                             description: RetryType represents the type of retrying
                               flush operations. Flush operations can be retried either

--- a/pkg/apis/logging/v1/clusterlogging_types.go
+++ b/pkg/apis/logging/v1/clusterlogging_types.go
@@ -356,6 +356,12 @@ type FluentdBufferSpec struct {
 	//
 	// +optional
 	RetryMaxInterval FluentdTimeUnit `json:"retryMaxInterval"`
+
+	// RetryTimeout represents the maxixum time interval to attempt retries before giving up
+	// and the record is disguarded.  If unspecified, the default will be used
+	//
+	// +optional
+	RetryTimeout FluentdTimeUnit `json:"retryTimeout"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -614,7 +614,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -664,7 +664,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -728,7 +728,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -778,7 +778,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
@@ -1337,7 +1337,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -1383,7 +1383,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -1443,7 +1443,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -1489,7 +1489,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -2048,7 +2048,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -2094,7 +2094,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -2154,7 +2154,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -2200,7 +2200,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -2628,7 +2628,7 @@ var _ = Describe("Generating fluentd config", func() {
 					retry_type exponential_backoff
 					retry_wait 1s
 					retry_max_interval 60s
-					retry_forever true
+					retry_timeout 60m
 					# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 					# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
 					# buffer to the remote - default is 'block' because in_tail handles that case
@@ -3180,7 +3180,7 @@ var _ = Describe("Generating fluentd config", func() {
               retry_type exponential_backoff
               retry_wait 1s
               retry_max_interval 60s
-							retry_forever true
+							retry_timeout 60m
               queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 						  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -3227,7 +3227,7 @@ var _ = Describe("Generating fluentd config", func() {
               retry_type exponential_backoff
               retry_wait 1s
  							retry_max_interval 60s
-							retry_forever true
+							retry_timeout 60m
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -3288,7 +3288,7 @@ var _ = Describe("Generating fluentd config", func() {
               retry_type exponential_backoff
               retry_wait 1s
               retry_max_interval 60s
-							retry_forever true
+							retry_timeout 60m
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -3335,7 +3335,7 @@ var _ = Describe("Generating fluentd config", func() {
               retry_type exponential_backoff
               retry_wait 1s
               retry_max_interval 60s
-							retry_forever true
+							retry_timeout 60m
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -3396,7 +3396,7 @@ var _ = Describe("Generating fluentd config", func() {
               retry_type exponential_backoff
               retry_wait 1s
               retry_max_interval 60s
-							retry_forever true
+							retry_timeout 60m
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -3443,7 +3443,7 @@ var _ = Describe("Generating fluentd config", func() {
               retry_type exponential_backoff
               retry_wait 1s
               retry_max_interval 60s
-							retry_forever true
+							retry_timeout 60m
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -3504,7 +3504,7 @@ var _ = Describe("Generating fluentd config", func() {
               retry_type exponential_backoff
               retry_wait 1s
               retry_max_interval 60s
-							retry_forever true
+							retry_timeout 60m
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -3551,7 +3551,7 @@ var _ = Describe("Generating fluentd config", func() {
               retry_type exponential_backoff
               retry_wait 1s
               retry_max_interval 60s
-							retry_forever true
+							retry_timeout 60m
 							queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 							total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 							chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
         retry_type exponential_backoff
         retry_wait 1s
 				retry_max_interval 60s
-				retry_forever true
+				retry_timeout 60m
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -163,7 +163,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
         retry_type exponential_backoff
         retry_wait 1s
 				retry_max_interval 60s
-				retry_forever true
+				retry_timeout 60m
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -237,7 +237,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
         retry_type exponential_backoff
         retry_wait 1s
 				retry_max_interval 60s
-				retry_forever true
+				retry_timeout 60m
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -280,7 +280,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
         retry_type exponential_backoff
         retry_wait 1s
 				retry_max_interval 60s
-				retry_forever true
+				retry_timeout 60m
 				queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 				total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 				chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"

--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
           # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
           # buffer to the remote - default is 'block' because in_tail handles that case
@@ -124,7 +124,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
           retry_type exponential_backoff
           retry_wait 1s
           retry_max_interval 60s
-          retry_forever true
+          retry_timeout 60m
           # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
           # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
           # buffer to the remote - default is 'block' because in_tail handles that case
@@ -176,7 +176,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
        retry_type exponential_backoff
        retry_wait 1s
        retry_max_interval 60s
-       retry_forever true
+       retry_timeout 60m
        # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
        # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
        # buffer to the remote - default is 'block' because in_tail handles that case
@@ -226,7 +226,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 					retry_type exponential_backoff
 					retry_wait 1s
 					retry_max_interval 60s
-					retry_forever true
+					retry_timeout 60m
 					# the systemd journald 0.0.8 input plugin will just throw away records if the buffer
 					# queue limit is hit - 'block' will halt further reads and keep retrying to flush the
 					# buffer to the remote - default is 'block' because in_tail handles that case

--- a/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_kafka_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 	           retry_type exponential_backoff
 	           retry_wait 1s
 	           retry_max_interval 60s
-	           retry_forever true
+	           retry_timeout 60m
 	           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 	           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 	           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -101,7 +101,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 	           retry_type exponential_backoff
 	           retry_wait 1s
 	           retry_max_interval 60s
-	           retry_forever true
+	           retry_timeout 60m
 	           queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 	           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 	           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -149,7 +149,7 @@ var _ = Describe("Generating external kafka server output store config block", f
 	         retry_type exponential_backoff
 	         retry_wait 1s
 	           retry_max_interval 60s
-	           retry_forever true
+	           retry_timeout 60m
 	         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 	           total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 	           chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"

--- a/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_syslog_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         retry_type exponential_backoff
         retry_wait 1s
         retry_max_interval 60s
-        retry_forever true
+        retry_timeout 60m
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -199,7 +199,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         retry_type exponential_backoff
         retry_wait 1s
         retry_max_interval 60s
-        retry_forever true
+        retry_timeout 60m
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -247,7 +247,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         retry_type exponential_backoff
         retry_wait 1s
         retry_max_interval 60s
-        retry_forever true
+        retry_timeout 60m
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -289,7 +289,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
         retry_type exponential_backoff
         retry_wait 1s
         retry_max_interval 60s
-        retry_forever true
+        retry_timeout 60m
         queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
         total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
         chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -390,7 +390,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 						retry_type exponential_backoff
 						retry_wait 1s
 						retry_max_interval 60s
-						retry_forever true
+						retry_timeout 60m
 						queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 						total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
 						chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer.go
@@ -19,6 +19,7 @@ const (
 	defaultRetryWait        = "1s"
 	defaultRetryType        = "exponential_backoff"
 	defaultRetryMaxInterval = "60s"
+	defaultRetryTimeout     = "60m"
 
 	// Output fluentdForward default
 	fluentdForwardOverflowAction = "block"
@@ -133,6 +134,14 @@ func (olc *outputLabelConf) RetryMaxInterval() string {
 	}
 
 	return defaultRetryMaxInterval
+}
+func (olc *outputLabelConf) RetryTimeout() string {
+	value := defaultRetryTimeout
+	if hasBufferConfig(olc.forwarder) && string(olc.forwarder.Fluentd.Buffer.RetryTimeout) != "" {
+		value = string(olc.forwarder.Fluentd.Buffer.RetryTimeout)
+	}
+
+	return fmt.Sprintf("retry_timeout %s", value)
 }
 
 func hasBufferConfig(config *loggingv1.ForwarderSpec) bool {

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -9,6 +9,34 @@ import (
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
+var _ = Describe("outputLabelConf buffer tuning", func() {
+	var (
+		forwarderSpec *loggingv1.ForwarderSpec
+		conf          *outputLabelConf
+	)
+	BeforeEach(func() {
+		forwarderSpec = &loggingv1.ForwarderSpec{
+			Fluentd: &loggingv1.FluentdForwarderSpec{
+				Buffer: &loggingv1.FluentdBufferSpec{},
+			},
+		}
+		conf = &outputLabelConf{
+			forwarder: forwarderSpec,
+		}
+	})
+	Context("#RetryTimeout", func() {
+		It("should return the default when not configured", func() {
+			Expect(conf.RetryTimeout()).To(Equal("retry_timeout " + defaultRetryTimeout))
+		})
+		It("should use the spec'd value when configured", func() {
+			forwarderSpec.Fluentd.Buffer.RetryTimeout = "72h"
+			Expect(conf.RetryTimeout()).To(Equal("retry_timeout 72h"))
+		})
+
+	})
+
+})
+
 var _ = Describe("Generating fluentd config", func() {
 	var (
 		outputs              []loggingv1.OutputSpec
@@ -107,7 +135,7 @@ var _ = Describe("Generating fluentd config", func() {
                 retry_type exponential_backoff
                 retry_wait 1s
                 retry_max_interval 60s
-                retry_forever true
+                retry_timeout 60m
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -150,7 +178,7 @@ var _ = Describe("Generating fluentd config", func() {
                 retry_type exponential_backoff
                 retry_wait 1s
                 retry_max_interval 60s
-                retry_forever true
+                retry_timeout 60m
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -233,7 +261,7 @@ var _ = Describe("Generating fluentd config", func() {
                 retry_type exponential_backoff
                 retry_wait 1s
                 retry_max_interval 60s
-                retry_forever true
+                retry_timeout 60m
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -276,7 +304,7 @@ var _ = Describe("Generating fluentd config", func() {
                 retry_type exponential_backoff
                 retry_wait 1s
                 retry_max_interval 60s
-                retry_forever true
+                retry_timeout 60m
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -343,7 +371,7 @@ var _ = Describe("Generating fluentd config", func() {
                 retry_type periodic
                 retry_wait 2s
                 retry_max_interval 600s
-                retry_forever true
+                retry_timeout 60m
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size 512m
                 chunk_limit_size 256m
@@ -386,7 +414,7 @@ var _ = Describe("Generating fluentd config", func() {
                 retry_type periodic
                 retry_wait 2s
                 retry_max_interval 600s
-                retry_forever true
+                retry_timeout 60m
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size 512m
                 chunk_limit_size 256m
@@ -441,7 +469,7 @@ var _ = Describe("Generating fluentd config", func() {
             retry_type exponential_backoff
             retry_wait 1s
             retry_max_interval 60s
-            retry_forever true
+            retry_timeout 60m
             # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
             # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
             # buffer to the remote - default is 'block' because in_tail handles that case
@@ -483,7 +511,7 @@ var _ = Describe("Generating fluentd config", func() {
           retry_type periodic
           retry_wait 2s
           retry_max_interval 600s
-          retry_forever true
+          retry_timeout 60m
           # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
           # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
           # buffer to the remote - default is 'block' because in_tail handles that case
@@ -558,7 +586,7 @@ var _ = Describe("Generating fluentd config", func() {
                 retry_type exponential_backoff
                 retry_wait 1s
                 retry_max_interval 60s
-                retry_forever true
+                retry_timeout 60m
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -612,7 +640,7 @@ var _ = Describe("Generating fluentd config", func() {
                 retry_type periodic
                 retry_wait 2s
                 retry_max_interval 600s
-                retry_forever true
+                retry_timeout 60m
                 queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                 total_limit_size 512m
                 chunk_limit_size 256m
@@ -665,7 +693,7 @@ var _ = Describe("Generating fluentd config", func() {
                retry_type exponential_backoff
                retry_wait 1s
                retry_max_interval 60s
-               retry_forever true
+               retry_timeout 60m
                queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
                chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
@@ -700,7 +728,7 @@ var _ = Describe("Generating fluentd config", func() {
                retry_type periodic
                retry_wait 2s
                retry_max_interval 600s
-               retry_forever true
+               retry_timeout 60m
                queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
                total_limit_size 512m
                chunk_limit_size 256m

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -756,7 +756,7 @@ tls_cert_path "{{$path}}"
   retry_type {{.RetryType}}
   retry_wait {{.RetryWait}}
   retry_max_interval {{.RetryMaxInterval}}
-  retry_forever true
+  {{.RetryTimeout}}
   # the systemd journald 0.0.8 input plugin will just throw away records if the buffer
   # queue limit is hit - 'block' will halt further reads and keep retrying to flush the
   # buffer to the remote - default is 'block' because in_tail handles that case
@@ -830,7 +830,7 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
     retry_type {{.RetryType}}
     retry_wait {{.RetryWait}}
     retry_max_interval {{.RetryMaxInterval}}
-    retry_forever true
+    {{.RetryTimeout}}
     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 {{- if .TotalLimitSize }}
     total_limit_size {{.TotalLimitSize}}
@@ -914,7 +914,7 @@ const storeSyslogTemplate = `{{- define "storeSyslog" -}}
     retry_type {{.RetryType}}
     retry_wait {{.RetryWait}}
     retry_max_interval {{.RetryMaxInterval}}
-    retry_forever true
+    {{.RetryTimeout}}
     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 {{- if .TotalLimitSize }}
     total_limit_size {{.TotalLimitSize}}
@@ -973,7 +973,7 @@ ssl_ca_cert '{{ .SecretPath "ca-bundle.crt"}}'
   retry_type {{.RetryType}}
   retry_wait {{.RetryWait}}
   retry_max_interval {{.RetryMaxInterval}}
-  retry_forever true
+  {{.RetryTimeout}}
   queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
 {{- if .TotalLimitSize }}
   total_limit_size {{.TotalLimitSize}}


### PR DESCRIPTION
### Description
This PR:
* Modifies buffer retry to drop log messages after 10 minutes
* Adds API to buffer tuning section to allow configuration of retry

/cc @alanconway 

### Links
* Ref: https://issues.redhat.com/browse/LOG-1500