### PR TITLE
LOG-1709: Migrate off v1beta1 Kube APIs deprecated in 1.22

### DIFF
--- a/hack/gen-olm-artifacts.py
+++ b/hack/gen-olm-artifacts.py
@@ -164,7 +164,7 @@ def generateCRDs(csv):
     name = crdDef['name']
     segments = name.split('.')
     crd = {
-        "apiVersion": "apiextensions.k8s.io/v1beta1",
+        "apiVersion": "apiextensions.k8s.io/v1",
         "kind" : "CustomResourceDefinition",
         "metadata" : {
           "name" : name


### PR DESCRIPTION
### Description

OCP 4.9 will be based on Kubernetes 1.22, which removes several v1beta1 APIs:  https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. This task is about migrating CLO code using the APIs to be removed in Kubernetes 1.22 to their v1 versions.

/cc @vimalk78
/assign @jcantrill

### Links

https://issues.redhat.com/browse/LOG-1709