### PR TITLE
Fix 'make generate' command after sdk upgrade

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,14 +1,24 @@
 FROM scratch
 
+# Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cluster-logging
 LABEL operators.operatorframework.io.bundle.channels.v1=stable,stable-5.3
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-unknown
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/
 
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.openshift.versions="v4.7"

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,7 +1,15 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable,stable-5.3
-  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: cluster-logging
+  operators.operatorframework.io.bundle.package.v1: cluster-logging-operator
+  operators.operatorframework.io.bundle.channels.v1: stable,stable-5.3
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-unknown
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -1,0 +1,10 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests: []
+storage:
+  spec:
+    mountPath: {}

--- a/hack/generate-crd.sh
+++ b/hack/generate-crd.sh
@@ -28,6 +28,12 @@ echo "--------------------------------------------------------------"
 $OPERATOR_SDK generate kustomize manifests -q
 	$KUSTOMIZE build config/manifests | $OPERATOR_SDK generate bundle -q --overwrite --version ${BUNDLE_VERSION} ${BUNDLE_METADATA_OPTS}
 rm ${BUNDLE_DIR}/cluster-logging-operator.clusterserviceversion.yaml
+#NOTE: temporary cleanup few generated files until 'make lint' will not respect those files
+rm ${BUNDLE_DIR}/clusterlogging-operator_rbac.authorization.k8s.io_v1_clusterrole.yaml
+rm ${BUNDLE_DIR}/leader-election-role_rbac.authorization.k8s.io_v1_role.yaml
+rm ${BUNDLE_DIR}/leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+rm ${BUNDLE_DIR}/manager-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+
 mv ${BUNDLE_DIR}/logging.openshift.io_clusterlogforwarders.yaml ${BUNDLE_DIR}/${CLF_CRD_FILE}
 mv ${BUNDLE_DIR}/logging.openshift.io_clusterloggings.yaml ${BUNDLE_DIR}/${CLO_CRD_FILE}
 


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description

- temporary cleanup few generated files until `make lint` will not respect those files
- add `bundle/tests/scorecard/config.yaml`
 
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @vimalk78 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
