### PR TITLE
LOG-2476: Change ES index as per OutputDefaults

### DIFF
--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -24,11 +24,6 @@ if match!(.message,r'(Warning|WARN|W[0-9]+|level=warn|Value:warn|"level":"warn")
 .level = level
 `
 
-	ChangeNSNameField = `
-namespace_name = .kubernetes.pod_namespace
-del(.kubernetes.pod_namespace)
-.kubernetes.namespace_name = namespace_name
-`
 	RemoveFile = `
 del(.file)
 `
@@ -62,7 +57,6 @@ func NormalizeContainerLogs(inLabel, outLabel string) []generator.Element {
 			Inputs:      helpers.MakeInputs(inLabel),
 			VRL: strings.Join(helpers.TrimSpaces([]string{
 				FixLogLevel,
-				ChangeNSNameField,
 				RemoveFile,
 				RemoveSourceType,
 				RemoveStream,

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -45,8 +45,8 @@ var _ = Describe("Generate Vector config", func() {
 				},
 			},
 			ExpectedConf: `
-# Adding _id field
-[transforms.es_1_add_es_id]
+# Set Elasticsearch index
+[transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
 source = """
@@ -61,12 +61,13 @@ source = """
     index = "audit"
   }
   .write_index = index + "-write"
+  
   ._id = encode_base64(uuid_v4())
 """
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
-inputs = ["es_1_add_es_id"]
+inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
 source = """
@@ -75,21 +76,21 @@ source = """
             emit(event)
             return
         end
-        if event.log.kubernetes.pod_labels == nil then
+        if event.log.kubernetes.labels == nil then
             emit(event)
             return
         end
-        dedot(event.log.kubernetes.pod_labels)
+        dedot(event.log.kubernetes.labels)
         -- create "flat_labels" key
         event.log.kubernetes.flat_labels = {}
         i = 1
         -- flatten the labels
-        for k,v in pairs(event.log.kubernetes.pod_labels) do
+        for k,v in pairs(event.log.kubernetes.labels) do
           event.log.kubernetes.flat_labels[i] = k.."="..v
           i=i+1
         end
-        -- delete the "pod_labels" key
-        event.log.kubernetes["pod_labels"] = nil
+        -- delete the "labels" key
+        event.log.kubernetes["labels"] = nil
         emit(event)
     end
 
@@ -154,8 +155,8 @@ password = "testpass"
 				},
 			},
 			ExpectedConf: `
-# Adding _id field
-[transforms.es_1_add_es_id]
+# Set Elasticsearch index
+[transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
 source = """
@@ -170,12 +171,13 @@ source = """
     index = "audit"
   }
   .write_index = index + "-write"
+  
   ._id = encode_base64(uuid_v4())
 """
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
-inputs = ["es_1_add_es_id"]
+inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
 source = """
@@ -184,21 +186,21 @@ source = """
             emit(event)
             return
         end
-        if event.log.kubernetes.pod_labels == nil then
+        if event.log.kubernetes.labels == nil then
             emit(event)
             return
         end
-        dedot(event.log.kubernetes.pod_labels)
+        dedot(event.log.kubernetes.labels)
         -- create "flat_labels" key
         event.log.kubernetes.flat_labels = {}
         i = 1
         -- flatten the labels
-        for k,v in pairs(event.log.kubernetes.pod_labels) do
+        for k,v in pairs(event.log.kubernetes.labels) do
           event.log.kubernetes.flat_labels[i] = k.."="..v
           i=i+1
         end
-        -- delete the "pod_labels" key
-        event.log.kubernetes["pod_labels"] = nil
+        -- delete the "labels" key
+        event.log.kubernetes["labels"] = nil
         emit(event)
     end
 
@@ -254,8 +256,8 @@ ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 			},
 			Secrets: security.NoSecrets,
 			ExpectedConf: `
-# Adding _id field
-[transforms.es_1_add_es_id]
+# Set Elasticsearch index
+[transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
 source = """
@@ -270,12 +272,13 @@ source = """
     index = "audit"
   }
   .write_index = index + "-write"
+  
   ._id = encode_base64(uuid_v4())
 """
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
-inputs = ["es_1_add_es_id"]
+inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
 source = """
@@ -284,21 +287,21 @@ source = """
             emit(event)
             return
         end
-        if event.log.kubernetes.pod_labels == nil then
+        if event.log.kubernetes.labels == nil then
             emit(event)
             return
         end
-        dedot(event.log.kubernetes.pod_labels)
+        dedot(event.log.kubernetes.labels)
         -- create "flat_labels" key
         event.log.kubernetes.flat_labels = {}
         i = 1
         -- flatten the labels
-        for k,v in pairs(event.log.kubernetes.pod_labels) do
+        for k,v in pairs(event.log.kubernetes.labels) do
           event.log.kubernetes.flat_labels[i] = k.."="..v
           i=i+1
         end
-        -- delete the "pod_labels" key
-        event.log.kubernetes["pod_labels"] = nil
+        -- delete the "labels" key
+        event.log.kubernetes["labels"] = nil
         emit(event)
     end
 
@@ -391,8 +394,8 @@ id_key = "_id"
 				},
 			},
 			ExpectedConf: `
-# Adding _id field
-[transforms.es_1_add_es_id]
+# Set Elasticsearch index
+[transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
 source = """
@@ -407,12 +410,13 @@ source = """
     index = "audit"
   }
   .write_index = index + "-write"
+  
   ._id = encode_base64(uuid_v4())
 """
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
-inputs = ["es_1_add_es_id"]
+inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
 source = """
@@ -421,21 +425,21 @@ source = """
             emit(event)
             return
         end
-        if event.log.kubernetes.pod_labels == nil then
+        if event.log.kubernetes.labels == nil then
             emit(event)
             return
         end
-        dedot(event.log.kubernetes.pod_labels)
+        dedot(event.log.kubernetes.labels)
         -- create "flat_labels" key
         event.log.kubernetes.flat_labels = {}
         i = 1
         -- flatten the labels
-        for k,v in pairs(event.log.kubernetes.pod_labels) do
+        for k,v in pairs(event.log.kubernetes.labels) do
           event.log.kubernetes.flat_labels[i] = k.."="..v
           i=i+1
         end
-        -- delete the "pod_labels" key
-        event.log.kubernetes["pod_labels"] = nil
+        -- delete the "labels" key
+        event.log.kubernetes["labels"] = nil
         emit(event)
     end
 
@@ -477,8 +481,8 @@ crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
 
 ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 
-# Adding _id field
-[transforms.es_2_add_es_id]
+# Set Elasticsearch index
+[transforms.es_2_add_es_index]
 type = "remap"
 inputs = ["application"]
 source = """
@@ -493,12 +497,13 @@ source = """
     index = "audit"
   }
   .write_index = index + "-write"
+  
   ._id = encode_base64(uuid_v4())
 """
 
 [transforms.es_2_dedot_and_flatten]
 type = "lua"
-inputs = ["es_2_add_es_id"]
+inputs = ["es_2_add_es_index"]
 version = "2"
 hooks.process = "process"
 source = """
@@ -507,21 +512,21 @@ source = """
             emit(event)
             return
         end
-        if event.log.kubernetes.pod_labels == nil then
+        if event.log.kubernetes.labels == nil then
             emit(event)
             return
         end
-        dedot(event.log.kubernetes.pod_labels)
+        dedot(event.log.kubernetes.labels)
         -- create "flat_labels" key
         event.log.kubernetes.flat_labels = {}
         i = 1
         -- flatten the labels
-        for k,v in pairs(event.log.kubernetes.pod_labels) do
+        for k,v in pairs(event.log.kubernetes.labels) do
           event.log.kubernetes.flat_labels[i] = k.."="..v
           i=i+1
         end
-        -- delete the "pod_labels" key
-        event.log.kubernetes["pod_labels"] = nil
+        -- delete the "labels" key
+        event.log.kubernetes["labels"] = nil
         emit(event)
     end
 
@@ -562,6 +567,322 @@ key_file = "/var/run/ocp-collector/secrets/es-2/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-2/tls.crt"
 
 ca_file = "/var/run/ocp-collector/secrets/es-2/ca-bundle.crt"
+`,
+		}),
+		Entry("with Elsticsearch StructuredTypeKey", generator.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type:   logging.OutputTypeElasticsearch,
+						Name:   "es-1",
+						URL:    "http://es.svc.infra.cluster:9200",
+						Secret: nil,
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Elasticsearch: &logging.Elasticsearch{
+								StructuredTypeKey: "kubernetes.labels.mylabel",
+							},
+						},
+					},
+				},
+			},
+			Secrets: security.NoSecrets,
+			ExpectedConf: `
+# Set Elasticsearch index
+[transforms.es_1_add_es_index]
+type = "remap"
+inputs = ["application"]
+source = """
+  index = "default"
+  if (.log_type == "application"){
+    index = "app"
+  }
+  if (.log_type == "infrastructure"){
+    index = "infra"
+  }
+  if (.log_type == "audit"){
+    index = "audit"
+  }
+  .write_index = index + "-write"
+  
+  ._id = encode_base64(uuid_v4())
+  
+  if .log_type == "application" && .structured != null {
+    val = .kubernetes.labels.mylabel
+    if val != null {
+      .write_index, err = "app-" + val + "-write"
+    }
+  }
+"""
+
+[transforms.es_1_dedot_and_flatten]
+type = "lua"
+inputs = ["es_1_add_es_index"]
+version = "2"
+hooks.process = "process"
+source = """
+    function process(event, emit)
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+        dedot(event.log.kubernetes.labels)
+        -- create "flat_labels" key
+        event.log.kubernetes.flat_labels = {}
+        i = 1
+        -- flatten the labels
+        for k,v in pairs(event.log.kubernetes.labels) do
+          event.log.kubernetes.flat_labels[i] = k.."="..v
+          i=i+1
+        end
+        -- delete the "labels" key
+        event.log.kubernetes["labels"] = nil
+        emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+"""
+
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["es_1_dedot_and_flatten"]
+endpoint = "http://es.svc.infra.cluster:9200"
+bulk.index = "{{ write_index }}"
+bulk.action = "create"
+request.timeout_secs = 2147483648
+id_key = "_id"
+`,
+		}),
+		Entry("with Elsticsearch StructuredTypeName", generator.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type:   logging.OutputTypeElasticsearch,
+						Name:   "es-1",
+						URL:    "http://es.svc.infra.cluster:9200",
+						Secret: nil,
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Elasticsearch: &logging.Elasticsearch{
+								StructuredTypeName: "myindex",
+							},
+						},
+					},
+				},
+			},
+			Secrets: security.NoSecrets,
+			ExpectedConf: `
+# Set Elasticsearch index
+[transforms.es_1_add_es_index]
+type = "remap"
+inputs = ["application"]
+source = """
+  index = "default"
+  if (.log_type == "application"){
+    index = "app"
+  }
+  if (.log_type == "infrastructure"){
+    index = "infra"
+  }
+  if (.log_type == "audit"){
+    index = "audit"
+  }
+  .write_index = index + "-write"
+  
+  ._id = encode_base64(uuid_v4())
+  
+  if .log_type == "application" && .structured != null {
+    .write_index = "app-myindex-write"
+  }
+"""
+
+[transforms.es_1_dedot_and_flatten]
+type = "lua"
+inputs = ["es_1_add_es_index"]
+version = "2"
+hooks.process = "process"
+source = """
+    function process(event, emit)
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+        dedot(event.log.kubernetes.labels)
+        -- create "flat_labels" key
+        event.log.kubernetes.flat_labels = {}
+        i = 1
+        -- flatten the labels
+        for k,v in pairs(event.log.kubernetes.labels) do
+          event.log.kubernetes.flat_labels[i] = k.."="..v
+          i=i+1
+        end
+        -- delete the "labels" key
+        event.log.kubernetes["labels"] = nil
+        emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+"""
+
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["es_1_dedot_and_flatten"]
+endpoint = "http://es.svc.infra.cluster:9200"
+bulk.index = "{{ write_index }}"
+bulk.action = "create"
+request.timeout_secs = 2147483648
+id_key = "_id"
+`,
+		}),
+		Entry("with both Elsticsearch StructuredTypeKey and StructuredTypeName", generator.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type:   logging.OutputTypeElasticsearch,
+						Name:   "es-1",
+						URL:    "http://es.svc.infra.cluster:9200",
+						Secret: nil,
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Elasticsearch: &logging.Elasticsearch{
+								StructuredTypeKey:  "kubernetes.labels.mylabel",
+								StructuredTypeName: "myindex",
+							},
+						},
+					},
+				},
+			},
+			Secrets: security.NoSecrets,
+			ExpectedConf: `
+# Set Elasticsearch index
+[transforms.es_1_add_es_index]
+type = "remap"
+inputs = ["application"]
+source = """
+  index = "default"
+  if (.log_type == "application"){
+    index = "app"
+  }
+  if (.log_type == "infrastructure"){
+    index = "infra"
+  }
+  if (.log_type == "audit"){
+    index = "audit"
+  }
+  .write_index = index + "-write"
+  
+  ._id = encode_base64(uuid_v4())
+  
+  if .log_type == "application" && .structured != null {
+    val = .kubernetes.labels.mylabel
+    if val != null {
+      .write_index, err = "app-" + val + "-write"
+    }
+  }
+"""
+
+[transforms.es_1_dedot_and_flatten]
+type = "lua"
+inputs = ["es_1_add_es_index"]
+version = "2"
+hooks.process = "process"
+source = """
+    function process(event, emit)
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+        dedot(event.log.kubernetes.labels)
+        -- create "flat_labels" key
+        event.log.kubernetes.flat_labels = {}
+        i = 1
+        -- flatten the labels
+        for k,v in pairs(event.log.kubernetes.labels) do
+          event.log.kubernetes.flat_labels[i] = k.."="..v
+          i=i+1
+        end
+        -- delete the "labels" key
+        event.log.kubernetes["labels"] = nil
+        emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+"""
+
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["es_1_dedot_and_flatten"]
+endpoint = "http://es.svc.infra.cluster:9200"
+bulk.index = "{{ write_index }}"
+bulk.action = "create"
+request.timeout_secs = 2147483648
+id_key = "_id"
 `,
 		}),
 	)

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -21,5 +21,7 @@ func (kl KubernetesLogs) Template() string {
 type = "kubernetes_logs"
 auto_partial_merge = true
 exclude_paths_glob_patterns = {{.ExcludePaths}}
+pod_annotation_fields.pod_labels = "kubernetes.labels"
+pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
 {{end}}`
 }

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -33,6 +33,8 @@ var _ = Describe("Vector Config Generation", func() {
 type = "kubernetes_logs"
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
+pod_annotation_fields.pod_labels = "kubernetes.labels"
+pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
 `,
 		}),
 		Entry("Only Infrastructure", generator.ConfGenerateTest{
@@ -53,6 +55,8 @@ exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.
 type = "kubernetes_logs"
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
+pod_annotation_fields.pod_labels = "kubernetes.labels"
+pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -110,6 +114,8 @@ include = ["/var/log/oauth-apiserver.audit.log"]
 type = "kubernetes_logs"
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
+pod_annotation_fields.pod_labels = "kubernetes.labels"
+pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
 
 [sources.raw_journal_logs]
 type = "journald"

--- a/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go
+++ b/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go
@@ -38,8 +38,8 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 		BeforeEach(func() {
 			ns := e2e.CreateTestNamespace()
 			appLabels := map[string]string{
-				"app":                    "cluster-monitoring-operator",
-				"app.kubernetes.io/name": "cluster-monitoring-operator",
+				"myapp":                    "test-log-generator",
+				"myapp.kubernetes.io/name": "test-log-generator",
 			}
 			if err := e2e.DeployLogGeneratorWithNamespaceAndLabels(ns, appLabels); err != nil {
 				Fail(fmt.Sprintf("Timed out waiting for the log generator to deploy: %v", err))

--- a/test/e2e/logforwarding/elasticsearchmanaged/forwarding_with_defaults_test.go
+++ b/test/e2e/logforwarding/elasticsearchmanaged/forwarding_with_defaults_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
+	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,7 +16,6 @@ import (
 	"github.com/ViaQ/logerr/log"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test/helpers"
-	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -43,9 +43,9 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 		}
 		SetupLogGeneratorWithLabels := func() {
 			appLabels := map[string]string{
-				"app":                    "cluster-monitoring-operator",
-				"app.kubernetes.io/name": "cluster-monitoring-operator",
-				"logFormat":              "redhat",
+				"myapp":                    "test-log-generator",
+				"myapp.kubernetes.io/name": "test-log-generator",
+				"logFormat":                "redhat",
 			}
 			generatorNS, generatorPod, err = e2e.DeployJsonLogGenerator(map[string]string{
 				"level":   "debug",
@@ -66,6 +66,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 		AfterEach(func() {
 			e2e.Cleanup()
 			e2e.WaitForCleanupCompletion(constants.OpenshiftNS, []string{constants.CollectorName, "elasticsearch"})
+			e2e.WaitForCleanupCompletion(generatorNS, []string{"component", "test"})
 		}, framework.DefaultCleanUpTimeout)
 
 		Context("forwarding logs to default output", func() {
@@ -137,7 +138,6 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 					})
 					AssertBehaviours()
 				})
-				/* UnComment after Handeling User Defined Inputs for Vector
 				Describe("for vector collector", func() {
 					BeforeEach(func() {
 						DeployLoggingWithComponents([]helpers.LogComponentType{helpers.ComponentTypeCollectorVector, helpers.ComponentTypeStore})
@@ -145,7 +145,6 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 					})
 					AssertBehaviours()
 				})
-				*/
 			})
 			Context("with IndexName set in outputDefaults", func() {
 				IndexName := "testindex"
@@ -222,7 +221,6 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 					})
 					AssertBehaviours()
 				})
-				/* UnComment after Handeling User Defined Inputs for Vector
 				Describe("for vector collector", func() {
 					BeforeEach(func() {
 						DeployLoggingWithComponents([]helpers.LogComponentType{helpers.ComponentTypeCollectorVector, helpers.ComponentTypeStore})
@@ -230,7 +228,6 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 					})
 					AssertBehaviours()
 				})
-				*/
 			})
 		})
 	})

--- a/test/framework/e2e/framework.go
+++ b/test/framework/e2e/framework.go
@@ -39,7 +39,7 @@ import (
 const (
 	clusterLoggingURI      = "apis/logging.openshift.io/v1/namespaces/openshift-logging/clusterloggings"
 	clusterlogforwarderURI = "apis/logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders"
-	DefaultCleanUpTimeout  = 60.0 * 2
+	DefaultCleanUpTimeout  = 60.0 * 5
 
 	defaultRetryInterval      = 1 * time.Second
 	defaultTimeout            = 10 * time.Minute
@@ -123,7 +123,7 @@ func (tc *E2ETestFramework) DeployLogGeneratorWithNamespaceAndLabels(namespace s
 		return err
 	}
 	for k, v := range labels {
-		if _, err2 := oc.Literal().From("oc label pod -n %s --all %s=%s", namespace, k, v).Run(); err != nil {
+		if _, err2 := oc.Literal().From("oc label pod -n %s --all %s=%s --overwrite", namespace, k, v).Run(); err2 != nil {
 			return err2
 		}
 	}
@@ -450,6 +450,7 @@ func (tc *E2ETestFramework) Cleanup() {
 			}
 		}
 	}
+	tc.CleanupFns = [](func() error){}
 	tc.CleanFluentDBuffers()
 }
 


### PR DESCRIPTION
### Description
This PR add the feature to change the elasticsearch index as per OutputDefaults for Elasticsearch output.
This feature is already implemented for fluentd, and this PR adds it for vector.

To have feature parity between fluentd and vector for feature "Changing index based on labels defined `structuredTypeKey`" we need pod labels to be presented in the same way for fluentd or vector.

Currently, for vector the pod labels are added under `kubernetes.pod_labels` which is different from fluentd `kubernetes.labels` 

So this PR changes `kubernetes_logs` config to change the way labels are captured. This may require higher version of vector than currently used. 

This PR also configures `kubernetes_logs` to produce `namespace_name` in place of `pod_namespace` and removes the VRL code which changes the field name.


/cc @jcantrill 
/assign 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:  https://issues.redhat.com/browse/LOG-2476
- Enhancement proposal: https://github.com/openshift/enhancements/blob/master/enhancements/cluster-logging/forwarding-json-structured-logs.md
