### PR TITLE
Fix hack/registry.sh for CI

### DIFF
--- a/hack/registry.sh
+++ b/hack/registry.sh
@@ -3,20 +3,23 @@
 
 set -e
 
-oc registry info $* && exit 0	# Already works
+# This flag is set during CI runs.
+if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
+    oc registry info $* && exit 0	# Already works
 
-if [ "$1" = --public ]; then
-    echo "activate public registry route and log in, may take several retries" 1>&2
-    oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge 1>&2
-    RETRY=0
-    until [ $(( RETRY++ )) -eq 50 ]; do
-	REGISTRY=$(oc registry info --public) &&
-	    test -n "$REGISTRY" &&
-	    oc registry login --insecure --registry $REGISTRY 1>&2 &&
-	    echo $REGISTRY &&
-	    exit 0
-	echo "retry registry login.." 1>&2
-	sleep 6
-    done
+    if [ "$1" = --public ]; then
+        echo "activate public registry route and log in, may take several retries" 1>&2
+        oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge 1>&2
+        RETRY=0
+        until [ $(( RETRY++ )) -eq 50 ]; do
+        REGISTRY=$(oc registry info --public) &&
+            test -n "$REGISTRY" &&
+            oc registry login --insecure --registry $REGISTRY 1>&2 &&
+            echo $REGISTRY &&
+            exit 0
+        echo "retry registry login.." 1>&2
+        sleep 6
+        done
+    fi
 fi
 exit 1


### PR DESCRIPTION
### Description
This PR avoids running  the `hack//registry.sh` script in CI environments.



/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
