### PR TITLE
LOG-1235: Fix output scheme to ES for https w/o secret

### DIFF
--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
@@ -183,9 +183,8 @@ func FlattenLabels(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o 
 func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 	// URL is parasable, checked at input sanitization
 	u, _ := url.Parse(o.URL)
-	conf := []Element{}
+	conf := append([]Element{}, TLS(url.IsTLSScheme(u.Scheme)))
 	if o.Secret != nil {
-		conf = append(conf, TLS(url.IsTLSScheme(u.Scheme)))
 		if security.HasUsernamePassword(secret) {
 			up := UserNamePass{
 				UsernamePath: security.SecretPath(o.Secret.Name, constants.ClientUsername),
@@ -206,8 +205,6 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 			}
 			conf = append(conf, ca)
 		}
-	} else {
-		conf = append(conf, TLS(false))
 	}
 	return conf
 }

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -386,6 +386,116 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
+		Entry("with https but without a secret", generator.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeElasticsearch,
+						Name: "es-1",
+						URL:  "https://es.svc.infra.cluster:9999",
+					},
+				},
+			},
+			Secrets: security.NoSecrets,
+			ExpectedConf: `
+<label @ES_1>
+  #remove structured field if present
+  <filter **>
+    @type record_modifier
+    remove_keys structured
+  </filter>
+  
+  #flatten labels to prevent field explosion in ES
+  <filter **>
+    @type record_transformer
+    enable_ruby true
+    <record>
+      kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+    </record>
+    remove_keys $.kubernetes.labels
+  </filter>
+  
+  <match retry_es_1>
+    @type elasticsearch
+    @id retry_es_1
+    host es.svc.infra.cluster
+    port 9999
+    verify_es_version_at_startup false
+    scheme https
+    ssl_version TLSv1_2
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    type_name _doc
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/retry_es_1'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+    </buffer>
+  </match>
+  
+  <match **>
+    @type elasticsearch
+    @id es_1
+    host es.svc.infra.cluster
+    port 9999
+    verify_es_version_at_startup false
+    scheme https
+    ssl_version TLSv1_2
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    type_name _doc
+    retry_tag retry_es_1
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/es_1'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+    </buffer>
+  </match>
+</label>
+`,
+		}),
 	)
 })
 

--- a/test/framework/functional/cluster_log_forwarder.go
+++ b/test/framework/functional/cluster_log_forwarder.go
@@ -67,7 +67,7 @@ func (p *PipelineBuilder) ToOutputWithVisitor(visit OutputSpecVisiter, outputNam
 			output = &logging.OutputSpec{
 				Name: logging.OutputTypeElasticsearch,
 				Type: logging.OutputTypeElasticsearch,
-				URL:  "https://0.0.0.0:9200",
+				URL:  "http://0.0.0.0:9200",
 			}
 		case logging.OutputTypeSyslog:
 			output = &logging.OutputSpec{


### PR DESCRIPTION
### Description
This PR:
* Fixes fluent conf generation to Elasticsearch when a secure scheme is defined without providing a secret

### Links
* https://issues.redhat.com/browse/LOG-1235
