### PR TITLE
Bug 1929363: Delay refresh to allow startup to bind metrics listener

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -178,6 +178,7 @@ var _ = Describe("Generating fluentd config", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
       @type multi_format
@@ -857,6 +858,7 @@ var _ = Describe("Generating fluentd config", func() {
 				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
+				skip_refresh_on_startup true
 				@label @MEASURE
 				<parse>
 				@type multi_format
@@ -1300,6 +1302,7 @@ var _ = Describe("Generating fluentd config", func() {
 				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
+				skip_refresh_on_startup true
 				@label @MEASURE
 				<parse>
 				@type multi_format
@@ -2191,6 +2194,7 @@ var _ = Describe("Generating fluentd config", func() {
       rotate_wait 5
       tag kubernetes.*
       read_from_head "true"
+	  skip_refresh_on_startup true
       @label @MEASURE
       <parse>
         @type multi_format

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
+		  skip_refresh_on_startup true
           @label @MEASURE
           <parse>
             @type multi_format
@@ -591,6 +592,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
+		  skip_refresh_on_startup true
           @label @MEASURE
           <parse>
             @type multi_format
@@ -1098,6 +1100,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
+		  skip_refresh_on_startup true
           @label @MEASURE
           <parse>
             @type multi_format

--- a/pkg/generators/forwarding/fluentd/source_test.go
+++ b/pkg/generators/forwarding/fluentd/source_test.go
@@ -40,6 +40,7 @@ var _ = Describe("generating source", func() {
 			rotate_wait 5
 			tag kubernetes.*
 			read_from_head "true"
+			skip_refresh_on_startup true
 			@label @MEASURE
 			<parse>
 			  @type multi_format
@@ -107,6 +108,7 @@ var _ = Describe("generating source", func() {
 			  rotate_wait 5
 			  tag kubernetes.*
 			  read_from_head "true"
+			  skip_refresh_on_startup true
 			  @label @MEASURE
 			  <parse>
 				@type multi_format
@@ -233,6 +235,7 @@ var _ = Describe("generating source", func() {
 				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
+				skip_refresh_on_startup true
 				@label @MEASURE
 				<parse>
 				  @type multi_format

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -460,6 +460,7 @@ const inputSourceContainerTemplate = `{{- define "inputSourceContainerTemplate" 
   rotate_wait 5
   tag kubernetes.*
   read_from_head "true"
+  skip_refresh_on_startup true
   @label @MEASURE
   <parse>
     @type multi_format


### PR DESCRIPTION
### Description
This PR delays in_tail file refresh watcher at startup to allow the metrics endpoint to bind and complete initialization.

cc @vimalk78 @syedriko 

### Links
* https://bugzilla.redhat.com/show_bug.cgi?id=1929363
* https://github.com/fluent/fluent-plugin-prometheus/issues/92
