### PR TITLE
add env var to allow specifying ginko options

### DIFF
--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -10,6 +10,7 @@ os::test::junit::declare_suite_start "[ClusterLogging] Log Forwarding"
 
 start_seconds=$(date +%s)
 
+GINKGO_OPTS=${GINKGO_OPTS:-""}
 TEST_DIR=${TEST_DIR:-'./test/e2e/logforwarding/*/'}
 ARTIFACT_DIR=${ARTIFACT_DIR:-"$repo_dir/_output"}
 if [ ! -d $ARTIFACT_DIR ] ; then
@@ -79,7 +80,7 @@ for dir in $(eval echo $TEST_DIR); do
     artifact_dir=$artifact_dir \
     GENERATOR_NS=$GENERATOR_NS \
     SUCCESS_TIMEOUT=10m \
-    go test -count=1 -parallel=1 -timeout=90m "$dir" -ginkgo.noColor -ginkgo.trace -ginkgo.slowSpecThreshold=600.0 | tee -a "$artifact_dir/test.log" ; then
+    go test -count=1 -parallel=1 -timeout=90m "$dir" -ginkgo.noColor -ginkgo.trace -ginkgo.slowSpecThreshold=600.0 ${GINKGO_OPTS} | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "Logforwarding $dir passed"
     os::log::info "======================================================="


### PR DESCRIPTION
### Description
This PR:
* Allows us to specify e2e ginkgo options (e.g. skipping vector testing if needed)

cc @vimalk78 