### PR TITLE
LOG-1392: Output flush_interval only with flush_mode=interval

### DIFF
--- a/pkg/generator/fluentd/output/buffer.go
+++ b/pkg/generator/fluentd/output/buffer.go
@@ -34,25 +34,27 @@ var NOKEYS = []string{}
 
 func Buffer(bufkeys []string, bufspec *logging.FluentdBufferSpec, bufpath string, os *logging.OutputSpec) []Element {
 	return []Element{
-		MakeBuffer(bufkeys, bufspec, bufpath, os),
+		BufferConf{
+			BufferKeys:     bufkeys,
+			BufferConfData: MakeBuffer(bufkeys, bufspec, bufpath, os),
+		},
 	}
 }
 
-func MakeBuffer(bufkeys []string, bufspec *logging.FluentdBufferSpec, bufpath string, os *logging.OutputSpec) BufferConfig {
-	return BufferConfig{
-		BufferKeys:           bufkeys,
+func MakeBuffer(bufkeys []string, bufspec *logging.FluentdBufferSpec, bufpath string, os *logging.OutputSpec) BufferConfData {
+	return BufferConfData{
 		BufferPath:           BufferPath(bufpath),
-		FlushMode:            FlushMode(bufspec),
-		FlushThreadCount:     FlushThreadCount(bufspec),
-		FlushInterval:        FlushInterval(os, bufspec),
-		RetryType:            RetryType(bufspec),
-		RetryWait:            RetryWait(bufspec),
-		RetryMaxInterval:     RetryMaxInterval(bufspec),
-		RetryTimeout:         RetryTimeout(bufspec),
-		QueuedChunkLimitSize: QueuedChunkLimitSize(bufspec),
-		TotalLimitSize:       TotalLimitSize(bufspec),
-		ChunkLimitSize:       ChunkLimitSize(bufspec),
-		OverflowAction:       OverflowAction(os, bufspec),
+		FlushMode:            Optional("flush_mode", FlushMode(bufspec)),
+		FlushThreadCount:     Optional("flush_thread_count", FlushThreadCount(bufspec)),
+		FlushInterval:        Optional("flush_interval", FlushInterval(os, bufspec)),
+		RetryType:            Optional("retry_type", RetryType(bufspec)),
+		RetryWait:            Optional("retry_wait", RetryWait(bufspec)),
+		RetryMaxInterval:     Optional("retry_max_interval", RetryMaxInterval(bufspec)),
+		RetryTimeout:         Optional("retry_timeout", RetryTimeout(bufspec)),
+		QueuedChunkLimitSize: Optional("queued_chunks_limit_size", QueuedChunkLimitSize(bufspec)),
+		TotalLimitSize:       Optional("total_limit_size", TotalLimitSize(bufspec)),
+		ChunkLimitSize:       Optional("chunk_limit_size", ChunkLimitSize(bufspec)),
+		OverflowAction:       Optional("overflow_action", OverflowAction(os, bufspec)),
 	}
 }
 

--- a/pkg/generator/fluentd/output/buffer_conf.go
+++ b/pkg/generator/fluentd/output/buffer_conf.go
@@ -1,47 +1,65 @@
 package output
 
-type BufferConfig struct {
-	BufferKeys           []string
-	BufferPath           string
-	FlushMode            string
-	FlushInterval        string
-	FlushThreadCount     string
-	RetryType            string
-	RetryWait            string
-	RetryMaxInterval     string
-	RetryTimeout         string
-	QueuedChunkLimitSize string
-	TotalLimitSize       string
-	ChunkLimitSize       string
-	OverflowAction       string
+import (
+	. "github.com/openshift/cluster-logging-operator/pkg/generator"
+)
+
+type BufferConf struct {
+	BufferKeys     []string
+	BufferConfData Element
 }
 
-func (bc BufferConfig) Name() string {
-	return "bufferConfigTemplate"
+func (bc BufferConf) Name() string {
+	return "bufferConfTemplate"
 }
 
-func (bc BufferConfig) Template() string {
+func (bc BufferConf) Template() string {
 	return `{{define "` + bc.Name() + `" -}}
 {{if .BufferKeys -}}
 <buffer {{comma_separated .BufferKeys}}>
 {{- else -}}
 <buffer>
 {{- end}}
-  @type file
-  path '{{.BufferPath}}'
-  flush_mode {{.FlushMode}}
-  flush_interval {{.FlushInterval}}
-  flush_thread_count {{.FlushThreadCount}}
-  flush_at_shutdown true
-  retry_type {{.RetryType}}
-  retry_wait {{.RetryWait}}
-  retry_max_interval {{.RetryMaxInterval}}
-  retry_timeout {{.RetryTimeout}}
-  queued_chunks_limit_size {{.QueuedChunkLimitSize}}
-  total_limit_size {{.TotalLimitSize}}
-  chunk_limit_size {{.ChunkLimitSize}}
-  overflow_action {{.OverflowAction}}
+{{compose_one .BufferConfData | indent 2}}
 </buffer>
-{{- end}}
+{{end}}`
+}
+
+type BufferConfData struct {
+	BufferPath           string
+	FlushMode            Element
+	FlushInterval        Element
+	FlushThreadCount     Element
+	RetryType            Element
+	RetryWait            Element
+	RetryMaxInterval     Element
+	RetryTimeout         Element
+	QueuedChunkLimitSize Element
+	TotalLimitSize       Element
+	ChunkLimitSize       Element
+	OverflowAction       Element
+}
+
+func (bc BufferConfData) Name() string {
+	return "bufferConfDataTemplate"
+}
+
+func (bc BufferConfData) Template() string {
+	return `{{define "` + bc.Name() + `" -}}
+@type file
+path '{{.BufferPath}}'
+{{optional .FlushMode -}}
+{{optional .FlushInterval -}}
+{{optional .FlushThreadCount -}}
+flush_at_shutdown true
+{{optional .RetryType -}}
+{{optional .RetryWait -}}
+{{optional .RetryMaxInterval -}}
+{{optional .RetryTimeout -}}
+{{optional .QueuedChunkLimitSize -}}
+{{optional .TotalLimitSize -}}
+{{optional .ChunkLimitSize -}}
+{{optional .OverflowAction -}}
+{{end}}
 `
 }

--- a/pkg/generator/fluentd/output/buffer_conf_test.go
+++ b/pkg/generator/fluentd/output/buffer_conf_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Generate fluentd conf", func() {
 							TotalLimitSize:   "800000000",
 							OverflowAction:   "throw_exception",
 							FlushThreadCount: 128,
-							FlushMode:        "immediate",
+							FlushMode:        "interval",
 							FlushInterval:    "25s",
 							RetryWait:        "20s",
 							RetryType:        "periodic",
@@ -50,7 +50,7 @@ var _ = Describe("Generate fluentd conf", func() {
 <buffer time, tag>
   @type file
   path '/var/lib/fluentd/es_1'
-  flush_mode immediate
+  flush_mode interval
   flush_interval 25s
   flush_thread_count 128
   flush_at_shutdown true
@@ -63,7 +63,43 @@ var _ = Describe("Generate fluentd conf", func() {
   chunk_limit_size 8m
   overflow_action throw_exception
 </buffer>`,
-		}))
+		}),
+		Entry("when tuning flush_mode other then interval", ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Name: "es-1",
+					},
+				},
+			},
+			CLSpec: logging.ClusterLoggingSpec{
+				Forwarder: &logging.ForwarderSpec{
+					Fluentd: &logging.FluentdForwarderSpec{
+						Buffer: &logging.FluentdBufferSpec{
+							FlushMode:     "lazy",
+							FlushInterval: "25s",
+						},
+					},
+				},
+			},
+			ExpectedConf: `
+<buffer time, tag>
+  @type file
+  path '/var/lib/fluentd/es_1'
+  flush_mode lazy
+  flush_thread_count 2
+  flush_at_shutdown true
+  retry_type exponential_backoff
+  retry_wait 1s
+  retry_max_interval 60s
+  retry_timeout 60m
+  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE'] || '8589934592'}"
+  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+  overflow_action block
+</buffer>`,
+		}),
+	)
 })
 
 var _ = Describe("Generate fluentd conf", func() {

--- a/pkg/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/pkg/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -348,7 +348,6 @@ var _ = Describe("Generating fluentd config", func() {
                 @type file
                 path '/var/lib/fluentd/retry_other_elasticsearch'
                 flush_mode immediate
-                flush_interval 2s
                 flush_thread_count 4
                 flush_at_shutdown true
                 retry_type periodic
@@ -388,7 +387,6 @@ var _ = Describe("Generating fluentd config", func() {
                 @type file
                 path '/var/lib/fluentd/other_elasticsearch'
                 flush_mode immediate
-                flush_interval 2s
                 flush_thread_count 4
                 flush_at_shutdown true
                 retry_type periodic
@@ -478,7 +476,6 @@ var _ = Describe("Generating fluentd config", func() {
           @type file
           path '/var/lib/fluentd/secureforward_receiver'
           flush_mode immediate
-          flush_interval 2s
           flush_thread_count 4
           flush_at_shutdown true
           retry_type periodic
@@ -681,7 +678,6 @@ var _ = Describe("Generating fluentd config", func() {
                @type file
                path '/var/lib/fluentd/kafka_receiver'
                flush_mode immediate
-               flush_interval 2s
                flush_thread_count 4
                flush_at_shutdown true
                retry_type periodic

--- a/pkg/generator/fluentd/output/syslog/syslog.go
+++ b/pkg/generator/fluentd/output/syslog/syslog.go
@@ -51,10 +51,10 @@ port {{.Port}}
 rfc {{.Rfc}}
 facility {{.Facility}}
 severity {{.Severity}}
-{{kv .AppName -}}
-{{kv .MsgID -}}
-{{kv .ProcID -}}
-{{kv .Tag -}}
+{{optional .AppName -}}
+{{optional .MsgID -}}
+{{optional .ProcID -}}
+{{optional .Tag -}}
 protocol {{.Protocol}}
 packet_size 4096
 hostname "#{ENV['NODE_NAME']}"

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -56,7 +56,7 @@ func (g Generator) generate(es []Element) (string, error) {
 		return "", nil
 	}
 	t := template.New("generate")
-	t.Funcs(template.FuncMap{
+	f := template.FuncMap{
 		"compose": g.generate,
 		"compose_one": func(e Element) (string, error) {
 			return g.generate([]Element{e})
@@ -72,7 +72,9 @@ func (g Generator) generate(es []Element) (string, error) {
 		"comma_separated": func(arr []string) string {
 			return strings.Join(arr, ", ")
 		},
-	})
+	}
+	f["optional"] = f["kv"]
+	t.Funcs(f)
 	b := &bytes.Buffer{}
 	for i, e := range es {
 		if e == nil || e == Nil {

--- a/pkg/generator/keyval.go
+++ b/pkg/generator/keyval.go
@@ -24,3 +24,9 @@ func KV(k, v string) KeyVal {
 		Val: v,
 	}
 }
+
+type OptElement = KeyVal
+
+func Optional(k, v string) KeyVal {
+	return KV(k, v)
+}


### PR DESCRIPTION
### Description
1. Added an Optional Element, to support optional buffer conf fields
2. Fixed bug [LOG-1392](https://issues.redhat.com/browse/LOG-1392), Output flush_interval only with flush_mode=interval

/cc @jcantrill 
/assign 

manually cherry-pick 
*release-5.2
*release-4.6

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1392

