### PR TITLE
Correctly fixing the hack/registry.sh

### DIFF
--- a/hack/registry.sh
+++ b/hack/registry.sh
@@ -4,7 +4,7 @@
 set -e
 
 # This flag is set during CI runs.
-if [[ "${OPENSHIFT_CI:-}" == "true" ]]; then
+if [[ "${OPENSHIFT_CI:-}" == "false" ]]; then
     oc registry info $* && exit 0	# Already works
 
     if [ "$1" = --public ]; then


### PR DESCRIPTION
### Description
Avoid the `hack/registry.sh` script in CI.
change the CI environment variable check in script.

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
