### PR TITLE
Makefile: tag images with branch name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ export GO111MODULE=on
 export GODEBUG=x509ignoreCN=0
 
 export APP_NAME=cluster-logging-operator
-export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(APP_NAME):latest
+export CURRENT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(APP_NAME):$(CURRENT_BRANCH)
 
 export LOGGING_VERSION?=$(shell basename $(shell ls -d manifests/[0-9]*))
 export NAMESPACE?=openshift-logging
@@ -146,14 +147,14 @@ deploy-image: image
 deploy:  deploy-image deploy-elasticsearch-operator deploy-catalog install
 
 install:
-	IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc:5000/openshift/origin-cluster-logging-operator:latest \
+	IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc:5000/openshift/origin-cluster-logging-operator:$(CURRENT_BRANCH) \
 	$(MAKE) cluster-logging-operator-install
 
-deploy-catalog:
-	LOCAL_IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=127.0.0.1:5000/openshift/cluster-logging-operator-registry \
+deploy-catalog: .target
+	LOCAL_IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=127.0.0.1:5000/openshift/cluster-logging-operator-registry:$(CURRENT_BRANCH) \
 	$(MAKE) cluster-logging-catalog-build
-	IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=image-registry.openshift-image-registry.svc:5000/openshift/cluster-logging-operator-registry \
-	IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc:5000/openshift/origin-cluster-logging-operator:latest \
+	IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=image-registry.openshift-image-registry.svc:5000/openshift/cluster-logging-operator-registry:$(CURRENT_BRANCH) \
+	IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc:5000/openshift/origin-cluster-logging-operator:$(CURRENT_BRANCH) \
 	$(MAKE) cluster-logging-catalog-deploy
 
 deploy-elasticsearch-operator:
@@ -204,8 +205,8 @@ test-e2e-olm: $(JUNITREPORT)
 test-e2e-local: $(JUNITREPORT) deploy-image
 	CLF_INCLUDES=$(CLF_TEST_INCLUDES) \
 	INCLUDES=$(E2E_TEST_INCLUDES) \
-	IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc:5000/openshift/origin-cluster-logging-operator:latest \
-	IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=image-registry.openshift-image-registry.svc:5000/openshift/cluster-logging-operator-registry:latest \
+	IMAGE_CLUSTER_LOGGING_OPERATOR=image-registry.openshift-image-registry.svc:5000/openshift/origin-cluster-logging-operator:$(CURRENT_BRANCH) \
+	IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY=image-registry.openshift-image-registry.svc:5000/openshift/cluster-logging-operator-registry:$(CURRENT_BRANCH) \
 	hack/test-e2e-olm.sh
 
 test-svt:

--- a/olm_deploy/operatorregistry/registry-deployment.yaml
+++ b/olm_deploy/operatorregistry/registry-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       initContainers:
       - name: mutate-csv-and-generate-sqlite-db
         image: ${IMAGE_CLUSTER_LOGGING_OPERATOR_REGISTRY}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         command:
         - sh
         args:


### PR DESCRIPTION
### Description
For local development and debugging, many times it is needed to deploy logging from different branches to compare a feature across branches, and need to switch back again. Since the images are tagged `latest`, the same image pull spec cannot be used across branches even though the image has been pushed to cluster.

This PR attempts to tag the images in the cluster with branch name so that images in cluster do not get overwritten.

```
# do testing/debugging on 5.3
> git checkout release-5.3
> make deploy


# delete the deployments
> oc delete ns openshift-logging openshift-operators-redhat

# do testing/debugging on master
> git checkout master
> make deploy

# now cluster has two CLO images tagged 
$ oc -n openshift get is/origin-cluster-logging-operator -o jsonpath='{.status.tags[*].tag}' 
master release-5.3

# delete the deployments
> oc delete ns openshift-logging openshift-operators-redhat

# easily switch back to release-5.3, without building and pushing image to cluster again
> git checkout release-5.3
> make deploy-catalog
> make install

# now cluster has logging deployed from release-5.3

```

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign one approver from top-level OWNERS file -->

/cherry-pick release-5.3

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
