### PR TITLE
Update README.md

### DIFF
--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -4,6 +4,8 @@ cluster-logging must-gather
 `cluster-logging-must-gather` is a tool built on top of [OpenShift must-gather](https://github.com/openshift/must-gather)
 that expands its capabilities to gather Openshift Cluster Logging information.
 
+**Note:** This image is only built for x86_64 architecture
+
 ### Usage
 To gather only Openshift Cluster Logging information: 
 ```sh


### PR DESCRIPTION
fixes #1207 to note the upstream image is only built for x86

