### PR TITLE
LOG 1400: Fix flaky test case

### DIFF
--- a/test/e2e/logforwarding/elasticsearchmanaged/forwarding_with_defaults_test.go
+++ b/test/e2e/logforwarding/elasticsearchmanaged/forwarding_with_defaults_test.go
@@ -35,8 +35,8 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 				Fail(fmt.Sprintf("Timed out waiting for the log generator to deploy: %v", err))
 			}
 			for k, v := range appLabels {
-				if _, err := oc.Literal().From("oc -n %s label pods %s %s=%s", ns, pod, k, v).Run(); err != nil {
-					Fail(fmt.Sprintf("Timed out waiting for the log generator to apply labels: %v", err))
+				if _, err := oc.Literal().From("oc -n %s label pods %s %s=%s --overwrite=true", ns, pod, k, v).Run(); err != nil {
+					Fail(fmt.Sprintf("Failed to apply labels to log generator. err: %v", err))
 				}
 			}
 


### PR DESCRIPTION
### Description
This PR fixes a flake in test. Test requires a log-generator pod with specific labels. The command to add the labels sometimes fails by saying that the labels already exist.
PR fixes that by adding `--owerwrite=true` flag to `oc` command.


/cc 
/assign 

/cherry-pick release-5.1

