### PR TITLE
Added read perms for config.openshift.io/infrastructures, needed for cloudwatch

### DIFF
--- a/bundle/manifests/cluster-logging.v5.2.0.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.v5.2.0.clusterserviceversion.yaml
@@ -271,6 +271,7 @@ spec:
           - config.openshift.io
           resources:
           - proxies
+          - infrastructures
           verbs:
           - get
           - list

--- a/manifests/5.2/cluster-logging.v5.2.0.clusterserviceversion.yaml
+++ b/manifests/5.2/cluster-logging.v5.2.0.clusterserviceversion.yaml
@@ -271,6 +271,7 @@ spec:
           - config.openshift.io
           resources:
           - proxies
+          - infrastructures
           verbs:
           - get
           - list


### PR DESCRIPTION
### Description
Added get/list/watch perms for config.openshift.io/infrastructures to the cluster-logging-operator SA, the Cloudwatch forwarding code needs it here https://github.com/openshift/cluster-logging-operator/blob/e598ed31aa9672de8e3db0206b84d338c6dc2970/pkg/k8shandler/forwarding.go#L100

/cc @igor-karpukhin 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1173

