### PR TITLE
LOG-1576: Revert utf-8 encoding and revert LOG-1569

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -264,6 +264,11 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
+    <filter **>
+      @type record_modifier
+      char_encoding utf-8
+    </filter>
+
     <filter journal>
       @type grep
       <exclude>
@@ -559,10 +564,6 @@ var _ = Describe("Generating fluentd config", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
-	</filter>
     #flatten labels to prevent field explosion in ES
     <filter ** >
       @type record_transformer
@@ -676,10 +677,6 @@ var _ = Describe("Generating fluentd config", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
-	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
 	</filter>
     #flatten labels to prevent field explosion in ES
     <filter ** >
@@ -991,6 +988,11 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
+    <filter **>
+      @type record_modifier
+      char_encoding utf-8
+    </filter>
+
     <filter journal>
       @type grep
       <exclude>
@@ -1281,10 +1283,6 @@ var _ = Describe("Generating fluentd config", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
-	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
 		@type record_transformer    
@@ -1390,10 +1388,6 @@ var _ = Describe("Generating fluentd config", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
-	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
 	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
@@ -1699,6 +1693,11 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
+    <filter **>
+      @type record_modifier
+      char_encoding utf-8
+    </filter>
+
     <filter journal>
       @type grep
       <exclude>
@@ -1991,10 +1990,6 @@ var _ = Describe("Generating fluentd config", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
-	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
 		@type record_transformer    
@@ -2100,10 +2095,6 @@ var _ = Describe("Generating fluentd config", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
-	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
 	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
@@ -2366,6 +2357,10 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
+				<filter **>
+					@type record_modifier
+					char_encoding utf-8
+				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -2843,6 +2838,10 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
+				<filter **>
+					@type record_modifier
+					char_encoding utf-8
+				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -3122,10 +3121,6 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
-          		<filter **>
-            		@type record_modifier
-            		char_encoding ascii-8bit:utf-8
-          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3234,10 +3229,6 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
-          		<filter **>
-            		@type record_modifier
-            		char_encoding ascii-8bit:utf-8
-          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3346,10 +3337,6 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
-          		<filter **>
-            		@type record_modifier
-            		char_encoding ascii-8bit:utf-8
-          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3458,10 +3445,6 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
-          		<filter **>
-            		@type record_modifier
-            		char_encoding ascii-8bit:utf-8
-          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3796,6 +3779,11 @@ var _ = Describe("Generating fluentd config", func() {
     <label @INGRESS>
 
       ## filters
+      <filter **>
+        @type record_modifier
+        char_encoding utf-8
+      </filter>
+
       <filter journal>
         @type grep
         <exclude>

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -264,12 +264,7 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
-    <filter **>
-      @type record_modifier
-      char_encoding utf-8
-    </filter>
-
-    <filter journal>
+   <filter journal>
       @type grep
       <exclude>
         key PRIORITY
@@ -988,11 +983,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
-    <filter **>
-      @type record_modifier
-      char_encoding utf-8
-    </filter>
-
     <filter journal>
       @type grep
       <exclude>
@@ -1693,11 +1683,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
-    <filter **>
-      @type record_modifier
-      char_encoding utf-8
-    </filter>
-
     <filter journal>
       @type grep
       <exclude>
@@ -2357,10 +2342,6 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
-				<filter **>
-					@type record_modifier
-					char_encoding utf-8
-				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -2838,10 +2819,6 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
-				<filter **>
-					@type record_modifier
-					char_encoding utf-8
-				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -3779,11 +3756,6 @@ var _ = Describe("Generating fluentd config", func() {
     <label @INGRESS>
 
       ## filters
-      <filter **>
-        @type record_modifier
-        char_encoding utf-8
-      </filter>
-
       <filter journal>
         @type grep
         <exclude>

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -69,10 +69,6 @@ var _ = Describe("Generating fluentd config blocks", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
-	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
 		@type record_transformer    
@@ -197,10 +193,6 @@ var _ = Describe("Generating fluentd config blocks", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
-	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
 	</filter>
 	#flatten labels to prevent field explosion in ES
 	<filter ** >

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -225,6 +225,11 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
+          <filter **>
+            @type record_modifier
+            char_encoding utf-8
+          </filter>
+
           <filter journal>
             @type grep
             <exclude>
@@ -706,6 +711,11 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
+          <filter **>
+            @type record_modifier
+            char_encoding utf-8
+          </filter>
+
           <filter journal>
             @type grep
             <exclude>
@@ -1197,6 +1207,11 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
+          <filter **>
+            @type record_modifier
+            char_encoding utf-8
+          </filter>
+
           <filter journal>
             @type grep
             <exclude>

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -225,11 +225,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>
@@ -711,11 +706,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>
@@ -1207,11 +1197,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -64,10 +64,6 @@ var _ = Describe("Generating fluentd config", func() {
 		    @type record_modifier
 		    remove_keys structured
 		  </filter>
-		  <filter **>
-			@type record_modifier
-			char_encoding ascii-8bit:utf-8
-		  </filter>
 		  #flatten labels to prevent field explosion in ES    
 		  <filter ** >       
 			  @type record_transformer    
@@ -194,10 +190,6 @@ var _ = Describe("Generating fluentd config", func() {
 		    @type record_modifier
 		    remove_keys structured
 		  </filter>
-		  <filter **>
-				@type record_modifier
-				char_encoding ascii-8bit:utf-8
-		  </filter>
 		  #flatten labels to prevent field explosion in ES    
 		  <filter ** >       
 			  @type record_transformer    
@@ -306,10 +298,6 @@ var _ = Describe("Generating fluentd config", func() {
 		<filter **>
 		  @type record_modifier
 		  remove_keys structured
-		</filter>
-		<filter **>
-			@type record_modifier
-			char_encoding ascii-8bit:utf-8
 		</filter>
 		  #flatten labels to prevent field explosion in ES    
 		  <filter ** >       

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -140,11 +140,6 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 <label @INGRESS>
 
   ## filters
-  <filter **>
-    @type record_modifier
-    char_encoding utf-8
-  </filter>
-
   <filter journal>
     @type grep
     <exclude>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -138,7 +138,13 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 #syslog input config here
 
 <label @INGRESS>
+
   ## filters
+  <filter **>
+    @type record_modifier
+    char_encoding utf-8
+  </filter>
+
   <filter journal>
     @type grep
     <exclude>
@@ -624,10 +630,6 @@ const outputLabelConfTemplate = `{{- define "outputLabelConf" -}}
   </filter>
   {{- end}}
   {{- if .IsElasticSearchOutput}}
-  <filter **>
-    @type record_modifier
-    char_encoding ascii-8bit:utf-8
-  </filter>
   #flatten labels to prevent field explosion in ES
   <filter ** >
     @type record_transformer


### PR DESCRIPTION
### Description
This PR:
* Reverts UTF-8 conversion introduced by [LOG-1569](https://issues.redhat.com/browse/LOG-1569)
* Drops any utf-8 conversion under the assumptions:
  * The existing filter uses #force_encoding that fundamentally has no impact
  * The point at which error occurs there is no place where a fix can be made by the collector
  * The record will be dropped for ES based on the latest changes to the fluent es plugin
  * Trying to force the encoding assuming ascii-8bit results in [LOG-1569](https://issues.redhat.com/browse/LOG-1569)

### Links
* https://issues.redhat.com/browse/LOG-1576
* Revert utf8 change of https://issues.redhat.com/browse/LOG-1569