### PR TITLE
LOG-2163: Remove ownerRef for invalid across namespace ownership

### DIFF
--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/openshift/cluster-logging-operator/internal/metrics"
-	"github.com/openshift/cluster-logging-operator/internal/utils"
 
 	"github.com/ViaQ/logerr/log"
 	configv1 "github.com/openshift/api/config/v1"
@@ -75,7 +74,7 @@ func Reconcile(requestCluster *logging.ClusterLogging, requestClient client.Clie
 	}
 
 	// Reconcile metrics Dashboards
-	if err = metrics.ReconcileDashboards(clusterLoggingRequest.Client, reader, utils.AsOwner(clusterLoggingRequest.Cluster)); err != nil {
+	if err = metrics.ReconcileDashboards(clusterLoggingRequest.Client, reader); err != nil {
 		log.Error(err, "Unable to create or update metrics dashboards", "clusterName", clusterLoggingRequest.Cluster.Name)
 	}
 

--- a/internal/metrics/dashboards.go
+++ b/internal/metrics/dashboards.go
@@ -8,7 +8,6 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/configmaps"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"path"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,9 +38,8 @@ func newDashboardConfigMap() *corev1.ConfigMap {
 	return cm
 }
 
-func ReconcileDashboards(writer client.Writer, reader client.Reader, owner metav1.OwnerReference) (err error) {
+func ReconcileDashboards(writer client.Writer, reader client.Reader) (err error) {
 	cm := newDashboardConfigMap()
-	utils.AddOwnerRefToObject(cm, owner)
 	if err := reconcile.ReconcileConfigmap(writer, reader, cm, configmaps.CompareLabels); err != nil {
 		return err
 	}

--- a/internal/metrics/dashboards_test.go
+++ b/internal/metrics/dashboards_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -28,9 +27,8 @@ var _ = Describe("ReconcileDashboards", func() {
 				fakeClient = fake.NewClientBuilder().WithObjects(cm).Build()
 			}
 		}
-		exp      = newDashboardConfigMap()
-		initial  *corev1.ConfigMap
-		ownerRef = v1.OwnerReference{}
+		exp     = newDashboardConfigMap()
+		initial *corev1.ConfigMap
 	)
 
 	BeforeEach(func() {
@@ -43,7 +41,7 @@ var _ = Describe("ReconcileDashboards", func() {
 			setup(nil)
 		})
 		It("should create a new dashboard configmap", func() {
-			Expect(ReconcileDashboards(fakeClient, fakeClient, ownerRef)).To(Succeed())
+			Expect(ReconcileDashboards(fakeClient, fakeClient)).To(Succeed())
 			Expect(GetDashboard()).To(Equal(exp))
 		})
 	})
@@ -54,13 +52,13 @@ var _ = Describe("ReconcileDashboards", func() {
 			initial := newDashboardConfigMap()
 			initial.Labels[constants.TrustedCABundleHashName] = "abc"
 			setup(initial)
-			Expect(ReconcileDashboards(fakeClient, fakeClient, ownerRef)).To(Succeed())
+			Expect(ReconcileDashboards(fakeClient, fakeClient)).To(Succeed())
 			Expect(GetDashboard()).To(Equal(exp), "Exp the configmap to be updated")
 		})
 
 		It("should do nothing to the configmap when the dashboard is the same", func() {
 			setup(initial)
-			Expect(ReconcileDashboards(fakeClient, fakeClient, ownerRef)).To(Succeed())
+			Expect(ReconcileDashboards(fakeClient, fakeClient)).To(Succeed())
 			Expect(GetDashboard()).To(Equal(exp))
 		})
 	})


### PR DESCRIPTION
(cherry picked from commit 224a583b57fb28cccb2c705d8888614d09bf6ddc)

### Description
This PR:

removes the ownerref from the dashboard configmap since this is invalid across namespaces (Not obvious)
backport of #1306 

### Links
* https://issues.redhat.com/browse/LOG-2175
