### PR TITLE
LOG-1337: Prep CLO for collector migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ test-forwarder-generator: bin/forwarder-generator
 .PHONY: test-forwarder-generator
 
 test-functional-benchmarker: bin/functional-benchmarker
-	@bin/functional-benchmarker > /dev/null
+	@out=$$(bin/functional-benchmarker 2>&1); if [ "$$?" != "0" ] ; then echo "$$out"; exit 1; fi
 .PHONY: test-functional-benchmarker
 
 test-unit: test-forwarder-generator

--- a/hack/testing-olm/assertions
+++ b/hack/testing-olm/assertions
@@ -3,7 +3,7 @@ source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/utils"
 assert_resources_exist(){
 
 	# verify DS
-	os::cmd::try_until_success "oc -n $NAMESPACE get ds fluentd" ${TIMEOUT_MIN}
+	os::cmd::try_until_success "oc -n $NAMESPACE get ds collector" ${TIMEOUT_MIN}
 
 	# verify ER
 	os::cmd::try_until_success "oc -n $NAMESPACE get elasticsearch elasticsearch" ${TIMEOUT_MIN}
@@ -17,7 +17,7 @@ assert_kibana_instance_exists() {
 
 assert_resources_does_not_exist(){
 	os::cmd::try_until_failure "oc -n $NAMESPACE get cronjob curator"
-	os::cmd::try_until_failure "oc -n $NAMESPACE get ds fluentd"
+	os::cmd::try_until_failure "oc -n $NAMESPACE get ds collector"
 	os::cmd::try_until_failure "oc -n $NAMESPACE get elasticsearch elasticsearch"
 
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -20,7 +20,6 @@ const (
 	TrustedCABundleMountDir    = "/etc/pki/ca-trust/extracted/pem/"
 	TrustedCABundleHashName    = "logging.openshift.io/hash"
 	SecretHashPrefix           = "logging.openshift.io/"
-	FluentdTrustedCAName       = "fluentd-trusted-ca-bundle"
 	KibanaTrustedCAName        = "kibana-trusted-ca-bundle"
 	// internal elasticsearch FQDN to prevent to connect to the global proxy
 	ElasticsearchFQDN          = "elasticsearch.openshift-logging.svc"
@@ -33,10 +32,15 @@ const (
 	LogfilesmetricexporterName = "logfilesmetricexporter"
 	LogStoreURL                = "https://" + ElasticsearchFQDN + ":" + ElasticsearchPort
 	MasterCASecretName         = "master-certs"
-	CollectorSecretName        = "fluentd"
+	CollectorSecretName        = "collector"
 	// Disable gosec linter, complains "possible hard-coded secret"
 	CollectorSecretsDir     = "/var/run/ocp-collector/secrets" //nolint:gosec
 	KibanaSessionSecretName = "kibana-session-secret"          //nolint:gosec
+
+	CollectorName             = "collector"
+	CollectorMetricSecretName = "collector-metrics"
+	CollectorMonitorJobLabel  = "monitor-collector"
+	CollectorTrustedCAName    = "collector-trusted-ca-bundle"
 
 	LegacySecureforward = "_LEGACY_SECUREFORWARD"
 	LegacySyslog        = "_LEGACY_SYSLOG"
@@ -47,4 +51,4 @@ const (
 	ClusterInfrastructureInstance = "cluster"
 )
 
-var ReconcileForGlobalProxyList = []string{FluentdTrustedCAName}
+var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}

--- a/internal/k8shandler/certificates_test.go
+++ b/internal/k8shandler/certificates_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Reconciling", func() {
 			It("should provide a X509 cert for `CN=system.logging.fluentd`", func() {
 				Expect(clusterRequest.createOrUpdateFluentdSecret()).Should(Succeed())
 				secret := &corev1.Secret{}
-				key := types.NamespacedName{Name: constants.FluentdName, Namespace: constants.OpenshiftNS}
+				key := types.NamespacedName{Name: constants.CollectorName, Namespace: constants.OpenshiftNS}
 				Expect(client.Get(context.TODO(), key, secret)).Should(Succeed())
 
 				Expect(secret).Should(ContainKeys("ca-bundle.crt", "tls.crt", "tls.key"))

--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -43,13 +43,13 @@ var _ = Describe("Reconciling", func() {
 		}
 		fluentdSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fluentd",
+				Name:      constants.CollectorName,
 				Namespace: cluster.GetNamespace(),
 			},
 		}
 		fluentdCABundle = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      constants.FluentdTrustedCAName,
+				Name:      constants.CollectorTrustedCAName,
 				Namespace: cluster.GetNamespace(),
 				Labels: map[string]string{
 					constants.InjectTrustedCABundleLabel: "true",
@@ -82,11 +82,11 @@ var _ = Describe("Reconciling", func() {
                   -----END CERTIFICATE-------
                 `
 				trustedCABundleVolume = corev1.Volume{
-					Name: constants.FluentdTrustedCAName,
+					Name: constants.CollectorTrustedCAName,
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: constants.FluentdTrustedCAName,
+								Name: constants.CollectorTrustedCAName,
 							},
 							Items: []corev1.KeyToPath{
 								{
@@ -98,7 +98,7 @@ var _ = Describe("Reconciling", func() {
 					},
 				}
 				trustedCABundleVolumeMount = corev1.VolumeMount{
-					Name:      constants.FluentdTrustedCAName,
+					Name:      constants.CollectorTrustedCAName,
 					ReadOnly:  true,
 					MountPath: constants.TrustedCABundleMountDir,
 				}
@@ -118,12 +118,12 @@ var _ = Describe("Reconciling", func() {
 			It("should use the default CA bundle in fluentd", func() {
 				Expect(clusterRequest.CreateOrUpdateCollection()).Should(Succeed())
 
-				key := types.NamespacedName{Name: constants.FluentdTrustedCAName, Namespace: cluster.GetNamespace()}
+				key := types.NamespacedName{Name: constants.CollectorTrustedCAName, Namespace: cluster.GetNamespace()}
 				fluentdCaBundle := &corev1.ConfigMap{}
 				Expect(client.Get(context.TODO(), key, fluentdCaBundle)).Should(Succeed())
 				Expect(fluentdCABundle.Data).To(Equal(fluentdCaBundle.Data))
 
-				key = types.NamespacedName{Name: constants.FluentdName, Namespace: cluster.GetNamespace()}
+				key = types.NamespacedName{Name: constants.CollectorName, Namespace: cluster.GetNamespace()}
 				ds := &appsv1.DaemonSet{}
 				Expect(client.Get(context.TODO(), key, ds)).Should(Succeed())
 
@@ -145,7 +145,7 @@ var _ = Describe("Reconciling", func() {
 				// Reconcile with injected custom CA bundle
 				Expect(clusterRequest.CreateOrUpdateCollection()).Should(Succeed())
 
-				key := types.NamespacedName{Name: constants.FluentdName, Namespace: cluster.GetNamespace()}
+				key := types.NamespacedName{Name: constants.CollectorName, Namespace: cluster.GetNamespace()}
 				ds := &appsv1.DaemonSet{}
 				Expect(client.Get(context.TODO(), key, ds)).Should(Succeed())
 
@@ -167,13 +167,13 @@ var _ = Describe("compareFluentdCollectorStatus", func() {
 
 	BeforeEach(func() {
 		lhs = loggingv1.FluentdCollectorStatus{
-			DaemonSet:  constants.FluentdName,
+			DaemonSet:  constants.CollectorName,
 			Conditions: map[string]loggingv1.ClusterConditions{},
 			Nodes:      map[string]string{},
 			Pods:       map[loggingv1.PodStateType][]string{},
 		}
 		rhs = loggingv1.FluentdCollectorStatus{
-			DaemonSet:  constants.FluentdName,
+			DaemonSet:  constants.CollectorName,
 			Conditions: map[string]loggingv1.ClusterConditions{},
 			Nodes:      map[string]string{},
 			Pods:       map[loggingv1.PodStateType][]string{},

--- a/internal/k8shandler/fluentd_test.go
+++ b/internal/k8shandler/fluentd_test.go
@@ -251,7 +251,7 @@ func TestNewFluentdPodSpecWhenProxyConfigExists(t *testing.T) {
 	podSpec := newFluentdPodSpec(cluster, &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "openshift-logging",
-			Name:      constants.FluentdTrustedCAName,
+			Name:      constants.CollectorTrustedCAName,
 		},
 		Data: map[string]string{
 			constants.TrustedCABundleKey: caBundle,
@@ -266,7 +266,7 @@ func TestNewFluentdPodSpecWhenProxyConfigExists(t *testing.T) {
 	checkFluentdProxyEnvVar(t, podSpec, "HTTPS_PROXY", httpproxy)
 	checkFluentdProxyEnvVar(t, podSpec, "NO_PROXY", noproxy)
 
-	checkFluentdProxyVolumesAndVolumeMounts(t, podSpec, constants.FluentdTrustedCAName)
+	checkFluentdProxyVolumesAndVolumeMounts(t, podSpec, constants.CollectorTrustedCAName)
 }
 
 func TestFluentdPodInitContainerWithDefaultForwarding(t *testing.T) {

--- a/internal/k8shandler/forwarding_test.go
+++ b/internal/k8shandler/forwarding_test.go
@@ -2,6 +2,7 @@ package k8shandler
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -583,7 +584,7 @@ var _ = Describe("Normalizing forwarder", func() {
 outputs:
 - name: default
 	secret:
-		name: fluentd
+		name: collector
 	type: elasticsearch
 	url: https://elasticsearch.openshift-logging.svc:9200
 pipelines:
@@ -617,7 +618,7 @@ pipelines:
 			Expect(spec.Outputs).To(HaveLen(1))
 			Expect(spec.Outputs[0].Name).To(Equal("default"))
 			Expect(spec.Outputs[0].URL).To(Equal("https://elasticsearch.openshift-logging.svc:9200"))
-			Expect(spec.Outputs[0].Secret.Name).To(Equal("fluentd"))
+			Expect(spec.Outputs[0].Secret.Name).To(Equal(constants.CollectorSecretName))
 			Expect(spec.Outputs[0].Type).To(Equal("elasticsearch"))
 
 			Expect(status.Conditions).To(HaveCondition("Ready", true, "", ""))

--- a/internal/k8shandler/status.go
+++ b/internal/k8shandler/status.go
@@ -2,6 +2,7 @@ package k8shandler
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"sort"
 
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
@@ -15,7 +16,7 @@ func (clusterRequest *ClusterLoggingRequest) getFluentdCollectorStatus() (loggin
 
 	fluentdStatus := logging.FluentdCollectorStatus{}
 	selector := map[string]string{
-		"logging-infra": "fluentd",
+		"logging-infra": constants.CollectorName,
 	}
 
 	fluentdDaemonsetList, err := clusterRequest.GetDaemonSetList(selector)
@@ -39,7 +40,7 @@ func (clusterRequest *ClusterLoggingRequest) getFluentdCollectorStatus() (loggin
 		fluentdStatus.Pods = podStateMap(podList.Items)
 		fluentdStatus.Nodes = podNodeMap
 
-		fluentdStatus.Conditions, err = clusterRequest.getPodConditions("fluentd")
+		fluentdStatus.Conditions, err = clusterRequest.getPodConditions(constants.CollectorName)
 		if err != nil {
 			return fluentdStatus, fmt.Errorf("unable to get pod conditions. E: %s", err.Error())
 		}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -32,6 +32,7 @@ const (
 
 // COMPONENT_IMAGES are thee keys are based on the "container name" + "-{image,version}"
 var COMPONENT_IMAGES = map[string]string{
+	constants.CollectorName:              constants.FluentdImageEnvVar,
 	"curator":                            "CURATOR_IMAGE",
 	constants.FluentdName:                constants.FluentdImageEnvVar,
 	"kibana":                             "KIBANA_IMAGE",

--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -40,6 +40,7 @@ oc -n $NAMESPACE get ds -o wide > ${clo_folder}/daemonsets.txt 2>&1
 oc -n $NAMESPACE get pods -o wide > ${clo_folder}/pods.txt 2>&1
 oc -n $NAMESPACE extract secret/elasticsearch --to=${clo_folder}
 oc -n $NAMESPACE extract configmap/fluentd --to=${clo_folder}
+oc -n $NAMESPACE extract configmap/collector --to=${clo_folder}
 oc -n $NAMESPACE extract configmap/secure-forward --to=${clo_folder}
 oc -n $NAMESPACE extract secret/secure-forward --to=${clo_folder}
 oc -n $NAMESPACE get events --field-selector involvedObject.kind=ClusterLogging -o yaml > ${clo_folder}/clo-events.yaml 2>&1

--- a/must-gather/collection-scripts/gather_collection_resources
+++ b/must-gather/collection-scripts/gather_collection_resources
@@ -21,14 +21,15 @@ check_collector_connectivity() {
 
   es_host=$(oc -n $NAMESPACE  get pod $pod  -o jsonpath='{.spec.containers[0].env[?(@.name=="ES_HOST")].value}')
   es_port=$(oc -n $NAMESPACE  get pod $pod  -o jsonpath='{.spec.containers[0].env[?(@.name=="ES_PORT")].value}')
+
   collector=fluent
-  container=fluentd
+  for container in "fluentd" "collector"; do
+    echo "  with ca" >> $collector_folder/$pod
+    oc -n $NAMESPACE exec $pod -c $container -- curl -ILvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert --cacert /etc/$collector/keys/ca -XGET https://$es_host:$es_port &>> $collector_folder/$pod
 
-  echo "  with ca" >> $collector_folder/$pod
-  oc -n $NAMESPACE exec $pod -c $container -- curl -ILvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert --cacert /etc/$collector/keys/ca -XGET https://$es_host:$es_port &>> $collector_folder/$pod
-
-  echo "  without ca" >> $collector_folder/$pod
-  oc -n $NAMESPACE exec $pod -c $container -- curl -ILkvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert -XGET https://$es_host:$es_port &>> $collector_folder/$pod
+    echo "  without ca" >> $collector_folder/$pod
+    oc -n $NAMESPACE exec $pod -c $container -- curl -ILkvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert -XGET https://$es_host:$es_port &>> $collector_folder/$pod
+  done
 }
 
 check_collector_persistence() {
@@ -41,34 +42,40 @@ check_collector_persistence() {
   if [ -z "$fbstoragePath" ] ; then
     echo "No filebuffer storage defined" >>  $collector_folder/$pod
   else
-    oc -n $NAMESPACE exec $pod -c $collector -- df -h $fbstoragePath >> $collector_folder/$pod
-    oc -n $NAMESPACE exec $pod -c $collector -- ls -lr $fbstoragePath >> $collector_folder/$pod
+    for collector in "fluentd" "collector"; do
+      oc -n $NAMESPACE exec $pod -c $collector -- df -h $fbstoragePath >> $collector_folder/$pod
+      oc -n $NAMESPACE exec $pod -c $collector -- ls -lr $fbstoragePath >> $collector_folder/$pod
+    done
   fi
 }
 
-echo "Gathering data for collection component"
-mkdir -p $collector_folder
+echo "if the collector 'fluentd' or 'collector' is missing thats OK"
+echo "this must gather is trying to cover all cases for name migration"
+for collector in "fluentd" "collector"; do
+  echo "Gathering data for collection component: $collector"
+  mkdir -p $collector_folder
 
-echo "-- Retrieving configmaps"
-mkdir -p $collector_folder/cm/fluentd
-oc -n $NAMESPACE extract configmap/fluentd --to=$collector_folder/cm/fluentd
-mkdir -p $collector_folder/cm/secure-forward
-oc -n $NAMESPACE extract configmap/secure-forward --to=$collector_folder/cm/secure-forward
-mkdir -p $collector_folder/cm/syslog
-oc -n $NAMESPACE extract configmap/syslog --to=$collector_folder/cm/syslog
+  echo "-- Retrieving configmaps: $collector"
+  mkdir -p $collector_folder/cm/$collector
+  oc -n $NAMESPACE extract configmap/$collector --to=$collector_folder/cm/$collector
+  mkdir -p $collector_folder/cm/secure-forward
+  oc -n $NAMESPACE extract configmap/secure-forward --to=$collector_folder/cm/secure-forward
+  mkdir -p $collector_folder/cm/syslog
+  oc -n $NAMESPACE extract configmap/syslog --to=$collector_folder/cm/syslog
 
-echo "-- Checking Collector health"
-pods="$(oc -n $NAMESPACE get pods -l logging-infra=fluentd -o jsonpath='{.items[*].metadata.name}')"
-for pod in $pods
-do
-    echo "---- Collector pod: $pod"
-    oc -n $NAMESPACE describe pod/$pod > $collector_folder/$pod.describe 2>&1
-    get_env $pod $collector_folder "$NAMESPACE"
-    check_collector_connectivity $pod
-    check_collector_persistence $pod
-    oc -n openshift-logging exec -- ls -l /var/lib/fluentd/clo_default_output_es > $collector_folder/$pod.es-buffers.txt
-    oc -n openshift-logging exec -- ls -l /var/lib/fluentd/retry_clo_default_output_es > $outdir/$pod.buffers.es-retry.txt
-    echo "$pod" >> $collector_folder/output-buffer-size.txt
-    echo "---------------" >> $collector_folder/output-buffer-size.txt
-    oc -n openshift-logging exec $pod -- bash -c ' du -sh /var/lib/fluentd/*' >> $collector_folder/output-buffer-size.txt
+  echo "-- Checking Collector health: $collector"
+  pods="$(oc -n $NAMESPACE get pods -l logging-infra=$collector -o jsonpath='{.items[*].metadata.name}')"
+  for pod in $pods
+  do
+      echo "---- Collector pod: $pod"
+      oc -n $NAMESPACE describe pod/$pod > $collector_folder/$pod.describe 2>&1
+      get_env $pod $collector_folder "$NAMESPACE"
+      check_collector_connectivity $pod
+      check_collector_persistence $pod
+      oc -n openshift-logging exec $pod -- ls -l /var/lib/$collector/clo_default_output_es > $collector_folder/$pod.es-buffers.txt
+      oc -n openshift-logging exec $pod -- ls -l /var/lib/$collector/retry_clo_default_output_es > $outdir/$pod.buffers.es-retry.txt
+      echo "$pod" >> $collector_folder/output-buffer-size.txt
+      echo "---------------" >> $collector_folder/output-buffer-size.txt
+      oc -n openshift-logging exec $pod -- bash -c ' du -sh /var/lib/fluentd/*' >> $collector_folder/output-buffer-size.txt
+  done
 done

--- a/must-gather/collection-scripts/gather_install_resources
+++ b/must-gather/collection-scripts/gather_install_resources
@@ -24,7 +24,7 @@ oc get -n openshift-operators-redhat subscriptions.operators.coreos.com -o yaml 
 
 echo "-- Install Plan"
 oc get -n ${NAMESPACE} installplans.operators.coreos.com -o yaml > "$install_folder/install_plan-clo"
-oc get -n openshift-operators-redhat installplans.operators.coreos.com -o yaml > "$install_folder/install_plan-eo""
+oc get -n openshift-operators-redhat installplans.operators.coreos.com -o yaml > "$install_folder/install_plan-eo"
 
 echo "-- Catalog Operator logs"
 oc logs -n openshift-operator-lifecycle-manager -l app=catalog-operator > "$install_folder/co_logs"

--- a/test/e2e/collection/cleanup.sh
+++ b/test/e2e/collection/cleanup.sh
@@ -9,4 +9,7 @@ gather_logging_resources "openshift-logging" "$artifact_dir" "$runtime"
 oc -n "$GENERATOR_NS" describe deployment/log-generator  > "$artifact_dir/$runtime/log-generator.describe" ||:
 oc -n "$GENERATOR_NS" logs deployment/log-generator  > "$artifact_dir/$runtime/log-generator.logs" ||:
 oc -n "$GENERATOR_NS" get deployment/log-generator -o yaml > "$artifact_dir/$runtime/log-generator.deployment.yaml" ||:
-oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=fluent-receiver -o name| sed 's/pod\///') -- cat /tmp/app-logs > "$artifact_dir/$runtime/fluent-receiver-app-logs" ||:
+RECEIVER=$(oc -n openshift-logging get pods -l component=fluent-receiver -o name||:)
+if [ "$RECEIVER" != "" ] ; then
+  oc -n openshift-logging exec $(echo $RECEIVER| sed 's/pod\///') -- cat /tmp/app-logs > "$artifact_dir/$runtime/fluent-receiver-app-logs" ||:
+fi

--- a/test/e2e/collection/fluentd/collector_only_test.go
+++ b/test/e2e/collection/fluentd/collector_only_test.go
@@ -2,6 +2,7 @@ package fluentd
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"runtime"
 
 	. "github.com/onsi/ginkgo"
@@ -34,7 +35,7 @@ var _ = Describe("[Collection] Provides only a fluentd daemonset", func() {
 
 		AfterEach(func() {
 			e2e.Cleanup()
-			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{"fluentd"})
+			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{constants.CollectorName})
 		}, helpers.DefaultCleanUpTimeout)
 
 		It("should default to a running collector", func() {

--- a/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go
+++ b/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go
@@ -2,6 +2,7 @@ package elasticsearchmanaged
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"runtime"
 	"strings"
 
@@ -40,7 +41,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 
 		AfterEach(func() {
 			e2e.Cleanup()
-			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{"fluentd", "elasticsearch"})
+			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{constants.CollectorName, "elasticsearch"})
 		}, helpers.DefaultCleanUpTimeout)
 
 		It("should default to forwarding logs to the spec'd logstore", func() {

--- a/test/e2e/logforwarding/elasticsearchunmanaged/forward_to_unmanaged_elasticsearch_test.go
+++ b/test/e2e/logforwarding/elasticsearchunmanaged/forward_to_unmanaged_elasticsearch_test.go
@@ -2,6 +2,7 @@ package elasticsearchunmanaged
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"path/filepath"
 	"runtime"
 
@@ -97,7 +98,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 
 		AfterEach(func() {
 			e2e.Cleanup()
-			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{"fluentd", "elasticsearch"})
+			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{constants.CollectorName, "elasticsearch"})
 		})
 
 		It("should send logs to the forward.Output logstore", func() {

--- a/test/e2e/logforwarding/fluent/fixture_test.go
+++ b/test/e2e/logforwarding/fluent/fixture_test.go
@@ -2,6 +2,7 @@ package fluent_test
 
 import (
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/test/client"
 	"github.com/openshift/cluster-logging-operator/test/helpers/fluentd"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
@@ -42,7 +43,7 @@ func (f *Fixture) Create(c *client.Client) {
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "fluentd",
+			Name:      constants.CollectorName,
 			Namespace: f.ClusterLogging.Namespace,
 		},
 	}))
@@ -57,7 +58,7 @@ func (f *Fixture) Create(c *client.Client) {
 				APIVersion: "apps/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fluentd",
+				Name:      constants.CollectorName,
 				Namespace: f.ClusterLogging.Namespace,
 			},
 		},

--- a/test/e2e/logforwarding/fluentlegacy/forward_to_fluent_test.go
+++ b/test/e2e/logforwarding/fluentlegacy/forward_to_fluent_test.go
@@ -3,6 +3,7 @@ package fluentlegacy
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -107,7 +108,7 @@ var _ = Describe("[ClusterLogging] Forwards logs", func() {
 
 		AfterEach(func() {
 			e2e.Cleanup()
-			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{"fluent-receiver", "fluentd", "elasticsearch"})
+			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{"fluent-receiver", constants.CollectorName, "elasticsearch"})
 		})
 	})
 

--- a/test/e2e/logforwarding/multiple_outputs/forward_to_multiple_outputs_test.go
+++ b/test/e2e/logforwarding/multiple_outputs/forward_to_multiple_outputs_test.go
@@ -31,7 +31,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 		fluentRcv      *apps.Deployment
 		elasticsearch  *eologgingv1.Elasticsearch
 		pipelineSecret *corev1.Secret
-		selectors      = []string{"elasticsearch", "fluent-receiver", "fluentd"}
+		selectors      = []string{"elasticsearch", "fluent-receiver", constants.CollectorName}
 	)
 
 	BeforeEach(func() {

--- a/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
@@ -3,6 +3,7 @@ package syslog
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -689,7 +690,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 		AfterEach(func() {
 			e2e.Cleanup()
 			e2e.WaitForCleanupCompletion(logGenNS, []string{"test"})
-			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{"fluentd", "syslog-receiver"})
+			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{constants.CollectorName, "syslog-receiver"})
 			generatorPayload = map[string]string{}
 		})
 	})

--- a/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/sysloglegacy/forward_to_syslog_test.go
@@ -2,6 +2,7 @@ package sysloglegacy
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"path/filepath"
 	"runtime"
 
@@ -138,7 +139,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 
 		AfterEach(func() {
 			e2e.Cleanup()
-			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{"fluentd", "syslog-receiver", "elasticsearch"})
+			e2e.WaitForCleanupCompletion(helpers.OpenshiftLoggingNS, []string{constants.CollectorName, "syslog-receiver", "elasticsearch"})
 		})
 
 	})

--- a/test/functional/metrics/fluentd_test.go
+++ b/test/functional/metrics/fluentd_test.go
@@ -33,7 +33,7 @@ var _ = Describe("[Metrics] Function testing of fluentd metrics", func() {
 
 	Context("when using a service address", func() {
 		It("should return successfully", func() {
-			metrics, _ := framework.RunCommand(constants.FluentdName, "curl", "-ksv", fmt.Sprintf("https://%s.%s:24231/metrics", framework.Name, framework.Namespace))
+			metrics, _ := framework.RunCommand(constants.CollectorName, "curl", "-ksv", fmt.Sprintf("https://%s.%s:24231/metrics", framework.Name, framework.Namespace))
 			Expect(metrics).To(ContainSubstring(sampleMetric))
 		})
 	})

--- a/test/functional/outputs/loki/application_logs_test.go
+++ b/test/functional/outputs/loki/application_logs_test.go
@@ -28,7 +28,7 @@ func TestLokiOutput(t *testing.T) {
 
 		containerTag = func(f *functional.FluentdFunctionalFramework) string {
 			for _, s := range f.Pod.Status.ContainerStatuses {
-				if s.Name == constants.FluentdName {
+				if s.Name == constants.CollectorName {
 					containerId := s.ContainerID[len("cri-o://"):]
 					return fmt.Sprintf("kubernetes.var.log.containers.%s_%s_%s-%s.log", f.Pod.Name, f.Pod.Namespace, f.Pod.Spec.Containers[0].Name, containerId)
 				}


### PR DESCRIPTION
### Description
This PR:
* Does the minimal work to prep CLO to migrate to a new collector by naming the deployed objects as "collector" in lieu of "fluentd"
* Follow-on work should be done to remove "fluentd" from source ref as appropriate

### Links
* https://issues.redhat.com/browse/LOG-1337