### PR TITLE
LOG-2185: /var/lib/fluentd is world-readable

### DIFF
--- a/internal/components/fluentd/run_script.go
+++ b/internal/components/fluentd/run_script.go
@@ -4,6 +4,8 @@ package fluentd
 const RunScript = `
 #!/bin/bash
 
+umask 0077
+
 CFG_DIR=/etc/fluent/configs.d
 
 fluentdargs="--no-supervisor"


### PR DESCRIPTION
### Description

[LOG-2185](https://issues.redhat.com/browse/LOG-2185): /var/lib/fluentd is world-readable. Limit access to fluentd buffers on disk.
Unlike Fluentd 1.14, Fluentd 1.7 is umask-transparent and doesn't need umask fixes. Meaning Fluentd 1.7 adopts the umask set in the shell that execs it.

/cc @alanconway
/assign @jcantrill

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2185