### PR TITLE
LOG-2052: Vector: Fix capturing journal logs

### DIFF
--- a/internal/k8shandler/fluentd.go
+++ b/internal/k8shandler/fluentd.go
@@ -38,6 +38,8 @@ const (
 	logOauthapiserverValue = "/var/log/oauth-apiserver"
 	logOpenshiftapiserver  = "varlogopenshiftapiserver"
 
+	logJournalTransientValue = "/run/log/journal"
+
 	logOpenshiftapiserverValue = "/var/log/openshift-apiserver"
 	logKubeapiserver           = "varlogkubeapiserver"
 	logKubeapiserverValue      = "/var/log/kube-apiserver"

--- a/internal/k8shandler/vector.go
+++ b/internal/k8shandler/vector.go
@@ -100,7 +100,7 @@ func newVectorPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *corev1
 	vectorContainer.VolumeMounts = []corev1.VolumeMount{
 		{Name: logContainers, ReadOnly: true, MountPath: logContainersValue},
 		{Name: logPods, ReadOnly: true, MountPath: logPodsValue},
-		{Name: logJournal, ReadOnly: true, MountPath: logJournalValue},
+		{Name: logJournal, ReadOnly: true, MountPath: logJournalTransientValue},
 		{Name: logAudit, ReadOnly: true, MountPath: logAuditValue},
 		{Name: logOvn, ReadOnly: true, MountPath: logOvnValue},
 		{Name: logOauthapiserver, ReadOnly: true, MountPath: logOauthapiserverValue},


### PR DESCRIPTION
### Description
Journal logs are collected by `journalctl` utility. By default (as per `/etc/systemd/journald.conf`) `journalctl` reads from path `/run/log/journal`. But container has persistent journal logs in path `/var/log/journal`. So collector needs to be configured with the correct path. 
For `fluentd`, the configuration is
```
<source>
  @type systemd
  path '/var/log/journal'
</source>
```
But vector 0.14's `journald` does not have configuration to set the path. A config parameter `journal_directory` is present in latest version, but not in v0.14

So a workaround is used in this PR to mount host's `/var/log/journal` as `/run/log/journal`. This fixes reading journal logs in vector container.

/cc 
/assign 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2052

