### PR TITLE
LOG-1491:Adding support for elastic-search as output in vector conf generator

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -169,7 +169,7 @@ route.infra = 'starts_with!(.kubernetes.pod_namespace,"kube") || starts_with!(.k
 type = "remap"
 inputs = ["route_container_logs.app"]
 source = """
-.
+.log_type = "app"
 """
 
 
@@ -178,7 +178,7 @@ source = """
 type = "remap"
 inputs = ["route_container_logs.infra","journal_logs"]
 source = """
-.
+.log_type = "infra"
 """
 
 
@@ -187,7 +187,7 @@ source = """
 type = "remap"
 inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs"]
 source = """
-.
+.log_type = "audit"
 """
 
 
@@ -215,6 +215,175 @@ key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"
 enabled = true
+`,
+		}),
+		Entry("with complex spec for elastic-search", generator.ConfGenerateTest{
+			CLSpec: logging.ClusterLoggingSpec{
+				Forwarder: &logging.ForwarderSpec{},
+			},
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Pipelines: []logging.PipelineSpec{
+					{
+						InputRefs: []string{
+							logging.InputNameApplication,
+							logging.InputNameInfrastructure,
+							logging.InputNameAudit},
+						OutputRefs: []string{"elastic-search"},
+						Name:       "pipeline",
+					},
+				},
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeElasticsearch,
+						Name: "elastic-search",
+						URL:  "https://es.svc.messaging.cluster.local:9200",
+						Secret: &logging.OutputSecretSpec{
+							Name: "secret",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"elastic-search": {
+					Data: map[string][]byte{
+						"tls.key":       []byte("junk"),
+						"tls.crt":       []byte("junk"),
+						"ca-bundle.crt": []byte("junk"),
+					},
+				},
+			},
+			ExpectedConf: `
+# Logs from containers (including openshift containers)
+[sources.raw_container_logs]
+type = "kubernetes_logs"
+auto_partial_merge = true
+exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
+
+[sources.raw_journal_logs]
+type = "journald"
+
+# Logs from host audit
+[sources.host_audit_logs]
+type = "file"
+ignore_older_secs = 600
+include = ["/var/log/audit/audit.log"]
+
+# Logs from kubernetes audit
+[sources.k8s_audit_logs]
+type = "file"
+ignore_older_secs = 600
+include = ["/var/log/kube-apiserver/audit.log"]
+
+# Logs from openshift audit
+[sources.openshift_audit_logs]
+type = "file"
+ignore_older_secs = 600
+include = ["/var/log/oauth-apiserver.audit.log"]
+
+[transforms.container_logs]
+type = "remap"
+inputs = ["raw_container_logs"]
+source = '''
+  level = "unknown"
+  if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
+	level = "warn"
+  } else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
+	level = "info"
+  } else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
+	level = "error"
+  } else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
+	level = "debug"
+  }
+  .level = level
+
+  .pipeline_metadata.collector.name = "vector"
+  .pipeline_metadata.collector.version = "0.14.1"
+  ip4, err = get_env_var("NODE_IPV4")
+  .pipeline_metadata.collector.ipaddr4 = ip4
+  received, err = format_timestamp(now(),"%+")
+  .pipeline_metadata.collector.received_at = received
+  .pipeline_metadata.collector.error = err
+ '''
+
+[transforms.journal_logs]
+type = "remap"
+inputs = ["raw_journal_logs"]
+source = '''
+  level = "unknown"
+  if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
+	level = "warn"
+  } else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
+	level = "info"
+  } else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
+	level = "error"
+  } else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
+	level = "debug"
+  }
+  .level = level
+
+  .pipeline_metadata.collector.name = "vector"
+  .pipeline_metadata.collector.version = "0.14.1"
+  ip4, err = get_env_var("NODE_IPV4")
+  .pipeline_metadata.collector.ipaddr4 = ip4
+  received, err = format_timestamp(now(),"%+")
+  .pipeline_metadata.collector.received_at = received
+  .pipeline_metadata.collector.error = err
+ '''
+
+
+[transforms.route_container_logs]
+type = "route"
+inputs = ["container_logs"]
+route.app = '!(starts_with!(.kubernetes.pod_namespace,"kube") && starts_with!(.kubernetes.pod_namespace,"openshift") && .kubernetes.pod_namespace == "default")'
+route.infra = 'starts_with!(.kubernetes.pod_namespace,"kube") || starts_with!(.kubernetes.pod_namespace,"openshift") || .kubernetes.pod_namespace == "default"'
+
+
+# Rename log stream to "application"
+[transforms.application]
+type = "remap"
+inputs = ["route_container_logs.app"]
+source = """
+.log_type = "app"
+"""
+
+
+# Rename log stream to "infrastructure"
+[transforms.infrastructure]
+type = "remap"
+inputs = ["route_container_logs.infra","journal_logs"]
+source = """
+.log_type = "infra"
+"""
+
+
+# Rename log stream to "audit"
+[transforms.audit]
+type = "remap"
+inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs"]
+source = """
+.log_type = "audit"
+"""
+
+
+[transforms.pipeline]
+type = "remap"
+inputs = ["application","infrastructure","audit"]
+source = """
+.
+"""
+
+[sinks.elastic_search]
+type = "elasticsearch"
+inputs = ["pipeline"]
+endpoint = "https://es.svc.messaging.cluster.local:9200"
+index = "{{ log_type }}-write"
+request.timeout_secs = 2147483648
+bulk_action = "create"
+# TLS Config
+[sinks.elastic_search.tls]
+key_file = "/var/run/ocp-collector/secrets/secret/tls.key"
+crt_file = "/var/run/ocp-collector/secrets/secret/tls.crt"
+ca_file = "/var/run/ocp-collector/secrets/secret/ca-bundle.crt"
 `,
 		}),
 	)

--- a/internal/generator/vector/helpers/helpers.go
+++ b/internal/generator/vector/helpers/helpers.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+var Replacer = strings.NewReplacer(" ", "_", "-", "_", ".", "_")
+
 func MakeInputs(in ...string) string {
 	out := make([]string, len(in))
 	for i, o := range in {

--- a/internal/generator/vector/inputs_to_pipeline.go
+++ b/internal/generator/vector/inputs_to_pipeline.go
@@ -13,7 +13,7 @@ func InputsToPipelines(spec *logging.ClusterLogForwarderSpec, op generator.Optio
 		r := Remap{
 			ComponentID: p.Name,
 			Inputs:      helpers.MakeInputs(p.InputRefs...),
-			VRL:         PassThrough,
+			VRL:         SrcPassThrough,
 		}
 		el = append(el, r)
 

--- a/internal/generator/vector/output/elasticsearch/basic.go
+++ b/internal/generator/vector/output/elasticsearch/basic.go
@@ -1,0 +1,19 @@
+package elasticsearch
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+)
+
+type BasicAuthConf generator.ConfLiteral
+
+func (t BasicAuthConf) Name() string {
+	return "elasticsearchBasicAuthConf"
+}
+
+func (t BasicAuthConf) Template() string {
+	return `
+{{define "elasticsearchBasicAuthConf" -}}
+# {{.Desc}}
+[sinks.{{.ComponentID}}.auth]
+{{- end}}`
+}

--- a/internal/generator/vector/output/elasticsearch/ca-file.go
+++ b/internal/generator/vector/output/elasticsearch/ca-file.go
@@ -1,0 +1,18 @@
+package elasticsearch
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
+)
+
+type CAFile security.CAFile
+
+func (ca CAFile) Name() string {
+	return "elasticsearchCAFileTemplate"
+}
+
+func (ca CAFile) Template() string {
+	return `{{define "` + ca.Name() + `" -}}
+ca_file = {{.CAFilePath}}
+{{- end}}
+`
+}

--- a/internal/generator/vector/output/elasticsearch/cert-key.go
+++ b/internal/generator/vector/output/elasticsearch/cert-key.go
@@ -1,0 +1,18 @@
+package elasticsearch
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
+)
+
+type TLSKeyCert security.TLSCertKey
+
+func (kc TLSKeyCert) Name() string {
+	return "elasticsearchCertKeyTemplate"
+}
+
+func (kc TLSKeyCert) Template() string {
+	return `{{define "` + kc.Name() + `" -}}
+key_file = {{.KeyPath}}
+crt_file = {{.CertPath}}
+{{- end}}`
+}

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -1,0 +1,118 @@
+package elasticsearch
+
+import (
+	"strings"
+
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	. "github.com/openshift/cluster-logging-operator/internal/generator"
+	vectorhelpers "github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Elasticsearch struct {
+	ID_Key      string
+	Desc        string
+	ComponentID string
+	Inputs      string
+	Index       string
+	Endpoint    string
+}
+
+func (e Elasticsearch) Name() string {
+	return "elasticsearchTemplate"
+}
+
+func (e Elasticsearch) Template() string {
+	return `{{define "` + e.Name() + `" -}}
+
+[sinks.{{.ComponentID}}]
+type = "elasticsearch"
+inputs = {{.Inputs}}
+endpoint = "{{.Endpoint}}"
+index = "{{ "{{ log_type }}-write" }}"
+request.timeout_secs = 2147483648
+bulk_action = "create"
+{{- end}}
+`
+}
+
+func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
+	outputs := []Element{}
+
+	outputs = MergeElements(outputs,
+		[]Element{
+			Output(o, inputs, secret, op),
+		},
+		TLSConf(o, secret),
+		BasicAuth(o, secret),
+	)
+
+	return outputs
+}
+
+func Output(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) Element {
+
+	return Elasticsearch{
+		ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
+		Endpoint:    o.URL,
+		Inputs:      vectorhelpers.MakeInputs(inputs...),
+	}
+}
+
+func TLSConf(o logging.OutputSpec, secret *corev1.Secret) []Element {
+	conf := []Element{}
+	if o.Secret != nil {
+		hasTLS := false
+		conf = append(conf, security.TLSConf{
+			Desc:        "TLS Config",
+			ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
+		})
+
+		if o.Name == logging.OutputNameDefault || security.HasTLSCertAndKey(secret) {
+			hasTLS = true
+			kc := TLSKeyCert{
+				CertPath: security.SecretPath(o.Secret.Name, constants.ClientCertKey),
+				KeyPath:  security.SecretPath(o.Secret.Name, constants.ClientPrivateKey),
+			}
+			conf = append(conf, kc)
+		}
+		if o.Name == logging.OutputNameDefault || security.HasCABundle(secret) {
+			hasTLS = true
+			ca := CAFile{
+				CAFilePath: security.SecretPath(o.Secret.Name, constants.TrustedCABundleKey),
+			}
+			conf = append(conf, ca)
+		}
+		if !hasTLS {
+			return []Element{}
+		}
+	}
+	return conf
+}
+
+func BasicAuth(o logging.OutputSpec, secret *corev1.Secret) []Element {
+	conf := []Element{}
+
+	if o.Secret != nil {
+		hasBasicAuth := false
+		conf = append(conf, BasicAuthConf{
+			Desc:        "Basic Auth Config",
+			ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
+		})
+		if security.HasUsernamePassword(secret) {
+			hasBasicAuth = true
+			up := UserNamePass{
+				UsernamePath: security.SecretPath(o.Secret.Name, constants.ClientUsername),
+				PasswordPath: security.SecretPath(o.Secret.Name, constants.ClientPassword),
+			}
+			conf = append(conf, up)
+		}
+		if !hasBasicAuth {
+			return []Element{}
+		}
+	}
+
+	return conf
+}

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -1,0 +1,123 @@
+package elasticsearch
+
+import (
+	"testing"
+
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Generate Vector config", func() {
+	inputPipeline := []string{"application"}
+	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
+		return Conf(clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], generator.NoOptions)
+	}
+	DescribeTable("For Elasticsearch output", generator.TestGenerateConfWith(f),
+		Entry("with username,password", generator.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeElasticsearch,
+						Name: "es-1",
+						URL:  "https://es.svc.infra.cluster:9200",
+						Secret: &logging.OutputSecretSpec{
+							Name: "es-1",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"es-1": {
+					Data: map[string][]byte{
+						"username": []byte("junk"),
+						"password": []byte("junk"),
+					},
+				},
+			},
+			ExpectedConf: `
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["application"]
+endpoint = "https://es.svc.infra.cluster:9200"
+index = "{{ log_type }}-write"
+request.timeout_secs = 2147483648
+bulk_action = "create"
+# Basic Auth Config
+[sinks.es_1.auth]
+strategy = "basic"
+user = ""
+password = ""
+`,
+		}),
+		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeElasticsearch,
+						Name: "es-1",
+						URL:  "https://es.svc.infra.cluster:9200",
+						Secret: &logging.OutputSecretSpec{
+							Name: "es-1",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"es-1": {
+					Data: map[string][]byte{
+						"tls.key":       []byte("junk"),
+						"tls.crt":       []byte("junk"),
+						"ca-bundle.crt": []byte("junk"),
+					},
+				},
+			},
+			ExpectedConf: `
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["application"]
+endpoint = "https://es.svc.infra.cluster:9200"
+index = "{{ log_type }}-write"
+request.timeout_secs = 2147483648
+bulk_action = "create"
+# TLS Config
+[sinks.es_1.tls]
+key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
+crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
+ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
+`,
+		}),
+		Entry("without security", generator.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type:   logging.OutputTypeElasticsearch,
+						Name:   "es-1",
+						URL:    "http://es.svc.infra.cluster:9200",
+						Secret: nil,
+					},
+				},
+			},
+			Secrets: security.NoSecrets,
+			ExpectedConf: `
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["application"]
+endpoint = "http://es.svc.infra.cluster:9200"
+index = "{{ log_type }}-write"
+request.timeout_secs = 2147483648
+bulk_action = "create"
+`,
+		}),
+	)
+})
+
+func TestVectorConfGenerator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Vector Conf Generation")
+}

--- a/internal/generator/vector/output/elasticsearch/output_conf_es_test.go
+++ b/internal/generator/vector/output/elasticsearch/output_conf_es_test.go
@@ -1,0 +1,96 @@
+package elasticsearch_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/elasticsearch"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Generating vector config blocks", func() {
+
+	var (
+		outputs  []logging.OutputSpec
+		pipeline logging.PipelineSpec
+		clfspec  logging.ClusterLogForwarderSpec
+		g        generator.Generator
+		secrets  map[string]*corev1.Secret
+	)
+	BeforeEach(func() {
+		g = generator.MakeGenerator()
+	})
+
+	Context("for a secure endpoint", func() {
+		BeforeEach(func() {
+			outputs = []logging.OutputSpec{
+				{
+					Type: logging.OutputTypeElasticsearch,
+					Name: "oncluster-elasticsearch",
+					URL:  "https://es.svc.messaging.cluster.local:9200",
+					Secret: &logging.OutputSecretSpec{
+						Name: "my-es-secret",
+					},
+				},
+			}
+			pipeline = logging.PipelineSpec{
+				Name:       "my-secure-pipeline",
+				InputRefs:  []string{logging.InputNameApplication},
+				OutputRefs: []string{"oncluster-elasticsearch"},
+			}
+			secrets = map[string]*corev1.Secret{
+				"oncluster-elasticsearch": {
+					ObjectMeta: v1.ObjectMeta{
+						Name: "my-es-secret",
+					},
+					Data: map[string][]byte{
+						"tls.key":       []byte("test-key"),
+						"tls.crt":       []byte("test-crt"),
+						"ca-bundle.crt": []byte("test-bundle"),
+					},
+				},
+			}
+		})
+
+		It("should produce well formed configuration with input application and output as elastic search", func() {
+			inputPipeline := []string{"application"}
+			clfspec.Pipelines = []logging.PipelineSpec{pipeline}
+			clfspec.Outputs = outputs
+			g := generator.MakeGenerator()
+			e := elasticsearch.Conf(clfspec.Outputs[0], inputPipeline, nil, generator.NoOptions)
+			results, err := g.GenerateConf(e...)
+			Expect(err).To(BeNil())
+			Expect(results).To(EqualTrimLines(`
+    [sinks.oncluster_elasticsearch]
+    type = "elasticsearch"
+    inputs = ["application"]
+    endpoint = "https://es.svc.messaging.cluster.local:9200"
+    index = "{{ log_type }}-write"
+    request.timeout_secs = 2147483648
+    bulk_action = "create"
+`))
+		})
+		It("should produce well formed output label config with username/password", func() {
+			inputPipeline := []string{"application"}
+			results, err := g.GenerateConf(elasticsearch.Conf(outputs[0], inputPipeline, secrets[outputs[0].Name], nil)...)
+			Expect(err).To(BeNil())
+			Expect(results).To(EqualTrimLines(`
+  [sinks.oncluster_elasticsearch]
+  type = "elasticsearch"
+  inputs = ["application"]
+  endpoint = "https://es.svc.messaging.cluster.local:9200"
+  index = "{{ log_type }}-write"
+  request.timeout_secs = 2147483648
+  bulk_action = "create"
+  # TLS Config
+  [sinks.oncluster_elasticsearch.tls]
+  key_file = "/var/run/ocp-collector/secrets/my-es-secret/tls.key"
+  crt_file = "/var/run/ocp-collector/secrets/my-es-secret/tls.crt"
+  ca_file = "/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt"
+`))
+		})
+	})
+})

--- a/internal/generator/vector/output/elasticsearch/userpass.go
+++ b/internal/generator/vector/output/elasticsearch/userpass.go
@@ -1,0 +1,20 @@
+package elasticsearch
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
+)
+
+type UserNamePass security.UserNamePass
+
+func (up UserNamePass) Name() string {
+	return "elasticsearchUsernamePasswordTemplate"
+}
+
+func (up UserNamePass) Template() string {
+	return `{{define "` + up.Name() + `" -}}
+strategy = "basic"
+user = ""
+password = ""
+{{- end}}
+`
+}

--- a/internal/generator/vector/outputs.go
+++ b/internal/generator/vector/outputs.go
@@ -3,6 +3,7 @@ package vector
 import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/elasticsearch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/kafka"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -10,11 +11,15 @@ import (
 func Outputs(clspec *logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 	outputs := []generator.Element{}
 	route := PipelineToOutputs(clfspec, op)
+
 	for _, o := range clfspec.Outputs {
 		secret := secrets[o.Name]
 		inputs := route[o.Name].List()
-		if o.Type == logging.OutputTypeKafka {
+		switch o.Type {
+		case logging.OutputTypeKafka:
 			outputs = generator.MergeElements(outputs, kafka.Conf(o, inputs, secret, op))
+		case logging.OutputTypeElasticsearch:
+			outputs = generator.MergeElements(outputs, elasticsearch.Conf(o, inputs, secret, op))
 		}
 	}
 	return outputs

--- a/internal/generator/vector/sources_to_inputs.go
+++ b/internal/generator/vector/sources_to_inputs.go
@@ -11,7 +11,10 @@ const (
 	AppContainerLogsExpr   = `'!(starts_with!(.kubernetes.pod_namespace,"kube") && starts_with!(.kubernetes.pod_namespace,"openshift") && .kubernetes.pod_namespace == "default")'`
 	InfraContainerLogsExpr = `'starts_with!(.kubernetes.pod_namespace,"kube") || starts_with!(.kubernetes.pod_namespace,"openshift") || .kubernetes.pod_namespace == "default"'`
 
-	PassThrough = "."
+	SrcPassThrough  = "."
+	AddLogTypeApp   = ".log_type = \"app\""
+	AddLogTypeInfra = ".log_type = \"infra\""
+	AddLogTypeAudit = ".log_type = \"audit\""
 )
 
 var (
@@ -46,7 +49,7 @@ func SourcesToInputs(spec *logging.ClusterLogForwarderSpec, o generator.Options)
 			Desc:        `Rename log stream to "application"`,
 			ComponentID: "application",
 			Inputs:      helpers.MakeInputs("route_container_logs.app"),
-			VRL:         PassThrough,
+			VRL:         AddLogTypeApp,
 		}
 		el = append(el, r)
 	}
@@ -55,7 +58,7 @@ func SourcesToInputs(spec *logging.ClusterLogForwarderSpec, o generator.Options)
 			Desc:        `Rename log stream to "infrastructure"`,
 			ComponentID: "infrastructure",
 			Inputs:      helpers.MakeInputs("route_container_logs.infra", InputJournalLogs),
-			VRL:         PassThrough,
+			VRL:         AddLogTypeInfra,
 		}
 		el = append(el, r)
 	}
@@ -64,7 +67,7 @@ func SourcesToInputs(spec *logging.ClusterLogForwarderSpec, o generator.Options)
 			Desc:        `Rename log stream to "audit"`,
 			ComponentID: "audit",
 			Inputs:      helpers.MakeInputs("host_audit_logs", "k8s_audit_logs", "openshift_audit_logs"),
-			VRL:         PassThrough,
+			VRL:         AddLogTypeAudit,
 		}
 		el = append(el, r)
 	}


### PR DESCRIPTION
### Description
This PR generates configuration for vector log collector.

/cc @vimalk78 
/assign @jcantrill 

- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-1491
- Enhancement proposal:

Added support for elastic search as output. 
Sample conf:
```
# Logs from containers (including openshift containers)
[sources.raw_container_logs]
type = "kubernetes_logs"
auto_partial_merge = true
exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]

[sources.raw_journal_logs]
type = "journald"

# Logs from host audit
[sources.host_audit_logs]
type = "file"
ignore_older_secs = 600
include = ["/var/log/audit/audit.log"]

# Logs from kubernetes audit
[sources.k8s_audit_logs]
type = "file"
ignore_older_secs = 600
include = ["/var/log/kube-apiserver/audit.log"]

# Logs from openshift audit
[sources.openshift_audit_logs]
type = "file"
ignore_older_secs = 600
include = ["/var/log/oauth-apiserver.audit.log"]

[transforms.container_logs]
type = "remap"
inputs = ["raw_container_logs"]
source = '''
  level = "unknown"
  if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
	level = "warn"
  } else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
	level = "info"
  } else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
	level = "error"
  } else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
	level = "debug"
  }
  .level = level

  .pipeline_metadata.collector.name = "vector"
  .pipeline_metadata.collector.version = "0.14.1"
  ip4, err = get_env_var("NODE_IPV4")
  .pipeline_metadata.collector.ipaddr4 = ip4
  received, err = format_timestamp(now(),"%+")
  .pipeline_metadata.collector.received_at = received
  .pipeline_metadata.collector.error = err
 '''

[transforms.journal_logs]
type = "remap"
inputs = ["raw_journal_logs"]
source = '''
  level = "unknown"
  if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
	level = "warn"
  } else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
	level = "info"
  } else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
	level = "error"
  } else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
	level = "debug"
  }
  .level = level

  .pipeline_metadata.collector.name = "vector"
  .pipeline_metadata.collector.version = "0.14.1"
  ip4, err = get_env_var("NODE_IPV4")
  .pipeline_metadata.collector.ipaddr4 = ip4
  received, err = format_timestamp(now(),"%+")
  .pipeline_metadata.collector.received_at = received
  .pipeline_metadata.collector.error = err
 '''


[transforms.route_container_logs]
type = "route"
inputs = ["container_logs"]
route.app = '!(starts_with!(.kubernetes.pod_namespace,"kube") && starts_with!(.kubernetes.pod_namespace,"openshift") && .kubernetes.pod_namespace == "default")'
route.infra = 'starts_with!(.kubernetes.pod_namespace,"kube") || starts_with!(.kubernetes.pod_namespace,"openshift") || .kubernetes.pod_namespace == "default"'


# Rename log stream to "application"
[transforms.application]
type = "remap"
inputs = ["route_container_logs.app"]
source = """
.log_type = "app"
"""


# Rename log stream to "infrastructure"
[transforms.infrastructure]
type = "remap"
inputs = ["route_container_logs.infra","journal_logs"]
source = """
.log_type = "infra"
"""


# Rename log stream to "audit"
[transforms.audit]
type = "remap"
inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs"]
source = """
.log_type = "audit"
"""


[transforms.pipeline]
type = "remap"
inputs = ["application","infrastructure","audit"]
source = """
.
"""

[sinks.elastic_search]
type = "elasticsearch"
inputs = ["pipeline"]
endpoint = "https://es.svc.messaging.cluster.local:9200"
index = "{{ log_type }}-write"
request.timeout_secs = 2147483648
bulk_action = "create"
# TLS Config
[sinks.elastic_search.tls]
key_file = "/var/run/ocp-collector/secrets/secret/tls.key"
crt_file = "/var/run/ocp-collector/secrets/secret/tls.crt"
ca_file = "/var/run/ocp-collector/secrets/secret/ca-bundle.crt"
```