### PR TITLE
LOG-1713: fix prometheus roles to be namespaced scoped

### DIFF
--- a/bundle/manifests/cluster-logging-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/cluster-logging-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cluster-logging-operator-metrics-monitor
 spec:
   endpoints:
-    - port: http-metrics
+  - port: http-metrics
   namespaceSelector: {}
   selector:
     matchLabels:

--- a/bundle/manifests/log-collector-privileged-binding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/log-collector-privileged-binding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: log-collector-privileged-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: log-collector-privileged
+subjects:
+- kind: ServiceAccount
+  name: logcollector

--- a/bundle/manifests/log-collector-privileged_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/log-collector-privileged_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: log-collector-privileged
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - log-collector-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -64,15 +64,16 @@ spec:
                         logs.
                       properties:
                         namespaces:
-                          description: Namespaces is a list of namespaces from which
-                            to collect application logs. If the list is empty, logs
-                            are collected from all namespaces.
+                          description: Namespaces from which to collect application
+                            logs. Only messages from these namespaces are collected.
+                            If absent or empty, logs are collected from all namespaces.
                           items:
                             type: string
                           type: array
                         selector:
-                          description: Selector selects logs from all pods with matching
-                            labels. For testing purpose, MatchLabels is only supported.
+                          description: Selector for logs from pods with matching labels.
+                            Only messages from pods with these labels are collected.
+                            If absent or empty, logs are collected regardless of labels.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -252,35 +253,35 @@ spec:
                       description: Name used to refer to the output from a `pipeline`.
                       type: string
                     secret:
-                      description: "Secret for authentication. Name of a secret in
-                        the same namespace as the cluster logging operator. \n All
-                        sensitive authentication information is provided via a kubernetes
-                        Secret object. A Secret is a key:value map, common keys are
-                        described here. Some output types support additional specialized
-                        keys, documented with the output-specific configuration field.
-                        All secret keys are optional, enable the security features
-                        you want by setting the relevant keys. \n Transport Layer
-                        Security (TLS) \n Using a TLS URL ('https://...' or 'ssl://...')
-                        without any secret enables basic TLS: client authenticates
-                        server using system default certificate authority. \n Additional
-                        TLS features are enabled by including a Secret and setting
-                        the following optional fields: \n   `tls.crt`: (string) File
-                        name containing a client certificate.     Enables mutual authentication.
-                        Requires `tls.key`.   `tls.key`: (string) File name containing
-                        the private key to unlock the client certificate.     Requires
-                        `tls.crt`   `passphrase`: (string) Passphrase to decode an
-                        encoded TLS private key.     Requires tls.key.   `ca-bundle.crt`:
-                        (string) File name of a custom CA for server authentication.
-                        \n Username and Password \n   `username`: (string) Authentication
-                        user name. Requires `password`.   `password`: (string) Authentication
-                        password. Requires `username`. \n Simple Authentication Security
-                        Layer (SASL) \n   `sasl.enable`: (boolean) Explicitly enable
-                        or disable SASL.     If missing, SASL is automatically enabled
-                        when any of the other `sasl.` keys are set.   `sasl.mechanisms`:
-                        (array) List of allowed SASL mechanism names.     If missing
-                        or empty, the system defaults are used.   `sasl.allow-insecure`:
-                        (boolean) Allow mechanisms that send clear-text passwords.
-                        \    Default false."
+                      description: "Secret for authentication. \n Names a secret in
+                        the same namespace as the ClusterLogForwarder. \n Sensitive
+                        authentication information is stored in a separate Secret
+                        object. A Secret is like a ConfigMap, where the keys are strings
+                        and the values are base64-encoded binary data, for example
+                        TLS certificates. \n Common keys are described here. Some
+                        output types support additional keys, documented with the
+                        output-specific configuration field. All secret keys are optional,
+                        enable the security features you want by setting the relevant
+                        keys. \n Transport Layer Security (TLS) \n Using a TLS URL
+                        ('https://...' or 'ssl://...') without any secret enables
+                        basic TLS: client authenticates server using system default
+                        certificate authority. \n Additional TLS features are enabled
+                        by referencing a Secret with the following optional fields
+                        in its spec.data. All data fields are base64 encoded. \n   `tls.crt`:
+                        A client certificate, for mutual authentication. Requires
+                        `tls.key`.   `tls.key`: Private key to unlock the client certificate.
+                        Requires `tls.crt`   `passphrase`: Passphrase to decode an
+                        encoded TLS private key. Requires tls.key.   `ca-bundle.crt`:
+                        Custom CA to validate certificates. \n Username and Password
+                        \n   `username`: Authentication user name. Requires `password`.
+                        \  `password`: Authentication password. Requires `username`.
+                        \n Simple Authentication Security Layer (SASL) \n   `sasl.enable`:
+                        (boolean) Explicitly enable or disable SASL.     If missing,
+                        SASL is automatically enabled if any `sasl.*` keys are set.
+                        \  `sasl.mechanisms`: (array of string) List of allowed SASL
+                        mechanism names.     If missing or empty, the system defaults
+                        are used.   `sasl.allow-insecure`: (boolean) Allow mechanisms
+                        that send clear-text passwords.     Default false."
                       properties:
                         name:
                           description: Name of a secret in the namespace configured
@@ -400,7 +401,9 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels lists labels applied to this pipeline
+                      description: Labels applied to log records passing through this
+                        pipeline. These labels appear in the `openshift.labels` map
+                        in the log record.
                       type: object
                     name:
                       description: Name is optional, but must be unique in the `pipelines`

--- a/bundle/manifests/metadata-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/metadata-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: metadata-reader
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs: ["get", "list", "watch"]

--- a/bundle/manifests/prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: clusterlogging-collector-metrics
+  name: prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: clusterlogging-collector-metrics
+  kind: Role
+  name: prometheus
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -45,12 +45,12 @@ spec:
                       description: Application, if present, enables `application` logs.
                       properties:
                         namespaces:
-                          description: Namespaces is a list of namespaces from which to collect application logs. If the list is empty, logs are collected from all namespaces.
+                          description: Namespaces from which to collect application logs. Only messages from these namespaces are collected. If absent or empty, logs are collected from all namespaces.
                           items:
                             type: string
                           type: array
                         selector:
-                          description: Selector selects logs from all pods with matching labels. For testing purpose, MatchLabels is only supported.
+                          description: Selector for logs from pods with matching labels. Only messages from pods with these labels are collected. If absent or empty, logs are collected regardless of labels.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -168,7 +168,7 @@ spec:
                       description: Name used to refer to the output from a `pipeline`.
                       type: string
                     secret:
-                      description: "Secret for authentication. Name of a secret in the same namespace as the cluster logging operator. \n All sensitive authentication information is provided via a kubernetes Secret object. A Secret is a key:value map, common keys are described here. Some output types support additional specialized keys, documented with the output-specific configuration field. All secret keys are optional, enable the security features you want by setting the relevant keys. \n Transport Layer Security (TLS) \n Using a TLS URL ('https://...' or 'ssl://...') without any secret enables basic TLS: client authenticates server using system default certificate authority. \n Additional TLS features are enabled by including a Secret and setting the following optional fields: \n   `tls.crt`: (string) File name containing a client certificate.     Enables mutual authentication. Requires `tls.key`.   `tls.key`: (string) File name containing the private key to unlock the client certificate.     Requires `tls.crt`   `passphrase`: (string) Passphrase to decode an encoded TLS private key.     Requires tls.key.   `ca-bundle.crt`: (string) File name of a custom CA for server authentication. \n Username and Password \n   `username`: (string) Authentication user name. Requires `password`.   `password`: (string) Authentication password. Requires `username`. \n Simple Authentication Security Layer (SASL) \n   `sasl.enable`: (boolean) Explicitly enable or disable SASL.     If missing, SASL is automatically enabled when any of the other `sasl.` keys are set.   `sasl.mechanisms`: (array) List of allowed SASL mechanism names.     If missing or empty, the system defaults are used.   `sasl.allow-insecure`: (boolean) Allow mechanisms that send clear-text passwords.     Default false."
+                      description: "Secret for authentication. \n Names a secret in the same namespace as the ClusterLogForwarder. \n Sensitive authentication information is stored in a separate Secret object. A Secret is like a ConfigMap, where the keys are strings and the values are base64-encoded binary data, for example TLS certificates. \n Common keys are described here. Some output types support additional keys, documented with the output-specific configuration field. All secret keys are optional, enable the security features you want by setting the relevant keys. \n Transport Layer Security (TLS) \n Using a TLS URL ('https://...' or 'ssl://...') without any secret enables basic TLS: client authenticates server using system default certificate authority. \n Additional TLS features are enabled by referencing a Secret with the following optional fields in its spec.data. All data fields are base64 encoded. \n   `tls.crt`: A client certificate, for mutual authentication. Requires `tls.key`.   `tls.key`: Private key to unlock the client certificate. Requires `tls.crt`   `passphrase`: Passphrase to decode an encoded TLS private key. Requires tls.key.   `ca-bundle.crt`: Custom CA to validate certificates. \n Username and Password \n   `username`: Authentication user name. Requires `password`.   `password`: Authentication password. Requires `username`. \n Simple Authentication Security Layer (SASL) \n   `sasl.enable`: (boolean) Explicitly enable or disable SASL.     If missing, SASL is automatically enabled if any `sasl.*` keys are set.   `sasl.mechanisms`: (array of string) List of allowed SASL mechanism names.     If missing or empty, the system defaults are used.   `sasl.allow-insecure`: (boolean) Allow mechanisms that send clear-text passwords.     Default false."
                       properties:
                         name:
                           description: Name of a secret in the namespace configured for log forwarder secrets.
@@ -248,7 +248,7 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels lists labels applied to this pipeline
+                      description: Labels applied to log records passing through this pipeline. These labels appear in the `openshift.labels` map in the log record.
                       type: object
                     name:
                       description: Name is optional, but must be unique in the `pipelines` list if provided.

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
 - log_collector_privileged_binding.yaml
 - metadata_reader_clusterrole.yaml
 - metadata_reader_clusterrolebinding.yaml
+- prometheus_role.yaml
+- prometheus_role_binding.yaml
 #- leader_election_role.yaml
 #- leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable

--- a/config/rbac/prometheus_role.yaml
+++ b/config/rbac/prometheus_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: clusterlogging-collector-metrics
+  name: prometheus
 rules:
 - apiGroups: [""]
   resources:

--- a/config/rbac/prometheus_role_binding.yaml
+++ b/config/rbac/prometheus_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring 

--- a/hack/generate-bundle.sh
+++ b/hack/generate-bundle.sh
@@ -24,7 +24,5 @@ LABEL \\
     maintainer="AOS Logging <aos-logging@redhat.com>"
 EOF
 
-find bundle/manifests/ -type f ! \( -name "cluster-logging*" -o -name "*crd.yaml" \) -delete
-
 echo "validating bundle..."
 $OPERATOR_SDK bundle validate --verbose bundle

--- a/manifests/5.5/cluster-logging-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/manifests/5.5/cluster-logging-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cluster-logging-operator-metrics-monitor
 spec:
   endpoints:
-    - port: http-metrics
+  - port: http-metrics
   namespaceSelector: {}
   selector:
     matchLabels:

--- a/manifests/5.5/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/manifests/5.5/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -64,15 +64,16 @@ spec:
                         logs.
                       properties:
                         namespaces:
-                          description: Namespaces is a list of namespaces from which
-                            to collect application logs. If the list is empty, logs
-                            are collected from all namespaces.
+                          description: Namespaces from which to collect application
+                            logs. Only messages from these namespaces are collected.
+                            If absent or empty, logs are collected from all namespaces.
                           items:
                             type: string
                           type: array
                         selector:
-                          description: Selector selects logs from all pods with matching
-                            labels. For testing purpose, MatchLabels is only supported.
+                          description: Selector for logs from pods with matching labels.
+                            Only messages from pods with these labels are collected.
+                            If absent or empty, logs are collected regardless of labels.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -252,35 +253,35 @@ spec:
                       description: Name used to refer to the output from a `pipeline`.
                       type: string
                     secret:
-                      description: "Secret for authentication. Name of a secret in
-                        the same namespace as the cluster logging operator. \n All
-                        sensitive authentication information is provided via a kubernetes
-                        Secret object. A Secret is a key:value map, common keys are
-                        described here. Some output types support additional specialized
-                        keys, documented with the output-specific configuration field.
-                        All secret keys are optional, enable the security features
-                        you want by setting the relevant keys. \n Transport Layer
-                        Security (TLS) \n Using a TLS URL ('https://...' or 'ssl://...')
-                        without any secret enables basic TLS: client authenticates
-                        server using system default certificate authority. \n Additional
-                        TLS features are enabled by including a Secret and setting
-                        the following optional fields: \n   `tls.crt`: (string) File
-                        name containing a client certificate.     Enables mutual authentication.
-                        Requires `tls.key`.   `tls.key`: (string) File name containing
-                        the private key to unlock the client certificate.     Requires
-                        `tls.crt`   `passphrase`: (string) Passphrase to decode an
-                        encoded TLS private key.     Requires tls.key.   `ca-bundle.crt`:
-                        (string) File name of a custom CA for server authentication.
-                        \n Username and Password \n   `username`: (string) Authentication
-                        user name. Requires `password`.   `password`: (string) Authentication
-                        password. Requires `username`. \n Simple Authentication Security
-                        Layer (SASL) \n   `sasl.enable`: (boolean) Explicitly enable
-                        or disable SASL.     If missing, SASL is automatically enabled
-                        when any of the other `sasl.` keys are set.   `sasl.mechanisms`:
-                        (array) List of allowed SASL mechanism names.     If missing
-                        or empty, the system defaults are used.   `sasl.allow-insecure`:
-                        (boolean) Allow mechanisms that send clear-text passwords.
-                        \    Default false."
+                      description: "Secret for authentication. \n Names a secret in
+                        the same namespace as the ClusterLogForwarder. \n Sensitive
+                        authentication information is stored in a separate Secret
+                        object. A Secret is like a ConfigMap, where the keys are strings
+                        and the values are base64-encoded binary data, for example
+                        TLS certificates. \n Common keys are described here. Some
+                        output types support additional keys, documented with the
+                        output-specific configuration field. All secret keys are optional,
+                        enable the security features you want by setting the relevant
+                        keys. \n Transport Layer Security (TLS) \n Using a TLS URL
+                        ('https://...' or 'ssl://...') without any secret enables
+                        basic TLS: client authenticates server using system default
+                        certificate authority. \n Additional TLS features are enabled
+                        by referencing a Secret with the following optional fields
+                        in its spec.data. All data fields are base64 encoded. \n   `tls.crt`:
+                        A client certificate, for mutual authentication. Requires
+                        `tls.key`.   `tls.key`: Private key to unlock the client certificate.
+                        Requires `tls.crt`   `passphrase`: Passphrase to decode an
+                        encoded TLS private key. Requires tls.key.   `ca-bundle.crt`:
+                        Custom CA to validate certificates. \n Username and Password
+                        \n   `username`: Authentication user name. Requires `password`.
+                        \  `password`: Authentication password. Requires `username`.
+                        \n Simple Authentication Security Layer (SASL) \n   `sasl.enable`:
+                        (boolean) Explicitly enable or disable SASL.     If missing,
+                        SASL is automatically enabled if any `sasl.*` keys are set.
+                        \  `sasl.mechanisms`: (array of string) List of allowed SASL
+                        mechanism names.     If missing or empty, the system defaults
+                        are used.   `sasl.allow-insecure`: (boolean) Allow mechanisms
+                        that send clear-text passwords.     Default false."
                       properties:
                         name:
                           description: Name of a secret in the namespace configured
@@ -400,7 +401,9 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels lists labels applied to this pipeline
+                      description: Labels applied to log records passing through this
+                        pipeline. These labels appear in the `openshift.labels` map
+                        in the log record.
                       type: object
                     name:
                       description: Name is optional, but must be unique in the `pipelines`

--- a/manifests/5.5/prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/manifests/5.5/prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs: ["get", "list", "watch"]

--- a/manifests/5.5/prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/manifests/5.5/prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring 


### PR DESCRIPTION
### Description
This PR:
* Fixes the prometheus roles to be namespace scoped

### Links
* https://issues.redhat.com/browse/LOG-1713