### PR TITLE
LOG-2375: Vector: Added Status for missong preview annotation

### DIFF
--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -80,7 +80,12 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 		if collectorType == logging.LogCollectionTypeVector && (!found || enabled != "enabled") {
 			err = errors.NewBadRequest(fmt.Sprintf("Vector as collector not enabled via annotation on ClusterLogging %s", PreviewVectorCollector))
 			log.V(9).Error(err, "Vector as collector not enabled via annotation on ClusterLogging")
-			return err
+			return clusterRequest.UpdateCondition(
+				logging.CollectorDeadEnd,
+				"Add annotation \"logging.openshift.io/preview-vector-collector: enabled\" to ClusterLogging CR",
+				"Vector as collector not enabled via annotation on ClusterLogging",
+				corev1.ConditionTrue,
+			)
 		}
 
 		if err = clusterRequest.removeCollectorSecretIfOwnedByCLO(); err != nil {


### PR DESCRIPTION
### Description
This PR adds a Status if vector is used as collector and preview annotation is missing

```
  status:
    clusterConditions:
    - lastTransitionTime: "2022-03-15T09:14:45Z"
      message: 'Add annotation "logging.openshift.io/preview-vector-collector: enabled"
        to ClusterLogging CR'
      reason: Vector as collector not enabled via annotation on ClusterLogging
      status: "True"
      type: CollectorDeadEnd

```

/cc @alanconway @jcantrill 


/cherry-pick release-5.4

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2375
