### PR TITLE
LOG-2249: Vector: Fix loki pod labels

### DIFF
--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -17,17 +17,22 @@ import (
 )
 
 const (
-	lokiLabelKubernetesHost = "kubernetes.host"
+	logType                          = "log_type"
+	lokiLabelKubernetesNamespaceName = "kubernetes.namespace_name"
+	lokiLabelKubernetesPodName       = "kubernetes.pod_name"
+	lokiLabelKubernetesHost          = "kubernetes.host"
+	lokiLabelKubernetesContainerName = "kubernetes.container_name"
+	podNamespace                     = "kubernetes.pod_namespace"
 )
 
 var (
 	defaultLabelKeys = []string{
-		"log_type",
+		logType,
 
 		//container labels
-		"kubernetes.namespace_name",
-		"kubernetes.pod_name",
-		"kubernetes.container_name",
+		lokiLabelKubernetesNamespaceName,
+		lokiLabelKubernetesPodName,
+		lokiLabelKubernetesContainerName,
 	}
 	requiredLabelKeys = []string{
 		lokiLabelKubernetesHost,
@@ -165,7 +170,10 @@ func lokiLabels(lo *logging.Loki) []Label {
 			Value: fmt.Sprintf("{{%s}}", k),
 		}
 		if k == lokiLabelKubernetesHost {
-			l.Value = "${NODE_NAME}"
+			l.Value = "${VECTOR_SELF_NODE_NAME}"
+		}
+		if k == lokiLabelKubernetesNamespaceName {
+			l.Value = fmt.Sprintf("{{%s}}", podNamespace)
 		}
 		ls = append(ls, l)
 	}

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -77,8 +77,8 @@ codec = "json"
 
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
-kubernetes_host = "${NODE_NAME}"
-kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
+kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
+kubernetes_namespace_name = "{{kubernetes.pod_namespace}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
 
@@ -124,7 +124,7 @@ codec = "json"
 
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
-kubernetes_host = "${NODE_NAME}"
+kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_labels_app = "{{kubernetes.labels.app}}"
 
 # Basic Auth Config
@@ -170,8 +170,8 @@ codec = "json"
 
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
-kubernetes_host = "${NODE_NAME}"
-kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
+kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
+kubernetes_namespace_name = "{{kubernetes.pod_namespace}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
 

--- a/internal/k8shandler/vector.go
+++ b/internal/k8shandler/vector.go
@@ -87,7 +87,7 @@ func newVectorPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *corev1
 	}
 
 	vectorContainer.Env = []corev1.EnvVar{
-		{Name: "LOG", Value: "debug"},
+		{Name: "LOG", Value: "info"},
 		{Name: "VECTOR_SELF_NODE_NAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "spec.nodeName"}}},
 		{Name: "METRICS_CERT", Value: "/etc/vector/metrics/tls.crt"},
 		{Name: "METRICS_KEY", Value: "/etc/vector/metrics/tls.key"},


### PR DESCRIPTION
### Description
read value of `kubernetes.host` label from `VECTOR_SELF_NODE_NAME` environment variable
read value of `kubernetes.namespace_name` label from `kubernetes.pod_namespace`

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2249#add-comment

