### PR TITLE
LOG-1499: Force encoding to utf-8 and replace invalid chars

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -264,11 +264,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
-    <filter **>
-      @type record_modifier
-      char_encoding utf-8
-    </filter>
-
     <filter journal>
       @type grep
       <exclude>
@@ -568,6 +563,10 @@ var _ = Describe("Generating fluentd config", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
+	<filter **>
+		@type record_modifier
+		char_encoding ascii-8bit:utf-8
+	</filter>
     #flatten labels to prevent field explosion in ES
     <filter ** >
       @type record_transformer
@@ -681,6 +680,10 @@ var _ = Describe("Generating fluentd config", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
+	</filter>
+	<filter **>
+		@type record_modifier
+		char_encoding ascii-8bit:utf-8
 	</filter>
     #flatten labels to prevent field explosion in ES
     <filter ** >
@@ -992,11 +995,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
-    <filter **>
-      @type record_modifier
-      char_encoding utf-8
-    </filter>
-
     <filter journal>
       @type grep
       <exclude>
@@ -1291,6 +1289,10 @@ var _ = Describe("Generating fluentd config", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
+	<filter **>
+		@type record_modifier
+		char_encoding ascii-8bit:utf-8
+	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
 		@type record_transformer    
@@ -1396,6 +1398,10 @@ var _ = Describe("Generating fluentd config", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
+	</filter>
+	<filter **>
+		@type record_modifier
+		char_encoding ascii-8bit:utf-8
 	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
@@ -1701,11 +1707,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
-    <filter **>
-      @type record_modifier
-      char_encoding utf-8
-    </filter>
-
     <filter journal>
       @type grep
       <exclude>
@@ -2002,6 +2003,10 @@ var _ = Describe("Generating fluentd config", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
+	<filter **>
+		@type record_modifier
+		char_encoding ascii-8bit:utf-8
+	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
 		@type record_transformer    
@@ -2107,6 +2112,10 @@ var _ = Describe("Generating fluentd config", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
+	</filter>
+	<filter **>
+		@type record_modifier
+		char_encoding ascii-8bit:utf-8
 	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
@@ -2369,10 +2378,6 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
-				<filter **>
-					@type record_modifier
-					char_encoding utf-8
-				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -2850,10 +2855,6 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
-				<filter **>
-					@type record_modifier
-					char_encoding utf-8
-				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -3133,6 +3134,10 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
+          		<filter **>
+            		@type record_modifier
+            		char_encoding ascii-8bit:utf-8
+          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3241,6 +3246,10 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
+          		<filter **>
+            		@type record_modifier
+            		char_encoding ascii-8bit:utf-8
+          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3349,6 +3358,10 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
+          		<filter **>
+            		@type record_modifier
+            		char_encoding ascii-8bit:utf-8
+          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3457,6 +3470,10 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
+          		<filter **>
+            		@type record_modifier
+            		char_encoding ascii-8bit:utf-8
+          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3791,11 +3808,6 @@ var _ = Describe("Generating fluentd config", func() {
     <label @INGRESS>
 
       ## filters
-      <filter **>
-        @type record_modifier
-        char_encoding utf-8
-      </filter>
-
       <filter journal>
         @type grep
         <exclude>

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -69,6 +69,10 @@ var _ = Describe("Generating fluentd config blocks", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
+	<filter **>
+		@type record_modifier
+		char_encoding ascii-8bit:utf-8
+	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
 		@type record_transformer    
@@ -193,6 +197,10 @@ var _ = Describe("Generating fluentd config blocks", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
+	</filter>
+	<filter **>
+		@type record_modifier
+		char_encoding ascii-8bit:utf-8
 	</filter>
 	#flatten labels to prevent field explosion in ES
 	<filter ** >

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -225,11 +225,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>
@@ -711,11 +706,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>
@@ -1207,11 +1197,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -92,6 +92,10 @@ var _ = Describe("Generating fluentd config", func() {
 		    @type record_modifier
 		    remove_keys structured
 		  </filter>
+		  <filter **>
+			@type record_modifier
+			char_encoding ascii-8bit:utf-8
+		  </filter>
 		  #flatten labels to prevent field explosion in ES    
 		  <filter ** >       
 			  @type record_transformer    
@@ -218,6 +222,10 @@ var _ = Describe("Generating fluentd config", func() {
 		    @type record_modifier
 		    remove_keys structured
 		  </filter>
+		  <filter **>
+				@type record_modifier
+				char_encoding ascii-8bit:utf-8
+		  </filter>
 		  #flatten labels to prevent field explosion in ES    
 		  <filter ** >       
 			  @type record_transformer    
@@ -326,6 +334,10 @@ var _ = Describe("Generating fluentd config", func() {
 		<filter **>
 		  @type record_modifier
 		  remove_keys structured
+		</filter>
+		<filter **>
+			@type record_modifier
+			char_encoding ascii-8bit:utf-8
 		</filter>
 		  #flatten labels to prevent field explosion in ES    
 		  <filter ** >       

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -138,13 +138,7 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 #syslog input config here
 
 <label @INGRESS>
-
   ## filters
-  <filter **>
-    @type record_modifier
-    char_encoding utf-8
-  </filter>
-
   <filter journal>
     @type grep
     <exclude>
@@ -634,6 +628,10 @@ const outputLabelConfTemplate = `{{- define "outputLabelConf" -}}
   </filter>
   {{- end}}
   {{- if .IsElasticSearchOutput}}
+  <filter **>
+    @type record_modifier
+    char_encoding ascii-8bit:utf-8
+  </filter>
   #flatten labels to prevent field explosion in ES
   <filter ** >
     @type record_transformer


### PR DESCRIPTION
### Description
This PR:
* Explicitly forces messages to be converted to utf-8
* Replaces any invalid characters with a char that can be consumed by Elasticsearch

Tested by:
* using hexedit to change a message line to have 0x92 in it
* setup fluent.conf to write to elasticsearch
* include filter in conf to explicitly convert before writing to elasticsearch
* demonstrated ES rejection without conversion and acceptance with conversion

### Links
* https://issues.redhat.com/browse/LOG-1499