### PR TITLE
Extend the container security e2e test timeout to 3 min

### DIFF
--- a/test/e2e/collection/fluentd/container_security_test.go
+++ b/test/e2e/collection/fluentd/container_security_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	timeout         = `1m`
+	timeout         = `3m`
 	pollingInterval = `10s`
 )
 


### PR DESCRIPTION
### Description
This PR extends the e2e container security test timeout to 3 min since there is evidence of a possible timing issue.  The test times out at 60s and the pod shows an age of 72s

/assign @syedriko 

