### PR TITLE
Specify elasticsearch-operator container to collect logs [issue 1329]

### DIFF
--- a/must-gather/collection-scripts/gather_elasticsearch_operator_resources
+++ b/must-gather/collection-scripts/gather_elasticsearch_operator_resources
@@ -34,4 +34,4 @@ oc -n openshift-logging exec -c elasticsearch \
 
 oc -n $NAMESPACE get deployment elasticsearch-operator -o wide > ${eo_folder}/eo-deployment.txt 2>&1
 oc -n $NAMESPACE describe deployment elasticsearch-operator > ${eo_folder}/eo-deployment.describe 2>&1
-oc -n $NAMESPACE logs deployment/elasticsearch-operator > ${eo_folder}/elasticsearch-operator.logs 2>&1
+oc -n $NAMESPACE logs deployment/elasticsearch-operator -c elasticsearch-operator > ${eo_folder}/elasticsearch-operator.logs 2>&1


### PR DESCRIPTION
### Description
This fix will update the gather_elasticsearch_operator_resources script so it captures the elasticsearch-operator logs instead of failing with the error message: error: "a container name must be specified for pod elasticsearch-operator-<id>".

/cc jcantrill
/assign vimalk78

### Links

- Github issue: https://github.com/openshift/cluster-logging-operator/issues/1329

