### PR TITLE
LOG-2289: Add test to verify multiline error detection with applicati…

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -466,5 +466,8 @@ func WrapError(err error) error {
 }
 
 func ToJsonLogs(logs []string) string {
+	if len(logs) == 1 && strings.HasPrefix(logs[0], "[") && strings.HasSuffix(logs[0], "]") {
+		return logs[0]
+	}
 	return fmt.Sprintf("[%s]", strings.Join(logs, ","))
 }

--- a/test/framework/functional/write.go
+++ b/test/framework/functional/write.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLogInNamespace(msg, namespace string, numOfLogs int) error {
+	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], namespace, f.Pod.Name, f.Pod.UID, constants.CollectorName)
+	return f.WriteMessagesToLog(msg, numOfLogs, filename)
+}
 func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLog(msg string, numOfLogs int) error {
 	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], f.Pod.Namespace, f.Pod.Name, f.Pod.UID, constants.CollectorName)
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)


### PR DESCRIPTION
### Desciption
This PR:
* Modifies the multiline error test to verify logs forwarded to multiple locations are received
* Updates the test to use: external elasticsearch, fluentd
* Selectively forwards logs from explicit namespaces only
* Relies upon https://github.com/ViaQ/logging-fluentd/pull/9 to further control kube api results

@kabirbhartiRH this seems to disprove [LOG-2289](https://issues.redhat.com/browse/LOG-2289).  I will additionally be adding a test for release-5.4.  Please review to ensure it properly matches your reported test case. The test produces the following clusterlogforwarder which looks to functionally match what you reported:
```
apiVersion: logging.openshift.io/v1
kind: ClusterLogForwarder
metadata:
  creationTimestamp: null
  name: instance
  namespace: test-r327hsp4
spec:
  inputs:
  - application:
      namespaces:
      - multi-line-test
      - multi-line-test-2
    name: multiline-log-ns
  outputs:
  - name: fluentdForward
    type: fluentdForward
    url: tcp://0.0.0.0:24224
  - name: elasticsearch
    type: elasticsearch
    url: http://0.0.0.0:9200
  pipelines:
  - detectMultilineErrors: true
    inputRefs:
    - multiline-log-ns
    name: forward-pipeline
    outputRefs:
    - fluentdForward
  - detectMultilineErrors: true
    inputRefs:
    - multiline-log-ns
    name: other
    outputRefs:
    - elasticsearch
```

### Links
* https://issues.redhat.com/browse/LOG-2289

cc @kabirbhartiRH 
