### PR TITLE
Vector: Add vector to forwarder-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,8 @@ test-functional-vector:
 .PHONY: test-functional-vector
 
 test-forwarder-generator: bin/forwarder-generator
-	@bin/forwarder-generator --file hack/logforwarder.yaml > /dev/null
+	@bin/forwarder-generator --file hack/logforwarder.yaml --collector=fluentd > /dev/null
+	@bin/forwarder-generator --file hack/logforwarder.yaml --collector=vector > /dev/null
 .PHONY: test-forwarder-generator
 
 test-functional-benchmarker: bin/functional-benchmarker


### PR DESCRIPTION
### Description
Added an option "collector" to forwarder-generator, and supported two values `fluentd` and `vector`

```
$ ./bin/forwarder-generator -h
Usage of ./bin/forwarder-generator:
      --collector string        collector type: fluentd or vector (default "fluentd")
      --debug-output            Generate config normally, but replace output plugins with @stdout plugin, so that records can be printed in collector logs.
      --file string             ClusterLogForwarder yaml file. - for stdin
      --help                    This message
      --include-default-store   Include the default storage when generating the config (default true)

```

/cc @jcantrill 
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
