### PR TITLE
fixes for CLO Telemetry metrics LOG-710 issues - LOG-2013,LOG-2315,LOG-2018, LOG-2320

### DIFF
--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -83,7 +83,7 @@ func Reconcile(requestCluster *logging.ClusterLogging, requestClient client.Clie
 		if updateCLInfo != nil {
 			log.V(1).Info("Error in updating clusterlogging info for updating metrics", "updateCLInfo", updateCLInfo)
 		}
-		erru := telemetry.UpdateMetrics()
+		erru := telemetry.UpdateCLMetrics()
 		if erru != nil {
 			log.V(1).Error(erru, "Error in updating clo metrics for telemetry")
 		}
@@ -139,7 +139,7 @@ func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, req
 	if updateCLFInfo != nil {
 		log.V(1).Info("Error in updating CLF Info for CLF specific metrics", "updateCLFInfo", updateCLFInfo)
 	}
-	erru := telemetry.UpdateMetrics()
+	erru := telemetry.UpdateCLFMetrics()
 	if erru != nil {
 		log.V(0).Error(erru, "Error in updating clo metrics for telemetry")
 	}
@@ -241,9 +241,9 @@ func UpdateInfofromCL(request *ClusterLoggingRequest) (err error) {
 	if clspec.LogStore != nil {
 		log.V(1).Info("LogStore Type", "clspecLogStoreType", clspec.LogStore.Type)
 		if clspec.LogStore.Type == "elasticsearch" {
-			telemetry.Data.CLOutputType.Set("elasticsearch", "1")
+			telemetry.Data.CLLogStoreType.Set("elasticsearch", "1")
 		} else {
-			telemetry.Data.CLOutputType.Set("elasticsearch", "0")
+			telemetry.Data.CLLogStoreType.Set("elasticsearch", "0")
 		}
 	}
 

--- a/internal/telemetry/cloteleminfo_test.go
+++ b/internal/telemetry/cloteleminfo_test.go
@@ -52,8 +52,8 @@ var _ = Describe("telemetry", func() {
 			})
 			It("Info metric must have version, managedStatus, healthStatus as default values", func() {
 				Expect(CLinfo["version"]).To(Equal(version.Version))
-				Expect(CLFinputType["application"]).To(Equal("1"))
-				Expect(CLFoutputType["default"]).To(Equal("1"))
+				Expect(CLFinputType["application"]).To(Equal("0"))
+				Expect(CLFoutputType["elasticsearch"]).To(Equal("0"))
 			})
 		})
 	})
@@ -72,9 +72,12 @@ var _ = Describe("telemetry", func() {
 		Context("Updating metrics for prometheus", func() {
 			It("Show metrics updated without throwing any errors", func() {
 				CLinfo["version"] = "0.0.2"
-				err := UpdateMetrics()
-				fmt.Printf("UpdateMetrics call returns %v", err)
-				Expect(err).Should(BeNil())
+				err1 := UpdateCLMetrics()
+				fmt.Printf("UpdateMetrics call returns %v", err1)
+				err2 := UpdateCLFMetrics()
+				fmt.Printf("UpdateMetrics call returns %v", err2)
+				Expect(err1).Should(BeNil())
+				Expect(err2).Should(BeNil())
 			})
 
 		})

--- a/main.go
+++ b/main.go
@@ -145,10 +145,6 @@ func main() {
 	if errr != nil {
 		log.Error(err, "Error in registering clo metrics for telemetry")
 	}
-	erru := telemetry.UpdateMetrics()
-	if erru != nil {
-		log.Error(err, "Error in registering clo metrics for telemetry")
-	}
 
 	log.Info("Starting the Cmd.")
 	// Start the Cmd


### PR DESCRIPTION
### Description
Fixes for the below QE raised issues on CLO Telemetry metrics:
[LOG-2320](https://issues.redhat.com/browse/LOG-2320) : Should report as default when outputRefs to default 
[LOG-2313](https://issues.redhat.com/browse/LOG-2313): The CLO shouldn't expose metrics when no clusterlogging/instance 
[LOG-2315](https://issues.redhat.com/browse/LOG-2315): Duplicated items in log_logging_info metrics 
[LOG-2318](https://issues.redhat.com/browse/LOG-2318): Two items for metrics  log_forwarder_input_info  and log_forwarder_output_info 



- JIRA: https://issues.redhat.com/browse/LOG-2313, https://issues.redhat.com/browse/LOG-2315, https://issues.redhat.com/browse/LOG-2318, https://issues.redhat.com/browse/LOG-2320
