### PR TITLE
LOG-1033: <transport tls> Prometheus config for fluentd 1.14

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -91,11 +91,10 @@ var _ = Describe("Testing Complete Config Generation", func() {
 <source>
   @type prometheus
   bind "#{ENV['POD_IP']}"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -202,11 +202,10 @@ var _ = Describe("Generating fluentd config", func() {
 <source>
   @type prometheus
   bind "#{ENV['POD_IP']}"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>
@@ -982,11 +981,10 @@ var _ = Describe("Generating fluentd config", func() {
 <source>
   @type prometheus
   bind "#{ENV['POD_IP']}"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>
@@ -1747,11 +1745,10 @@ var _ = Describe("Generating fluentd config", func() {
 <source>
   @type prometheus
   bind "#{ENV['POD_IP']}"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>
@@ -2457,11 +2454,10 @@ var _ = Describe("Generating fluentd config", func() {
 <source>
   @type prometheus
   bind "#{ENV['POD_IP']}"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>
@@ -2929,11 +2925,10 @@ var _ = Describe("Generating fluentd config", func() {
 <source>
   @type prometheus
   bind "#{ENV['POD_IP']}"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>
@@ -4011,11 +4006,10 @@ inputs:
 <source>
   @type prometheus
   bind "#{ENV['POD_IP']}"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>

--- a/internal/generator/fluentd/prometheus.go
+++ b/internal/generator/fluentd/prometheus.go
@@ -13,11 +13,10 @@ const PrometheusMonitorTemplate = `
 <source>
   @type prometheus
   bind "#{ENV['POD_IP']}"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>

--- a/internal/generator/fluentd/sources_test.go
+++ b/internal/generator/fluentd/sources_test.go
@@ -492,11 +492,10 @@ var _ = Describe("Testing Config Generation", func() {
 <source>
   @type prometheus
   bind "#{ENV['POD_IP']}"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>


### PR DESCRIPTION
### Description
[LOG-1033](https://issues.redhat.com/browse/LOG-1033): Update fluentd to the latest version (1.14.1). Prometheus listener needs `<transport tls>` configuration to enable async HTTP server instead of Webrick. Otherwise, no functional changes.

/cc @jcantrill 
/assign @vimalk78 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1033
- GitHub: https://github.com/ViaQ/logging-fluentd/pull/22