### PR TITLE
LOG-1392: Outpt flush_interval only with flush_mode=interval

### DIFF
--- a/pkg/generator/fluentd/output/buffer_conf.go
+++ b/pkg/generator/fluentd/output/buffer_conf.go
@@ -30,7 +30,7 @@ func (bc BufferConfig) Template() string {
   @type file
   path '{{.BufferPath}}'
   flush_mode {{.FlushMode}}
-  flush_interval {{.FlushInterval}}
+  {{.FlushInterval}}
   flush_thread_count {{.FlushThreadCount}}
   flush_at_shutdown true
   retry_type {{.RetryType}}

--- a/pkg/generator/fluentd/output/buffer_conf_test.go
+++ b/pkg/generator/fluentd/output/buffer_conf_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Generate fluentd conf", func() {
 							TotalLimitSize:   "800000000",
 							OverflowAction:   "throw_exception",
 							FlushThreadCount: 128,
-							FlushMode:        "immediate",
+							FlushMode:        "interval",
 							FlushInterval:    "25s",
 							RetryWait:        "20s",
 							RetryType:        "periodic",
@@ -50,7 +50,7 @@ var _ = Describe("Generate fluentd conf", func() {
 <buffer time, tag>
   @type file
   path '/var/lib/fluentd/es_1'
-  flush_mode immediate
+  flush_mode interval
   flush_interval 25s
   flush_thread_count 128
   flush_at_shutdown true
@@ -62,6 +62,41 @@ var _ = Describe("Generate fluentd conf", func() {
   total_limit_size 800000000
   chunk_limit_size 8m
   overflow_action throw_exception
+</buffer>`,
+		}),
+		Entry("when tuning flush_mode other then interval", ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Name: "es-1",
+					},
+				},
+			},
+			CLSpec: logging.ClusterLoggingSpec{
+				Forwarder: &logging.ForwarderSpec{
+					Fluentd: &logging.FluentdForwarderSpec{
+						Buffer: &logging.FluentdBufferSpec{
+							FlushMode:        "lazy",
+							FlushInterval:    "25s",
+						},
+					},
+				},
+			},
+			ExpectedConf: `
+<buffer time, tag>
+  @type file
+  path '/var/lib/fluentd/es_1'
+  flush_mode lazy
+  flush_thread_count 2
+  flush_at_shutdown true
+  retry_type exponential_backoff
+  retry_wait 1s
+  retry_max_interval 60s
+  retry_timeout 60m
+  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] || '8589934592'}"
+  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+  overflow_action block
 </buffer>`,
 		}))
 })

--- a/pkg/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/pkg/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -356,7 +356,6 @@ var _ = Describe("Generating fluentd config", func() {
                 @type file
                 path '/var/lib/fluentd/retry_other_elasticsearch'
                 flush_mode immediate
-                flush_interval 2s
                 flush_thread_count 4
                 flush_at_shutdown true
                 retry_type periodic
@@ -396,7 +395,6 @@ var _ = Describe("Generating fluentd config", func() {
                 @type file
                 path '/var/lib/fluentd/other_elasticsearch'
                 flush_mode immediate
-                flush_interval 2s
                 flush_thread_count 4
                 flush_at_shutdown true
                 retry_type periodic
@@ -486,7 +484,6 @@ var _ = Describe("Generating fluentd config", func() {
           @type file
           path '/var/lib/fluentd/secureforward_receiver'
           flush_mode immediate
-          flush_interval 2s
           flush_thread_count 4
           flush_at_shutdown true
           retry_type periodic
@@ -698,7 +695,6 @@ var _ = Describe("Generating fluentd config", func() {
                @type file
                path '/var/lib/fluentd/kafka_receiver'
                flush_mode immediate
-               flush_interval 2s
                flush_thread_count 4
                flush_at_shutdown true
                retry_type periodic

--- a/pkg/generator/test_common.go
+++ b/pkg/generator/test_common.go
@@ -28,9 +28,12 @@ func TestGenerateConfWith(gf GenerateFunc) func(ConfGenerateTest) {
 		e := gf(testcase.CLSpec, testcase.Secrets, testcase.CLFSpec, testcase.Options)
 		conf, err := g.GenerateConf(e...)
 		Expect(err).To(BeNil())
+		block := func(entry string) bool {
+			return  strings.TrimSpace(entry) != ""
+		}
 		diff := cmp.Diff(
-			strings.Split(strings.TrimSpace(testcase.ExpectedConf), "\n"),
-			strings.Split(strings.TrimSpace(conf), "\n"))
+			collect(strings.Split(strings.TrimSpace(testcase.ExpectedConf), "\n"), block),
+			collect(strings.Split(strings.TrimSpace(conf), "\n"), block))
 		if diff != "" {
 			//b, _ := json.MarshalIndent(e, "", " ")
 			//fmt.Printf("elements:\n%s\n", string(b))
@@ -39,4 +42,15 @@ func TestGenerateConfWith(gf GenerateFunc) func(ConfGenerateTest) {
 		}
 		Expect(diff).To(Equal(""))
 	}
+}
+
+//collect returns a filtered array of elements where elements evaluating to 'true' for block are returned
+func collect(in []string, block func(string)bool) []string{
+	collected := []string{}
+	for _, s := range in {
+		if block(s) {
+			collected = append(collected, s)
+		}
+	}
+	return collected
 }


### PR DESCRIPTION
### Description
This PR:
* Outputs collector buffer flush_interval only when flush_mode= interval

To correct:

```
2021-05-20 00:28:32 +0000 [error]: fluent/log.rb:362:error: config error file="/etc/fluent/fluent.conf" error_class=Fluent::ConfigError error="'flush_interval' can't be specified when 'flush_mode' is not 'interval' explicitly: 'immediate'"
```

/cc @vimalk78 

This will require manual cherrypicks to:

*release-5.2
*release-4.6

### Links
* https://issues.redhat.com/browse/LOG-1392
