### PR TITLE
LOG-2056: fix wrong certs when OutputDefaults are defined

### DIFF
--- a/internal/cmd/forwarder-generator/main.go
+++ b/internal/cmd/forwarder-generator/main.go
@@ -4,8 +4,13 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"strconv"
 
 	"github.com/openshift/cluster-logging-operator/internal/pkg/generator/forwarder"
@@ -65,10 +70,51 @@ func main() {
 
 	log.Info("Finished reading yaml", "content", string(content))
 
-	generatedConfig, err := forwarder.Generate(string(content), *includeDefaultLogStore, *debugOutput, nil)
+	clfYaml := string(content)
+	client := buildClient(clfYaml)
+	generatedConfig, err := forwarder.Generate(clfYaml, *includeDefaultLogStore, *debugOutput, client)
 	if err != nil {
 		log.Error(err, "Unable to generate log configuration")
 		os.Exit(1)
 	}
 	fmt.Println(generatedConfig)
+}
+
+func buildClient(clfYaml string) client.Client {
+
+	instance, err := forwarder.UnMarshalClusterLogForwarder(clfYaml)
+	if err != nil {
+		log.Error(err, "Unable to generate log configuration")
+		os.Exit(1)
+	}
+
+	secrets := []client.Object{}
+	for _, output := range instance.Spec.Outputs {
+		if output.Secret != nil {
+			s := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: constants.OpenshiftNS,
+					Name:      output.Secret.Name,
+				},
+				Data: map[string][]byte{
+					constants.ClientPrivateKey:   []byte("value"),
+					constants.ClientCertKey:      []byte("value"),
+					constants.TrustedCABundleKey: []byte("value"),
+				},
+			}
+			secrets = append(secrets, s)
+		}
+	}
+	secrets = append(secrets, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.CollectorSecretName,
+			Namespace: constants.OpenshiftNS,
+		},
+		Data: map[string][]byte{
+			constants.ClientPrivateKey:   []byte("value"),
+			constants.ClientCertKey:      []byte("value"),
+			constants.TrustedCABundleKey: []byte("value"),
+		},
+	})
+	return fake.NewClientBuilder().WithObjects(secrets...).Build()
 }

--- a/internal/k8shandler/clusterloggingrequest.go
+++ b/internal/k8shandler/clusterloggingrequest.go
@@ -25,10 +25,6 @@ type ClusterLoggingRequest struct {
 
 	// OutputSecrets are retrieved during validation and used for generation.
 	OutputSecrets map[string]*corev1.Secret
-
-	//CLFVerifier is a collection of functions to control verification
-	//of ClusterLogForwarding
-	CLFVerifier ClusterLogForwarderVerifier
 }
 
 type ClusterLogForwarderVerifier struct {

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -19,6 +19,15 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func applyOutputDefaults(outputDefaults *logging.OutputDefaults, out logging.OutputSpec) logging.OutputSpec {
+	if outputDefaults != nil && outputDefaults.Elasticsearch != nil {
+		if out.Type == logging.OutputTypeElasticsearch && out.Elasticsearch == nil {
+			out.Elasticsearch = outputDefaults.Elasticsearch
+		}
+	}
+	return out
+}
+
 func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config string, err error) {
 
 	if clusterRequest.Cluster == nil || clusterRequest.Cluster.Spec.Collection == nil {
@@ -41,27 +50,6 @@ func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config s
 	spec, status := clusterRequest.NormalizeForwarder()
 	clusterRequest.ForwarderSpec = *spec
 	clusterRequest.ForwarderRequest.Status = *status
-
-	if clusterRequest.ForwarderSpec.OutputDefaults != nil {
-		defaultOutputSpecs := clusterRequest.ForwarderSpec.OutputDefaults
-		if defaultOutputSpecs.Elasticsearch != nil {
-			for i, out := range clusterRequest.ForwarderSpec.Outputs {
-				// copy from defaults if output specific spec not present
-				if out.Type == logging.OutputTypeElasticsearch && out.Elasticsearch == nil {
-					out.Elasticsearch = defaultOutputSpecs.Elasticsearch
-					out.Secret = &logging.OutputSecretSpec{
-						Name: constants.CollectorSecretName,
-					}
-					secret, err := clusterRequest.GetSecret(constants.CollectorSecretName)
-					if err != nil {
-						log.V(2).Info("no secret for default output type")
-					}
-					clusterRequest.OutputSecrets[out.Name] = secret
-					clusterRequest.ForwarderSpec.Outputs[i] = out
-				}
-			}
-		}
-	}
 
 	op := generator.Options{}
 	if clusterRequest.useOldRemoteSyslogPlugin() {
@@ -124,9 +112,7 @@ func (clusterRequest *ClusterLoggingRequest) readClusterName() (string, error) {
 
 // NormalizeForwarder normalizes the clusterRequest.ForwarderSpec, returns a normalized spec and status.
 func (clusterRequest *ClusterLoggingRequest) NormalizeForwarder() (*logging.ClusterLogForwarderSpec, *logging.ClusterLogForwarderStatus) {
-	if clusterRequest.CLFVerifier.VerifyOutputSecret == nil {
-		clusterRequest.CLFVerifier.VerifyOutputSecret = clusterRequest.verifyOutputSecret
-	}
+	clusterRequest.OutputSecrets = make(map[string]*corev1.Secret, len(clusterRequest.ForwarderSpec.Outputs))
 
 	// Check for default configuration
 	if len(clusterRequest.ForwarderSpec.Pipelines) == 0 {
@@ -189,6 +175,7 @@ func (clusterRequest *ClusterLoggingRequest) NormalizeForwarder() (*logging.Clus
 		}
 		status.Conditions.SetCondition(condReady)
 	}
+
 	return spec, status
 }
 
@@ -302,7 +289,6 @@ func (clusterRequest *ClusterLoggingRequest) verifyInputs(spec *logging.ClusterL
 
 func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.ClusterLogForwarderSpec, status *logging.ClusterLogForwarderStatus) {
 	status.Outputs = logging.NamedConditions{}
-	clusterRequest.OutputSecrets = make(map[string]*corev1.Secret, len(clusterRequest.ForwarderSpec.Outputs))
 	names := sets.NewString() // Collect pipeline names
 	for i, output := range clusterRequest.ForwarderSpec.Outputs {
 		i, output := i, output // Don't bind range variable.
@@ -328,8 +314,6 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.Cluster
 			log.V(3).Info("verifyOutputs failed", "reason", "output URL is invalid", "output URL", output.URL)
 		case !clusterRequest.verifyOutputSecret(&output, status.Outputs):
 			log.V(3).Info("verifyOutputs failed", "reason", "output secret is invalid")
-		case !clusterRequest.CLFVerifier.VerifyOutputSecret(&output, status.Outputs):
-			break
 		case output.Type == logging.OutputTypeCloudwatch && output.Cloudwatch == nil:
 			log.V(3).Info("verifyOutputs failed", "reason", "Cloudwatch output requires type spec", "output name", output.Name)
 			status.Outputs.Set(output.Name, condInvalid("output %q: Cloudwatch output requires type spec", output.Name))
@@ -365,6 +349,11 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.Cluster
 			})
 			status.Outputs.Set(name, condReady)
 		}
+	}
+
+	for i, out := range spec.Outputs {
+		out = applyOutputDefaults(clusterRequest.ForwarderSpec.OutputDefaults, out)
+		spec.Outputs[i] = out
 	}
 
 	if clusterRequest.ForwarderSpec.OutputDefaults != nil {

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -21,9 +21,19 @@ const (
 	useOldRemoteSyslogPlugin = false
 )
 
-func Generate(clfYaml string, includeDefaultLogStore, debugOutput bool, client *client.Client) (string, error) {
+func UnMarshalClusterLogForwarder(clfYaml string) (forwarder *logging.ClusterLogForwarder, err error) {
+	forwarder = &logging.ClusterLogForwarder{}
+	if clfYaml != "" {
+		err = yaml.Unmarshal([]byte(clfYaml), forwarder)
+		if err != nil {
+			return nil, fmt.Errorf("Error Unmarshalling %q: %v", clfYaml, err)
+		}
+	}
+	return forwarder, err
+}
 
-	var err error
+func Generate(clfYaml string, includeDefaultLogStore, debugOutput bool, client client.Client) (string, error) {
+
 	g := generator.MakeGenerator()
 	op := generator.Options{}
 	if useOldRemoteSyslogPlugin {
@@ -33,14 +43,12 @@ func Generate(clfYaml string, includeDefaultLogStore, debugOutput bool, client *
 		op["debug_output"] = ""
 	}
 
-	forwarder := &logging.ClusterLogForwarder{}
-	if clfYaml != "" {
-		err = yaml.Unmarshal([]byte(clfYaml), forwarder)
-		if err != nil {
-			return "", fmt.Errorf("Error Unmarshalling %q: %v", clfYaml, err)
-		}
+	forwarder, err := UnMarshalClusterLogForwarder(clfYaml)
+	if err != nil {
+		return "", fmt.Errorf("Error Unmarshalling %q: %v", clfYaml, err)
 	}
 	log.V(2).Info("Unmarshalled", "forwarder", forwarder)
+
 	clRequest := &k8shandler.ClusterLoggingRequest{
 		ForwarderSpec: forwarder.Spec,
 		Cluster: &logging.ClusterLogging{
@@ -49,13 +57,10 @@ func Generate(clfYaml string, includeDefaultLogStore, debugOutput bool, client *
 			},
 			Spec: logging.ClusterLoggingSpec{},
 		},
-		CLFVerifier: k8shandler.ClusterLogForwarderVerifier{
-			VerifyOutputSecret: func(output *logging.OutputSpec, conds logging.NamedConditions) bool { return true },
-		},
 	}
 
 	if client != nil {
-		clRequest.Client = *client
+		clRequest.Client = client
 	}
 
 	if includeDefaultLogStore {
@@ -73,8 +78,6 @@ func Generate(clfYaml string, includeDefaultLogStore, debugOutput bool, client *
 		Forwarder: tunings,
 	}
 	if logCollectorType == logging.LogCollectionTypeFluentd {
-
-		//passing a secret for a secure connection between fluentd output plugin and forwarder endpoint
 
 		sections := fluentd.Conf(&clspec, clRequest.OutputSecrets, spec, op)
 		es := generator.MergeSections(sections)

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -130,7 +130,7 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 	debugOutput := false
 	testClient := client.Get().ControllerRuntimeClient()
 	if strings.TrimSpace(f.Conf) == "" {
-		if f.Conf, err = forwarder.Generate(string(clfYaml), false, debugOutput, &testClient); err != nil {
+		if f.Conf, err = forwarder.Generate(string(clfYaml), false, debugOutput, testClient); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
(cherry picked from commit 7dd9b001082a2e5ed56f9af539277ff09d0eeb06)
### Description
This PR:
* Fixes how outputdefaults are applied to only set them if not defined on the output
* Fixes modifying the output secret if OutputDefaults are applied
* Fixes the forward-generator tool 

5.4 forward port of https://github.com/openshift/cluster-logging-operator/pull/1282

/assign @alanconway 

### Links
* https://issues.redhat.com/browse/LOG-2056