### PR TITLE
LOG-1685: Delay refresh to allow startup to bind metrics listener

### DIFF
--- a/pkg/generators/forwarding/fluentd/fluent_conf_test.go
+++ b/pkg/generators/forwarding/fluentd/fluent_conf_test.go
@@ -179,6 +179,7 @@ var _ = Describe("Generating fluentd config", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
       @type multi_format
@@ -902,6 +903,7 @@ var _ = Describe("Generating fluentd config", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
       @type multi_format
@@ -1606,6 +1608,7 @@ var _ = Describe("Generating fluentd config", func() {
     rotate_wait 5
     tag kubernetes.*
     read_from_head "true"
+	skip_refresh_on_startup true
     @label @MEASURE
     <parse>
       @type multi_format
@@ -2270,6 +2273,7 @@ var _ = Describe("Generating fluentd config", func() {
 				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
+				skip_refresh_on_startup true
 				@label @MEASURE
 				<parse>
 				@type multi_format
@@ -2700,6 +2704,7 @@ var _ = Describe("Generating fluentd config", func() {
 				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
+				skip_refresh_on_startup true
 				@label @MEASURE
 				<parse>
 				@type multi_format
@@ -3683,6 +3688,7 @@ var _ = Describe("Generating fluentd config", func() {
       rotate_wait 5
       tag kubernetes.*
       read_from_head "true"
+	  skip_refresh_on_startup true
       @label @MEASURE
       <parse>
         @type multi_format

--- a/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
+++ b/pkg/generators/forwarding/fluentd/output_conf_legacy_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
+		  skip_refresh_on_startup true
           @label @MEASURE
           <parse>
             @type multi_format
@@ -576,6 +577,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
+		  skip_refresh_on_startup true
           @label @MEASURE
           <parse>
             @type multi_format
@@ -1067,6 +1069,7 @@ var _ = Describe("Generating fluentd legacy output store config blocks", func() 
           rotate_wait 5
           tag kubernetes.*
           read_from_head "true"
+		  skip_refresh_on_startup true
           @label @MEASURE
           <parse>
             @type multi_format

--- a/pkg/generators/forwarding/fluentd/source_test.go
+++ b/pkg/generators/forwarding/fluentd/source_test.go
@@ -40,6 +40,7 @@ var _ = Describe("generating source", func() {
 			rotate_wait 5
 			tag kubernetes.*
 			read_from_head "true"
+		    skip_refresh_on_startup true
 			@label @MEASURE
 			<parse>
 			  @type multi_format
@@ -107,6 +108,7 @@ var _ = Describe("generating source", func() {
 			  rotate_wait 5
 			  tag kubernetes.*
 			  read_from_head "true"
+			  skip_refresh_on_startup true
 			  @label @MEASURE
 			  <parse>
 				@type multi_format
@@ -233,6 +235,7 @@ var _ = Describe("generating source", func() {
 				rotate_wait 5
 				tag kubernetes.*
 				read_from_head "true"
+			    skip_refresh_on_startup true
 				@label @MEASURE
 				<parse>
 				  @type multi_format

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -446,6 +446,7 @@ const inputSourceContainerTemplate = `{{- define "inputSourceContainerTemplate" 
   rotate_wait 5
   tag kubernetes.*
   read_from_head "true"
+  skip_refresh_on_startup true
   @label @MEASURE
   <parse>
     @type multi_format


### PR DESCRIPTION
### Description
This PR delays in_tail file refresh watcher at startup to allow the metrics endpoint to bind and complete initialization.

cc @vimalk78 @syedriko 

### Links
* https://github.com/openshift/cluster-logging-operator/pull/1134
* https://github.com/fluent/fluent-plugin-prometheus/issues/92
* 5.1 port of https://github.com/openshift/cluster-logging-operator/pull/1133