### PR TITLE
Bump slow spec threshold for e2e tests to cleanup logs

### DIFF
--- a/hack/testing-olm/test-030-collection.sh
+++ b/hack/testing-olm/test-030-collection.sh
@@ -50,7 +50,7 @@ for dir in $(ls -d $TEST_DIR); do
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/collection/cleanup.sh $artifact_dir $GENERATOR_NS" \
     artifact_dir=$artifact_dir \
     GENERATOR_NS=$GENERATOR_NS \
-    go test -count=1 -parallel=1 -timeout=60m "$dir" -ginkgo.noColor -ginkgo.trace | tee -a "$artifact_dir/test.log" ; then
+    go test -count=1 -parallel=1 -timeout=60m "$dir" -ginkgo.noColor -ginkgo.trace -ginkgo.slowSpecThreshold=300.0 | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "Collection $dir passed"
     os::log::info "======================================================="

--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -62,7 +62,7 @@ for dir in $(ls -d $TEST_DIR); do
     artifact_dir=$artifact_dir \
     GENERATOR_NS=$GENERATOR_NS \
     SUCCESS_TIMEOUT=10m \
-    go test -count=1 -parallel=1 -timeout=90m "$dir" -ginkgo.noColor -ginkgo.trace | tee -a "$artifact_dir/test.log" ; then
+    go test -count=1 -parallel=1 -timeout=90m "$dir" -ginkgo.noColor -ginkgo.trace -ginkgo.slowSpecThreshold=300.0 | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "Logforwarding $dir passed"
     os::log::info "======================================================="


### PR DESCRIPTION
### Description
This PR bumps the slow threshold warning so successful, long running e2e test do not pollute the test run with unnecessary log information
```
• [SLOW TEST:195.994 seconds]
[Collection] Namespace filtering
/go/src/github.com/openshift/cluster-logging-operator/test/e2e/collection/fluentd/namespace_filtering_test.go:20
  should send logs from one namespace only
  /go/src/github.com/openshift/cluster-logging-operator/test/e2e/collection/fluentd/namespace_filtering_test.go:97
```
