### PR TITLE
update minimal test to check unmanaged CL first

### DIFF
--- a/hack/testing-olm/test-010-deploy-via-olm-minimal.sh
+++ b/hack/testing-olm/test-010-deploy-via-olm-minimal.sh
@@ -62,6 +62,19 @@ os::cmd::try_until_text "oc -n $NAMESPACE get deployment cluster-logging-operato
 # test the validation of an invalid cr
 os::cmd::expect_failure_and_text "oc -n $NAMESPACE create -f ${repo_dir}/hack/cr_invalid.yaml" "invalid: metadata.name: Unsupported value"
 
+# deploy cluster logging with unmanaged state
+os::cmd::expect_success "oc -n $NAMESPACE create -f ${repo_dir}/hack/cr-unmanaged.yaml"
+
+# wait few seconds
+sleep 10
+# assert does not exist
+assert_resources_does_not_exist
+# assert kibana instance does not exists
+assert_kibana_instance_does_not_exists
+
+# delete cluster logging
+os::cmd::expect_success "oc -n $NAMESPACE delete -f ${repo_dir}/hack/cr-unmanaged.yaml"
+
 # deploy cluster logging
 os::cmd::expect_success "oc -n $NAMESPACE create -f ${repo_dir}/hack/cr.yaml"
 
@@ -73,12 +86,3 @@ assert_kibana_instance_exists
 # delete cluster logging
 os::cmd::expect_success "oc -n $NAMESPACE delete -f ${repo_dir}/hack/cr.yaml"
 
-# deploy cluster logging with unmanaged state
-os::cmd::expect_success "oc -n $NAMESPACE create -f ${repo_dir}/hack/cr-unmanaged.yaml"
-
-# wait few seconds
-sleep 10
-# assert does not exist
-assert_resources_does_not_exist
-# assert kibana instance does not exists
-assert_kibana_instance_does_not_exists


### PR DESCRIPTION
### Description
This PR introduces a similar change from master to check for unmananged logging before managed.  This change was made in an effort to fix issues like https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/ViaQ_logging-fluentd/12/pull-ci-ViaQ-logging-fluentd-v1.7.4-cluster-logging-operator-e2e-5-2/1502645978719588352 which is otherwise a successful test

/assign @vimalk78 @alanconway 

### Links
* should unblock https://github.com/ViaQ/logging-fluentd/pull/12
