### PR TITLE
LOG-2259: Vector: Add Route transform for application routing only once

### DIFF
--- a/internal/generator/vector/sources_to_inputs.go
+++ b/internal/generator/vector/sources_to_inputs.go
@@ -96,6 +96,7 @@ func SourcesToInputs(spec *logging.ClusterLogForwarderSpec, o generator.Options)
 		el = append(el, r)
 	}
 	userDefined := spec.InputMap()
+	routeMap := map[string]string{}
 	for _, pipeline := range spec.Pipelines {
 		for _, inRef := range pipeline.InputRefs {
 			if input, ok := userDefined[inRef]; ok {
@@ -121,17 +122,18 @@ func SourcesToInputs(spec *logging.ClusterLogForwarderSpec, o generator.Options)
 						}
 					}
 					if len(matchNS) != 0 || len(matchLabels) != 0 {
-						el = append(el, Route{
-							ComponentID: RouteApplicationLogs,
-							Inputs:      helpers.MakeInputs(logging.InputNameApplication),
-							Routes: map[string]string{
-								input.Name: Quote(AND(OR(matchNS...), AND(matchLabels...))),
-							},
-						})
+						routeMap[input.Name] = Quote(AND(OR(matchNS...), AND(matchLabels...)))
 					}
 				}
 			}
 		}
+	}
+	if len(routeMap) != 0 {
+		el = append(el, Route{
+			ComponentID: RouteApplicationLogs,
+			Inputs:      helpers.MakeInputs(logging.InputNameApplication),
+			Routes:      routeMap,
+		})
 	}
 
 	return el


### PR DESCRIPTION
### Description
The Route transform was added for each input with user defined inputs. Just one Route transform is sufficient with a map for each user defined input.

/cc @jcantrill 
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2259

