### PR TITLE
LOG-2241: fix multiline error detection for multiple pipelines

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -622,7 +622,6 @@ var _ = Describe("Testing Complete Config Generation", func() {
 # Copying pipeline pipeline to outputs
 <label @PIPELINE>
   <match kubernetes.**>
-    @id multiline-detect-except
     @type detect_exceptions
     remove_tag_prefix 'kubernetes'
     message message

--- a/internal/generator/fluentd/multiline_detect_exceptions.go
+++ b/internal/generator/fluentd/multiline_detect_exceptions.go
@@ -4,7 +4,6 @@ const (
 	MultilineDetectExceptionTemplate = `
 {{define "matchMultilineDetectException" -}}
 <match kubernetes.**>
-  @id multiline-detect-except
   @type detect_exceptions
   remove_tag_prefix 'kubernetes'
   message message

--- a/test/framework/functional/cluster_log_forwarder.go
+++ b/test/framework/functional/cluster_log_forwarder.go
@@ -139,7 +139,7 @@ func (p *PipelineBuilder) ToOutputWithVisitor(visit OutputSpecVisiter, outputNam
 		clf.Spec.Outputs = append(clf.Spec.Outputs, *output)
 	}
 
-	if p.input.Application != nil {
+	if p.input != nil {
 		clf.Spec.Inputs = append(clf.Spec.Inputs, *p.input)
 	}
 

--- a/test/functional/normalization/multiline_exception_test.go
+++ b/test/functional/normalization/multiline_exception_test.go
@@ -52,10 +52,18 @@ created by main.main
 
 	BeforeEach(func() {
 		framework = functional.NewCollectorFunctionalFramework()
-		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+		b := functional.NewClusterLogForwarderBuilder(framework.Forwarder).
 			FromInput(logging.InputNameApplication).
 			WithMultineErrorDetection().
 			ToFluentForwardOutput()
+		//LOG-2241
+		b.FromInput(logging.InputNameApplication).
+			Named("other").
+			WithMultineErrorDetection().
+			ToOutputWithVisitor(func(spec *logging.OutputSpec) {
+				spec.Type = logging.OutputTypeFluentdForward
+				spec.URL = "tcp://0.0.0.0:24234"
+			}, "missing")
 		Expect(framework.Deploy()).To(BeNil())
 	})
 	AfterEach(func() {


### PR DESCRIPTION
### Description
This PR:
* fixes an error in the fluent log where multiple multiline plugin configurations have the same id

### Links
* https://issues.redhat.com/browse/LOG-2241