### PR TITLE
LOG-1910: Mount host filesystem to leverage CRIO rollover

### DIFF
--- a/internal/cmd/functional-benchmarker/runners/cluster/cluster_runner.go
+++ b/internal/cmd/functional-benchmarker/runners/cluster/cluster_runner.go
@@ -11,56 +11,24 @@ import (
 	"github.com/openshift/cluster-logging-operator/test/client"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
-	"io/ioutil"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"os"
-	"path"
 	"strings"
 	"time"
 )
 
-const containerVolumeName = "container"
+const (
+	containerVolumeName = "container"
+	PodLogsDirName      = "varlogpods"
+)
 
 type ClusterRunner struct {
 	framework *functional.CollectorFunctionalFramework
 	config.Options
-	loaders []loader
-}
-
-type loader struct {
-	Name string
-	File string
 }
 
 func New(options config.Options) *ClusterRunner {
 	return &ClusterRunner{
 		Options: options,
-		loaders: []loader{},
-	}
-}
-
-/* #nosec G306*/
-func (r *ClusterRunner) DumpLoaderArtifacts() {
-	maxDuration, _ := time.ParseDuration("5m")
-	defaultRetryInterval, _ := time.ParseDuration("10s")
-	for _, l := range r.loaders {
-		var result string
-		name := l.Name
-		file := l.File
-		err := wait.PollImmediate(defaultRetryInterval, maxDuration, func() (done bool, err error) {
-			result, err = r.framework.RunCommand(name, "cat", file)
-			if result != "" && err == nil {
-				return true, nil
-			}
-			log.V(4).Error(err, "Polling logs")
-			return false, nil
-		})
-		if err == nil {
-			file := path.Base(l.File)
-			if err := ioutil.WriteFile(path.Join(r.ArtifactDir, file), []byte(result), 0655); err != nil {
-				log.V(0).Error(err, "Unable to write l logs", "file", file)
-			}
-		}
 	}
 }
 
@@ -80,18 +48,21 @@ func (r *ClusterRunner) Deploy() {
 	functional.NewClusterLogForwarderBuilder(r.framework.Forwarder).
 		FromInput(logging.InputNameApplication).
 		ToFluentForwardOutput()
+
+	//modify config to only collect loader containers
+	r.framework.VisitConfig = func(conf string) string {
+		conf = strings.Replace(conf, "/var/log/containers/*.log", "/var/log/containers/*_*_loader-*.log", 1)
+		return conf
+	}
+
 	err := r.framework.DeployWithVisitors([]runtime.PodBuilderVisitor{
 		func(b *runtime.PodBuilder) error {
 			for i := 0; i < r.TotalLogStressors; i++ {
 				name := fmt.Sprintf("loader-%d", i)
-				file := fmt.Sprintf("%s/%s_%s_%s-12345.log", config.ContainerLogDir, b.Pod.Name, b.Pod.Namespace, name)
 				args := []string{
 					"generate",
-					"--destination=file",
-					"--output-format=crio",
 					fmt.Sprintf("--source=%s", r.PayloadSource),
 					fmt.Sprintf("--log-lines-rate=%d", r.LinesPerSecond),
-					fmt.Sprintf("--file=%s", file),
 				}
 				if r.PayloadSource == "synthetic" {
 					args = append(args, fmt.Sprintf("--synthetic-payload-size=%d", r.MsgSize))
@@ -99,19 +70,22 @@ func (r *ClusterRunner) Deploy() {
 
 				b.AddContainer(name, config.LogStressorImage).
 					WithCmdArgs(args).
-					AddVolumeMount(containerVolumeName, "/var/log/containers", "", false).
+					AddVolumeMount(containerVolumeName, constants.ContainerLogDir, "", false).
+					AddVolumeMount(PodLogsDirName, constants.PodLogDir, "", false).
 					End()
-				r.loaders = append(r.loaders, loader{Name: name, File: file})
 			}
-			b.AddEmptyDirVolume(containerVolumeName)
-			b.GetContainer(constants.CollectorName).
-				AddVolumeMount(containerVolumeName, "/var/log/containers", "", false).
-				Update()
+			b.AddHostPathVolume(containerVolumeName, constants.ContainerLogDir)
+			b.AddHostPathVolume(PodLogsDirName, constants.PodLogDir)
+			collectorBuilder := b.GetContainer(constants.CollectorName).
+				AddVolumeMount(containerVolumeName, constants.ContainerLogDir, "", true).
+				AddVolumeMount(PodLogsDirName, constants.PodLogDir, "", true).
+				WithPrivilege()
+			collectorBuilder.Update()
 			return r.framework.AddBenchmarkForwardOutput(b, r.framework.Forwarder.Spec.Outputs[0])
 		},
 	})
 	if err != nil {
-		log.Error(err, "Error deploying test pod")
+		log.Error(err, "Error deploying test pod", "pod", r.framework.Pod)
 		os.Exit(1)
 	}
 

--- a/internal/cmd/functional-benchmarker/runners/runner.go
+++ b/internal/cmd/functional-benchmarker/runners/runner.go
@@ -14,7 +14,6 @@ type Runner interface {
 	Cleanup()
 	Namespace() string
 	Pod() string
-	DumpLoaderArtifacts()
 }
 
 func NewRunner(options config.Options) Runner {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -75,6 +75,9 @@ const (
 	LogfilesmetricImageEnvVar     = "LOGFILEMETRICEXPORTER_IMAGE"
 	CertEventName                 = "cluster-logging-certs-generate"
 	ClusterInfrastructureInstance = "cluster"
+
+	ContainerLogDir = "/var/log/containers"
+	PodLogDir       = "/var/log/pods"
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}

--- a/internal/runtime/pod.go
+++ b/internal/runtime/pod.go
@@ -232,6 +232,17 @@ func (builder *PodBuilder) AddEmptyDirVolume(name string) *PodBuilder {
 	})
 	return builder
 }
+func (builder *PodBuilder) AddHostPathVolume(name, path string) *PodBuilder {
+	builder.Pod.Spec.Volumes = append(builder.Pod.Spec.Volumes, corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: path,
+			},
+		},
+	})
+	return builder
+}
 
 func (builder *ContainerBuilder) AddContainerPort(name string, port int32) *ContainerBuilder {
 	builder.container.Ports = append(builder.container.Ports, corev1.ContainerPort{Name: name, ContainerPort: port})

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -50,6 +50,8 @@ type CollectorFunctionalFramework struct {
 	closeClient       func()
 
 	collector CollectorFramework
+	//VisitConfig allows the framework to modify the config after generating from logforwardering
+	VisitConfig func(string) string
 }
 
 func NewCollectorFunctionalFramework() *CollectorFunctionalFramework {
@@ -132,6 +134,9 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 	if strings.TrimSpace(f.Conf) == "" {
 		if f.Conf, err = forwarder.Generate(string(clfYaml), false, debugOutput, testClient); err != nil {
 			return err
+		}
+		if f.VisitConfig != nil {
+			f.Conf = f.VisitConfig(f.Conf)
 		}
 	} else {
 		log.V(2).Info("Using provided collector conf instead of generating one")


### PR DESCRIPTION
### Description
This PR:
* Refactors the functional-benchmarker to mount the host filesystem to take advantage of CRIO rollover instead of mimicking it

This will make our tests more accurate and additionally allow us to add logic to check for log loss due to load and file rotation.

/cc @alanconway @syedriko 


### Links
* https://issues.redhat.com/browse/LOG-1910
