### PR TITLE
Revert "Merge pull request #1155 from periklis/use-pinned-operand-versions-5.0"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(APP_NAME):latest
 export OCP_VERSION?=$(shell basename $(shell find manifests/  -maxdepth 1  -not -name manifests -not -name patches -type d))
 export NAMESPACE?=openshift-logging
 
-FLUENTD_IMAGE?=quay.io/openshift-logging/fluentd:1.7.4
+FLUENTD_IMAGE?=quay.io/openshift/origin-logging-fluentd:latest
 REPLICAS?=0
 export E2E_TEST_INCLUDES?=
 export CLF_TEST_INCLUDES?=

--- a/bundle/manifests/cluster-logging.v5.0.0.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.v5.0.0.clusterserviceversion.yaml
@@ -335,9 +335,9 @@ spec:
                   - name: OPERATOR_NAME
                     value: "cluster-logging-operator"
                   - name: FLUENTD_IMAGE
-                    value: "quay.io/openshift-logging/fluentd:1.7.4"
+                    value: "quay.io/openshift/origin-logging-fluentd:latest"
                   - name: CURATOR_IMAGE
-                    value: "quay.io/openshift-logging/curator5:1.7.4"
+                    value: "quay.io/openshift/origin-logging-curator5:latest"
   customresourcedefinitions:
     owned:
     - name: clusterloggings.logging.openshift.io

--- a/manifests/5.0/cluster-logging.v5.0.0.clusterserviceversion.yaml
+++ b/manifests/5.0/cluster-logging.v5.0.0.clusterserviceversion.yaml
@@ -335,9 +335,9 @@ spec:
                   - name: OPERATOR_NAME
                     value: "cluster-logging-operator"
                   - name: FLUENTD_IMAGE
-                    value: "quay.io/openshift-logging/fluentd:1.7.4"
+                    value: "quay.io/openshift/origin-logging-fluentd:latest"
                   - name: CURATOR_IMAGE
-                    value: "quay.io/openshift-logging/curator5:5.8.1"
+                    value: "quay.io/openshift/origin-logging-curator5:latest"
   customresourcedefinitions:
     owned:
     - name: clusterloggings.logging.openshift.io

--- a/manifests/5.0/image-references
+++ b/manifests/5.0/image-references
@@ -9,8 +9,8 @@ spec:
   - name: logging-curator5
     from:
       kind: DockerImage
-      name: quay.io/openshift-logging/curator5:5.8.1
+      name: quay.io/openshift/origin-logging-curator5:latest
   - name: logging-fluentd
     from:
       kind: DockerImage
-      name: quay.io/openshift-logging/fluentd:1.7.4
+      name: quay.io/openshift/origin-logging-fluentd:latest

--- a/olm_deploy/scripts/registry-init.sh
+++ b/olm_deploy/scripts/registry-init.sh
@@ -6,16 +6,21 @@ echo -e "Dumping IMAGE env vars\n"
 env | grep IMAGE
 echo -e "\n\n"
 
+
 IMAGE_CLUSTER_LOGGING_OPERATOR=${IMAGE_CLUSTER_LOGGING_OPERATOR:-quay.io/openshift/origin-cluster-logging-operator:latest}
 IMAGE_OAUTH_PROXY=${IMAGE_OAUTH_PROXY:-quay.io/openshift/origin-oauth-proxy:latest}
-IMAGE_LOGGING_CURATOR5=${IMAGE_LOGGING_CURATOR5:-quay.io/openshift-logging/curator5:5.8.1}
-IMAGE_LOGGING_FLUENTD=${IMAGE_LOGGING_FLUENTD:-quay.io/openshift-logging/fluentd:1.7.4}
+IMAGE_LOGGING_CURATOR5=${IMAGE_LOGGING_CURATOR5:-quay.io/openshift/origin-logging-curator5:latest}
+IMAGE_LOGGING_FLUENTD=${IMAGE_LOGGING_FLUENTD:-quay.io/openshift/origin-logging-fluentd:latest}
+IMAGE_ELASTICSEARCH6=${IMAGE_ELASTICSEARCH6:-quay.io/openshift/origin-logging-elasticsearch6:latest}
+IMAGE_LOGGING_KIBANA6=${IMAGE_LOGGING_KIBANA6:-quay.io/openshift/origin-logging-kibana6:latest}
 
 # update the manifest with the image built by ci
 sed -i "s,quay.io/openshift/origin-cluster-logging-operator:latest,${IMAGE_CLUSTER_LOGGING_OPERATOR}," /manifests/*/*clusterserviceversion.yaml
 sed -i "s,quay.io/openshift/origin-oauth-proxy:latest,${IMAGE_OAUTH_PROXY}," /manifests/*/*clusterserviceversion.yaml
-sed -i "s,quay.io/openshift-logging/curator5:5.8.1,${IMAGE_LOGGING_CURATOR5}," /manifests/*/*clusterserviceversion.yaml
-sed -i "s,quay.io/openshift-logging/fluentd:1.7.4,${IMAGE_LOGGING_FLUENTD}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-logging-curator5:latest,${IMAGE_LOGGING_CURATOR5}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-logging-fluentd:latest,${IMAGE_LOGGING_FLUENTD}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-logging-elasticsearch6:latest,${IMAGE_ELASTICSEARCH6}," /manifests/*/*clusterserviceversion.yaml
+sed -i "s,quay.io/openshift/origin-logging-kibana6:latest,${IMAGE_LOGGING_KIBANA6}," /manifests/*/*clusterserviceversion.yaml
 
 # update the manifest to pull always the operator image for non-CI environments
 if [ "${OPENSHIFT_CI:-false}" == "false" ] ; then

--- a/test/helpers/fluentd.go
+++ b/test/helpers/fluentd.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -170,7 +169,6 @@ func (fluent *fluentReceiverLogStore) ApplicationLogs(timeToWait time.Duration) 
 func (fluent fluentReceiverLogStore) HasInfraStructureLogs(timeToWait time.Duration) (bool, error) {
 	return fluent.hasLogs("/tmp/infra.logs", timeToWait)
 }
-
 func (fluent *fluentReceiverLogStore) HasApplicationLogs(timeToWait time.Duration) (bool, error) {
 	return fluent.hasLogs("/tmp/app.logs", timeToWait)
 }
@@ -275,7 +273,7 @@ func (tc *E2ETestFramework) DeployFluentdReceiver(rootDir string, secure bool) (
 	}
 	container := corev1.Container{
 		Name:            receiverName,
-		Image:           "quay.io/openshift-logging/fluentd:1.7.4",
+		Image:           "quay.io/openshift/origin-logging-fluentd:latest",
 		ImagePullPolicy: corev1.PullAlways,
 		Args:            []string{"fluentd", "-c", "/fluentd/etc/fluent.conf"},
 		VolumeMounts: []corev1.VolumeMount{

--- a/test/helpers/fluentd/receiver.go
+++ b/test/helpers/fluentd/receiver.go
@@ -93,7 +93,7 @@ func NewReceiver(ns, name string) *Receiver {
 	runtime.Labels(r.Pod)[appName] = name
 	r.Pod.Spec.Containers = []corev1.Container{{
 		Name:  name,
-		Image: "quay.io/openshift-logging/fluentd:1.7.4",
+		Image: "quay.io/openshift/origin-logging-fluentd:latest",
 		Args:  []string{"fluentd", "-c", filepath.Join(configDir, "fluent.conf")},
 		VolumeMounts: []corev1.VolumeMount{
 			{


### PR DESCRIPTION
### Description
This reverts commit 8c5ee3bf174d01bf628282a3bb2ce8d0bb847259, reversing changes made to 4513e5ac5cb52035b42cd54c39b6fdd350025db9. Operand images from `5.y` imagestream tag are not compatible operand  for 5.0.z release due to: 
- https://github.com/openshift/origin-aggregated-logging/pull/2077
- https://github.com/openshift/origin-aggregated-logging/pull/2100

/cc @jcantrill 
/assign @jcantrill 