### PR TITLE
LOG-2442 Remove -dir flag from log metric exporter.

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -219,7 +219,7 @@ func newLogMetricsExporterContainer() *v1.Container {
 			Protocol:      v1.ProtocolTCP,
 		},
 	}
-	exporter.Command = []string{"/usr/local/bin/log-file-metric-exporter", "-verbosity=2", " -dir=/var/log/containers", "-http=:2112", "-keyFile=/etc/fluent/metrics/tls.key", "-crtFile=/etc/fluent/metrics/tls.crt"}
+	exporter.Command = []string{"/usr/local/bin/log-file-metric-exporter", "-verbosity=2", "-http=:2112", "-keyFile=/etc/fluent/metrics/tls.key", "-crtFile=/etc/fluent/metrics/tls.crt"}
 
 	exporter.VolumeMounts = []v1.VolumeMount{
 		{Name: logContainers, ReadOnly: true, MountPath: logContainersValue},


### PR DESCRIPTION
Not needed, let the exporter choose the default directory(ies) to scan.
Newer version of the exporter will scan /var/log/pods.