### PR TITLE
LOG-2066: Modify client to also watch cluster config NS

### DIFF
--- a/controllers/clusterlogging/clusterlogging_controller.go
+++ b/controllers/clusterlogging/clusterlogging_controller.go
@@ -58,7 +58,12 @@ var _ reconcile.Reconciler = &ReconcileClusterLogging{}
 type ReconcileClusterLogging struct {
 	// This Client, initialized using mgr.Client() above, is a split Client
 	// that reads objects from the cache and writes to the apiserver
-	Client   client.Client
+	Client client.Client
+
+	// Reader is an initialized client.Reader that reads objects directly from the apiserver
+	// instead of the cache. Useful for cases where need to read/write to a namespace other than
+	// the deployed namespace (e.g. openshift-config-managed)
+	Reader   client.Reader
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 }
@@ -93,7 +98,7 @@ func (r *ReconcileClusterLogging) Reconcile(ctx context.Context, request reconci
 		return reconcile.Result{}, nil
 	}
 
-	if err = k8shandler.Reconcile(instance, r.Client, r.Recorder); err != nil {
+	if err = k8shandler.Reconcile(instance, r.Client, r.Reader, r.Recorder); err != nil {
 		log.Error(err, "Error reconciling clusterlogging instance")
 	}
 

--- a/hack/testing-olm/test-010-deploy-via-olm-minimal.sh
+++ b/hack/testing-olm/test-010-deploy-via-olm-minimal.sh
@@ -62,23 +62,24 @@ os::cmd::try_until_text "oc -n $NAMESPACE get deployment cluster-logging-operato
 # test the validation of an invalid cr
 os::cmd::expect_failure_and_text "oc -n $NAMESPACE create -f ${repo_dir}/hack/cr_invalid.yaml" "invalid: metadata.name: Unsupported value"
 
-# deploy cluster logging
-os::cmd::expect_success "oc -n $NAMESPACE create -f ${repo_dir}/hack/cr.yaml"
-
-# assert deployment
-assert_resources_exist
-# assert kibana instance exists
-assert_kibana_instance_exists
-
-# delete cluster logging
-os::cmd::expect_success "oc -n $NAMESPACE delete -f ${repo_dir}/hack/cr.yaml"
-
 # deploy cluster logging with unmanaged state
 os::cmd::expect_success "oc -n $NAMESPACE create -f ${repo_dir}/hack/cr-unmanaged.yaml"
-
 # wait few seconds
 sleep 10
 # assert does not exist
 assert_resources_does_not_exist
 # assert kibana instance does not exists
 assert_kibana_instance_does_not_exists
+# wait few seconds
+sleep 10
+# delete cluster logging
+os::cmd::expect_success "oc -n $NAMESPACE delete -f ${repo_dir}/hack/cr-unmanaged.yaml"
+
+# deploy cluster logging
+os::cmd::expect_success "oc -n $NAMESPACE create -f ${repo_dir}/hack/cr.yaml"
+# assert deployment
+assert_resources_exist
+# assert kibana instance exists
+assert_kibana_instance_exists
+
+

--- a/internal/k8shandler/clusterloggingrequest.go
+++ b/internal/k8shandler/clusterloggingrequest.go
@@ -15,6 +15,7 @@ import (
 
 type ClusterLoggingRequest struct {
 	Client        client.Client
+	Reader        client.Reader
 	Cluster       *logging.ClusterLogging
 	EventRecorder record.EventRecorder
 	// ForwarderRequest is a logforwarder instance

--- a/internal/metrics/dashboards.go
+++ b/internal/metrics/dashboards.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/configmaps"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"path"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -38,9 +39,10 @@ func newDashboardConfigMap() *corev1.ConfigMap {
 	return cm
 }
 
-func ReconcileDashboards(k8client client.Client) (err error) {
+func ReconcileDashboards(writer client.Writer, reader client.Reader, owner metav1.OwnerReference) (err error) {
 	cm := newDashboardConfigMap()
-	if err := reconcile.ReconcileConfigmap(k8client, cm, configmaps.CompareLabels); err != nil {
+	utils.AddOwnerRefToObject(cm, owner)
+	if err := reconcile.ReconcileConfigmap(writer, reader, cm, configmaps.CompareLabels); err != nil {
 		return err
 	}
 

--- a/internal/metrics/dashboards_test.go
+++ b/internal/metrics/dashboards_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -27,8 +28,9 @@ var _ = Describe("ReconcileDashboards", func() {
 				fakeClient = fake.NewClientBuilder().WithObjects(cm).Build()
 			}
 		}
-		exp     = newDashboardConfigMap()
-		initial *corev1.ConfigMap
+		exp      = newDashboardConfigMap()
+		initial  *corev1.ConfigMap
+		ownerRef = v1.OwnerReference{}
 	)
 
 	BeforeEach(func() {
@@ -41,7 +43,7 @@ var _ = Describe("ReconcileDashboards", func() {
 			setup(nil)
 		})
 		It("should create a new dashboard configmap", func() {
-			Expect(ReconcileDashboards(fakeClient)).To(Succeed())
+			Expect(ReconcileDashboards(fakeClient, fakeClient, ownerRef)).To(Succeed())
 			Expect(GetDashboard()).To(Equal(exp))
 		})
 	})
@@ -52,13 +54,13 @@ var _ = Describe("ReconcileDashboards", func() {
 			initial := newDashboardConfigMap()
 			initial.Labels[constants.TrustedCABundleHashName] = "abc"
 			setup(initial)
-			Expect(ReconcileDashboards(fakeClient)).To(Succeed())
+			Expect(ReconcileDashboards(fakeClient, fakeClient, ownerRef)).To(Succeed())
 			Expect(GetDashboard()).To(Equal(exp), "Exp the configmap to be updated")
 		})
 
 		It("should do nothing to the configmap when the dashboard is the same", func() {
 			setup(initial)
-			Expect(ReconcileDashboards(fakeClient)).To(Succeed())
+			Expect(ReconcileDashboards(fakeClient, fakeClient, ownerRef)).To(Succeed())
 			Expect(GetDashboard()).To(Equal(exp))
 		})
 	})

--- a/internal/reconcile/configmaps.go
+++ b/internal/reconcile/configmaps.go
@@ -10,34 +10,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ReconcileConfigmap(k8Client client.Client, configMap *corev1.ConfigMap, opts ...configmaps.ComparisonOption) error {
-	err := k8Client.Create(context.TODO(), configMap)
-	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("Failure creating configmap: %v", err)
+func ReconcileConfigmap(k8Client client.Writer, reader client.Reader, configMap *corev1.ConfigMap, opts ...configmaps.ComparisonOption) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &corev1.ConfigMap{}
+		key := client.ObjectKeyFromObject(configMap)
+		if err := reader.Get(context.TODO(), key, current); err != nil {
+			if errors.IsNotFound(err) {
+				return k8Client.Create(context.TODO(), configMap)
+			}
+			return fmt.Errorf("Failed to get %v configmap: %v", key, err)
 		}
-
-		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			current := &corev1.ConfigMap{}
-			key := client.ObjectKeyFromObject(configMap)
-			if err = k8Client.Get(context.TODO(), key, current); err != nil {
-				if errors.IsNotFound(err) {
-					// the object doesn't exist -- it was likely culled
-					// recreate it on the next time through if necessary
-					return nil
-				}
-				return fmt.Errorf("Failed to get %v configmap: %v", key, err)
-			}
-
-			if configmaps.AreSame(current, configMap, opts...) {
-				return nil
-			} else {
-				current.Data = configMap.Data
-				current.Labels = configMap.Labels
-			}
-			return k8Client.Update(context.TODO(), current)
-		})
-		return retryErr
-	}
-	return nil
+		if configmaps.AreSame(current, configMap, opts...) {
+			return nil
+		} else {
+			current.Data = configMap.Data
+			current.Labels = configMap.Labels
+		}
+		return k8Client.Update(context.TODO(), current)
+	})
 }

--- a/internal/utils/comparators/configmaps/comparator.go
+++ b/internal/utils/comparators/configmaps/comparator.go
@@ -1,6 +1,7 @@
 package configmaps
 
 import (
+	"github.com/ViaQ/logerr/log"
 	corev1 "k8s.io/api/core/v1"
 	"reflect"
 )
@@ -15,6 +16,9 @@ const (
 //AreSame compares configmaps for equality and return true equal otherwise false.  This comparison
 //only compares the data of the configmap by default unless otherwise configured
 func AreSame(actual *corev1.ConfigMap, desired *corev1.ConfigMap, options ...ComparisonOption) bool {
+	log.V(5).Info("Compare configmaps", "actual", actual)
+	log.V(5).Info("Compare configmaps", "desired", desired)
+	log.V(5).Info("Compare configmaps", "options", options)
 	dataAreEqual := reflect.DeepEqual(actual.Data, desired.Data)
 	labelsAreEqual := true
 	annotationsAreEqual := true
@@ -26,6 +30,6 @@ func AreSame(actual *corev1.ConfigMap, desired *corev1.ConfigMap, options ...Com
 			labelsAreEqual = reflect.DeepEqual(actual.Labels, desired.Labels)
 		}
 	}
-
+	log.V(3).Info("Compare configmaps", "dateAreEqual", dataAreEqual, "labelsAreEqual", labelsAreEqual, "annotationsAreEqual", annotationsAreEqual)
 	return dataAreEqual && labelsAreEqual && annotationsAreEqual
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -191,14 +191,18 @@ const defaultShareDir = "/usr/share/logging"
 func GetShareDir() string {
 	// shareDir is <repo-root>/files - try to find from working dir.
 	const sep = string(os.PathSeparator)
-	const repoRoot = sep + "cluster-logging-operator" + sep
+	const repoRoot = sep + "cluster-logging-operator"
 	wd, err := os.Getwd()
 	if err != nil {
+		log.V(3).Error(err, "Error determining share directory. Returning default", "default", defaultShareDir)
 		return defaultShareDir
 	}
+	log.V(5).Info("GetShareDir", "workingdir", wd)
 	i := strings.LastIndex(wd, repoRoot)
 	if i >= 0 {
-		return filepath.Join(wd[0:i+len(repoRoot)] + "files")
+		shareDir := filepath.Join(wd, "files")
+		log.V(5).Info("GetShareDir", "sharedir", shareDir)
+		return shareDir
 	}
 	return defaultShareDir
 }

--- a/main.go
+++ b/main.go
@@ -106,6 +106,7 @@ func main() {
 
 	if err = (&clusterlogging.ReconcileClusterLogging{
 		Client: mgr.GetClient(),
+		Reader: mgr.GetAPIReader(),
 		//Log:    ctrl.Log.WithName("controllers").WithName("ClusterLogForwarder"),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("clusterlogging-controller"),


### PR DESCRIPTION
### Description
This PR:
* Fixes configmap dashboard reconciliation by configuring API client to watch openshift-config-managed NS


### Links
ref: https://issues.redhat.com/browse/LOG-2066
