### PR TITLE
make "go list" happy wrt github.com/prometheus/client_golang/prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/openshift/elasticsearch-operator v0.0.0-20220110181307-4e889bb6cdcf
 	github.com/pavel-v-chernykh/keystore-go/v4 v4.1.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/atomic v1.8.0 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,6 +182,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.11.0
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal


### PR DESCRIPTION
### Description
cachito fails with
```
The command "go list -find ./..." failed with: package github.com/openshift/cluster-logging-operator/internal/telemetry imports github.com/prometheus/client_golang/prometheus from implicitly required module; to add missing requirements, run:
	go get github.com/prometheus/client_golang@v1.11.0
```
this PR is to make it happy. This is new for Go 1.17.
/cc @vimalk78 
/assign @jcantrill 
