### PR TITLE
Vector: Add annotation controlled stdout sink conf generation

### DIFF
--- a/internal/generator/helpers/debug.go
+++ b/internal/generator/helpers/debug.go
@@ -5,8 +5,12 @@ import (
 	elements2 "github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
 )
 
+const (
+	EnableDebugOutput = "debug-output"
+)
+
 func IsDebugOutput(op generator.Options) bool {
-	_, ok := op["debug_output"]
+	_, ok := op[EnableDebugOutput]
 	return ok
 }
 

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -7,6 +7,7 @@ import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	. "github.com/openshift/cluster-logging-operator/internal/generator"
+	genhelper "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 	. "github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	vectorhelpers "github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
@@ -122,9 +123,15 @@ func ID(id1, id2 string) string {
 }
 
 func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
-
 	outputs := []Element{}
 	outputName := strings.ToLower(vectorhelpers.Replacer.Replace(o.Name))
+	if genhelper.IsDebugOutput(op) {
+		return []Element{
+			AddEsID(ID(outputName, "add_es_id"), inputs),
+			DeDotAndFlattenLabels(ID(outputName, "dedot_and_flatten"), []string{ID(outputName, "add_es_id")}),
+			Debug(strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)), vectorhelpers.MakeInputs([]string{ID(outputName, "dedot_and_flatten")}...)),
+		}
+	}
 	outputs = MergeElements(outputs,
 		[]Element{
 			AddEsID(ID(outputName, "add_es_id"), inputs),

--- a/internal/generator/vector/output/kafka/kafka.go
+++ b/internal/generator/vector/output/kafka/kafka.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/helpers"
 	genhelper "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 	urlhelper "github.com/openshift/cluster-logging-operator/internal/generator/url"
+	. "github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	vectorhelpers "github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
 	corev1 "k8s.io/api/core/v1"
@@ -46,6 +47,11 @@ topic = {{.Topic}}
 }
 
 func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
+	if genhelper.IsDebugOutput(op) {
+		return []Element{
+			Debug(strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)), vectorhelpers.MakeInputs(inputs...)),
+		}
+	}
 	return MergeElements(
 		[]Element{
 			Output(o, inputs, secret, op),

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -42,6 +42,8 @@ const (
 	metricsPortName                 = "metrics"
 	metricsVolumeName               = "collector-metrics"
 	prometheusCAFile                = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+
+	AnnotationDebugOutput = "logging.openshift.io/debug-output"
 )
 
 var (

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -3,8 +3,10 @@ package k8shandler
 import (
 	"context"
 	"fmt"
-	forwardergenerator "github.com/openshift/cluster-logging-operator/internal/generator/forwarder"
 	"strings"
+
+	forwardergenerator "github.com/openshift/cluster-logging-operator/internal/generator/forwarder"
+	"github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 
 	"github.com/ViaQ/logerr/log"
 	configv1 "github.com/openshift/api/config/v1"
@@ -53,6 +55,9 @@ func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config s
 	op := generator.Options{}
 	if clusterRequest.useOldRemoteSyslogPlugin() {
 		op[generator.UseOldRemoteSyslogPlugin] = ""
+	}
+	if debug, ok := clusterRequest.ForwarderRequest.Annotations[AnnotationDebugOutput]; ok && strings.ToLower(debug) == "true" {
+		op[helpers.EnableDebugOutput] = "true"
 	}
 
 	var collectorType = clusterRequest.Cluster.Spec.Collection.Logs.Type

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -3,7 +3,9 @@ package forwarder
 import (
 	"errors"
 	"fmt"
+
 	forwardergenerator "github.com/openshift/cluster-logging-operator/internal/generator/forwarder"
+	"github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
@@ -72,7 +74,7 @@ func Generate(collectionType logging.LogCollectionType, clfYaml string, includeD
 		op[generator.UseOldRemoteSyslogPlugin] = ""
 	}
 	if debugOutput {
-		op["debug_output"] = ""
+		op[helpers.EnableDebugOutput] = ""
 	}
 	configGenerator := forwardergenerator.New(collectionType)
 	if configGenerator == nil {


### PR DESCRIPTION
### Description

To debug records reaching a log store, we need to observe what records are being sent out from output sinks.

This PR adds a `stdout` sink instead of the output sink configured in the forwarder, and all the records are logged in the vector's logs.

```
[sinks.<output-name>]
inputs = ["test-app"]
type = "console"
target = "stdout"
[sinks.<output-name>.encoding]
codec = "json"
```
This feature can be controlled by adding an annotation `logging.openshift.io/debug-output: "true"`  to the ClusterLogForwarder 
```
apiVersion: "logging.openshift.io/v1"    
kind: "ClusterLogForwarder"    
metadata:    
  name: "instance"    
  namespace: "openshift-logging"    
  annotations:    
    logging.openshift.io/debug-output: "true"    
spec:    
  outputs:    
    - name: kafka-app    
      url: tls://kafka.kafka_namespace.svc.cluster.local:9092/clo-topic    
      type: kafka    
  pipelines:    
    - name: test-app    
      inputRefs:    
        - infrastructure    
      outputRefs:    
        - kafka-app  
```


/cc @jcantrill @alanconway 
/assign 

