### PR TITLE
fix for LOG-1623 -  Metric  log_collected_bytes_total is not exposed

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -160,6 +160,13 @@ var _ = Describe("Generating fluentd config", func() {
   # excluding prometheus_tail_monitor
   # since it leaks namespace/pod info
   # via file paths
+  # including new plugin which publishes log_collected_bytes_total
+  <source>
+    @type collected_tail_monitor
+    <labels>
+      hostname ${hostname}
+    </labels>
+  </source>
 
   # This is considered experimental by the repo
   <source>
@@ -873,6 +880,13 @@ var _ = Describe("Generating fluentd config", func() {
   # excluding prometheus_tail_monitor
   # since it leaks namespace/pod info
   # via file paths
+  # including new plugin which publishes log_collected_bytes_total
+  <source>
+    @type collected_tail_monitor
+    <labels>
+      hostname ${hostname}
+    </labels>
+  </source>
 
   # This is considered experimental by the repo
   <source>
@@ -1580,6 +1594,13 @@ var _ = Describe("Generating fluentd config", func() {
   # excluding prometheus_tail_monitor
   # since it leaks namespace/pod info
   # via file paths
+  # including new plugin which publishes log_collected_bytes_total
+  <source>
+    @type collected_tail_monitor
+    <labels>
+      hostname ${hostname}
+    </labels>
+  </source>
 
   # This is considered experimental by the repo
   <source>
@@ -2251,6 +2272,13 @@ var _ = Describe("Generating fluentd config", func() {
    # excluding prometheus_tail_monitor
    # since it leaks namespace/pod info
    # via file paths
+   # including new plugin which publishes log_collected_bytes_total
+   <source>
+    @type collected_tail_monitor
+    <labels>
+     hostname ${hostname}
+    </labels>
+   </source>
 
    # This is considered experimental by the repo
    <source>
@@ -2669,6 +2697,13 @@ var _ = Describe("Generating fluentd config", func() {
    # excluding prometheus_tail_monitor
    # since it leaks namespace/pod info
    # via file paths
+   # including new plugin which publishes log_collected_bytes_total
+   <source>
+    @type collected_tail_monitor
+    <labels>
+     hostname ${hostname}
+    </labels>
+   </source>
 
    # This is considered experimental by the repo
    <source>
@@ -3100,7 +3135,6 @@ var _ = Describe("Generating fluentd config", func() {
      </store>
     </match>
    </label>
-
    # Relabel specific pipelines to multiple, outputs (e.g. ES, kafka stores)
    <label @APPS_PIPELINE>
     <match **>
@@ -3687,6 +3721,13 @@ var _ = Describe("Generating fluentd config", func() {
     # excluding prometheus_tail_monitor
     # since it leaks namespace/pod info
     # via file paths
+    # including new plugin which publishes log_collected_bytes_total
+    <source>
+      @type collected_tail_monitor
+      <labels>
+        hostname ${hostname}
+      </labels>
+    </source>
 
     # This is considered experimental by the repo
     <source>

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -59,6 +59,13 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         # excluding prometheus_tail_monitor
         # since it leaks namespace/pod info
         # via file paths
+        # including new plugin which publishes log_collected_bytes_total
+        <source>
+          @type collected_tail_monitor
+          <labels>
+            hostname ${hostname}
+          </labels>
+        </source>
 
         # This is considered experimental by the repo
         <source>
@@ -561,6 +568,13 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         # excluding prometheus_tail_monitor
         # since it leaks namespace/pod info
         # via file paths
+        # including new plugin which publishes log_collected_bytes_total
+        <source>
+          @type collected_tail_monitor
+          <labels>
+            hostname ${hostname}
+          </labels>
+        </source>
 
         # This is considered experimental by the repo
         <source>
@@ -1063,6 +1077,13 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
         # excluding prometheus_tail_monitor
         # since it leaks namespace/pod info
         # via file paths
+        # including new plugin which publishes log_collected_bytes_total
+        <source>
+          @type collected_tail_monitor
+          <labels>
+            hostname ${hostname}
+          </labels>
+        </source>
 
         # This is considered experimental by the repo
         <source>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -59,6 +59,13 @@ const fluentConfTemplate = `{{- define "fluentConf" -}}
 # excluding prometheus_tail_monitor
 # since it leaks namespace/pod info
 # via file paths
+# including new plugin which publishes log_collected_bytes_total
+<source>
+  @type collected_tail_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
 
 # This is considered experimental by the repo
 <source>


### PR DESCRIPTION
### Description
fixing fluent.conf generation for new fluent plugin working. This plugin publishes log_collected_bytes_total metric.

/cc @vimalk78 
/assign @jcantrill 


### Links
- JIRA:https://issues.redhat.com/browse/LOG-1623

