### PR TITLE
LOG_2072: Collector fails with multiple log stores

### DIFF
--- a/internal/generator/test_common.go
+++ b/internal/generator/test_common.go
@@ -25,6 +25,9 @@ type GenerateFunc func(logging.ClusterLoggingSpec, map[string]*corev1.Secret, lo
 func TestGenerateConfWith(gf GenerateFunc) func(ConfGenerateTest) {
 	return func(testcase ConfGenerateTest) {
 		g := MakeGenerator()
+		if testcase.Options == nil {
+			testcase.Options = Options{}
+		}
 		e := gf(testcase.CLSpec, testcase.Secrets, testcase.CLFSpec, testcase.Options)
 		conf, err := g.GenerateConf(e...)
 		Expect(err).To(BeNil())

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -16,7 +16,7 @@ import (
 var _ = Describe("Generate Vector config", func() {
 	inputPipeline := []string{"application"}
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
-		return Conf(clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], generator.NoOptions)
+		return Conf(clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], op)
 	}
 	DescribeTable("For Elasticsearch output", generator.TestGenerateConfWith(f),
 		Entry("with username,password", generator.ConfGenerateTest{

--- a/test/functional/outputs/multiple/multiple_test.go
+++ b/test/functional/outputs/multiple/multiple_test.go
@@ -1,8 +1,9 @@
 package multiple
 
 import (
-	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"sort"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
Collector pods fail to start when a ClusterLogForwarder instance is created to forward logs to multiple log stores

/cc @vimalk78 
/assign @vimalk78 


- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2072
- Enhancement proposal:
