### PR TITLE
LOG-1517: OLM Workaround for workload partioning

### DIFF
--- a/bundle/manifests/cluster-logging.v5.1.0.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.v5.1.0.clusterserviceversion.yaml
@@ -24,6 +24,10 @@ metadata:
     support: AOS Logging
     # The version value is substituted by the ART pipeline
     olm.skipRange: ">=4.6.0-0 <5.1.0"
+    # This annotation injection is a workaround for BZ-1950047, since the associated
+    # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
+    # TODO: remove the next line after BZ-1950047 is resolved.
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     alm-examples: |-
         [
           {

--- a/manifests/5.1/cluster-logging.v5.1.0.clusterserviceversion.yaml
+++ b/manifests/5.1/cluster-logging.v5.1.0.clusterserviceversion.yaml
@@ -24,6 +24,10 @@ metadata:
     support: AOS Logging
     # The version value is substituted by the ART pipeline
     olm.skipRange: ">=4.6.0-0 <5.1.0"
+    # This annotation injection is a workaround for BZ-1950047, since the associated
+    # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
+    # TODO: remove the next line after BZ-1950047 is resolved.
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     alm-examples: |-
         [
           {


### PR DESCRIPTION
### Description
required for supporting the workload partitioning feature for ocp 4.8.
However, OLM has a bug in processing the annotations (BZ 1950047).
This PR provides a workaround necessary to release the workload
partitioning in OCP 4.8.

### Links
* https://issues.redhat.com/browse/LOG-1517
* backport of https://github.com/openshift/cluster-logging-operator/pull/1042

cc @vimalk78 