### PR TITLE
Add a 1s sleep between log line output to avoid flaky functional tests

### DIFF
--- a/test/functional/framework.go
+++ b/test/functional/framework.go
@@ -371,7 +371,7 @@ func (f *FluentdFunctionalFramework) WritesNApplicationLogsOfSize(numOfLogs, siz
 
 func (f *FluentdFunctionalFramework) WriteMessagesToLog(msg string, numOfLogs int, filename string) error {
 	logPath := filepath.Dir(filename)
-	cmd := fmt.Sprintf("bash -c 'mkdir -p %s;for n in {1..%d};do echo \"%s\" >> %s;done'", logPath, numOfLogs, msg, filename)
+	cmd := fmt.Sprintf("bash -c 'mkdir -p %s;for n in {1..%d};do echo \"%s\" >> %s;sleep 1s;done'", logPath, numOfLogs, msg, filename)
 	log.V(3).Info("Writing mesages to log with command", "cmd", cmd)
 	result, err := f.RunCommand(constants.FluentdName, "bash", "-c", cmd)
 	log.V(3).Info("FluentdFunctionalFramework.WriteMessagesToLog", "result", result, "err", err)


### PR DESCRIPTION
### Description

In release-5.1, add a 1s sleep between log lines to avoid flaky functional tests. This sleep is there on the release-5.2 and master branches. Functional test flakes on the release-5.1 branch interfere with https://github.com/openshift/origin-aggregated-logging/pull/2189

/cc @jcantrill 
/assign @vimalk78 

### Links
- JIRA:  https://issues.redhat.com/browse/LOG-1033
- PR: https://github.com/openshift/origin-aggregated-logging/pull/2189
