### PR TITLE
LOG-1464: Disable audit log source when only legacy syslog forwarding enabled

### DIFF
--- a/pkg/generators/forwarding/fluentd/generators.go
+++ b/pkg/generators/forwarding/fluentd/generators.go
@@ -62,10 +62,12 @@ func (engine *ConfigGenerator) Generate(clfSpec *logging.ClusterLogForwarderSpec
 		inputs.Insert(
 			logging.InputNameInfrastructure,
 			logging.InputNameApplication,
-			logging.InputNameAudit,
 		)
+		if engine.includeLegacyForwardConfig {
+			inputs.Insert(logging.InputNameAudit)
+		}
 		for _, logType := range inputs.List() {
-			if engine.includeLegacySyslogConfig {
+			if engine.includeLegacySyslogConfig && logType != logging.InputNameAudit {
 				routeMap.Insert(logType, constants.LegacySyslog)
 			}
 			if engine.includeLegacyForwardConfig {

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -645,66 +645,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             </pattern>
           </parse>
         </source>
-        # linux audit logs
-        <source>
-          @type tail
-          @id audit-input
-          @label @MEASURE
-          path "/var/log/audit/audit.log"
-          pos_file "/var/lib/fluentd/pos/audit.log.pos"
-          tag linux-audit.log
-          <parse>
-            @type viaq_host_audit
-          </parse>
-        </source>
-        # k8s audit logs
-        <source>
-          @type tail
-          @id k8s-audit-input
-          @label @MEASURE
-          path "/var/log/kube-apiserver/audit.log"
-          pos_file "/var/lib/fluentd/pos/kube-apiserver.audit.log.pos"
-          tag k8s-audit.log
-          <parse>
-            @type json
-            time_key requestReceivedTimestamp
-            # In case folks want to parse based on the requestReceivedTimestamp key
-            keep_time_key true
-            time_format %Y-%m-%dT%H:%M:%S.%N%z
-          </parse>
-        </source>
-
-        # Openshift audit logs
-        <source>
-          @type tail
-          @id openshift-audit-input
-          @label @MEASURE
-          path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
-          pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
-          tag openshift-audit.log
-          <parse>
-            @type json
-            time_key requestReceivedTimestamp
-            # In case folks want to parse based on the requestReceivedTimestamp key
-            keep_time_key true
-            time_format %Y-%m-%dT%H:%M:%S.%N%z
-          </parse>
-        </source>
-        # Openshift Virtual Network (OVN) audit logs
-        <source>
-          @type tail
-          @id ovn-audit-input
-          @label @MEASURE
-          path "/var/log/ovn/acl-audit-log.log"
-          pos_file "/var/lib/fluentd/pos/acl-audit-log.pos"
-          tag ovn-audit.log
-          refresh_interval 5
-          rotate_wait 5
-          read_from_head true
-          <parse>
-            @type none
-          </parse>
-        </source>
         <label @MEASURE>
         <filter **>
           @type record_transformer
@@ -998,8 +938,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           </match>
 
           <match linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**>
-            @type relabel
-            @label @_AUDIT
+            @type null
           </match>
 
           <match **>
@@ -1014,21 +953,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
 						@type record_modifier
 						<record>
 							log_type application
-						</record>
-					</filter>
-          <match **>
-            @type copy
-            <store>
-              @type relabel
-              @label @_LEGACY_SYSLOG
-            </store>
-          </match>
-        </label>
-        <label @_AUDIT>
-					<filter **>
-						@type record_modifier
-						<record>
-							log_type audit
 						</record>
 					</filter>
           <match **>
@@ -1568,11 +1492,6 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
             <store>
               @type relabel
               @label @_LEGACY_SECUREFORWARD
-            </store>
-
-            <store>
-              @type relabel
-              @label @_LEGACY_SYSLOG
             </store>
           </match>
         </label>

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go.rej
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go.rej
@@ -1,0 +1,18 @@
+--- pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
++++ pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+@@ -939,15 +878,6 @@ var _ = Describe("Generating fluentd leg
+             </store>
+           </match>
+         </label>
+-        <label @_AUDIT>
+-          <match **>
+-            @type copy
+-            <store>
+-              @type relabel
+-              @label @_LEGACY_SYSLOG
+-            </store>
+-          </match>
+-        </label>
+         <label @_INFRASTRUCTURE>
+           <match **>
+             @type copy


### PR DESCRIPTION
### Description
The current legacy syslog forwarding keeps sending empty audit messages to an external rsyslog server.
This issue is caused by the behavior of the legacy method which doesn't skip to send an empty string.
As for k8s audit records, the value of "message" field is always empty string and the legacy syslog forwarding 
tries to use the "message" field from records to set payload by default. 
As a result, the external rsyslog server receives the empty audit log. This is the reason why this issue happens.

This PR disables audit log source when only legacy syslog forwarding is enabled.
There are several options to fix this issue:
  1. Fix the behavior of out_syslog and out_syslog_buffered plugins to skip to send empty string
  2. Transform audit fluentd records to inject audit information into the "message" field
  3. Disable audit source not to send audit messages to an external rsyslog server

The approach I took is the "3" option because the legacy syslog forwarding doesn't have TLS support to send logs securely.

/cc @jcantrill @alanconway 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1464
