### PR TITLE
LOG-2281: Feature Gate Vector to enable for preview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,6 @@ COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/must-g
 
 # this is required because the operator invokes a script as `bash scripts/cert_generation.sh`
 WORKDIR /usr/bin
-ENV ENABLE_VECTOR_COLLECTOR=true
 CMD ["/usr/bin/cluster-logging-operator"]
 
 LABEL \

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -62,7 +62,6 @@ COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/must-g
 
 # this is required because the operator invokes a script as `bash scripts/cert_generation.sh`
 WORKDIR /usr/bin
-ENV ENABLE_VECTOR_COLLECTOR=true
 CMD ["/usr/bin/cluster-logging-operator"]
 
 LABEL \

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -3,7 +3,6 @@ package k8shandler
 import (
 	"context"
 	"fmt"
-	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -75,10 +74,10 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 		if err = clusterRequest.removeCollector(constants.FluentdName); err != nil {
 			log.V(2).Info("Error removing legacy fluentd collector.  ", "err", err)
 		}
-		enabled, present := os.LookupEnv("ENABLE_VECTOR_COLLECTOR")
-		if collectorType == logging.LogCollectionTypeVector && (!present || strings.ToLower(enabled) != "true") {
-			err = errors.NewBadRequest("Vector as collector not enabled via env variable ENABLE_VECTOR_COLLECTOR")
-			log.V(9).Error(err, "Vector as collector not enabled via env variable ENABLE_VECTOR_COLLECTOR")
+		enabled, found := clusterRequest.Cluster.Annotations[PreviewVectorCollector]
+		if collectorType == logging.LogCollectionTypeVector && (!found || enabled != "enabled") {
+			err = errors.NewBadRequest(fmt.Sprintf("Vector as collector not enabled via annotation on ClusterLogging %s", PreviewVectorCollector))
+			log.V(9).Error(err, "Vector as collector not enabled via annotation on ClusterLogging")
 			return err
 		}
 

--- a/internal/k8shandler/vector.go
+++ b/internal/k8shandler/vector.go
@@ -17,6 +17,8 @@ const (
 	vectorConfigValue = "/etc/vector"
 	dataDir           = "datadir"
 	vectorDataDir     = "/var/lib/vector"
+
+	PreviewVectorCollector = "logging.openshift.io/preview-vector-collector"
 )
 
 func (clusterRequest *ClusterLoggingRequest) createOrUpdateVectorDaemonset(fluentdTrustBundle *corev1.ConfigMap, pipelineConfHash string) (err error) {

--- a/test/e2e/logforwarding/loki/forward_to_loki_test.go
+++ b/test/e2e/logforwarding/loki/forward_to_loki_test.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/k8shandler"
 	"github.com/openshift/cluster-logging-operator/test/client"
 	"github.com/openshift/cluster-logging-operator/test/framework/e2e"
 	"github.com/openshift/cluster-logging-operator/test/helpers/loki"
@@ -83,6 +84,7 @@ func TestLogForwardingToLokiWithFluentd(t *testing.T) {
 
 func TestLogForwardingToLokiWithVector(t *testing.T) {
 	cl := runtime.NewClusterLogging()
+	cl.Annotations = map[string]string{k8shandler.PreviewVectorCollector: "enabled"}
 	cl.Spec.Collection.Logs.Type = loggingv1.LogCollectionTypeVector
 	cl.Spec.Collection.Logs.FluentdSpec = loggingv1.FluentdSpec{}
 	clf := runtime.NewClusterLogForwarder()

--- a/test/helpers/clusterlogging.go
+++ b/test/helpers/clusterlogging.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/k8shandler"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,6 +77,7 @@ func NewClusterLogging(componentTypes ...LogComponentType) *cl.ClusterLogging {
 				},
 			}
 		case ComponentTypeCollectorVector:
+			instance.Annotations = map[string]string{k8shandler.PreviewVectorCollector: "enabled"}
 			instance.Spec.Collection = &cl.CollectionSpec{
 				Logs: cl.LogCollectionSpec{
 					Type: cl.LogCollectionTypeVector,


### PR DESCRIPTION
### Description
Added an annotation check while deploying collector.
Need to add `logging.openshift.io/preview-vector-collector: enabled` annotation to `ClusterLogging` to deploy vector as a collector. 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2281

