### PR TITLE
LOG-2255: Vector: Support Pod Label based routing

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -172,8 +172,8 @@ source = '''
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!(starts_with!(.kubernetes.pod_namespace,"kube") || starts_with!(.kubernetes.pod_namespace,"openshift") || .kubernetes.pod_namespace == "default")'
-route.infra = 'starts_with!(.kubernetes.pod_namespace,"kube") || starts_with!(.kubernetes.pod_namespace,"openshift") || .kubernetes.pod_namespace == "default"'
+route.app = '!((starts_with!(.kubernetes.pod_namespace,"kube")) || (starts_with!(.kubernetes.pod_namespace,"openshift")) || (.kubernetes.pod_namespace == "default"))'
+route.infra = '(starts_with!(.kubernetes.pod_namespace,"kube")) || (starts_with!(.kubernetes.pod_namespace,"openshift")) || (.kubernetes.pod_namespace == "default")'
 
 
 # Rename log stream to "application"
@@ -206,7 +206,7 @@ source = """
 [transforms.route_application_logs]
 type = "route"
 inputs = ["application"]
-route.mytestapp = '(.kubernetes.pod_namespace == "test-ns")'
+route.mytestapp = '.kubernetes.pod_namespace == "test-ns"'
 
 
 [transforms.pipeline]
@@ -367,8 +367,8 @@ source = '''
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!(starts_with!(.kubernetes.pod_namespace,"kube") || starts_with!(.kubernetes.pod_namespace,"openshift") || .kubernetes.pod_namespace == "default")'
-route.infra = 'starts_with!(.kubernetes.pod_namespace,"kube") || starts_with!(.kubernetes.pod_namespace,"openshift") || .kubernetes.pod_namespace == "default"'
+route.app = '!((starts_with!(.kubernetes.pod_namespace,"kube")) || (starts_with!(.kubernetes.pod_namespace,"openshift")) || (.kubernetes.pod_namespace == "default"))'
+route.infra = '(starts_with!(.kubernetes.pod_namespace,"kube")) || (starts_with!(.kubernetes.pod_namespace,"openshift")) || (.kubernetes.pod_namespace == "default")'
 
 
 # Rename log stream to "application"
@@ -703,8 +703,8 @@ source = '''
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!(starts_with!(.kubernetes.pod_namespace,"kube") || starts_with!(.kubernetes.pod_namespace,"openshift") || .kubernetes.pod_namespace == "default")'
-route.infra = 'starts_with!(.kubernetes.pod_namespace,"kube") || starts_with!(.kubernetes.pod_namespace,"openshift") || .kubernetes.pod_namespace == "default"'
+route.app = '!((starts_with!(.kubernetes.pod_namespace,"kube")) || (starts_with!(.kubernetes.pod_namespace,"openshift")) || (.kubernetes.pod_namespace == "default"))'
+route.infra = '(starts_with!(.kubernetes.pod_namespace,"kube")) || (starts_with!(.kubernetes.pod_namespace,"openshift")) || (.kubernetes.pod_namespace == "default")'
 
 
 # Rename log stream to "application"

--- a/internal/generator/vector/elements/elements.go
+++ b/internal/generator/vector/elements/elements.go
@@ -1,5 +1,9 @@
 package elements
 
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+)
+
 type Route struct {
 	ComponentID string
 	Desc        string
@@ -52,4 +56,23 @@ source = """
 """
 {{end}}
 `
+}
+
+func Debug(id string, inputs string) generator.Element {
+	return generator.ConfLiteral{
+		Desc:         "Sending records to stdout for debug purposes",
+		ComponentID:  id,
+		InLabel:      inputs,
+		TemplateName: "debug",
+		TemplateStr: `
+{{define "debug" -}}
+[sinks.{{.ComponentID}}]
+inputs = {{.InLabel}}
+type = "console"
+target = "stdout"
+[sinks.{{.ComponentID}}.encoding]
+codec = "json"
+{{end}}
+`,
+	}
 }

--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -6,7 +6,6 @@ import (
 
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
-	"github.com/openshift/cluster-logging-operator/internal/generator"
 	. "github.com/openshift/cluster-logging-operator/internal/generator"
 	genhelper "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 	. "github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
@@ -105,22 +104,7 @@ func (l LokiLabels) Template() string {
 func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
 	if genhelper.IsDebugOutput(op) {
 		return []Element{
-			generator.ConfLiteral{
-				Desc:         "Sending records to stdout for debug purposes",
-				ComponentID:  strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
-				InLabel:      vectorhelpers.MakeInputs(inputs...),
-				TemplateName: "lokidebug",
-				TemplateStr: `
-{{define "lokidebug" -}}
-[sinks.{{.ComponentID}}]
-inputs = {{.InLabel}}
-type = "console"
-target = "stdout"
-[sinks.{{.ComponentID}}.encoding]
-codec = "json"
-{{end}}
-`,
-			},
+			Debug(strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)), vectorhelpers.MakeInputs(inputs...)),
 		}
 	}
 	return MergeElements(

--- a/internal/generator/vector/vrl.go
+++ b/internal/generator/vector/vrl.go
@@ -1,0 +1,49 @@
+package vector
+
+import (
+	"fmt"
+	"strings"
+)
+
+var (
+	SkipEmpty = func(in []string) []string {
+		vals := []string{}
+		for _, v := range in {
+			if strings.TrimSpace(v) != "" {
+				vals = append(vals, v)
+			}
+		}
+		return vals
+	}
+	Paren = func(in string) string {
+		return fmt.Sprintf("(%s)", in)
+	}
+	ParenAll = func(in []string) []string {
+		if len(in) == 1 {
+			return in
+		}
+		vals := []string{}
+		for _, v := range in {
+			vals = append(vals, Paren(v))
+		}
+		return vals
+	}
+	StartWith = func(x, y string) string {
+		return fmt.Sprintf("starts_with!(%s,%q)", x, y)
+	}
+	Eq = func(x, y string) string {
+		return fmt.Sprintf("%s == %q", x, y)
+	}
+	Quote = func(expr string) string {
+		return fmt.Sprintf("'%s'", expr)
+	}
+	OR = func(nsExpr ...string) string {
+		return strings.Join(ParenAll(SkipEmpty(nsExpr)), " || ")
+	}
+	AND = func(nsExpr ...string) string {
+		return strings.Join(ParenAll(SkipEmpty(nsExpr)), " && ")
+	}
+	Neg = func(expr string) string {
+		return fmt.Sprintf("!%s", expr)
+	}
+)


### PR DESCRIPTION
### Description
Support Pod Label based routing of Application logs


/cc @jcantrill @alanconway 
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2255

