### PR TITLE
LOG-2027: Move SA constructor to use runtime package

### DIFF
--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -3,6 +3,7 @@ package k8shandler
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"io/ioutil"
 	"os"
 	"path"
@@ -147,7 +148,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 			}
 		}
 	} else {
-		if err = clusterRequest.RemoveServiceAccount("logcollector"); err != nil {
+		if err = clusterRequest.RemoveServiceAccount(constants.CollectorServiceAccountName); err != nil {
 			return
 		}
 
@@ -542,7 +543,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateCollectorServiceAccou
 
 	cluster := clusterRequest.Cluster
 
-	collectorServiceAccount := NewServiceAccount(constants.CollectorServiceAccountName, cluster.Namespace)
+	collectorServiceAccount := runtime.NewServiceAccount(clusterRequest.Cluster.Namespace, constants.CollectorServiceAccountName)
 
 	utils.AddOwnerRefToObject(collectorServiceAccount, utils.AsOwner(clusterRequest.Cluster))
 
@@ -595,7 +596,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateCollectorServiceAccou
 
 	subject := NewSubject(
 		"ServiceAccount",
-		"logcollector",
+		constants.CollectorServiceAccountName,
 	)
 	subject.APIGroup = ""
 
@@ -630,7 +631,7 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateCollectorServiceAccou
 	}
 	subject = NewSubject(
 		"ServiceAccount",
-		"logcollector",
+		constants.CollectorServiceAccountName,
 	)
 	subject.Namespace = cluster.Namespace
 	subject.APIGroup = ""

--- a/internal/k8shandler/fluentd.go
+++ b/internal/k8shandler/fluentd.go
@@ -224,7 +224,7 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *v1.Co
 	)
 
 	fluentdPodSpec := NewPodSpec(
-		"logcollector",
+		constants.CollectorServiceAccountName,
 		[]v1.Container{fluentdContainer, exporterContainer},
 		[]v1.Volume{
 			{Name: logVolumeMountName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: logVolumePath}}},

--- a/internal/runtime/core.go
+++ b/internal/runtime/core.go
@@ -37,6 +37,13 @@ func NewService(namespace, name string) *corev1.Service {
 	return svc
 }
 
+// NewServiceAccount returns a corev1.ServiceAccount with namespace and name.
+func NewServiceAccount(namespace, name string) *corev1.ServiceAccount {
+	obj := &corev1.ServiceAccount{}
+	Initialize(obj, namespace, name)
+	return obj
+}
+
 // NewSecret returns a corev1.Secret with namespace and name.
 func NewSecret(namespace, name string, data map[string][]byte) *corev1.Secret {
 	if data == nil {

--- a/test/framework/e2e/fluentd.go
+++ b/test/framework/e2e/fluentd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/factory"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -208,7 +209,7 @@ func (fluent *fluentReceiverLogStore) ClusterLocalEndpoint() string {
 
 func (tc *E2ETestFramework) createServiceAccount() (serviceAccount *corev1.ServiceAccount, err error) {
 	opts := metav1.CreateOptions{}
-	serviceAccount = k8shandler.NewServiceAccount("fluent-receiver", constants.OpenshiftNS)
+	serviceAccount = runtime.NewServiceAccount(constants.OpenshiftNS, "fluent-receiver")
 	if serviceAccount, err = tc.KubeClient.CoreV1().ServiceAccounts(constants.OpenshiftNS).Create(context.TODO(), serviceAccount, opts); err != nil {
 		return nil, err
 	}

--- a/test/framework/e2e/syslog.go
+++ b/test/framework/e2e/syslog.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/factory"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -166,7 +167,7 @@ func (syslog *syslogReceiverLogStore) ClusterLocalEndpoint() string {
 
 func (tc *E2ETestFramework) createSyslogServiceAccount() (serviceAccount *corev1.ServiceAccount, err error) {
 	opts := metav1.CreateOptions{}
-	serviceAccount = k8shandler.NewServiceAccount("syslog-receiver", constants.OpenshiftNS)
+	serviceAccount = runtime.NewServiceAccount(constants.OpenshiftNS, "syslog-receiver")
 	if serviceAccount, err = tc.KubeClient.CoreV1().ServiceAccounts(constants.OpenshiftNS).Create(context.TODO(), serviceAccount, opts); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description
This PR:
* Moves SA construction to use a single package

### Links
Ref: https://issues.redhat.com/browse/LOG-2027
