### PR TITLE
LOG-1733: Improve must-gather for ES store

### DIFF
--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -44,13 +44,20 @@ Example must-gather for cluster-logging output:
 │  │  └── elasticsearch-operator-7dc7d97b9d-jb4r4
 │  ├── es
 │  │  ├── cluster-elasticsearch
-│  │  │  ├── aliases
-│  │  │  ├── health
-│  │  │  ├── indices
+│  │  │  ├── aliases.cat
+│  │  │  ├── health.cat
+│  │  │  ├── hot_threads.txt
+│  │  │  ├── indices.cat
+│  │  │  ├── indices_size.cat
 │  │  │  ├── latest_documents.json
-│  │  │  ├── nodes
+│  │  │  ├── nodes.cat
+│  │  │  ├── nodes_state.json
 │  │  │  ├── nodes_stats.json
-│  │  │  └── thread_pool
+│  │  │  ├── pending_tasks.cat      (iff cluster health not green)
+│  │  │  ├── recovery.cat           (iff cluster health not green)
+│  │  │  ├── shards.cat             (iff cluster health not green)
+│  │  │  ├── thread_pool.cat
+│  │  │  └── unassigned_shards.cat  (iff cluster health not green)
 │  │  ├── cr
 │  │  ├── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
 │  │  └── logs

--- a/must-gather/collection-scripts/gather_logstore_resources
+++ b/must-gather/collection-scripts/gather_logstore_resources
@@ -67,16 +67,18 @@ get_elasticsearch_status() {
   local cluster_folder=$es_folder/cluster-$comp
   mkdir -p $cluster_folder
 
-  curl_es='curl -s --max-time 5 --key /etc/elasticsearch/secret/admin-key --cert /etc/elasticsearch/secret/admin-cert --cacert /etc/elasticsearch/secret/admin-ca https://localhost:9200'
+  curl_es='curl -s --max-time 20 --key /etc/elasticsearch/secret/admin-key --cert /etc/elasticsearch/secret/admin-cert --cacert /etc/elasticsearch/secret/admin-ca https://localhost:9200'
   local cat_items=(health nodes aliases thread_pool)
   for cat_item in ${cat_items[@]}
   do
-    oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/$cat_item
+    oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/${cat_item}.cat
   done
 
-  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/indices?v\&bytes=m &> $cluster_folder/indices
-  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/indices?h=i,creation.date,creation.date.string,store.size,pri.store.size > $cluster_folder/indices_size
+  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_nodes/hot_threads &> $cluster_folder/hot_threads.txt
+  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/indices?v\&bytes=m &> $cluster_folder/indices.cat
+  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/indices?h=i,creation.date,creation.date.string,store.size,pri.store.size > $cluster_folder/indices_size.cat
   oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_search?sort=@timestamp:desc\&pretty > $cluster_folder/latest_documents.json
+  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_nodes/?pretty > $cluster_folder/nodes_state.json
   oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_nodes/stats?pretty > $cluster_folder/nodes_stats.json
   local health=$(oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/health?h=status)
   if [ -z "$health" ]
@@ -89,10 +91,10 @@ get_elasticsearch_status() {
     cat_items=(recovery shards pending_tasks)
     for cat_item in ${cat_items[@]}
     do
-      oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/$cat_item
+      oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/${cat_item}.cat
     done
 
-    oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/shards?h=index,shard,prirep,state,unassigned.reason,unassigned.description | grep UNASSIGNED &> $cluster_folder/unassigned_shards
+    oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/shards?h=index,shard,prirep,state,unassigned.reason,unassigned.description | grep UNASSIGNED &> $cluster_folder/unassigned_shards.cat
   fi
 }
 


### PR DESCRIPTION
### Description

Adding new resources:

- Adding [_nodes](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/cluster-nodes-info.html)
- Adding [hot_threads](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/cluster-nodes-hot-threads.html)

Extending curl timout to 20 sec:

We are experiencing empty resource logs in must-gather archives. Instead of expected content they only contain message referencing to "timeout error code (28)".

Completing the documentation.

Adding suffix to each type of resource.
- .json is a json content (can be directly processed by jq)
- .cat is output of _cat endpoint (can be processed by awk or sed)
- .txt is non-structural text format


/cc @btaani
/assign @periklis 

### Links

- JIRA: https://issues.redhat.com/browse/LOG-1733
