### PR TITLE
Log499revert

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -264,6 +264,11 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
+    <filter **>
+      @type record_modifier
+      char_encoding utf-8
+    </filter>
+
     <filter journal>
       @type grep
       <exclude>
@@ -563,10 +568,6 @@ var _ = Describe("Generating fluentd config", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
-	</filter>
     #flatten labels to prevent field explosion in ES
     <filter ** >
       @type record_transformer
@@ -680,10 +681,6 @@ var _ = Describe("Generating fluentd config", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
-	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
 	</filter>
     #flatten labels to prevent field explosion in ES
     <filter ** >
@@ -995,6 +992,11 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
+    <filter **>
+      @type record_modifier
+      char_encoding utf-8
+    </filter>
+
     <filter journal>
       @type grep
       <exclude>
@@ -1289,10 +1291,6 @@ var _ = Describe("Generating fluentd config", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
-	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
 		@type record_transformer    
@@ -1398,10 +1396,6 @@ var _ = Describe("Generating fluentd config", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
-	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
 	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
@@ -1707,6 +1701,11 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
+    <filter **>
+      @type record_modifier
+      char_encoding utf-8
+    </filter>
+
     <filter journal>
       @type grep
       <exclude>
@@ -2003,10 +2002,6 @@ var _ = Describe("Generating fluentd config", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
-	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
 		@type record_transformer    
@@ -2112,10 +2107,6 @@ var _ = Describe("Generating fluentd config", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
-	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
 	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
@@ -2378,6 +2369,10 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
+				<filter **>
+					@type record_modifier
+					char_encoding utf-8
+				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -2855,6 +2850,10 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
+				<filter **>
+					@type record_modifier
+					char_encoding utf-8
+				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -3134,10 +3133,6 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
-          		<filter **>
-            		@type record_modifier
-            		char_encoding ascii-8bit:utf-8
-          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3246,10 +3241,6 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
-          		<filter **>
-            		@type record_modifier
-            		char_encoding ascii-8bit:utf-8
-          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3358,10 +3349,6 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
-          		<filter **>
-            		@type record_modifier
-            		char_encoding ascii-8bit:utf-8
-          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3470,10 +3457,6 @@ var _ = Describe("Generating fluentd config", func() {
 				  @type record_modifier
 				  remove_keys structured
 				</filter>
-          		<filter **>
-            		@type record_modifier
-            		char_encoding ascii-8bit:utf-8
-          		</filter>
 				#flatten labels to prevent field explosion in ES
 				<filter ** >
 					@type record_transformer
@@ -3808,6 +3791,11 @@ var _ = Describe("Generating fluentd config", func() {
     <label @INGRESS>
 
       ## filters
+      <filter **>
+        @type record_modifier
+        char_encoding utf-8
+      </filter>
+
       <filter journal>
         @type grep
         <exclude>

--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -264,12 +264,7 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
-    <filter **>
-      @type record_modifier
-      char_encoding utf-8
-    </filter>
-
-    <filter journal>
+   <filter journal>
       @type grep
       <exclude>
         key PRIORITY
@@ -992,11 +987,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
-    <filter **>
-      @type record_modifier
-      char_encoding utf-8
-    </filter>
-
     <filter journal>
       @type grep
       <exclude>
@@ -1701,11 +1691,6 @@ var _ = Describe("Generating fluentd config", func() {
   <label @INGRESS>
 
     ## filters
-    <filter **>
-      @type record_modifier
-      char_encoding utf-8
-    </filter>
-
     <filter journal>
       @type grep
       <exclude>
@@ -2369,10 +2354,6 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
-				<filter **>
-					@type record_modifier
-					char_encoding utf-8
-				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -2850,10 +2831,6 @@ var _ = Describe("Generating fluentd config", func() {
 
 			<label @INGRESS>
 				## filters
-				<filter **>
-					@type record_modifier
-					char_encoding utf-8
-				</filter>
 				<filter journal>
 					@type grep
 					<exclude>
@@ -3791,11 +3768,6 @@ var _ = Describe("Generating fluentd config", func() {
     <label @INGRESS>
 
       ## filters
-      <filter **>
-        @type record_modifier
-        char_encoding utf-8
-      </filter>
-
       <filter journal>
         @type grep
         <exclude>

--- a/pkg/generators/forwarding/fluentd/output_conf_es_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_es_test.go
@@ -69,10 +69,6 @@ var _ = Describe("Generating fluentd config blocks", func() {
 	  @type record_modifier
 	  remove_keys structured
 	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
-	</filter>
 	#flatten labels to prevent field explosion in ES    
 	<filter ** >       
 		@type record_transformer    
@@ -197,10 +193,6 @@ var _ = Describe("Generating fluentd config blocks", func() {
 	<filter **>
 	  @type record_modifier
 	  remove_keys structured
-	</filter>
-	<filter **>
-		@type record_modifier
-		char_encoding ascii-8bit:utf-8
 	</filter>
 	#flatten labels to prevent field explosion in ES
 	<filter ** >

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -225,6 +225,11 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
+          <filter **>
+            @type record_modifier
+            char_encoding utf-8
+          </filter>
+
           <filter journal>
             @type grep
             <exclude>
@@ -706,6 +711,11 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
+          <filter **>
+            @type record_modifier
+            char_encoding utf-8
+          </filter>
+
           <filter journal>
             @type grep
             <exclude>
@@ -1197,6 +1207,11 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
+          <filter **>
+            @type record_modifier
+            char_encoding utf-8
+          </filter>
+
           <filter journal>
             @type grep
             <exclude>

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -225,11 +225,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>
@@ -711,11 +706,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>
@@ -1207,11 +1197,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         <label @INGRESS>
 
           ## filters
-          <filter **>
-            @type record_modifier
-            char_encoding utf-8
-          </filter>
-
           <filter journal>
             @type grep
             <exclude>

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer_test.go
@@ -92,10 +92,6 @@ var _ = Describe("Generating fluentd config", func() {
 		    @type record_modifier
 		    remove_keys structured
 		  </filter>
-		  <filter **>
-			@type record_modifier
-			char_encoding ascii-8bit:utf-8
-		  </filter>
 		  #flatten labels to prevent field explosion in ES    
 		  <filter ** >       
 			  @type record_transformer    
@@ -222,10 +218,6 @@ var _ = Describe("Generating fluentd config", func() {
 		    @type record_modifier
 		    remove_keys structured
 		  </filter>
-		  <filter **>
-				@type record_modifier
-				char_encoding ascii-8bit:utf-8
-		  </filter>
 		  #flatten labels to prevent field explosion in ES    
 		  <filter ** >       
 			  @type record_transformer    
@@ -334,10 +326,6 @@ var _ = Describe("Generating fluentd config", func() {
 		<filter **>
 		  @type record_modifier
 		  remove_keys structured
-		</filter>
-		<filter **>
-			@type record_modifier
-			char_encoding ascii-8bit:utf-8
 		</filter>
 		  #flatten labels to prevent field explosion in ES    
 		  <filter ** >       

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -140,11 +140,6 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 <label @INGRESS>
 
   ## filters
-  <filter **>
-    @type record_modifier
-    char_encoding utf-8
-  </filter>
-
   <filter journal>
     @type grep
     <exclude>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -138,7 +138,13 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 #syslog input config here
 
 <label @INGRESS>
+
   ## filters
+  <filter **>
+    @type record_modifier
+    char_encoding utf-8
+  </filter>
+
   <filter journal>
     @type grep
     <exclude>
@@ -628,10 +634,6 @@ const outputLabelConfTemplate = `{{- define "outputLabelConf" -}}
   </filter>
   {{- end}}
   {{- if .IsElasticSearchOutput}}
-  <filter **>
-    @type record_modifier
-    char_encoding ascii-8bit:utf-8
-  </filter>
   #flatten labels to prevent field explosion in ES
   <filter ** >
     @type record_transformer


### PR DESCRIPTION
### Description
This PR:
* Reverts UTF-8 conversion introduced by [LOG-1499](https://issues.redhat.com/browse/LOG-1499)
* Drops any utf-8 conversion under the assumptions:
  * The existing filter uses #force_encoding that fundamentally has no impact
  * The point at which error occurs there is no place where a fix can be made by the collector
  * The record will be dropped for ES based on the latest changes to the fluent es plugin
  * Trying to force the encoding assuming ascii-8bit results in [LOG-1499](https://issues.redhat.com/browse/LOG-1499)

### Links
* Resolves https://issues.redhat.com/browse/LOG-1576 for 5.2
* Revert utf8 change of https://issues.redhat.com/browse/LOG-1499
* https://github.com/openshift/cluster-logging-operator/pull/1090
* 5.2 PR for https://github.com/openshift/cluster-logging-operator/pull/1100