### PR TITLE
LOG-1102: Finalize Log forwarding to Cloudwatch for GA

### DIFF
--- a/pkg/generators/forwarding/fluentd/output_cloudwatch_test.go
+++ b/pkg/generators/forwarding/fluentd/output_cloudwatch_test.go
@@ -87,8 +87,8 @@ var _ = Describe("Generating fluentd config", func() {
 					remove_log_group_name_key true
 					auto_create_stream true
 					concurrency 2
-					aws_key_id "#{open('/var/run/ocp-collector/secrets/my-secret/aws_access_key_id','r') do |f|f.read end}"
-					aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read end}"
+					aws_key_id "#{open('/var/run/ocp-collector/secrets/my-secret/aws_access_key_id','r') do |f|f.read.strip end}"
+					aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
 					include_time_key true
 					log_rejected_request true
 				</match>
@@ -140,8 +140,8 @@ var _ = Describe("Generating fluentd config", func() {
 					remove_log_group_name_key true
 					auto_create_stream true
 					concurrency 2
-					aws_key_id "#{open('/var/run/ocp-collector/secrets/my-secret/aws_access_key_id','r') do |f|f.read end}"
-					aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read end}"
+					aws_key_id "#{open('/var/run/ocp-collector/secrets/my-secret/aws_access_key_id','r') do |f|f.read.strip end}"
+					aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
 					include_time_key true
 					log_rejected_request true
 				</match>
@@ -196,8 +196,8 @@ var _ = Describe("Generating fluentd config", func() {
 					remove_log_group_name_key true
 					auto_create_stream true
 					concurrency 2
-					aws_key_id "#{open('/var/run/ocp-collector/secrets/my-secret/aws_access_key_id','r') do |f|f.read end}"
-					aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read end}"
+					aws_key_id "#{open('/var/run/ocp-collector/secrets/my-secret/aws_access_key_id','r') do |f|f.read.strip end}"
+					aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
 					include_time_key true
 					log_rejected_request true
 				</match>

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -689,10 +689,10 @@ const outputLabelConfCloudwatch = `{{- define "outputLabelConfCloudwatch" -}}
     auto_create_stream true
     concurrency 2
 {{- with $path := .SecretPath "aws_access_key_id"}}
-    aws_key_id "#{open('{{ $path }}','r') do |f|f.read end}"
+    aws_key_id "#{open('{{ $path }}','r') do |f|f.read.strip end}"
 {{- end}}
 {{- with $path := .SecretPath "aws_secret_access_key"}}
-    aws_sec_key "#{open('{{ $path }}','r') do |f|f.read end}"
+    aws_sec_key "#{open('{{ $path }}','r') do |f|f.read.strip end}"
 {{- end}}
     include_time_key true
     log_rejected_request true

--- a/pkg/k8shandler/forwarding.go
+++ b/pkg/k8shandler/forwarding.go
@@ -318,6 +318,9 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.Cluster
 			log.V(3).Info("verifyOutputs failed", "reason", "output secret is invalid")
 		case !clusterRequest.CLFVerifier.VerifyOutputSecret(&output, status.Outputs):
 			break
+		case output.Type == logging.OutputTypeCloudwatch && output.Cloudwatch == nil:
+			log.V(3).Info("verifyOutputs failed", "reason", "Cloudwatch output requires type spec", "output name", output.Name)
+			status.Outputs.Set(output.Name, condInvalid("output %q: Cloudwatch output requires type spec", output.Name))
 		default:
 			status.Outputs.Set(output.Name, condReady)
 			spec.Outputs = append(spec.Outputs, output)


### PR DESCRIPTION
### Description
- For Cloudwatch forwarding output, added enforcement of output type spec
- Added .strip to reading of AWS access keys to prevent HTTP headers with CR/LF

/cc @igor-karpukhin 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1102
