### PR TITLE
[release-5.1] LOG-1390: Allow optional pod_ip for eventrouter tests

### DIFF
--- a/test/functional/normalization/eventrouter_test.go
+++ b/test/functional/normalization/eventrouter_test.go
@@ -32,6 +32,7 @@ var _ = Describe("[Normalization] Fluentd normalization for EventRouter messages
 			ContainerImage:   "*",
 			ContainerImageID: "*",
 			PodID:            "*",
+			PodIP:            "**optional**",
 			Host:             "*",
 			MasterURL:        "*",
 			NamespaceID:      "*",


### PR DESCRIPTION
### Description
This PR:
* Makes pod_ip optional when doing message normalization check
* Required to unblock merge of https://github.com/openshift/origin-aggregated-logging/pull/2149


### Links
* https://issues.redhat.com/browse/LOG-1390