### PR TITLE
Add linter to check if focused tests are defined

### DIFF
--- a/hack/run-linter
+++ b/hack/run-linter
@@ -30,4 +30,16 @@ for f in $(ls $bundleDir); do
   fi
 done
 
+set +e
+fitCheck=$(grep -nEIr --include=*_test.go 'FContext|FEntry|FDescribe|FDescribeTable|FIt')
+if [ "$fitCheck" != "" ]; then
+    rc=1
+    echo "Focused tests were found in the code base"
+    echo "Please remove any of FIt, FEntry, FDescribeTable, etc. from:"
+    echo ""
+    echo "$fitCheck"
+    echo ""
+fi
+set -e
+
 exit $rc


### PR DESCRIPTION
### Description
This PR:
* Adds a lint check to determine if a focused test slipped into a commit (e.g. FIt, FDescribe, etc)

cc @vimalk78 @alanconway 
