### PR TITLE
Fix bundle annotations for release 5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ LABEL \
         io.openshift.tags="openshift,logging" \
         com.redhat.delivery.appregistry="false" \
         maintainer="AOS Logging <aos-logging@redhat.com>" \
-        License="GPLv2+" \
+        License="Apache-2.0" \
         name="openshift-logging/cluster-logging-rhel8-operator" \
         com.redhat.component="cluster-logging-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -68,7 +68,7 @@ LABEL \
         io.openshift.tags="openshift,logging" \
         com.redhat.delivery.appregistry="false" \
         maintainer="AOS Logging <aos-logging@redhat.com>" \
-        License="GPLv2+" \
+        License="Apache-2.0" \
         name="openshift-logging/cluster-logging-rhel8-operator" \
         com.redhat.component="cluster-logging-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ test-unit: test-forwarder-generator
 test-cluster:
 	go test  -cover -race ./test/... -- -root=$(CURDIR)
 
-OPENSHIFT_VERSIONS?="v4.8"
+OPENSHIFT_VERSIONS?="v4.7"
 CHANNELS="stable,stable-${LOGGING_VERSION}"
 DEFAULT_CHANNEL="stable"
 generate-bundle: regenerate $(OPM)

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -3,7 +3,7 @@ FROM scratch
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=cluster-logging-operator
+LABEL operators.operatorframework.io.bundle.package.v1=cluster-logging
 LABEL operators.operatorframework.io.bundle.channels.v1=stable,stable-5.3
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-unknown
@@ -14,3 +14,16 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
+
+LABEL com.redhat.delivery.operator.bundle=true
+LABEL com.redhat.openshift.versions="v4.7"
+
+LABEL \
+    com.redhat.component="cluster-logging-operator" \
+    version="v1.1" \
+    name="cluster-logging-operator" \
+    License="ASL 2.0" \
+    io.k8s.display-name="cluster-logging-operator bundle" \
+    io.k8s.description="bundle for the cluster-logging-operator" \
+    summary="This is the bundle for the cluster-logging-operator" \
+    maintainer="AOS Logging <aos-logging@redhat.com>"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -22,7 +22,7 @@ LABEL \
     com.redhat.component="cluster-logging-operator" \
     version="v1.1" \
     name="cluster-logging-operator" \
-    License="ASL 2.0" \
+    License="Apache-2.0" \
     io.k8s.display-name="cluster-logging-operator bundle" \
     io.k8s.description="bundle for the cluster-logging-operator" \
     summary="This is the bundle for the cluster-logging-operator" \

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,10 +1,10 @@
 annotations:
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable,stable-5.2
+  operators.operatorframework.io.bundle.channels.v1: stable,stable-5.3
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: cluster-logging-operator
+  operators.operatorframework.io.bundle.package.v1: cluster-logging
   operators.operatorframework.io.metrics.builder: operator-sdk-unknown
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2

--- a/hack/generate-bundle.sh
+++ b/hack/generate-bundle.sh
@@ -17,7 +17,7 @@ LABEL \\
     com.redhat.component="cluster-logging-operator" \\
     version="v1.1" \\
     name="cluster-logging-operator" \\
-    License="ASL 2.0" \\
+    License="Apache-2.0" \\
     io.k8s.display-name="cluster-logging-operator bundle" \\
     io.k8s.description="bundle for the cluster-logging-operator" \\
     summary="This is the bundle for the cluster-logging-operator" \\


### PR DESCRIPTION
### Description
This PR provides a small fix to the bundle annotations for `release-5.3`, i.e. the channels are set to `stable,stable-5.3` and the package name to `cluster-logging`.

To address: https://issues.redhat.com/browse/LOG-1749

/cc @jcantrill 
/assign @jcantrill 