### PR TITLE
LOG-2393: Fix loki output url parse and add bearer_token support

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -12,6 +12,7 @@ const (
 	ClientPrivateKey   = "tls.key"
 	TrustedCABundleKey = "ca-bundle.crt"
 	Passphrase         = "passphrase"
+	BearerTokenFileKey = "token"
 
 	// Username/Password keys, used by any output with username/password authentication.
 

--- a/internal/generator/fluentd/output/loki/bearer-token-file.go
+++ b/internal/generator/fluentd/output/loki/bearer-token-file.go
@@ -1,0 +1,18 @@
+package loki
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+)
+
+type BearerTokenFile security.BearerTokenFile
+
+func (bt BearerTokenFile) Name() string {
+	return "lokiBearerTokenFileTemplate"
+}
+
+func (bt BearerTokenFile) Template() string {
+	return `{{define "` + bt.Name() + `" -}}
+bearer_token_file "{{ .BearerTokenFilePath }}"
+{{- end}}
+`
+}

--- a/internal/generator/fluentd/output/loki/ca-file.go
+++ b/internal/generator/fluentd/output/loki/ca-file.go
@@ -7,7 +7,7 @@ import (
 type CAFile security.CAFile
 
 func (ca CAFile) Name() string {
-	return "elasticsearchCAFileTemplate"
+	return "lokiCAFileTemplate"
 }
 
 func (ca CAFile) Template() string {

--- a/internal/generator/fluentd/output/loki/cert-key.go
+++ b/internal/generator/fluentd/output/loki/cert-key.go
@@ -7,7 +7,7 @@ import (
 type TLSKeyCert security.TLSCertKey
 
 func (kc TLSKeyCert) Name() string {
-	return "elasticsearchCertKeyTemplate"
+	return "lokiCertKeyTemplate"
 }
 
 func (kc TLSKeyCert) Template() string {

--- a/internal/generator/fluentd/output/loki/loki.go
+++ b/internal/generator/fluentd/output/loki/loki.go
@@ -87,7 +87,7 @@ func Output(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o logging
 	}
 	// url is parasable, checked at input sanitization
 	u, _ := urlhelper.Parse(o.URL)
-	urlBase := fmt.Sprintf("%v://%v", u.Scheme, u.Host)
+	urlBase := fmt.Sprintf("%v://%v%v", u.Scheme, u.Host, u.Path)
 	storeID := helpers.StoreID("", o.Name, "")
 	return Match{
 		MatchTags: "**",
@@ -124,6 +124,12 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 				CAFilePath: security.SecretPath(o.Secret.Name, constants.TrustedCABundleKey),
 			}
 			conf = append(conf, ca)
+		}
+		if security.HasBearerTokenFileKey(secret) {
+			bt := BearerTokenFile{
+				BearerTokenFilePath: security.GetFromSecret(secret, constants.BearerTokenFileKey),
+			}
+			conf = append(conf, bt)
 		}
 	}
 	return conf

--- a/internal/generator/fluentd/output/loki/userpass.go
+++ b/internal/generator/fluentd/output/loki/userpass.go
@@ -7,7 +7,7 @@ import (
 type UserNamePass security2.UserNamePass
 
 func (up UserNamePass) Name() string {
-	return "elasticsearchUsernamePasswordTemplate"
+	return "lokiUsernamePasswordTemplate"
 }
 
 func (up UserNamePass) Template() string {

--- a/internal/generator/fluentd/output/security/security.go
+++ b/internal/generator/fluentd/output/security/security.go
@@ -34,6 +34,10 @@ type Passphrase struct {
 	PassphrasePath string
 }
 
+type BearerTokenFile struct {
+	BearerTokenFilePath string
+}
+
 var NoSecrets = map[string]*corev1.Secret{}
 
 func HasUsernamePassword(secret *corev1.Secret) bool {
@@ -54,6 +58,10 @@ func HasSharedKey(secret *corev1.Secret) bool {
 
 func HasPassphrase(secret *corev1.Secret) bool {
 	return HasKeys(secret, constants.Passphrase)
+}
+
+func HasBearerTokenFileKey(secret *corev1.Secret) bool {
+	return HasKeys(secret, constants.BearerTokenFileKey)
 }
 
 // GetKey if found return value and ok=true, else ok=false


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR:
- fixes loki output url parse method.
- add support for bearer_token in secrets.
- rename `elasticsearch` -> `loki` in all loki templates.

/cc @periklis 
/assign @periklis 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2393, https://issues.redhat.com/browse/LOG-2392
