### PR TITLE
LOG-2291: Fix OVN audit test to expect sequence no

### DIFF
--- a/test/functional/normalization/message_format_test.go
+++ b/test/functional/normalization/message_format_test.go
@@ -194,11 +194,14 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 
 		// Template expected as output Log
 		var outputLogTemplate = types.OVNAuditLog{
-			Message:          ovnLogLine,
-			Level:            level,
-			Hostname:         functional.FunctionalNodeName,
-			Timestamp:        time.Time{},
-			LogType:          "audit",
+			Message:   ovnLogLine,
+			Level:     level,
+			Hostname:  functional.FunctionalNodeName,
+			Timestamp: time.Time{},
+			LogType:   "audit",
+			Openshift: types.OpenshiftMeta{
+				Sequence: types.NewOptionalInt(""),
+			},
 			ViaqIndexName:    "audit-write",
 			ViaqMsgID:        "*",
 			PipelineMetadata: functional.TemplateForAnyPipelineMetadata,

--- a/test/helpers/types/types.go
+++ b/test/helpers/types/types.go
@@ -195,6 +195,7 @@ type OVNAuditLog struct {
 	ViaqIndexName    string           `json:"viaq_index_name"`
 	ViaqMsgID        string           `json:"viaq_msg_id"`
 	Kubernetes       Kubernetes       `json:"kubernetes"`
+	Openshift        OpenshiftMeta    `json:"openshift"`
 	Level            string           `json:"level,omitempty"`
 }
 


### PR DESCRIPTION
### Description
This PR:
* updates OVN audit log test to expect sequence number

### Links
* https://issues.redhat.com/browse/LOG-2291
