### PR TITLE
Bug 1951605: Force encoding to utf-8 and replace invalid chars

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf.go
@@ -78,6 +78,10 @@ func (conf *outputLabelConf) BufferPath() string {
 	return fmt.Sprintf("/var/lib/fluentd/%s", conf.StoreID())
 }
 
+func (conf *outputLabelConf) IsElasticSearchOutput() bool {
+	return conf.Target.Type == logging.OutputTypeElasticsearch
+}
+
 func (conf *outputLabelConf) IsTLS() bool {
 	return url.IsTLSScheme(conf.URL.Scheme) || conf.Secret != nil
 }

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -263,11 +263,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
   
     ## filters
-    <filter **>
-      @type record_modifier
-      char_encoding utf-8
-    </filter>
-  
     <filter journal>
       @type grep
       <exclude>
@@ -572,6 +567,10 @@ var _ = Describe("Generating fluentd config", func() {
   
   # Ship logs to specific outputs
   <label @APPS_ES_1>
+    <filter **>
+      @type record_modifier
+      char_encoding ascii-8bit:utf-8
+    </filter>
     <match retry_apps_es_1>
       @type copy
       <store>
@@ -673,6 +672,10 @@ var _ = Describe("Generating fluentd config", func() {
     </match>
   </label>
   <label @APPS_ES_2>
+    <filter **>
+      @type record_modifier
+      char_encoding ascii-8bit:utf-8
+    </filter>
     <match retry_apps_es_2>
       @type copy
       <store>
@@ -933,10 +936,6 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
-				<filter **>
-					@type record_modifier
-					char_encoding utf-8
-				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -1423,10 +1422,6 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
-				<filter **>
-					@type record_modifier
-					char_encoding utf-8
-				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -1711,6 +1706,10 @@ var _ = Describe("Generating fluentd config", func() {
 
 			# Ship logs to specific outputs
 			<label @INFRA_ES>
+				<filter **>
+					@type record_modifier
+					char_encoding ascii-8bit:utf-8
+				</filter>
 				<match retry_infra_es>
 					@type copy
 					<store>
@@ -1806,6 +1805,10 @@ var _ = Describe("Generating fluentd config", func() {
 				</match>
 			</label>
 			<label @APPS_ES_1>
+				<filter **>
+					@type record_modifier
+					char_encoding ascii-8bit:utf-8
+				</filter>
 				<match retry_apps_es_1>
 					@type copy
 					<store>
@@ -1901,6 +1904,10 @@ var _ = Describe("Generating fluentd config", func() {
 				</match>
 			</label>
 			<label @APPS_ES_2>
+				<filter **>
+					@type record_modifier
+					char_encoding ascii-8bit:utf-8
+				</filter>
 				<match retry_apps_es_2>
 					@type copy
 					<store>
@@ -1996,6 +2003,10 @@ var _ = Describe("Generating fluentd config", func() {
 				</match>
 			</label>
 			<label @AUDIT_ES>
+				<filter **>
+					@type record_modifier
+					char_encoding ascii-8bit:utf-8
+				</filter>
 				<match retry_audit_es>
 					@type copy
 					<store>
@@ -2268,11 +2279,6 @@ var _ = Describe("Generating fluentd config", func() {
     <label @INGRESS>
     
       ## filters
-      <filter **>
-        @type record_modifier
-        char_encoding utf-8
-      </filter>
-    
       <filter journal>
         @type grep
         <exclude>

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -65,6 +65,10 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(results[0]).To(EqualTrimLines(`<label @ONCLUSTER_ELASTICSEARCH>
+    <filter **>
+		@type record_modifier
+		char_encoding ascii-8bit:utf-8
+    </filter>
 	<match retry_oncluster_elasticsearch>
 		@type copy
 		<store>
@@ -177,6 +181,10 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			results, err := generator.generateOutputLabelBlocks(outputs, nil, forwarderSpec)
 			Expect(err).To(BeNil())
 			Expect(results[0]).To(EqualTrimLines(`<label @OTHER_ELASTICSEARCH>
+    <filter **>
+		@type record_modifier
+		char_encoding ascii-8bit:utf-8
+    </filter>
 	<match retry_other_elasticsearch>
 		@type copy
 		<store>

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -225,11 +225,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>
@@ -719,13 +714,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         #syslog input config here
 
         <label @INGRESS>
-
-          ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
+			## filters
           <filter journal>
             @type grep
             <exclude>
@@ -1228,11 +1217,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -60,6 +60,10 @@ var _ = Describe("Generating fluentd config", func() {
 		It("should provide a default buffer configuration", func() {
 			esConf := `
         <label @OTHER_ELASTICSEARCH>
+			<filter **>
+			  @type record_modifier
+			  char_encoding ascii-8bit:utf-8
+			</filter>
           <match retry_other_elasticsearch>
             @type copy
             <store>
@@ -173,6 +177,10 @@ var _ = Describe("Generating fluentd config", func() {
 		It("should provide a default buffer configuration", func() {
 			esConf := `
         <label @OTHER_ELASTICSEARCH>
+			<filter **>
+			  @type record_modifier
+			  char_encoding ascii-8bit:utf-8
+			</filter>
           <match retry_other_elasticsearch>
             @type copy
             <store>
@@ -269,6 +277,10 @@ var _ = Describe("Generating fluentd config", func() {
 		It("should override buffer configuration for given tuning parameters", func() {
 			esConf := `
         <label @OTHER_ELASTICSEARCH>
+			<filter **>
+			  @type record_modifier
+			  char_encoding ascii-8bit:utf-8
+			</filter>
           <match retry_other_elasticsearch>
             @type copy
             <store>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -139,11 +139,6 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 <label @INGRESS>
 
   ## filters
-  <filter **>
-    @type record_modifier
-    char_encoding utf-8
-  </filter>
-
   <filter journal>
     @type grep
     <exclude>
@@ -586,6 +581,12 @@ const pipelineToOutputCopyTemplate = `{{- define "pipelineToOutputCopyTemplate" 
 
 const outputLabelConfTemplate = `{{- define "outputLabelConf" -}}
 <label {{.LabelName}}>
+  {{- if .IsElasticSearchOutput}}
+  <filter **>
+    @type record_modifier
+    char_encoding ascii-8bit:utf-8
+  </filter>
+  {{- end}}
   <match {{.RetryTag}}>
     @type copy
 {{ include .StoreTemplate . "prefix_as_retry" | indent 4}}


### PR DESCRIPTION
### Description
This PR:
* Explicitly forces messages to be converted to utf-8
* Replaces any invalid characters with a char that can be consumed by Elasticsearch

Tested by:
* using hexedit to change a message line to have 0x92 in it
* setup fluent.conf to write to elasticsearch
* include filter in conf to explicitly convert before writing to elasticsearch
* demonstrated ES rejection without conversion and acceptance with conversion

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1951605
* 4.6 backport of https://github.com/openshift/cluster-logging-operator/pull/1095