### PR TITLE
LOG-1681: Delay refresh to allow startup to bind metrics listener

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -235,6 +235,7 @@ var _ = Describe("Generating fluentd config", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
       @type multi_format
@@ -969,6 +970,7 @@ var _ = Describe("Generating fluentd config", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
       @type multi_format
@@ -1697,6 +1699,7 @@ var _ = Describe("Generating fluentd config", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
       @type multi_format
@@ -2377,6 +2380,7 @@ var _ = Describe("Generating fluentd config", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
     @type multi_format
@@ -2826,6 +2830,7 @@ var _ = Describe("Generating fluentd config", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
     @type multi_format
@@ -3849,6 +3854,7 @@ var _ = Describe("Generating fluentd config", func() {
       rotate_wait 5
       tag kubernetes.*
       read_from_head "true"
+	  skip_refresh_on_startup true
       @label @MEASURE
       <parse>
         @type multi_format

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
+		  skip_refresh_on_startup true
           @label @MEASURE
           <parse>
             @type multi_format
@@ -629,6 +630,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
+		  skip_refresh_on_startup true
           @label @MEASURE
           <parse>
             @type multi_format
@@ -1156,6 +1158,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
+		  skip_refresh_on_startup true
           @label @MEASURE
           <parse>
             @type multi_format

--- a/pkg/generators/forwarding/fluentd/source_test.go
+++ b/pkg/generators/forwarding/fluentd/source_test.go
@@ -40,6 +40,7 @@ var _ = Describe("generating source", func() {
      rotate_wait 5
      tag kubernetes.*
      read_from_head "true"
+	 skip_refresh_on_startup true
      @label @MEASURE
      <parse>
       @type multi_format
@@ -107,6 +108,7 @@ var _ = Describe("generating source", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
      @type multi_format
@@ -250,6 +252,7 @@ var _ = Describe("generating source", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
       @type multi_format

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -464,6 +464,7 @@ const inputSourceContainerTemplate = `{{- define "inputSourceContainerTemplate" 
   rotate_wait 5
   tag kubernetes.*
   read_from_head "true"
+  skip_refresh_on_startup true
   @label @MEASURE
   <parse>
     @type multi_format


### PR DESCRIPTION
### Description
This PR delays in_tail file refresh watcher at startup to allow the metrics endpoint to bind and complete initialization.

cc @vimalk78 @syedriko 

### Links
* https://issues.redhat.com/browse/LOG-1681
* https://github.com/fluent/fluent-plugin-prometheus/issues/92
* 5.2 port of https://github.com/openshift/cluster-logging-operator/pull/1133