### PR TITLE
LOG-2398: Fix ES DeDot lua script dropping Journal logs

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -445,6 +445,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)
@@ -524,6 +525,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)
@@ -797,6 +799,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)
@@ -876,6 +879,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -448,6 +448,10 @@ source = """
             emit(event)
             return
         end
+        if event.log.kubernetes.pod_labels == nil then
+            emit(event)
+            return
+        end
         dedot(event.log.kubernetes.pod_labels)
         -- create "flat_labels" key
         event.log.kubernetes.flat_labels = {}
@@ -525,6 +529,10 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.pod_labels == nil then
             emit(event)
             return
         end
@@ -802,6 +810,10 @@ source = """
             emit(event)
             return
         end
+        if event.log.kubernetes.pod_labels == nil then
+            emit(event)
+            return
+        end
         dedot(event.log.kubernetes.pod_labels)
         -- create "flat_labels" key
         event.log.kubernetes.flat_labels = {}
@@ -879,6 +891,10 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.pod_labels == nil then
             emit(event)
             return
         end

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -82,6 +82,10 @@ source = """
             emit(event)
             return
         end
+        if event.log.kubernetes.pod_labels == nil then
+            emit(event)
+            return
+        end
         dedot(event.log.kubernetes.pod_labels)
         -- create "flat_labels" key
         event.log.kubernetes.flat_labels = {}

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -79,6 +79,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -71,6 +71,10 @@ source = """
             emit(event)
             return
         end
+        if event.log.kubernetes.pod_labels == nil then
+            emit(event)
+            return
+        end
         dedot(event.log.kubernetes.pod_labels)
         -- create "flat_labels" key
         event.log.kubernetes.flat_labels = {}
@@ -175,6 +179,10 @@ source = """
             emit(event)
             return
         end
+        if event.log.kubernetes.pod_labels == nil then
+            emit(event)
+            return
+        end
         dedot(event.log.kubernetes.pod_labels)
         -- create "flat_labels" key
         event.log.kubernetes.flat_labels = {}
@@ -266,6 +274,10 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.pod_labels == nil then
             emit(event)
             return
         end

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -68,6 +68,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)
@@ -171,6 +172,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)
@@ -264,6 +266,7 @@ hooks.process = "process"
 source = """
     function process(event, emit)
         if event.log.kubernetes == nil then
+            emit(event)
             return
         end
         dedot(event.log.kubernetes.pod_labels)


### PR DESCRIPTION

### Description
A manual cherry pick of https://github.com/openshift/cluster-logging-operator/pull/1371 [LOG-2333](https://issues.redhat.com/browse/LOG-2333) 
A partial manual cherry pick of https://github.com/openshift/cluster-logging-operator/pull/1401/commits/80e5e27f86bfc9da3998a54c7357b5bb4176ae92 for fixing ES DeDot lua script which rejects records if ot does not contain pod labels.

/cc 
/assign 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2398

