### PR TITLE
LOG-1411: Calculate recommended queued_chunks_limit_size with fluentd tuning parameters

### DIFF
--- a/pkg/components/fluentd/run_script.go
+++ b/pkg/components/fluentd/run_script.go
@@ -73,7 +73,10 @@ fi
 ALLOWED_DF_LIMIT=$(expr $DF_LIMIT \* $ALLOWED_PERCENT_OF_DISK / 100) || :
 
 # TOTAL_LIMIT_SIZE per buffer
-TOTAL_LIMIT_SIZE=$(expr $ALLOWED_DF_LIMIT / $NUM_OUTPUTS) || :
+TOTAL_LIMIT_SIZE=$(echo ${TOTAL_LIMIT_SIZE:-0})
+if [ $TOTAL_LIMIT_SIZE -eq 0 ]; then
+    TOTAL_LIMIT_SIZE=$(expr $ALLOWED_DF_LIMIT / $NUM_OUTPUTS) || :
+fi
 echo "Setting each total_size_limit for $NUM_OUTPUTS buffers to $TOTAL_LIMIT_SIZE bytes"
 export TOTAL_LIMIT_SIZE
 

--- a/pkg/generators/forwarding/fluentd/output_fluentd_buffer.go
+++ b/pkg/generators/forwarding/fluentd/output_fluentd_buffer.go
@@ -27,19 +27,26 @@ const (
 )
 
 func (olc *outputLabelConf) ChunkLimitSize() string {
-	if hasBufferConfig(olc.forwarder) {
+	if hasBufferConfig(olc.forwarder) && olc.forwarder.Fluentd.Buffer.ChunkLimitSize != "" {
 		return string(olc.forwarder.Fluentd.Buffer.ChunkLimitSize)
+	} else {
+		size := ""
+		switch olc.Target.Type {
+		case loggingv1.OutputTypeFluentdForward:
+			size = "1m"
+		default:
+			size = "8m"
+		}
+		return fmt.Sprintf("\"#{ENV['BUFFER_SIZE_LIMIT'] || '%s'}\"", size)
 	}
-
-	return ""
 }
 
 func (olc *outputLabelConf) TotalLimitSize() string {
-	if hasBufferConfig(olc.forwarder) {
+	if hasBufferConfig(olc.forwarder) && olc.forwarder.Fluentd.Buffer.TotalLimitSize != "" {
 		return string(olc.forwarder.Fluentd.Buffer.TotalLimitSize)
+	} else {
+		return "\"#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }\" #8G"
 	}
-
-	return ""
 }
 
 func (olc *outputLabelConf) OverflowAction() string {

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -737,16 +737,8 @@ tls_client_private_key_passphrase "#{File.exists?('{{ $path }}') ? open('{{ $pat
   @type file
   path '{{.BufferPath}}'
   queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '1024' }"
-{{- if .TotalLimitSize }}
   total_limit_size {{.TotalLimitSize}}
-{{- else }}
-  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-{{- end }}
-{{- if .ChunkLimitSize }}
   chunk_limit_size {{.ChunkLimitSize}}
-{{- else }}
-  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '1m'}"
-{{- end }}
   flush_mode {{.FlushMode}}
   flush_interval {{.FlushInterval}}
   flush_at_shutdown true
@@ -830,16 +822,8 @@ const storeElasticsearchTemplate = `{{ define "storeElasticsearch" -}}
     retry_max_interval {{.RetryMaxInterval}}
     {{.RetryTimeout}}
     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
-{{- if .TotalLimitSize }}
     total_limit_size {{.TotalLimitSize}}
-{{- else }}
-    total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-{{- end}}
-{{- if .ChunkLimitSize }}
     chunk_limit_size {{.ChunkLimitSize}}
-{{- else }}
-    chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
-{{- end }}
     overflow_action {{.OverflowAction}}
   </buffer>
 </store>
@@ -914,16 +898,8 @@ const storeSyslogTemplate = `{{- define "storeSyslog" -}}
     retry_max_interval {{.RetryMaxInterval}}
     {{.RetryTimeout}}
     queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
-{{- if .TotalLimitSize }}
     total_limit_size {{.TotalLimitSize}}
-{{- else }}
-    total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-{{- end }}
-{{- if .ChunkLimitSize }}
     chunk_limit_size {{.ChunkLimitSize}}
-{{- else }}
-    chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
-{{- end }}
     overflow_action {{.OverflowAction}}
   </buffer>
 </store>
@@ -973,16 +949,8 @@ ssl_ca_cert '{{ .SecretPath "ca-bundle.crt"}}'
   retry_max_interval {{.RetryMaxInterval}}
   {{.RetryTimeout}}
   queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32' }"
-{{- if .TotalLimitSize }}
   total_limit_size {{.TotalLimitSize}}
-{{- else }}
-  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] ||  8589934592 }" #8G
-{{- end }}
-{{- if .ChunkLimitSize }}
   chunk_limit_size {{.ChunkLimitSize}}
-{{- else }}
-  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
-{{- end }}
   overflow_action {{.OverflowAction}}
 </buffer>
 {{- end}}

--- a/pkg/k8shandler/fluentd.go
+++ b/pkg/k8shandler/fluentd.go
@@ -406,6 +406,12 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *v1.Co
 					fluentdContainer.Env = append(fluentdContainer.Env, v1.EnvVar{Name: "BUFFER_SIZE_LIMIT", Value: strconv.FormatInt(chunkLimitSize.Value(), 10)})
 				}
 			}
+			if cluster.Spec.Forwarder.Fluentd.Buffer.TotalLimitSize != "" {
+				if totalLimitSize, err := utils.ParseQuantity(string(cluster.Spec.Forwarder.Fluentd.Buffer.TotalLimitSize)); err == nil {
+					fluentdContainer.Env = append(fluentdContainer.Env, v1.EnvVar{Name: "TOTAL_LIMIT_SIZE", Value: strconv.FormatInt(totalLimitSize.Value(), 10)})
+				}
+			}
+
 		}
 	}
 

--- a/pkg/k8shandler/fluentd_test.go
+++ b/pkg/k8shandler/fluentd_test.go
@@ -416,6 +416,34 @@ func TestNewFluentdPodWhenChunkLimitSizeExists(t *testing.T) {
 	checkFluentdForwarderEnvVar(t, podSpec, "BUFFER_SIZE_LIMIT", strconv.FormatInt(chunkLimitSize.Value(), 10))
 }
 
+func TestNewFluentdPodWhenTotalLimitSizeExists(t *testing.T) {
+	totalLimitSize, _ := utils.ParseQuantity("1g")
+	cluster := &logging.ClusterLogging{
+		Spec: logging.ClusterLoggingSpec{
+			Forwarder: &logging.ForwarderSpec{
+				Fluentd: &logging.FluentdForwarderSpec{
+					Buffer: &logging.FluentdBufferSpec{
+						TotalLimitSize: "1g",
+					},
+				},
+			},
+			Collection: &logging.CollectionSpec{
+				Logs: logging.LogCollectionSpec{
+					Type:        "fluentd",
+					FluentdSpec: logging.FluentdSpec{},
+				},
+			},
+		},
+	}
+	podSpec := newFluentdPodSpec(cluster, nil, logging.ClusterLogForwarderSpec{})
+
+	if len(podSpec.Containers) != 2 {
+		t.Error("Exp. there to be 2 fluentd container")
+	}
+
+	checkFluentdForwarderEnvVar(t, podSpec, "TOTAL_LIMIT_SIZE", strconv.FormatInt(totalLimitSize.Value(), 10))
+}
+
 func checkFluentdForwarderEnvVar(t *testing.T, podSpec v1.PodSpec, name string, value string) {
 	env := podSpec.Containers[0].Env
 	found := false


### PR DESCRIPTION
### Description
This PR changes:

- Encapsulate ChunkLimitSize and TotalLimitSize to remove if/else statements from template for clean-up purpose
- Echo correct chunkLimitSize which is set in ClusterLogging CR
- Add a 'TOTAL_LIMIT_SIZE' environment variable on fluentd pod
- Use the specified 'TOTAL_LIMIT_SIZE' to calculate 'queued_chunks_limit_size' when specifying 'totalLimitSize' in ClusterLogging CR

/cc @alanconway @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1411
