### PR TITLE
LOG-1390: Allow optional fields in message test framework

### DIFF
--- a/test/functional/message_templates.go
+++ b/test/functional/message_templates.go
@@ -24,6 +24,7 @@ var (
 		ContainerImage:   "*",
 		ContainerImageID: "*",
 		PodID:            "*",
+		PodIP:            "**optional**",
 		Host:             "*",
 		MasterURL:        "*",
 		FlatLabels:       []string{"*"},

--- a/test/helpers/types/types.go
+++ b/test/helpers/types/types.go
@@ -48,6 +48,7 @@ type Kubernetes struct {
 	ContainerImage    string            `json:"container_image,omitempty"`
 	ContainerImageID  string            `json:"container_image_id,omitempty"`
 	PodID             string            `json:"pod_id,omitempty"`
+	PodIP             string            `json:"pod_ip,omitempty"`
 	Host              string            `json:"host,omitempty"`
 	MasterURL         string            `json:"master_url,omitempty"`
 	NamespaceID       string            `json:"namespace_id,omitempty"`

--- a/test/matchers/log_format.go
+++ b/test/matchers/log_format.go
@@ -102,6 +102,10 @@ func compareLogLogic(name string, templateValue interface{}, value interface{}) 
 		logger.V(3).Info("CompareLogLogic: Same value for", "name", name, "value", valueString)
 		return true
 	}
+	if templateValueString == "**optional**" {
+		logger.V(3).Info("CompareLogLogic: Optional value for **optional** ", "fieldname", name, "value", value)
+		return true
+	}
 	if templateValueString == "*" && valueString != "" { // Any value, not Nil is ok if template value is "*"
 		logger.V(3).Info("CompareLogLogic: Any value for * ", "fieldname", name, "value", value)
 		return true


### PR DESCRIPTION
### Description
This PR:
* adds optional fields to the message test framework in order to support consuming plugins (e.g. metadata) that provide new fields
* Without this change we will be required to manual merge the changes because of circular deps

### Links
https://issues.redhat.com/browse/LOG-1390

cc @vimalk78 @eranra 