### PR TITLE
LOG-1525: Allow use private key protected by the passphrase

### DIFF
--- a/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_forward_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 						"tls.crt":       []byte("my-tls"),
 						"tls.key":       []byte("my-tls-key"),
 						"ca-bundle.crt": []byte("my-bundle"),
+						"passphrase":    []byte("my-tls-passphrase"),
 					},
 				},
 			}
@@ -51,6 +52,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
 			data := secrets["secureforward-receiver"].Data
 			delete(data, "shared_key")
 			delete(data, "tls.key")
+			delete(data, "passphrase")
 			results, err := generator.generateOutputLabelBlocks(outputs, secrets, nil)
 			Expect(err).To(BeNil())
 			Expect(len(results)).To(Equal(1))
@@ -162,6 +164,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
      tls_client_private_key_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.key"
      tls_client_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/tls.crt"
      tls_cert_path "/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt"
+     tls_client_private_key_passphrase "#{File.exists?('/var/run/ocp-collector/secrets/my-infra-secret/passphrase') ? open('/var/run/ocp-collector/secrets/my-infra-secret/passphrase','r') do |f|f.read end : ''}"
 
      <buffer>
        @type file

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -730,6 +730,9 @@ tls_client_cert_path "{{$path}}"
 {{- with $path := .SecretPathIfFound "ca-bundle.crt"}}
 tls_cert_path "{{$path}}"
 {{- end}}
+{{ with $path := .SecretPathIfFound "passphrase" -}}
+tls_client_private_key_passphrase "#{File.exists?('{{ $path }}') ? open('{{ $path }}','r') do |f|f.read end : ''}"
+{{ end -}} 
 
 {{- end}}
 
@@ -796,7 +799,7 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
   ssl_version TLSv1_2
   client_key '{{ .SecretPath "tls.key"}}'
   client_cert '{{ .SecretPath "tls.crt"}}'
-  ca_file '{{ .SecretPath "ca-bundle.crt"}}'
+  ca_file '{{ .SecretPath "ca-bundle.crt"}}' 
 {{ end -}}
 {{- else}}
   scheme http


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
If secret contain `passphrase` key, the value of it will be added as `tls_client_private_key_passphrase` to the `forward` section of `fluent.conf` file.
It will be work only in case well configured `tls.key` and `tls.crt`. See more: https://docs.fluentd.org/output/forward#tls_client_private_key_passphrase
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file --> @jcantrill 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-1525
- Enhancement proposal:
