### PR TITLE
Add conditional for EO setup in e2e tests

### DIFF
--- a/hack/test-e2e-olm.sh
+++ b/hack/test-e2e-olm.sh
@@ -27,12 +27,14 @@ cleanup(){
 }
 trap cleanup exit
 
-pushd ../elasticsearch-operator
-# install the catalog containing the elasticsearch operator csv
-ELASTICSEARCH_OPERATOR_NAMESPACE=openshift-operators-redhat olm_deploy/scripts/catalog-deploy.sh
-# install the elasticsearch operator from that catalog
-ELASTICSEARCH_OPERATOR_NAMESPACE=openshift-operators-redhat olm_deploy/scripts/operator-install.sh
-popd
+if [ "${DO_EO_SETUP:-true}" == "true" ] ; then
+    pushd ../elasticsearch-operator
+    # install the catalog containing the elasticsearch operator csv
+    ELASTICSEARCH_OPERATOR_NAMESPACE=openshift-operators-redhat olm_deploy/scripts/catalog-deploy.sh
+    # install the elasticsearch operator from that catalog
+    ELASTICSEARCH_OPERATOR_NAMESPACE=openshift-operators-redhat olm_deploy/scripts/operator-install.sh
+    popd
+fi
 
 get_setup_artifacts=false
 export JUNIT_REPORT_OUTPUT="/tmp/artifacts/junit/test-e2e-olm"


### PR DESCRIPTION
### Description
This PR addresses preparation issues to resolve openshift/release#20604. In detail it adds a conditional to install EO from a sibling repository. As per EO's upstream CI configuration moving to CI-managed operator installation via bundles, this PR adds a configuration option to make EO's CLO-gating job to use the CI-managed operator installation via bundles, too.

/cc @jcantrill 
/assign @jcantrill 