### PR TITLE
LOG-2291: Fix OptionalInt type

### DIFF
--- a/test/helpers/types/optional_int_test.go
+++ b/test/helpers/types/optional_int_test.go
@@ -18,7 +18,7 @@ var _ = Describe("OptionalInt", func() {
 	DescribeTable("#IsSatisfiedBy", func(expOptInt, otherValue string, satisfied bool) {
 		exp := NewOptionalInt(expOptInt)
 		other := NewOptionalInt(otherValue)
-		Expect(exp.IsSatisfiedBy(other)).To(Equal(satisfied), "Exp. %s to satisfy %s", otherValue, expOptInt)
+		Expect(exp.IsSatisfiedBy(other)).To(Equal(satisfied), "Exp. %q to satisfy %q", otherValue, expOptInt)
 	},
 		Entry("GreaterThan ", ">6", "7", true),
 		Entry("GreaterThan Equal ", ">=6", "6", true),
@@ -29,5 +29,7 @@ var _ = Describe("OptionalInt", func() {
 		Entry("LessThan Equal ", "<=6", "6", true),
 		Entry("LessThan Equal ", "<=6", "5", true),
 		Entry("Fail LessThan Equal ", "<=6", "8", false),
+		Entry("Equal empty values", "", "", true),
+		Entry("Optional provided but not required", "", "6", true),
 	)
 })

--- a/test/matchers/log_format.go
+++ b/test/matchers/log_format.go
@@ -104,6 +104,7 @@ func compareLogLogic(name string, templateValue interface{}, value interface{}) 
 	if reflect.TypeOf(templateValue).Name() == "OptionalInt" {
 		expValue := templateValue.(testtypes.OptionalInt)
 		actValue := value.(testtypes.OptionalInt)
+		logger.V(3).Info("CompareLogLogic: OptionalInt for", "name", name, "value", valueString, "exp", expValue, "act", actValue)
 		return expValue.IsSatisfiedBy(actValue)
 	}
 	if templateValueString == valueString { // Same value is ok

--- a/test/matchers/log_format_test.go
+++ b/test/matchers/log_format_test.go
@@ -53,6 +53,44 @@ var _ = Describe("Log Format matcher tests", func() {
 		nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 		Expect(types.AllLog{Timestamp: nanoTime}).To(FitLogFormatTemplate(types.AllLog{}))
 	})
+	Context("for optional ints", func() {
+		It("it should pass when field is missing and value is optional", func() {
+			Expect(types.AllLog{}).To(FitLogFormatTemplate(types.AllLog{
+				OpenshiftLabels: types.OpenshiftMeta{
+					Sequence: types.NewOptionalInt(""),
+				},
+			}))
+		})
+		It("it should pass when field exists and value is optional", func() {
+			Expect(types.AllLog{
+				OpenshiftLabels: types.OpenshiftMeta{
+					Sequence: types.NewOptionalInt("5"),
+				},
+			}).To(FitLogFormatTemplate(types.AllLog{
+				OpenshiftLabels: types.OpenshiftMeta{
+					Sequence: types.NewOptionalInt(""),
+				},
+			}))
+		})
+		It("it should fail when field is missing and match expected", func() {
+			Expect(types.AllLog{}).ToNot(FitLogFormatTemplate(types.AllLog{
+				OpenshiftLabels: types.OpenshiftMeta{
+					Sequence: types.NewOptionalInt("=8"),
+				},
+			}))
+		})
+		It("it should fail when field exists and value does not match spec", func() {
+			Expect(types.AllLog{
+				OpenshiftLabels: types.OpenshiftMeta{
+					Sequence: types.NewOptionalInt("5"),
+				},
+			}).ToNot(FitLogFormatTemplate(types.AllLog{
+				OpenshiftLabels: types.OpenshiftMeta{
+					Sequence: types.NewOptionalInt("=8"),
+				},
+			}))
+		})
+	})
 
 	It("do not match wrong time value", func() {
 		timestamp1 := "2013-03-28T14:36:03.243000+00:00"


### PR DESCRIPTION
### Description
This PR provides additional fixes to test code:
* Properly defining OptionalInt("") to mean accept anything including a missing value
* Add tests to verify OptionalInt expectations
* Blocks https://github.com/ViaQ/logging-fluentd/pull/20 and associated bugs
* Follows-up https://github.com/openshift/cluster-logging-operator/pull/1334

/assign @vimalk78 @cahartma 

### Links
* https://issues.redhat.com/browse/LOG-2291
