### PR TITLE
LOG-1494: Use "json", "single_json_value" formatter to fix syslog output

### DIFF
--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -529,6 +529,9 @@ var _ = Describe("Generating fluentd config", func() {
 		                keep_alive_idle 75
 		                keep_alive_cnt 9
 		                keep_alive_intvl 7200
+                        <format>
+                          @type json
+                        </format>
 		            <buffer>
 		                @type file
 		                path '/var/lib/fluentd/syslog_receiver'
@@ -579,6 +582,9 @@ var _ = Describe("Generating fluentd config", func() {
 		                keep_alive_idle 75
 		                keep_alive_cnt 9
 		                keep_alive_intvl 7200
+                        <format>
+                          @type json
+                        </format>
 		            <buffer>
 		                @type file
 		                path '/var/lib/fluentd/syslog_receiver'

--- a/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
+++ b/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
@@ -156,6 +156,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
     keep_alive_idle 75
     keep_alive_cnt 9
     keep_alive_intvl 7200
+    <format>
+      @type json
+    </format>
     <buffer>
       @type file
       path '/var/lib/fluentd/syslog_receiver'
@@ -194,6 +197,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
     protocol udp
     packet_size 4096
     hostname "#{ENV['NODE_NAME']}"
+    <format>
+      @type json
+    </format>
     <buffer>
       @type file
       path '/var/lib/fluentd/syslog_receiver'
@@ -241,6 +247,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
     keep_alive_idle 75
     keep_alive_cnt 9
     keep_alive_intvl 7200
+    <format>
+      @type json
+    </format>
     <buffer>
       @type file
       path '/var/lib/fluentd/syslog_receiver'
@@ -282,6 +291,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
     tls true
     verify_mode true
     ca_file '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
+    <format>
+      @type json
+    </format>
     <buffer>
       @type file
       path '/var/lib/fluentd/syslog_receiver'
@@ -390,6 +402,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
     keep_alive_idle 75
     keep_alive_cnt 9
     keep_alive_intvl 7200
+    <format>
+      @type json
+    </format>
     <buffer $.systemd.u.SYSLOG_IDENTIFIER>
       @type file
       path '/var/lib/fluentd/syslog_receiver_journal'
@@ -427,6 +442,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
     keep_alive_idle 75
     keep_alive_cnt 9
     keep_alive_intvl 7200
+    <format>
+      @type json
+    </format>
     <buffer>
       @type file
       path '/var/lib/fluentd/syslog_receiver'
@@ -521,6 +539,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
     keep_alive_idle 75
     keep_alive_cnt 9
     keep_alive_intvl 7200
+    <format>
+      @type json
+    </format>
     <buffer $.systemd.u.SYSLOG_IDENTIFIER>
       @type file
       path '/var/lib/fluentd/syslog_receiver_journal'
@@ -559,6 +580,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
     keep_alive_idle 75
     keep_alive_cnt 9
     keep_alive_intvl 7200
+    <format>
+      @type json
+    </format>
     <buffer>
       @type file
       path '/var/lib/fluentd/syslog_receiver'
@@ -654,6 +678,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
     keep_alive_idle 75
     keep_alive_cnt 9
     keep_alive_intvl 7200
+    <format>
+      @type json
+    </format>
     <buffer $.systemd.u.SYSLOG_IDENTIFIER>
       @type file
       path '/var/lib/fluentd/syslog_receiver_journal'
@@ -691,6 +718,9 @@ var _ = Describe("Generating external syslog server output store config blocks",
     keep_alive_idle 75
     keep_alive_cnt 9
     keep_alive_intvl 7200
+    <format>
+      @type json
+    </format>
     <buffer>
       @type file
       path '/var/lib/fluentd/syslog_receiver'

--- a/internal/generator/fluentd/output/syslog/syslog.go
+++ b/internal/generator/fluentd/output/syslog/syslog.go
@@ -71,8 +71,12 @@ keep_alive_intvl 7200
 {{end -}}
 {{if .PayloadKey -}}
 <format>
-  @type single_value
+  @type single_json_value
   message_key {{.PayloadKey}}
+</format>
+{{else -}}
+<format>
+  @type json
 </format>
 {{end -}}
 {{compose .BufferConfig}}

--- a/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
@@ -311,7 +311,6 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 					grepMsgContent := fmt.Sprintf(`grep %s %%s | tail -n 1 | awk -F' ' '{ s = ""; for (i = 8; i <= NF; i++) s = s $i " "; print s }'`, "rec_appname")
 					str, err := logStore.GrepLogs(grepMsgContent, helpers.DefaultWaitForLogsTimeout)
 					Expect(err).To(BeNil())
-					str = strings.ReplaceAll(str, "=>", ":")
 					msg := map[string]interface{}{}
 					err = json.Unmarshal([]byte(str), &msg)
 					Expect(err).To(BeNil())
@@ -580,7 +579,6 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 						grepMsgContent := fmt.Sprintf(`grep %s %%s | tail -n 1 | awk -F' ' '{ s = ""; for (i = 8; i <= NF; i++) s = s $i " "; print s }'`, "rec_tag")
 						str, err := logStore.GrepLogs(grepMsgContent, helpers.DefaultWaitForLogsTimeout)
 						Expect(err).To(BeNil())
-						str = strings.ReplaceAll(str, "=>", ":")
 						msg := map[string]interface{}{}
 						err = json.Unmarshal([]byte(str), &msg)
 						Expect(err).To(BeNil())


### PR DESCRIPTION
### Description
Syslog plugin uses LTSV formatter https://github.com/openshift/origin-aggregated-logging/blob/master/fluentd/vendored_gem_src/fluentd/lib/fluent/plugin/formatter_ltsv.rb to format the record sent to syslog.
This formatter produces a <key:value> set separated by TAB. The key-values are the first level values from record. If the value is a ruby Hash, it gets encoded as string representation of Hash which contains '=>' characters. Further when the logs are sent to rsyslog, rsyslog replaces tabs with "#11" characters which explains the log formatting we see in output.

This PR generates configuration for syslog plugin to use correct formatter. It generates config to use `json` formatter in the default case, and `single_json_value` (instead of `single_value` formatter) in specific cases.

`single_json_value` formatter was added in PR https://github.com/openshift/origin-aggregated-logging/pull/2175

Logs Before this change:
```
<15>1 2021-08-30T13:03:57.267519+00:00 functional-test-node myapp myproc mymsg - docker:{"container_id"=>"d694909e473b57b3fab963faa1bd785700db2f11651e720bc3a8f45b28fcc47a"}#011kubernetes:{"container_name"=>"fluentd", "namespace_name"=>"test-b3mqbayw", "pod_name"=>"functional", "container_image"=>"image-registry.openshift-image-registry.svc:5000/openshift/origin-logging-fluentd:latest", "container_image_id"=>"image-registry.openshift-image-registry.svc:5000/openshift/origin-logging-fluentd@sha256:8b910265ffe2112a5804db2266747a30079b952c773e1962f3b9219b20bf4094", "pod_id"=>"46260886-0782-4c8a-9818-5b9dfd8ebc5c", "host"=>"crc-txps5-master-0", "labels"=>{"test-client"=>"true", "testname"=>"functional", "testtype"=>"functional"}, "master_url"=>"https://kubernetes.default.svc", "namespace_id"=>"8dcb2c13-9156-4b3a-ae60-7fd70e70d184", "namespace_labels"=>{"test-client"=>"true", "kubernetes_io/metadata_name"=>"test-b3mqbayw"}}#011message:2021-02-17 17:46:36 "hello world"#011level:unknown#011hostname:crc-txps5-master-0#011pipeline_metadata:{"collector"=>{"ipaddr4"=>"10.217.0.183", "inputname"=>"fluent-plugin-systemd", "name"=>"fluentd", "received_at"=>"2021-08-30T13:03:56.011471+00:00", "version"=>"1.7.4 1.6.0"}}#011@timestamp:2013-03-28T14:36:03.243000+00:00#011viaq_index_name:app-write#011viaq_msg_id:NzE4MGQ0NWUtMzI0Yy00OTViLWEyNzItYWJkMmVkNDM2MDYz#011log_type:application
```

Logs after this change
```
<15>1 2021-08-30T12:44:46.009914+00:00 functional-test-node myapp myproc mymsg - {"docker":{"container_id":"eb48ee6f418fe3a30b518d1123be1c49a2643e54467f0d68cdf35683687e5971"},"kubernetes":{"container_name":"fluentd","namespace_name":"test-bjpabj6b","pod_name":"functional","container_image":"image-registry.openshift-image-registry.svc:5000/openshift/origin-logging-fluentd:latest","container_image_id":"image-registry.openshift-image-registry.svc:5000/openshift/origin-logging-fluentd@sha256:df2e8da3b973e93299420aaacf357a091d0304dfc6d90dc216a2adf45ebdfaff","pod_id":"99291cce-cfbb-40dd-900b-fc395f48a983","host":"crc-txps5-master-0","labels":{"test-client":"true","testname":"functional","testtype":"functional"},"master_url":"https://kubernetes.default.svc","namespace_id":"dba94d10-0616-447b-8fef-406743fd8b82","namespace_labels":{"test-client":"true","kubernetes_io/metadata_name":"test-bjpabj6b"}},"message":"2021-02-17 17:46:36 \"hello world\"","level":"unknown","hostname":"crc-txps5-master-0","pipeline_metadata":{"collector":{"ipaddr4":"10.217.0.176","inputname":"fluent-plugin-systemd","name":"fluentd","received_at":"2021-08-30T12:44:45.874481+00:00","version":"1.7.4 1.6.0"}},"@timestamp":"2013-03-28T14:36:03.243000+00:00","viaq_index_name":"app-write","viaq_msg_id":"NjZlNzQ1MjctOWYxZS00ZGRiLWJmNjItODUyYTA3NjlkYmQx","log_type":"application"}
```


/cc @jcantrill 
/assign 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1494

