### PR TITLE
LOG-1099: Fluentd firing far too many dns requests

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -44,8 +44,7 @@ const (
 	TrustedCABundleHashName    = "logging.openshift.io/hash"
 	SecretHashPrefix           = "logging.openshift.io/"
 	KibanaTrustedCAName        = "kibana-trusted-ca-bundle"
-	// internal elasticsearch FQDN to prevent to connect to the global proxy
-	ElasticsearchFQDN          = "elasticsearch.openshift-logging.svc"
+	ElasticsearchFQDN          = "elasticsearch"
 	ElasticsearchName          = "elasticsearch"
 	ElasticsearchPort          = "9200"
 	FluentdName                = "fluentd"

--- a/internal/k8shandler/forwarding_test.go
+++ b/internal/k8shandler/forwarding_test.go
@@ -587,7 +587,7 @@ outputs:
 	secret:
 		name: collector
 	type: elasticsearch
-	url: https://elasticsearch.openshift-logging.svc:9200
+	url: https://` + constants.ElasticsearchFQDN + `:9200
 pipelines:
 - inputRefs:
 	- application
@@ -618,7 +618,7 @@ pipelines:
 			spec, status := request.NormalizeForwarder()
 			Expect(spec.Outputs).To(HaveLen(1))
 			Expect(spec.Outputs[0].Name).To(Equal("default"))
-			Expect(spec.Outputs[0].URL).To(Equal("https://elasticsearch.openshift-logging.svc:9200"))
+			Expect(spec.Outputs[0].URL).To(Equal("https://" + constants.ElasticsearchFQDN + ":9200"))
 			Expect(spec.Outputs[0].Secret.Name).To(Equal(constants.CollectorSecretName))
 			Expect(spec.Outputs[0].Type).To(Equal("elasticsearch"))
 


### PR DESCRIPTION
### Description
Make Elastic's DNS name just "elasticsearch" as opposed to "elasticsearch.openshift-logging.svc" in order to avoid extra DNS queries from fluentd.

/cc @alanconway 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-1909
