### PR TITLE
LOG-1859: Continue to reconcile when cluster wide proxy is not enabled

### DIFF
--- a/internal/k8shandler/fluentd.go
+++ b/internal/k8shandler/fluentd.go
@@ -381,7 +381,8 @@ func (clusterRequest *ClusterLoggingRequest) getTrustedCABundleHash() (string, e
 	}
 
 	if _, ok := fluentdTrustBundle.Data[constants.TrustedCABundleKey]; !ok {
-		return "", fmt.Errorf("%v does not yet contain expected key %v", fluentdTrustBundle.Name, constants.TrustedCABundleKey)
+		log.V(1).Info("Cluster wide proxy may not be configured. ConfigMap does not contain expected key", "configmapName", fluentdTrustBundle.Name, "key", constants.TrustedCABundleKey)
+		return "", nil
 	}
 
 	trustedCAHashValue, err := calcTrustedCAHashValue(fluentdTrustBundle)
@@ -390,7 +391,8 @@ func (clusterRequest *ClusterLoggingRequest) getTrustedCABundleHash() (string, e
 	}
 
 	if trustedCAHashValue == "" {
-		return "", fmt.Errorf("Did not receive hashvalue for trusted CA value")
+		log.V(1).Info("Cluster wide proxy may not be configured. ConfigMap does not contain a ca bundle", "configmapName", fluentdTrustBundle.Name)
+		return "", nil
 	}
 
 	return trustedCAHashValue, nil

--- a/test/functional/outputs/multiple/forward_to_multiple_outputs_test.go
+++ b/test/functional/outputs/multiple/forward_to_multiple_outputs_test.go
@@ -39,7 +39,6 @@ var _ = Describe("[Functional][Outputs][Multiple]", func() {
 			})
 
 			It("should send logs to the fluentd receiver and elasticsearch", func() {
-				Expect(framework.WritesApplicationLogs(1)).To(BeNil())
 
 				logs, err := framework.ReadApplicationLogsFrom(loggingv1.OutputTypeFluentdForward)
 				Expect(err).To(BeNil(), "Expected no error reading logs from %s", loggingv1.OutputTypeFluentdForward)
@@ -63,7 +62,6 @@ var _ = Describe("[Functional][Outputs][Multiple]", func() {
 				Expect(framework.WritesApplicationLogs(1)).To(BeNil())
 			})
 			It("should send logs to the fluentd receiver only", func() {
-				Expect(framework.WritesApplicationLogs(1)).To(BeNil())
 				logs, err := framework.ReadApplicationLogsFrom(loggingv1.OutputTypeFluentdForward)
 				Expect(err).To(BeNil(), "Expected no error reading logs from %s", loggingv1.OutputTypeFluentdForward)
 				Expect(logs).To(HaveLen(1), "Exp. to receive a log message at output type %s", loggingv1.OutputTypeFluentdForward)


### PR DESCRIPTION
### Description
This PR fixes:
* Reconciliation of the collector when cluster wide proxy is not enabled
* No longer causes an early return when trusted CA configmap is missing a CA

### Links
https://issues.redhat.com/browse/LOG-1859
