### PR TITLE
LOG-1686 Log Exploration API integration: include service monitor

### DIFF
--- a/internal/k8shandler/defaults.go
+++ b/internal/k8shandler/defaults.go
@@ -19,4 +19,7 @@ var (
 
 	defaultFluentdMemory     resource.Quantity = resource.MustParse("736Mi")
 	defaultFluentdCpuRequest resource.Quantity = resource.MustParse("100m")
+
+	defaultLoggingApiMemory     resource.Quantity = resource.MustParse("736Mi")
+	defaultLoggingApiCpuRequest resource.Quantity = resource.MustParse("100m")
 )

--- a/internal/k8shandler/log-exploration-api.go
+++ b/internal/k8shandler/log-exploration-api.go
@@ -11,12 +11,12 @@ import (
 )
 
 const (
-	logAPIPort = 8080
-	logAPIService = "logexplorationapi-service"
+	logAPIPort            = 8080
+	logAPIService         = "logexplorationapi-service"
 	logAPIMetricsPortName = "prom-metrics"
 )
 
-func (clusterRequest *ClusterLoggingRequest)  createLogExplorationAPIServiceMonitor() error {
+func (clusterRequest *ClusterLoggingRequest) createLogExplorationAPIServiceMonitor() error {
 
 	cluster := clusterRequest.Cluster
 
@@ -53,7 +53,6 @@ func (clusterRequest *ClusterLoggingRequest)  createLogExplorationAPIServiceMoni
 	return nil
 }
 
-
 func newLogExplorationAPIRoute(routeName, namespace, serviceName, componentName, loggingComponent string) *route.Route {
 	return &route.Route{
 		TypeMeta: metav1.TypeMeta{
@@ -86,14 +85,14 @@ func (clusterRequest *ClusterLoggingRequest) createLogExplorationAPIService() er
 			{
 				Port:       logAPIPort,
 				TargetPort: intstr.FromInt(logAPIPort),
-				Name: logAPIMetricsPortName,
+				Name:       logAPIMetricsPortName,
 			},
 		},
 	)
 
 	// Override the label from factory.NewService
 	desired.Labels = map[string]string{
-		"component" : logAPIService,
+		"component": logAPIService,
 	}
 
 	utils.AddOwnerRefToObject(desired, utils.AsOwner(clusterRequest.Cluster))

--- a/internal/k8shandler/log-exploration-api.go
+++ b/internal/k8shandler/log-exploration-api.go
@@ -1,0 +1,180 @@
+package k8shandler
+
+import (
+	route "github.com/openshift/api/route/v1"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	logAPIPort = 8080
+)
+
+func newLogExplorationAPIRoute(routeName, namespace, serviceName, componentName, loggingComponent string) *route.Route {
+	return &route.Route{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Route",
+			APIVersion: route.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"component":     componentName,
+				"logging-infra": loggingComponent,
+			},
+		},
+		Spec: route.RouteSpec{
+			To: route.RouteTargetReference{
+				Name: serviceName,
+				Kind: "Service",
+			},
+		},
+	}
+}
+
+func (clusterRequest *ClusterLoggingRequest) createLogExplorationAPIService() error {
+	desired := factory.NewService(
+		"logexplorationapi-service",
+		clusterRequest.Cluster.Namespace,
+		"logexplorationapi",
+		[]v1.ServicePort{
+			{
+				Port:       logAPIPort,
+				TargetPort: intstr.FromInt(logAPIPort),
+			},
+		},
+	)
+
+	utils.AddOwnerRefToObject(desired, utils.AsOwner(clusterRequest.Cluster))
+	err := clusterRequest.Create(desired)
+	return err
+}
+func (clusterRequest *ClusterLoggingRequest) createLogExplorationAPIRoute() error {
+	apiRoute := newLogExplorationAPIRoute("logexplorationapi-route", clusterRequest.Cluster.Namespace, "logexplorationapi-service", "logexplorationapi", "logexplorationapi")
+	utils.AddOwnerRefToObject(apiRoute, utils.AsOwner(clusterRequest.Cluster))
+	err := clusterRequest.Create(apiRoute)
+	return err
+}
+func (clusterRequest *ClusterLoggingRequest) createLogExplorationAPIDeployment() error {
+
+	logApiPodSpec := newLogExplorationApiPodSpec()
+
+	logApiDeployment := NewDeployment("logexplorationapi", clusterRequest.Cluster.Namespace, "logexplorationapi", "logexplorationapi", logApiPodSpec)
+
+	utils.AddOwnerRefToObject(logApiDeployment, utils.AsOwner(clusterRequest.Cluster))
+
+	err := clusterRequest.Create(logApiDeployment)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func newLogExplorationApiPodSpec() v1.PodSpec {
+	resources := &v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceMemory: defaultLoggingApiMemory,
+			v1.ResourceCPU:    defaultLoggingApiCpuRequest,
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: defaultLoggingApiMemory,
+			v1.ResourceCPU:    defaultLoggingApiCpuRequest,
+		},
+	}
+
+	logExplorationApiContainer := NewContainer("logexplorationapi", "logApi", v1.PullIfNotPresent, *resources)
+
+	logExplorationApiContainer.Ports = []v1.ContainerPort{
+		{
+			ContainerPort: logAPIPort,
+		},
+	}
+	logExplorationApiContainer.Env = []v1.EnvVar{
+		{Name: "ES_ADDR", Value: "https://elasticsearch.openshift-logging:9200"},
+		{Name: "ES_CERT", Value: "/etc/openshift/elasticsearch/secret/tls.crt"},
+		{Name: "ES_KEY", Value: "/etc/openshift/elasticsearch/secret/tls.key"},
+		{Name: "ES_TLS", Value: "true"},
+		{Name: "POD_IP", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"}}},
+	}
+
+	logExplorationApiContainer.VolumeMounts = []v1.VolumeMount{
+		{Name: "certificates", MountPath: "/etc/openshift/elasticsearch/secret"},
+	}
+	httpGetStructLivenessProbe := &v1.HTTPGetAction{
+		Path: "/ready",
+		Port: intstr.FromInt(logAPIPort),
+	}
+	httpGetStructReadinessProbe := &v1.HTTPGetAction{
+		Path: "/health",
+		Port: intstr.FromInt(logAPIPort),
+	}
+	handlerStructLivenessProbe := v1.Handler{
+		HTTPGet: httpGetStructLivenessProbe,
+	}
+
+	handlerStructReadinessProbe := v1.Handler{
+		HTTPGet: httpGetStructReadinessProbe,
+	}
+	logExplorationApiContainer.ReadinessProbe = &v1.Probe{
+		Handler:             handlerStructReadinessProbe,
+		InitialDelaySeconds: 3,
+		PeriodSeconds:       3,
+	}
+	logExplorationApiContainer.LivenessProbe = &v1.Probe{
+		Handler:             handlerStructLivenessProbe,
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       3,
+		FailureThreshold:    30,
+	}
+
+	logExplorationApiPodSpec := newLogApiPodSpec([]v1.Container{logExplorationApiContainer},
+		[]v1.Volume{
+			{Name: "certificates", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "fluentd", DefaultMode: utils.GetInt32(420)}}},
+		},
+	)
+	return logExplorationApiPodSpec
+
+}
+
+func newLogApiPodSpec(containers []v1.Container, volumes []v1.Volume) v1.PodSpec {
+
+	return v1.PodSpec{
+		Containers: containers,
+		Volumes:    volumes,
+	}
+}
+
+func (clusterRequest *ClusterLoggingRequest) CreateOrDeleteLogExplorationApi() error {
+	if _, ok := clusterRequest.Cluster.Annotations["api-enabled"]; ok {
+
+		if err := clusterRequest.createLogExplorationAPIDeployment(); err != nil {
+			return err
+		}
+
+		if err := clusterRequest.createLogExplorationAPIService(); err != nil {
+			return err
+		}
+		if err := clusterRequest.createLogExplorationAPIRoute(); err != nil {
+			return err
+		}
+
+	} else {
+
+		if err := clusterRequest.RemoveDeployment("logging-api"); err != nil {
+			return err
+		}
+		if err := clusterRequest.RemoveService("logexplorationapi-service"); err != nil {
+			return err
+		}
+		if err := clusterRequest.RemoveRoute("logexplorationapi-route"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/k8shandler/log-exploration-api_test.go
+++ b/internal/k8shandler/log-exploration-api_test.go
@@ -1,0 +1,71 @@
+package k8shandler
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"testing"
+)
+
+var _ = Describe("fluentd.go#newFluentdPodSpec", func() {
+	var (
+		//cluster   = &logging.ClusterLogging{}
+		podSpec   v1.PodSpec
+		container v1.Container
+	)
+	BeforeEach(func() {
+		podSpec = newLogExplorationApiPodSpec()
+		container = podSpec.Containers[0]
+	})
+	Describe("when creating the logexplorationapi container", func() {
+
+		It("should provide the pod IP as an environment var", func() {
+			Expect(container.Env).To(IncludeEnvVar(v1.EnvVar{Name: "POD_IP",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						APIVersion: "v1", FieldPath: "status.podIP"}}}))
+		})
+	})
+
+})
+
+func TestNewLogExplorationAPIPodSpecWhenResourcesAreDefined(t *testing.T) {
+	limitMemory := resource.MustParse("736Mi")
+	limitCpu := resource.MustParse("100m")
+	requestMemory := resource.MustParse("736Mi")
+	requestCPU := resource.MustParse("100m")
+	//cluster := &logging.ClusterLogging{
+	//	Spec: logging.ClusterLoggingSpec{
+	//		Api: &logging.ApiSpec{
+	//			Enabled: true,
+	//			LoggingAPISpec: logging.LoggingAPISpec{
+	//				Resources: newResourceRequirements("128Mi", "500m", "64Mi", "250m"),
+	//			},
+	//		},
+	//	},
+	//}
+
+	//podSpec := newLogExplorationApiPodSpec(cluster)
+	podSpec := newLogExplorationApiPodSpec()
+	fmt.Println("podspec details: ", podSpec.Containers)
+	if len(podSpec.Containers) != 1 {
+		t.Error("Exp. there to be 1 fluentd container")
+	}
+
+	resources := podSpec.Containers[0].Resources
+	if resources.Limits[v1.ResourceMemory] != limitMemory {
+		t.Errorf("Exp. the spec memory limit to be %v", limitMemory)
+	}
+	if resources.Limits[v1.ResourceCPU] != limitCpu {
+		t.Errorf("Exp. the spec memory limit to be %v", limitCpu)
+	}
+	if resources.Requests[v1.ResourceMemory] != requestMemory {
+		t.Errorf("Exp. the spec memory request to be %v", requestMemory)
+	}
+	if resources.Requests[v1.ResourceCPU] != requestCPU {
+		t.Errorf("Exp. the spec CPU request to be %v", requestCPU)
+	}
+}

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -46,6 +46,9 @@ func Reconcile(requestCluster *logging.ClusterLogging, requestClient client.Clie
 			return fmt.Errorf("Unable to create or update logstore for %q: %v", clusterLoggingRequest.Cluster.Name, err)
 		}
 
+		if err = clusterLoggingRequest.CreateOrDeleteLogExplorationApi(); err != nil {
+			return fmt.Errorf("Unable to create or update logstore for %q: %v", clusterLoggingRequest.Cluster.Name, err)
+		}
 		// Reconcile Visualization
 		if err = clusterLoggingRequest.CreateOrUpdateVisualization(); err != nil {
 			return fmt.Errorf("Unable to create or update visualization for %q: %v", clusterLoggingRequest.Cluster.Name, err)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -36,6 +36,7 @@ var COMPONENT_IMAGES = map[string]string{
 	constants.FluentdName:                constants.FluentdImageEnvVar,
 	"kibana":                             "KIBANA_IMAGE",
 	constants.LogfilesmetricexporterName: constants.LogfilesmetricImageEnvVar,
+	"logApi":                             "LOG_API_IMAGE",
 }
 
 // GetAnnotation returns the value of an annoation for a given key and true if the key was found

--- a/test/e2e/logexplorationapi/api/deploy_and_collect_logs_from_elasticsearch_test.go
+++ b/test/e2e/logexplorationapi/api/deploy_and_collect_logs_from_elasticsearch_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"fmt"
+	apps "k8s.io/api/apps/v1"
+	"runtime"
+
+	"github.com/ViaQ/logerr/log"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
+)
+
+var _ = Describe("Deploys API and collect logs from elasticsearch", func() {
+	_, filename, _, _ := runtime.Caller(0)
+	log.Info("Running ", "filename", filename)
+	var (
+		e2e                         = helpers.NewE2ETestFramework()
+		components                  []helpers.LogComponentType
+		err                         error
+		logExplorationAPiDeployment *apps.Deployment
+	)
+	Describe("Deploying API and collecting logs from elasticsearch", func() {
+		BeforeEach(func() {
+
+			cr := helpers.NewClusterLogging(helpers.ComponentTypeCollector, helpers.ComponentTypeStore, helpers.ComponentLogAPI)
+			if err = e2e.CreateClusterLogging(cr); err != nil {
+				Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+				return
+			}
+			if err = e2e.WaitFor(helpers.ComponentTypeCollector); err != nil {
+				Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", helpers.ComponentTypeCollector, err))
+				return
+			}
+			if err = e2e.WaitFor(helpers.ComponentTypeStore); err != nil {
+				Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", helpers.ComponentTypeStore, err))
+				return
+			}
+			if e2e.ClusterLogging.ObjectMeta.Annotations["api-enabled"] == "true" {
+				logExplorationAPiDeployment, err = e2e.DeployLogExplorationAPI()
+				if err != nil {
+					Fail(fmt.Sprintf("Failed to deploy the compoenent %s: %v", helpers.ComponentLogAPI, err))
+				}
+			}
+			if err = e2e.WaitFor(helpers.ComponentLogAPI); err != nil {
+				Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", helpers.ComponentLogAPI, err))
+				return
+			}
+		})
+
+		It("should collect logs from the endpoint", func() {
+			for _, component := range components {
+				if err = e2e.WaitFor(component); err != nil {
+					Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
+				}
+			}
+
+			Expect(e2e.LogStores[logExplorationAPiDeployment.GetName()].HasApplicationLogs(helpers.DefaultWaitForLogsTimeout)).To(BeTrue(), "Expected to find stored application logs with ")
+		})
+
+		AfterEach(func() {
+			e2e.Cleanup()
+		}, helpers.DefaultCleanUpTimeout)
+	})
+})

--- a/test/e2e/logexplorationapi/api/log_exploration_api_suite_test.go
+++ b/test/e2e/logexplorationapi/api/log_exploration_api_suite_test.go
@@ -1,0 +1,15 @@
+package api
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogExplorationApi(t *testing.T) {
+
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "LogExplorationApi Suite")
+}

--- a/test/e2e/logexplorationapi/cleanup.sh
+++ b/test/e2e/logexplorationapi/cleanup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../../../hack/testing-olm/utils"
+artifact_dir=$1
+GENERATOR_NS=$2
+runtime=$(date +%s)
+mkdir -p "$artifact_dir/$runtime" ||:
+gather_logging_resources "openshift-logging" "$artifact_dir" "$runtime"
+
+oc -n "$GENERATOR_NS" describe deployment/log-generator  > "$artifact_dir/$runtime/log-generator.describe" ||:
+oc -n "$GENERATOR_NS" logs deployment/log-generator  > "$artifact_dir/$runtime/log-generator.logs" ||:
+oc -n "$GENERATOR_NS" get deployment/log-generator -o yaml > "$artifact_dir/$runtime/log-generator.deployment.yaml" ||:
+oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=fluent-receiver -o name| sed 's/pod\///') -- cat /tmp/app-logs > "$artifact_dir/$runtime/fluent-receiver-app-logs" ||:

--- a/test/helpers/clusterlogging.go
+++ b/test/helpers/clusterlogging.go
@@ -16,6 +16,7 @@ const (
 	ComponentTypeStore         LogComponentType = "LogStore"
 	ComponentTypeVisualization LogComponentType = "Visualization"
 	ComponentTypeCollector     LogComponentType = "Collector"
+	ComponentLogAPI            LogComponentType = "Api"
 )
 
 func NewClusterLogging(componentTypes ...LogComponentType) *cl.ClusterLogging {

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -76,9 +76,10 @@ type E2ETestFramework struct {
 func NewE2ETestFramework() *E2ETestFramework {
 	client, config := NewKubeClient()
 	framework := &E2ETestFramework{
-		RestConfig: config,
-		KubeClient: client,
-		LogStores:  make(map[string]LogStore, 4),
+		RestConfig:     config,
+		KubeClient:     client,
+		LogStores:      make(map[string]LogStore, 4),
+		ClusterLogging: &cl.ClusterLogging{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"api-enabled": "true"}}},
 	}
 	return framework
 }
@@ -214,6 +215,8 @@ func (tc *E2ETestFramework) WaitFor(component LogComponentType) error {
 		return tc.waitForFluentDaemonSet(defaultRetryInterval, defaultTimeout)
 	case ComponentTypeStore:
 		return tc.waitForElasticsearchPods(defaultRetryInterval, defaultTimeout)
+	case ComponentLogAPI:
+		return tc.waitForDeployment(OpenshiftLoggingNS, "logexplorationapi", defaultRetryInterval, defaultTimeout)
 	}
 	return fmt.Errorf("Unable to waitfor unrecognized component: %v", component)
 }

--- a/test/helpers/log-exploration-api.go
+++ b/test/helpers/log-exploration-api.go
@@ -1,0 +1,218 @@
+package helpers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	clolog "github.com/ViaQ/logerr/log"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
+	"github.com/openshift/cluster-logging-operator/internal/k8shandler"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"log"
+	"strconv"
+	"time"
+)
+
+const maxLogsLimit = 5
+
+type logExplorationAPI struct {
+	deployment *apps.Deployment
+	service    *corev1.Service
+	tc         *E2ETestFramework
+}
+
+func (l *logExplorationAPI) ApplicationLogs(timeToWait time.Duration) (types.Logs, error) {
+	panic("implement me")
+}
+func (l *logExplorationAPI) HasApplicationLogs(timeToWait time.Duration) (bool, error) {
+
+	logs, err := l.getLogs()
+	if err != nil {
+		return false, err
+	}
+	if len(logs) <= 1 {
+		time.Sleep(180 * time.Second)
+		logs, err = l.getLogs()
+		if err == nil && len(logs) > 1 {
+			return true, nil
+		} else {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func (l *logExplorationAPI) getLogs() ([]interface{}, error) {
+	options := metav1.ListOptions{
+		LabelSelector: "component=elasticsearch",
+	}
+
+	pods, err := l.tc.KubeClient.CoreV1().Pods(OpenshiftLoggingNS).List(context.TODO(), options)
+	if err != nil {
+		return nil, err
+	}
+	if len(pods.Items) == 0 {
+		return nil, errors.New("No pods found for elasticsearch")
+	}
+	clolog.V(3).Info("Pod ", "PodName", pods.Items[0].Name)
+	stdout, err := l.tc.PodExec(OpenshiftLoggingNS, pods.Items[0].Name, "elasticsearch", []string{"curl", "http://logexplorationapi:8080/logs?maxlogs=" + strconv.Itoa(maxLogsLimit)})
+	if err != nil {
+		log.Println("error while fetching logs is: ", err)
+		return nil, err
+	}
+	var jsonObjs map[string]interface{}
+
+	err = json.Unmarshal([]byte(stdout), &jsonObjs)
+	if err != nil {
+		log.Println("cannot unmarshall the response body", err)
+		return nil, err
+	}
+	objSlice, ok := jsonObjs["Logs"].([]interface{})
+	if !ok {
+		log.Println("cannot convert the JSON objects", err)
+		return nil, err
+	}
+	return objSlice, nil
+}
+func (l *logExplorationAPI) HasInfraStructureLogs(timeToWait time.Duration) (bool, error) {
+	panic("implement me")
+}
+
+func (l *logExplorationAPI) HasAuditLogs(timeToWait time.Duration) (bool, error) {
+	panic("implement me")
+}
+
+func (l *logExplorationAPI) GrepLogs(expr string, timeToWait time.Duration) (string, error) {
+	panic("implement me")
+}
+
+func (l *logExplorationAPI) RetrieveLogs() (map[string]string, error) {
+	panic("implement me")
+}
+
+func (l *logExplorationAPI) ClusterLocalEndpoint() string {
+	panic("implement me")
+}
+
+func (tc *E2ETestFramework) DeleteLogExplorationAPI(api logExplorationAPI) error {
+	var zerograce int64
+	opts := metav1.DeleteOptions{
+		GracePeriodSeconds: &zerograce,
+	}
+	return tc.KubeClient.AppsV1().Deployments(OpenshiftLoggingNS).Delete(context.TODO(), api.deployment.Name, opts)
+}
+
+func (tc *E2ETestFramework) DeployLogExplorationAPI() (deployment *apps.Deployment, err error) {
+	logExploration := &logExplorationAPI{
+		tc: tc,
+	}
+	httpGetStructLivenessProbe := &corev1.HTTPGetAction{
+		Path: "/ready",
+		Port: intstr.FromInt(8080),
+	}
+	httpGetStructReadinessProbe := &corev1.HTTPGetAction{
+		Path: "/health",
+		Port: intstr.FromInt(8080),
+	}
+	handlerStructLivenessProbe := &corev1.Handler{
+		HTTPGet: httpGetStructLivenessProbe,
+	}
+	handlerStructReadinessProbe := &corev1.Handler{
+		HTTPGet: httpGetStructReadinessProbe,
+	}
+	container := corev1.Container{
+		Name:            "logexplorationapi",
+		Image:           "quay.io/openshift-logging/log-exploration-api:latest",
+		ImagePullPolicy: corev1.PullAlways,
+		Env: []corev1.EnvVar{
+			{Name: "ES_ADDR", Value: "https://elasticsearch.openshift-logging:9200"},
+			{Name: "ES_CERT", Value: "/etc/openshift/elasticsearch/secret/tls.crt"},
+			{Name: "ES_KEY", Value: "/etc/openshift/elasticsearch/secret/tls.key"},
+			{Name: "ES_TLS", Value: "true"},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "certificates", MountPath: "/etc/openshift/elasticsearch/secret"},
+		},
+
+		LivenessProbe: &corev1.Probe{
+			Handler:             *handlerStructLivenessProbe,
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       3,
+			FailureThreshold:    30,
+		},
+		ReadinessProbe: &corev1.Probe{
+			Handler:             *handlerStructReadinessProbe,
+			InitialDelaySeconds: 3,
+			PeriodSeconds:       3,
+		},
+	}
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{container},
+		Volumes: []corev1.Volume{
+			{Name: "certificates", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "fluentd", DefaultMode: utils.GetInt32(420)}}},
+		},
+	}
+	dOpts := metav1.CreateOptions{}
+	logExplorationApiDeployment := k8shandler.NewDeployment(
+		container.Name,
+		OpenshiftLoggingNS,
+		container.Name,
+		container.Name,
+		podSpec,
+	)
+	logExplorationApiDeployment, err = tc.KubeClient.AppsV1().Deployments(OpenshiftLoggingNS).Create(context.TODO(), logExplorationApiDeployment, dOpts)
+
+	if err != nil {
+		return nil, err
+	}
+	service := factory.NewService(
+		container.Name,
+		OpenshiftLoggingNS,
+		container.Name,
+		[]corev1.ServicePort{
+			{
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			},
+		},
+	)
+	tc.AddCleanup(func() error {
+		_, err := oc.Exec().
+			WithNamespace(OpenshiftLoggingNS).
+			WithPodGetter(oc.Get().
+				WithNamespace(OpenshiftLoggingNS).
+				Pod().
+				OutputJsonpath("{.items[0].metadata.name}")).
+			Container(container.Name).
+			Run()
+		return err
+	})
+	tc.AddCleanup(func() error {
+		var zerograce int64
+		opts := metav1.DeleteOptions{
+			GracePeriodSeconds: &zerograce,
+		}
+		return tc.KubeClient.AppsV1().Deployments(OpenshiftLoggingNS).Delete(context.TODO(), logExplorationApiDeployment.Name, opts)
+	})
+	sOpts := metav1.CreateOptions{}
+	service, err = tc.KubeClient.CoreV1().Services(OpenshiftLoggingNS).Create(context.TODO(), service, sOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	tc.AddCleanup(func() error {
+		opts := metav1.DeleteOptions{}
+		return tc.KubeClient.CoreV1().Services(OpenshiftLoggingNS).Delete(context.TODO(), service.Name, opts)
+	})
+	logExploration.deployment = logExplorationApiDeployment
+	logExploration.service = service
+	name := logExplorationApiDeployment.GetName()
+	tc.LogStores[name] = logExploration
+	return logExplorationApiDeployment, tc.waitForDeployment(OpenshiftLoggingNS, logExplorationApiDeployment.Name, defaultRetryInterval, defaultTimeout)
+}


### PR DESCRIPTION
### Description
This PR is to include a ServiceMonitor for the integration of the log-exploration-api into the cluster-logging-operator. 

/cc @jcantrill
/assign @igor-karpukhin

### Links
- Depending on PR(s): https://github.com/openshift/cluster-logging-operator/pull/1166
- JIRA: https://issues.redhat.com/browse/LOG-1686

