### PR TITLE
LOG-1918: Fix the collector alert job name

### DIFF
--- a/files/fluentd/fluentd_prometheus_alerts.yaml
+++ b/files/fluentd/fluentd_prometheus_alerts.yaml
@@ -6,7 +6,7 @@
       "message": "Prometheus could not scrape fluentd {{ $labels.instance }} for more than 10m."
       "summary": "Fluentd cannot be scraped"
     "expr": |
-      absent(up{job="fluentd"} == 1)
+      absent(up{job="collector"} == 1)
     "for": "10m"
     "labels":
       "service": "fluentd"


### PR DESCRIPTION
### Description
This PR:
* Fixes the job name for the prometheus alert

/assign @periklis 
cc @anpingli 

### Links
https://issues.redhat.com/browse/LOG-1918
