### PR TITLE
LOG-2333: Fix ES DeDot lua script dropping Journal logs

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -126,13 +126,13 @@ type = "remap"
 inputs = ["raw_container_logs"]
 source = """
   level = "unknown"
-  if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
+  if match!(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
     level = "warn"
-  } else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
+  } else if match!(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
     level = "info"
-  } else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
+  } else if match!(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
     level = "error"
-  } else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
+  } else if match!(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
     level = "debug"
   }
   .level = level
@@ -154,29 +154,7 @@ source = """
 type = "remap"
 inputs = ["raw_journal_logs"]
 source = """
-  level = "unknown"
-  if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
-    level = "warn"
-  } else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
-    level = "info"
-  } else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
-    level = "error"
-  } else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
-    level = "debug"
-  }
-  .level = level
-  
-  namespace_name = .kubernetes.pod_namespace
-  del(.kubernetes.pod_namespace)
-  .kubernetes.namespace_name = namespace_name
-  
-  del(.file)
-  
-  del(.source_type)
-  
-  del(.stream)
-  
-  del(.kubernetes.pod_ips)
+  .
 """
 
 [transforms.route_container_logs]
@@ -332,13 +310,13 @@ type = "remap"
 inputs = ["raw_container_logs"]
 source = """
   level = "unknown"
-  if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
+  if match!(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
     level = "warn"
-  } else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
+  } else if match!(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
     level = "info"
-  } else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
+  } else if match!(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
     level = "error"
-  } else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
+  } else if match!(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
     level = "debug"
   }
   .level = level
@@ -360,29 +338,7 @@ source = """
 type = "remap"
 inputs = ["raw_journal_logs"]
 source = """
-  level = "unknown"
-  if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
-    level = "warn"
-  } else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
-    level = "info"
-  } else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
-    level = "error"
-  } else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
-    level = "debug"
-  }
-  .level = level
-  
-  namespace_name = .kubernetes.pod_namespace
-  del(.kubernetes.pod_namespace)
-  .kubernetes.namespace_name = namespace_name
-  
-  del(.file)
-  
-  del(.source_type)
-  
-  del(.stream)
-  
-  del(.kubernetes.pod_ips)
+  .
 """
 
 [transforms.route_container_logs]
@@ -449,6 +405,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)
@@ -530,6 +487,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)
@@ -683,13 +641,13 @@ type = "remap"
 inputs = ["raw_container_logs"]
 source = """
   level = "unknown"
-  if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
+  if match!(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
     level = "warn"
-  } else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
+  } else if match!(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
     level = "info"
-  } else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
+  } else if match!(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
     level = "error"
-  } else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
+  } else if match!(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
     level = "debug"
   }
   .level = level
@@ -711,29 +669,7 @@ source = """
 type = "remap"
 inputs = ["raw_journal_logs"]
 source = """
-  level = "unknown"
-  if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
-    level = "warn"
-  } else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
-    level = "info"
-  } else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
-    level = "error"
-  } else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
-    level = "debug"
-  }
-  .level = level
-  
-  namespace_name = .kubernetes.pod_namespace
-  del(.kubernetes.pod_namespace)
-  .kubernetes.namespace_name = namespace_name
-  
-  del(.file)
-  
-  del(.source_type)
-  
-  del(.stream)
-  
-  del(.kubernetes.pod_ips)
+  .
 """
 
 [transforms.route_container_logs]
@@ -807,6 +743,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)
@@ -888,6 +825,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)

--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -12,13 +12,13 @@ import (
 const (
 	FixLogLevel = `
 level = "unknown"
-if match(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
+if match!(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")'){
   level = "warn"
-} else if match(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
+} else if match!(.message, r'Info|INFO|I[0-9]+|level=info|Value:info|"level":"info"'){
   level = "info"
-} else if match(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
+} else if match!(.message, r'Error|ERROR|E[0-9]+|level=error|Value:error|"level":"error"'){
   level = "error"
-} else if match(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
+} else if match!(.message, r'Debug|DEBUG|D[0-9]+|level=debug|Value:debug|"level":"debug"'){
   level = "debug"
 }
 .level = level
@@ -81,5 +81,11 @@ func NormalizeContainerLogs(inLabel, outLabel string) []generator.Element {
 }
 
 func NormalizeJournalLogs(inLabel, outLabel string) []generator.Element {
-	return NormalizeContainerLogs(inLabel, outLabel)
+	return []generator.Element{
+		Remap{
+			ComponentID: outLabel,
+			Inputs:      helpers.MakeInputs(inLabel),
+			VRL:         SrcPassThrough,
+		},
+	}
 }

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -76,6 +76,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -68,6 +68,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)
@@ -172,6 +173,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)
@@ -267,6 +269,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)


### PR DESCRIPTION
### Description
Before the events are sent to Elasticsearch sink, a Lua script is used to substitute `.` with `_` in the pod_labels.
The lua script logic does a check for presence of `kubernetes` field in the record, and proceeds to do `DeDot` only if this field is present. The event was not emitted if this field was not present.

Fixed lua script to emit the event if `kubernetes` field is not found.

/cc @jcantrill 
/assign 



### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2333

