### PR TITLE
Remove support of 'years' and 'months' timeunits from CRD

### DIFF
--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -21,25 +21,13 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: "ClusterLogForwarder is an API to configure forwarding logs.
-          \n You configure forwarding by specifying a list of `pipelines`, which forward
-          from a set of named inputs to a set of named outputs. \n There are built-in
-          input names for common log categories, and you can define custom inputs
-          to do additional filtering. \n There is a built-in output name for the default
-          openshift log store, but you can define your own outputs with a URL and
-          other connection information to forward logs to other stores or processors,
-          inside or outside the cluster. \n For more details see the documentation
-          on the API fields."
+        description: "ClusterLogForwarder is an API to configure forwarding logs. \n You configure forwarding by specifying a list of `pipelines`, which forward from a set of named inputs to a set of named outputs. \n There are built-in input names for common log categories, and you can define custom inputs to do additional filtering. \n There is a built-in output name for the default openshift log store, but you can define your own outputs with a URL and other connection information to forward logs to other stores or processors, inside or outside the cluster. \n For more details see the documentation on the API fields."
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -52,53 +40,34 @@ spec:
             description: ClusterLogForwarderSpec defines the desired state of ClusterLogForwarder
             properties:
               inputs:
-                description: "Inputs are named filters for log messages to be forwarded.
-                  \n There are three built-in inputs named `application`, `infrastructure`
-                  and `audit`. You don't need to define inputs here if those are sufficient
-                  for your needs. See `inputRefs` for more."
+                description: "Inputs are named filters for log messages to be forwarded. \n There are three built-in inputs named `application`, `infrastructure` and `audit`. You don't need to define inputs here if those are sufficient for your needs. See `inputRefs` for more."
                 items:
                   description: InputSpec defines a selector of log messages.
                   properties:
                     application:
-                      description: Application, if present, enables `application`
-                        logs.
+                      description: Application, if present, enables `application` logs.
                       properties:
                         namespaces:
-                          description: Namespaces from which to collect application
-                            logs. Only messages from these namespaces are collected.
-                            If absent or empty, logs are collected from all namespaces.
+                          description: Namespaces from which to collect application logs. Only messages from these namespaces are collected. If absent or empty, logs are collected from all namespaces.
                           items:
                             type: string
                           type: array
                         selector:
-                          description: Selector for logs from pods with matching labels.
-                            Only messages from pods with these labels are collected.
-                            If absent or empty, logs are collected regardless of labels.
+                          description: Selector for logs from pods with matching labels. Only messages from pods with these labels are collected. If absent or empty, logs are collected regardless of labels.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
+                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
+                                    description: key is the label key that the selector applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -110,11 +79,7 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                       type: object
@@ -122,8 +87,7 @@ spec:
                       description: Audit, if present, enables `audit` logs.
                       type: object
                     infrastructure:
-                      description: Infrastructure, if present, enables `infrastructure`
-                        logs.
+                      description: Infrastructure, if present, enables `infrastructure` logs.
                       type: object
                     name:
                       description: Name used to refer to the input of a `pipeline`.
@@ -133,49 +97,29 @@ spec:
                   type: object
                 type: array
               outputDefaults:
-                description: OutputDefaults are used to specify default values for
-                  OutputSpec
+                description: OutputDefaults are used to specify default values for OutputSpec
                 properties:
                   elasticsearch:
-                    description: "Elasticsearch OutputSpec default values \n Values
-                      specified here will be used as default values for Elasticsearch
-                      Output spec"
+                    description: "Elasticsearch OutputSpec default values \n Values specified here will be used as default values for Elasticsearch Output spec"
                     properties:
                       enableStructuredContainerLogs:
-                        description: EnableStructuredContainerLogs enables multi-container
-                          structured logs to allow forwarding logs from containers
-                          within a pod to separate indices.  Annotating the pod with
-                          key 'containerType.logging.openshift.io/<container-name>'
-                          and value '<structure-type-name>' will forward those container
-                          logs to an alternate index from that defined by the other
-                          'structured' keys here
+                        description: EnableStructuredContainerLogs enables multi-container structured logs to allow forwarding logs from containers within a pod to separate indices.  Annotating the pod with key 'containerType.logging.openshift.io/<container-name>' and value '<structure-type-name>' will forward those container logs to an alternate index from that defined by the other 'structured' keys here
                         type: boolean
                       structuredTypeKey:
-                        description: StructuredTypeKey specifies the metadata key
-                          to be used as name of elasticsearch index It takes precedence
-                          over StructuredTypeName
+                        description: StructuredTypeKey specifies the metadata key to be used as name of elasticsearch index It takes precedence over StructuredTypeName
                         type: string
                       structuredTypeName:
-                        description: StructuredTypeName specifies the name of elasticsearch
-                          schema
+                        description: StructuredTypeName specifies the name of elasticsearch schema
                         type: string
                     type: object
                 type: object
               outputs:
-                description: "Outputs are named destinations for log messages. \n
-                  There is a built-in output named `default` which forwards to the
-                  default openshift log store. You can define outputs to forward to
-                  other stores or log processors, inside or outside the cluster."
+                description: "Outputs are named destinations for log messages. \n There is a built-in output named `default` which forwards to the default openshift log store. You can define outputs to forward to other stores or log processors, inside or outside the cluster."
                 items:
                   description: Output defines a destination for log messages.
                   properties:
                     cloudwatch:
-                      description: "Cloudwatch provides configuration for the output
-                        type `cloudwatch` \n Note: the cloudwatch output recognizes
-                        the following keys in the Secret: \n `aws_secret_access_key`:
-                        AWS secret access key. `aws_access_key_id`: AWS secret access
-                        key ID. \n Or for sts-enabled clusters `role_arn` key specifying
-                        a properly formatted role arn"
+                      description: "Cloudwatch provides configuration for the output type `cloudwatch` \n Note: the cloudwatch output recognizes the following keys in the Secret: \n `aws_secret_access_key`: AWS secret access key. `aws_access_key_id`: AWS secret access key ID. \n Or for sts-enabled clusters `role_arn` key specifying a properly formatted role arn"
                       properties:
                         groupBy:
                           description: GroupBy defines the strategy for grouping logstreams
@@ -185,10 +129,7 @@ spec:
                           - namespaceUUID
                           type: string
                         groupPrefix:
-                          description: GroupPrefix Add this prefix to all group names.
-                            Useful to avoid group name clashes if an AWS account is
-                            used for multiple clusters and used verbatim (e.g. ""
-                            means no prefix) The default prefix is cluster-name/log-type
+                          description: GroupPrefix Add this prefix to all group names. Useful to avoid group name clashes if an AWS account is used for multiple clusters and used verbatim (e.g. "" means no prefix) The default prefix is cluster-name/log-type
                           type: string
                         region:
                           type: string
@@ -196,178 +137,84 @@ spec:
                     elasticsearch:
                       properties:
                         enableStructuredContainerLogs:
-                          description: EnableStructuredContainerLogs enables multi-container
-                            structured logs to allow forwarding logs from containers
-                            within a pod to separate indices.  Annotating the pod
-                            with key 'containerType.logging.openshift.io/<container-name>'
-                            and value '<structure-type-name>' will forward those container
-                            logs to an alternate index from that defined by the other
-                            'structured' keys here
+                          description: EnableStructuredContainerLogs enables multi-container structured logs to allow forwarding logs from containers within a pod to separate indices.  Annotating the pod with key 'containerType.logging.openshift.io/<container-name>' and value '<structure-type-name>' will forward those container logs to an alternate index from that defined by the other 'structured' keys here
                           type: boolean
                         structuredTypeKey:
-                          description: StructuredTypeKey specifies the metadata key
-                            to be used as name of elasticsearch index It takes precedence
-                            over StructuredTypeName
+                          description: StructuredTypeKey specifies the metadata key to be used as name of elasticsearch index It takes precedence over StructuredTypeName
                           type: string
                         structuredTypeName:
-                          description: StructuredTypeName specifies the name of elasticsearch
-                            schema
+                          description: StructuredTypeName specifies the name of elasticsearch schema
                           type: string
                       type: object
                     fluentdForward:
-                      description: "FluentdForward does not provide additional fields,
-                        but note that the fluentforward output allows this additional
-                        keys in the Secret: \n `shared_key`: (string) Key to enable
-                        fluent-forward shared-key authentication."
+                      description: "FluentdForward does not provide additional fields, but note that the fluentforward output allows this additional keys in the Secret: \n `shared_key`: (string) Key to enable fluent-forward shared-key authentication."
                       type: object
                     kafka:
-                      description: 'Kafka provides optional extra properties for `type:
-                        kafka`'
+                      description: 'Kafka provides optional extra properties for `type: kafka`'
                       properties:
                         brokers:
-                          description: Brokers specifies the list of brokers to register
-                            in addition to the main output URL on initial connect
-                            to enhance reliability.
+                          description: Brokers specifies the list of brokers to register in addition to the main output URL on initial connect to enhance reliability.
                           items:
                             type: string
                           type: array
                         topic:
-                          description: Topic specifies the target topic to send logs
-                            to.
+                          description: Topic specifies the target topic to send logs to.
                           type: string
                       type: object
                     loki:
-                      description: 'Loki provides optional extra properties for `type:
-                        loki`'
+                      description: 'Loki provides optional extra properties for `type: loki`'
                       properties:
                         labelKeys:
-                          description: "LabelKeys is a list of meta-data field keys
-                            to replace the default Loki labels. \n Loki label names
-                            must match the regular expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\".
-                            Illegal characters in meta-data keys are replaced with
-                            \"_\" to form the label name. For example meta-data key
-                            \"kubernetes.labels.foo\" becomes Loki label \"kubernetes_labels_foo\".
-                            \n If LabelKeys is not set, the default keys are `[log_type,
-                            kubernetes.namespace_name, kubernetes.pod_name, kubernetes_host]`
-                            These keys are translated to Loki labels by replacing
-                            '.' with '_' as: `log_type`, `kubernetes_namespace_name`,
-                            `kubernetes_pod_name`, `kubernetes_host` Note that not
-                            all logs will include all of these keys: audit logs and
-                            infrastructure journal logs do not have namespace or pod
-                            name. \n Note: the set of labels should be small, Loki
-                            imposes limits on the size and number of labels allowed.
-                            See https://grafana.com/docs/loki/latest/configuration/#limits_config
-                            for more. You can still query based on any log record
-                            field using query filters."
+                          description: "LabelKeys is a list of meta-data field keys to replace the default Loki labels. \n Loki label names must match the regular expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\". Illegal characters in meta-data keys are replaced with \"_\" to form the label name. For example meta-data key \"kubernetes.labels.foo\" becomes Loki label \"kubernetes_labels_foo\". \n If LabelKeys is not set, the default keys are `[log_type, kubernetes.namespace_name, kubernetes.pod_name, kubernetes_host]` These keys are translated to Loki labels by replacing '.' with '_' as: `log_type`, `kubernetes_namespace_name`, `kubernetes_pod_name`, `kubernetes_host` Note that not all logs will include all of these keys: audit logs and infrastructure journal logs do not have namespace or pod name. \n Note: the set of labels should be small, Loki imposes limits on the size and number of labels allowed. See https://grafana.com/docs/loki/latest/configuration/#limits_config for more. You can still query based on any log record field using query filters."
                           items:
                             type: string
                           type: array
                         tenantKey:
-                          description: 'TenantKey is a meta-data key field to use
-                            as the TenantID, For example: ''TenantKey: kubernetes.namespace_name`
-                            will use the kubernetes namespace as the tenant ID.'
+                          description: 'TenantKey is a meta-data key field to use as the TenantID, For example: ''TenantKey: kubernetes.namespace_name` will use the kubernetes namespace as the tenant ID.'
                           type: string
                       type: object
                     name:
                       description: Name used to refer to the output from a `pipeline`.
                       type: string
                     secret:
-                      description: "Secret for authentication. \n Names a secret in
-                        the same namespace as the ClusterLogForwarder. \n Sensitive
-                        authentication information is stored in a separate Secret
-                        object. A Secret is like a ConfigMap, where the keys are strings
-                        and the values are base64-encoded binary data, for example
-                        TLS certificates. \n Common keys are described here. Some
-                        output types support additional keys, documented with the
-                        output-specific configuration field. All secret keys are optional,
-                        enable the security features you want by setting the relevant
-                        keys. \n Transport Layer Security (TLS) \n Using a TLS URL
-                        ('https://...' or 'tls://...') without any secret enables
-                        basic TLS: client authenticates server using system default
-                        certificate authority. \n Additional TLS features are enabled
-                        by referencing a Secret with the following optional fields
-                        in its spec.data. All data fields are base64 encoded. \n `tls.crt`:
-                        A client certificate, for mutual authentication. Requires
-                        `tls.key`. `tls.key`: Private key to unlock the client certificate.
-                        Requires `tls.crt` `passphrase`: Passphrase to decode an encoded
-                        TLS private key. Requires tls.key. `ca-bundle.crt`: Custom
-                        CA to validate certificates. \n `tls.insecure`: If this key
-                        is present (with any value) accept server certificates that
-                        are self-signed or have an incorrect hostname. This is INSECURE,
-                        the connection is susceptible to man-in-the-middle attacks.
-                        This is ONLY for development and testing when valid certificates
-                        are not available. \n Username and Password \n `username`:
-                        Authentication user name. Requires `password`. `password`:
-                        Authentication password. Requires `username`. \n Simple Authentication
-                        Security Layer (SASL) \n `sasl.enable`: (boolean) Explicitly
-                        enable or disable SASL. If missing, SASL is automatically
-                        enabled if any `sasl.*` keys are set. `sasl.mechanisms`: (array
-                        of string) List of allowed SASL mechanism names. If missing
-                        or empty, the system defaults are used. `sasl.allow-insecure`:
-                        (boolean) Allow mechanisms that send clear-text passwords.
-                        Default false."
+                      description: "Secret for authentication. \n Names a secret in the same namespace as the ClusterLogForwarder. \n Sensitive authentication information is stored in a separate Secret object. A Secret is like a ConfigMap, where the keys are strings and the values are base64-encoded binary data, for example TLS certificates. \n Common keys are described here. Some output types support additional keys, documented with the output-specific configuration field. All secret keys are optional, enable the security features you want by setting the relevant keys. \n Transport Layer Security (TLS) \n Using a TLS URL ('https://...' or 'tls://...') without any secret enables basic TLS: client authenticates server using system default certificate authority. \n Additional TLS features are enabled by referencing a Secret with the following optional fields in its spec.data. All data fields are base64 encoded. \n `tls.crt`: A client certificate, for mutual authentication. Requires `tls.key`. `tls.key`: Private key to unlock the client certificate. Requires `tls.crt` `passphrase`: Passphrase to decode an encoded TLS private key. Requires tls.key. `ca-bundle.crt`: Custom CA to validate certificates. \n `tls.insecure`: If this key is present (with any value) accept server certificates that are self-signed or have an incorrect hostname. This is INSECURE, the connection is susceptible to man-in-the-middle attacks. This is ONLY for development and testing when valid certificates are not available. \n Username and Password \n `username`: Authentication user name. Requires `password`. `password`: Authentication password. Requires `username`. \n Simple Authentication Security Layer (SASL) \n `sasl.enable`: (boolean) Explicitly enable or disable SASL. If missing, SASL is automatically enabled if any `sasl.*` keys are set. `sasl.mechanisms`: (array of string) List of allowed SASL mechanism names. If missing or empty, the system defaults are used. `sasl.allow-insecure`: (boolean) Allow mechanisms that send clear-text passwords. Default false."
                       properties:
                         name:
-                          description: Name of a secret in the namespace configured
-                            for log forwarder secrets.
+                          description: Name of a secret in the namespace configured for log forwarder secrets.
                           type: string
                       required:
                       - name
                       type: object
                     syslog:
-                      description: Syslog provides optional extra properties for output
-                        type `syslog`
+                      description: Syslog provides optional extra properties for output type `syslog`
                       properties:
                         addLogSource:
-                          description: AddLogSource adds log's source information
-                            to the log message If the logs are collected from a process;
-                            namespace_name, pod_name, container_name is added to the
-                            log In addition, it picks the originating process name
-                            and id(known as the `pid`) from the record and injects
-                            them into the header field."
+                          description: AddLogSource adds log's source information to the log message If the logs are collected from a process; namespace_name, pod_name, container_name is added to the log In addition, it picks the originating process name and id(known as the `pid`) from the record and injects them into the header field."
                           type: boolean
                         appName:
-                          description: "AppName is APP-NAME part of the syslog-msg
-                            header \n AppName needs to be specified if using rfc5424"
+                          description: "AppName is APP-NAME part of the syslog-msg header \n AppName needs to be specified if using rfc5424"
                           type: string
                         facility:
-                          description: "Facility to set on outgoing syslog records.
-                            \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
-                            The value can be a decimal integer. Facility keywords
-                            are not standardized, this API recognizes at least the
-                            following case-insensitive keywords (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels):
-                            \n kernel user mail daemon auth syslog lpr news uucp cron
-                            authpriv ftp ntp security console solaris-cron local0
-                            local1 local2 local3 local4 local5 local6 local7"
+                          description: "Facility to set on outgoing syslog records. \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1. The value can be a decimal integer. Facility keywords are not standardized, this API recognizes at least the following case-insensitive keywords (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels): \n kernel user mail daemon auth syslog lpr news uucp cron authpriv ftp ntp security console solaris-cron local0 local1 local2 local3 local4 local5 local6 local7"
                           type: string
                         msgID:
-                          description: "MsgID is MSGID part of the syslog-msg header
-                            \n MsgID needs to be specified if using rfc5424"
+                          description: "MsgID is MSGID part of the syslog-msg header \n MsgID needs to be specified if using rfc5424"
                           type: string
                         payloadKey:
-                          description: PayloadKey specifies record field to use as
-                            payload.
+                          description: PayloadKey specifies record field to use as payload.
                           type: string
                         procID:
-                          description: "ProcID is PROCID part of the syslog-msg header
-                            \n ProcID needs to be specified if using rfc5424"
+                          description: "ProcID is PROCID part of the syslog-msg header \n ProcID needs to be specified if using rfc5424"
                           type: string
                         rfc:
                           default: RFC5424
-                          description: "Rfc specifies the rfc to be used for sending
-                            syslog \n Rfc values can be one of: - RFC3164 (https://tools.ietf.org/html/rfc3164)
-                            - RFC5424 (https://tools.ietf.org/html/rfc5424) \n If
-                            unspecified, RFC5424 will be assumed."
+                          description: "Rfc specifies the rfc to be used for sending syslog \n Rfc values can be one of: - RFC3164 (https://tools.ietf.org/html/rfc3164) - RFC5424 (https://tools.ietf.org/html/rfc5424) \n If unspecified, RFC5424 will be assumed."
                           enum:
                           - RFC3164
                           - RFC5424
                           type: string
                         severity:
-                          description: "Severity to set on outgoing syslog records.
-                            \n Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1
-                            The value can be a decimal integer or one of these case-insensitive
-                            keywords: \n Emergency Alert Critical Error Warning Notice
-                            Informational Debug"
+                          description: "Severity to set on outgoing syslog records. \n Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1 The value can be a decimal integer or one of these case-insensitive keywords: \n Emergency Alert Critical Error Warning Notice Informational Debug"
                           type: string
                         tag:
                           description: Tag specifies a record field to use as tag.
@@ -387,15 +234,7 @@ spec:
                       - loki
                       type: string
                     url:
-                      description: "URL to send log records to. \n An absolute URL,
-                        with a scheme. Valid schemes depend on `type`. Special schemes
-                        `tcp`, `tls`, `udp` and `udps` are used for types that have
-                        no scheme of their own. For example, to send syslog records
-                        using secure UDP: \n { type: syslog, url: udps://syslog.example.com:1234
-                        } \n Basic TLS is enabled if the URL scheme requires it (for
-                        example 'https' or 'tls'). The 'username@password' part of
-                        `url` is ignored. Any additional authentication material is
-                        in the `secret`. See the `secret` field for more details."
+                      description: "URL to send log records to. \n An absolute URL, with a scheme. Valid schemes depend on `type`. Special schemes `tcp`, `tls`, `udp` and `udps` are used for types that have no scheme of their own. For example, to send syslog records using secure UDP: \n { type: syslog, url: udps://syslog.example.com:1234 } \n Basic TLS is enabled if the URL scheme requires it (for example 'https' or 'tls'). The 'username@password' part of `url` is ignored. Any additional authentication material is in the `secret`. See the `secret` field for more details."
                       pattern: ^$|[a-zA-z]+:\/\/.*
                       type: string
                   required:
@@ -404,47 +243,32 @@ spec:
                   type: object
                 type: array
               pipelines:
-                description: Pipelines forward the messages selected by a set of inputs
-                  to a set of outputs.
+                description: Pipelines forward the messages selected by a set of inputs to a set of outputs.
                 items:
                   properties:
                     detectMultilineErrors:
-                      description: DetectMultilineErrors enables multiline error detection
-                        of container logs
+                      description: DetectMultilineErrors enables multiline error detection of container logs
                       type: boolean
                     inputRefs:
-                      description: "InputRefs lists the names (`input.name`) of inputs
-                        to this pipeline. \n The following built-in input names are
-                        always available: \n `application` selects all logs from application
-                        pods. \n `infrastructure` selects logs from openshift and
-                        kubernetes pods and some node logs. \n `audit` selects node
-                        logs related to security audits."
+                      description: "InputRefs lists the names (`input.name`) of inputs to this pipeline. \n The following built-in input names are always available: \n `application` selects all logs from application pods. \n `infrastructure` selects logs from openshift and kubernetes pods and some node logs. \n `audit` selects node logs related to security audits."
                       items:
                         type: string
                       type: array
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels applied to log records passing through this
-                        pipeline. These labels appear in the `openshift.labels` map
-                        in the log record.
+                      description: Labels applied to log records passing through this pipeline. These labels appear in the `openshift.labels` map in the log record.
                       type: object
                     name:
-                      description: Name is optional, but must be unique in the `pipelines`
-                        list if provided.
+                      description: Name is optional, but must be unique in the `pipelines` list if provided.
                       type: string
                     outputRefs:
-                      description: "OutputRefs lists the names (`output.name`) of
-                        outputs from this pipeline. \n The following built-in names
-                        are always available: \n 'default' Output to the default log
-                        store provided by ClusterLogging."
+                      description: "OutputRefs lists the names (`output.name`) of outputs from this pipeline. \n The following built-in names are always available: \n 'default' Output to the default log store provided by ClusterLogging."
                       items:
                         type: string
                       type: array
                     parse:
-                      description: "Parse enables parsing of log entries into structured
-                        logs \n Logs are parsed according to parse value, only `json`
-                        is supported as of now."
+                      description: "Parse enables parsing of log entries into structured logs \n Logs are parsed according to parse value, only `json` is supported as of now."
                       enum:
                       - json
                       type: string
@@ -460,16 +284,7 @@ spec:
               conditions:
                 description: Conditions of the log forwarder.
                 items:
-                  description: "Condition represents an observation of an object's
-                    state. Conditions are an extension mechanism intended to be used
-                    when the details of an observation are not a priori known or would
-                    not apply to all instances of a given Kind. \n Conditions should
-                    be added to explicitly convey properties that users and components
-                    care about rather than requiring those properties to be inferred
-                    from other observations. Once defined, the meaning of a Condition
-                    can not be changed arbitrarily - it becomes part of the API, and
-                    has the same backwards- and forwards-compatibility concerns of
-                    any other part of the API."
+                  description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                   properties:
                     lastTransitionTime:
                       format: date-time
@@ -477,20 +292,12 @@ spec:
                     message:
                       type: string
                     reason:
-                      description: ConditionReason is intended to be a one-word, CamelCase
-                        representation of the category of cause of the current status.
-                        It is intended to be used in concise output, such as one-line
-                        kubectl get output, and in summarizing occurrences of causes.
+                      description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                       type: string
                     status:
                       type: string
                     type:
-                      description: "ConditionType is the type of the condition and
-                        is typically a CamelCased word or short phrase. \n Condition
-                        types should indicate state in the \"abnormal-true\" polarity.
-                        For example, if the condition indicates when a policy is invalid,
-                        the \"is valid\" case is probably the norm, so the condition
-                        should be called \"Invalid\"."
+                      description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                       type: string
                   required:
                   - status
@@ -501,16 +308,7 @@ spec:
                 additionalProperties:
                   description: Conditions is a set of Condition instances.
                   items:
-                    description: "Condition represents an observation of an object's
-                      state. Conditions are an extension mechanism intended to be
-                      used when the details of an observation are not a priori known
-                      or would not apply to all instances of a given Kind. \n Conditions
-                      should be added to explicitly convey properties that users and
-                      components care about rather than requiring those properties
-                      to be inferred from other observations. Once defined, the meaning
-                      of a Condition can not be changed arbitrarily - it becomes part
-                      of the API, and has the same backwards- and forwards-compatibility
-                      concerns of any other part of the API."
+                    description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -518,21 +316,12 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is intended to be a one-word,
-                          CamelCase representation of the category of cause of the
-                          current status. It is intended to be used in concise output,
-                          such as one-line kubectl get output, and in summarizing
-                          occurrences of causes.
+                        description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                         type: string
                       status:
                         type: string
                       type:
-                        description: "ConditionType is the type of the condition and
-                          is typically a CamelCased word or short phrase. \n Condition
-                          types should indicate state in the \"abnormal-true\" polarity.
-                          For example, if the condition indicates when a policy is
-                          invalid, the \"is valid\" case is probably the norm, so
-                          the condition should be called \"Invalid\"."
+                        description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                         type: string
                     required:
                     - status
@@ -545,16 +334,7 @@ spec:
                 additionalProperties:
                   description: Conditions is a set of Condition instances.
                   items:
-                    description: "Condition represents an observation of an object's
-                      state. Conditions are an extension mechanism intended to be
-                      used when the details of an observation are not a priori known
-                      or would not apply to all instances of a given Kind. \n Conditions
-                      should be added to explicitly convey properties that users and
-                      components care about rather than requiring those properties
-                      to be inferred from other observations. Once defined, the meaning
-                      of a Condition can not be changed arbitrarily - it becomes part
-                      of the API, and has the same backwards- and forwards-compatibility
-                      concerns of any other part of the API."
+                    description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -562,21 +342,12 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is intended to be a one-word,
-                          CamelCase representation of the category of cause of the
-                          current status. It is intended to be used in concise output,
-                          such as one-line kubectl get output, and in summarizing
-                          occurrences of causes.
+                        description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                         type: string
                       status:
                         type: string
                       type:
-                        description: "ConditionType is the type of the condition and
-                          is typically a CamelCased word or short phrase. \n Condition
-                          types should indicate state in the \"abnormal-true\" polarity.
-                          For example, if the condition indicates when a policy is
-                          invalid, the \"is valid\" case is probably the norm, so
-                          the condition should be called \"Invalid\"."
+                        description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                         type: string
                     required:
                     - status
@@ -589,16 +360,7 @@ spec:
                 additionalProperties:
                   description: Conditions is a set of Condition instances.
                   items:
-                    description: "Condition represents an observation of an object's
-                      state. Conditions are an extension mechanism intended to be
-                      used when the details of an observation are not a priori known
-                      or would not apply to all instances of a given Kind. \n Conditions
-                      should be added to explicitly convey properties that users and
-                      components care about rather than requiring those properties
-                      to be inferred from other observations. Once defined, the meaning
-                      of a Condition can not be changed arbitrarily - it becomes part
-                      of the API, and has the same backwards- and forwards-compatibility
-                      concerns of any other part of the API."
+                    description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -606,21 +368,12 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is intended to be a one-word,
-                          CamelCase representation of the category of cause of the
-                          current status. It is intended to be used in concise output,
-                          such as one-line kubectl get output, and in summarizing
-                          occurrences of causes.
+                        description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                         type: string
                       status:
                         type: string
                       type:
-                        description: "ConditionType is the type of the condition and
-                          is typically a CamelCased word or short phrase. \n Condition
-                          types should indicate state in the \"abnormal-true\" polarity.
-                          For example, if the condition indicates when a policy is
-                          invalid, the \"is valid\" case is probably the norm, so
-                          the condition should be called \"Invalid\"."
+                        description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                         type: string
                     required:
                     - status

--- a/bundle/manifests/logging.openshift.io_clusterloggings_crd.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterloggings_crd.yaml
@@ -28,14 +28,10 @@ spec:
         description: ClusterLogging is the Schema for the clusterloggings API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -60,8 +56,7 @@ spec:
                           nodeSelector:
                             additionalProperties:
                               type: string
-                            description: Define which Nodes the Pods are scheduled
-                              on.
+                            description: Define which Nodes the Pods are scheduled on.
                             nullable: true
                             type: object
                           resources:
@@ -75,8 +70,7 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -85,53 +79,28 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                             type: object
                           tolerations:
                             items:
-                              description: The pod this Toleration is attached to
-                                tolerates any taint that matches the triple <key,value,effect>
-                                using the matching operator <operator>.
+                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                               properties:
                                 effect:
-                                  description: Effect indicates the taint effect to
-                                    match. Empty means match all taint effects. When
-                                    specified, allowed values are NoSchedule, PreferNoSchedule
-                                    and NoExecute.
+                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                   type: string
                                 key:
-                                  description: Key is the taint key that the toleration
-                                    applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists;
-                                    this combination means to match all values and
-                                    all keys.
+                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                   type: string
                                 operator:
-                                  description: Operator represents a key's relationship
-                                    to the value. Valid operators are Exists and Equal.
-                                    Defaults to Equal. Exists is equivalent to wildcard
-                                    for value, so that a pod can tolerate all taints
-                                    of a particular category.
+                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                                   type: string
                                 tolerationSeconds:
-                                  description: TolerationSeconds represents the period
-                                    of time the toleration (which must be of effect
-                                    NoExecute, otherwise this field is ignored) tolerates
-                                    the taint. By default, it is not set, which means
-                                    tolerate the taint forever (do not evict). Zero
-                                    and negative values will be treated as 0 (evict
-                                    immediately) by the system.
+                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                                   format: int64
                                   type: integer
                                 value:
-                                  description: Value is the taint value the toleration
-                                    matches to. If the operator is Exists, the value
-                                    should be empty, otherwise just a regular string.
+                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                   type: string
                               type: object
                             type: array
@@ -167,8 +136,7 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                           requests:
                             additionalProperties:
@@ -177,55 +145,31 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                       schedule:
-                        description: The cron schedule that the Curator job is run.
-                          Defaults to "30 3 * * *"
+                        description: The cron schedule that the Curator job is run. Defaults to "30 3 * * *"
                         type: string
                       tolerations:
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -243,100 +187,65 @@ spec:
                 nullable: true
                 properties:
                   fluentd:
-                    description: FluentdForwarderSpec represents the configuration
-                      for forwarders of type fluentd.
+                    description: FluentdForwarderSpec represents the configuration for forwarders of type fluentd.
                     properties:
                       buffer:
-                        description: "FluentdBufferSpec represents a subset of fluentd
-                          buffer parameters to tune the buffer configuration for all
-                          fluentd outputs. It supports a subset of parameters to configure
-                          buffer and queue sizing, flush operations and retry flushing.
-                          \n For general parameters refer to: https://docs.fluentd.org/configuration/buffer-section#buffering-parameters
-                          \n For flush parameters refer to: https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
-                          \n For retry parameters refer to: https://docs.fluentd.org/configuration/buffer-section#retries-parameters"
+                        description: "FluentdBufferSpec represents a subset of fluentd buffer parameters to tune the buffer configuration for all fluentd outputs. It supports a subset of parameters to configure buffer and queue sizing, flush operations and retry flushing. \n For general parameters refer to: https://docs.fluentd.org/configuration/buffer-section#buffering-parameters \n For flush parameters refer to: https://docs.fluentd.org/configuration/buffer-section#flushing-parameters \n For retry parameters refer to: https://docs.fluentd.org/configuration/buffer-section#retries-parameters"
                         properties:
                           chunkLimitSize:
-                            description: ChunkLimitSize represents the maximum size
-                              of each chunk. Events will be written into chunks until
-                              the size of chunks become this size.
+                            description: ChunkLimitSize represents the maximum size of each chunk. Events will be written into chunks until the size of chunks become this size.
                             pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
                             type: string
                           flushInterval:
-                            description: 'FlushInterval represents the time duration
-                              to wait between two consecutive flush operations. Takes
-                              only effect used together with `flushMode: interval`.'
+                            description: 'FlushInterval represents the time duration to wait between two consecutive flush operations. Takes only effect used together with `flushMode: interval`.'
                             pattern: ^([0-9]+)([smhd]{0,1})$
                             type: string
                           flushMode:
-                            description: FlushMode represents the mode of the flushing
-                              thread to write chunks. The mode allows lazy (if `time`
-                              parameter set), per interval or immediate flushing.
+                            description: FlushMode represents the mode of the flushing thread to write chunks. The mode allows lazy (if `time` parameter set), per interval or immediate flushing.
                             enum:
                             - lazy
                             - interval
                             - immediate
                             type: string
                           flushThreadCount:
-                            description: FlushThreadCount reprents the number of threads
-                              used by the fluentd buffer plugin to flush/write chunks
-                              in parallel.
+                            description: FlushThreadCount reprents the number of threads used by the fluentd buffer plugin to flush/write chunks in parallel.
                             format: int32
                             type: integer
                           overflowAction:
-                            description: 'OverflowAction represents the action for
-                              the fluentd buffer plugin to execute when a buffer queue
-                              is full. (Default: block)'
+                            description: 'OverflowAction represents the action for the fluentd buffer plugin to execute when a buffer queue is full. (Default: block)'
                             enum:
                             - throw_exception
                             - block
                             - drop_oldest_chunk
                             type: string
                           retryMaxInterval:
-                            description: 'RetryMaxInterval represents the maximum
-                              time interval for exponential backoff between retries.
-                              Takes only effect if used together with `retryType:
-                              exponential_backoff`.'
+                            description: 'RetryMaxInterval represents the maximum time interval for exponential backoff between retries. Takes only effect if used together with `retryType: exponential_backoff`.'
                             pattern: ^([0-9]+)([smhd]{0,1})$
                             type: string
                           retryTimeout:
-                            description: RetryTimeout represents the maximum time
-                              interval to attempt retries before giving up and the
-                              record is disguarded.  If unspecified, the default will
-                              be used
+                            description: RetryTimeout represents the maximum time interval to attempt retries before giving up and the record is disguarded.  If unspecified, the default will be used
                             pattern: ^([0-9]+)([smhd]{0,1})$
                             type: string
                           retryType:
-                            description: RetryType represents the type of retrying
-                              flush operations. Flush operations can be retried either
-                              periodically or by applying exponential backoff.
+                            description: RetryType represents the type of retrying flush operations. Flush operations can be retried either periodically or by applying exponential backoff.
                             enum:
                             - exponential_backoff
                             - periodic
                             type: string
                           retryWait:
-                            description: RetryWait represents the time duration between
-                              two consecutive retries to flush buffers for periodic
-                              retries or a constant factor of time on retries with
-                              exponential backoff.
+                            description: RetryWait represents the time duration between two consecutive retries to flush buffers for periodic retries or a constant factor of time on retries with exponential backoff.
                             pattern: ^([0-9]+)([smhd]{0,1})$
                             type: string
                           totalLimitSize:
-                            description: TotalLimitSize represents the threshold of
-                              node space allowed per fluentd buffer to allocate. Once
-                              this threshold is reached, all append operations will
-                              fail with error (and data will be lost).
+                            description: TotalLimitSize represents the threshold of node space allowed per fluentd buffer to allocate. Once this threshold is reached, all append operations will fail with error (and data will be lost).
                             pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
                             type: string
                         type: object
                       inFile:
-                        description: "FluentdInFileSpec represents a subset of fluentd
-                          in-tail plugin parameters to tune the configuration for
-                          all fluentd in-tail inputs. \n For general parameters refer
-                          to: https://docs.fluentd.org/input/tail#parameters"
+                        description: "FluentdInFileSpec represents a subset of fluentd in-tail plugin parameters to tune the configuration for all fluentd in-tail inputs. \n For general parameters refer to: https://docs.fluentd.org/input/tail#parameters"
                         properties:
                           readLinesLimit:
-                            description: ReadLinesLimit represents the number of lines
-                              to read with each I/O operation
+                            description: ReadLinesLimit represents the number of lines to read with each I/O operation
                             type: integer
                         type: object
                     type: object
@@ -362,8 +271,7 @@ spec:
                         description: Specification of the Elasticsearch Proxy component
                         properties:
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
+                            description: ResourceRequirements describes the compute resource requirements.
                             nullable: true
                             properties:
                               limits:
@@ -373,8 +281,7 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -383,19 +290,14 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                             type: object
                         required:
                         - resources
                         type: object
                       redundancyPolicy:
-                        description: The policy towards data redundancy to specify
-                          the number of redundant primary shards
+                        description: The policy towards data redundancy to specify the number of redundant primary shards
                         enum:
                         - FullRedundancy
                         - MultipleRedundancy
@@ -413,8 +315,7 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                           requests:
                             additionalProperties:
@@ -423,69 +324,43 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                       storage:
-                        description: The storage specification for Elasticsearch data
-                          nodes
+                        description: The storage specification for Elasticsearch data nodes
                         nullable: true
                         properties:
                           size:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: The max storage capacity for the node to
-                              provision.
+                            description: The max storage capacity for the node to provision.
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           storageClassName:
-                            description: 'The name of the storage class to use with
-                              creating the node''s PVC. More info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
+                            description: 'The name of the storage class to use with creating the node''s PVC. More info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
                             type: string
                         type: object
                       tolerations:
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -493,8 +368,7 @@ spec:
                     - nodeCount
                     type: object
                   retentionPolicy:
-                    description: Retention policy defines the maximum age for an index
-                      after which it should be deleted
+                    description: Retention policy defines the maximum age for an index after which it should be deleted
                     nullable: true
                     properties:
                       application:
@@ -505,20 +379,15 @@ spec:
                             pattern: ^([0-9]+)([wdhHms]{0,1})$
                             type: string
                           namespaceSpec:
-                            description: The per namespace specification to delete
-                              documents older than a given minimum age
+                            description: The per namespace specification to delete documents older than a given minimum age
                             items:
                               properties:
                                 minAge:
-                                  description: Delete the records matching the namespaces
-                                    which are older than this MinAge (e.g. 1d)
+                                  description: Delete the records matching the namespaces which are older than this MinAge (e.g. 1d)
                                   pattern: ^([0-9]+)([wdhHms]{0,1})$
                                   type: string
                                 namespace:
-                                  description: Target Namespace to delete logs older
-                                    than MinAge (defaults to 7d) Can be one namespace
-                                    name or a prefix (e.g., "openshift-" covers all
-                                    namespaces with this prefix)
+                                  description: Target Namespace to delete logs older than MinAge (defaults to 7d) Can be one namespace name or a prefix (e.g., "openshift-" covers all namespaces with this prefix)
                                   type: string
                               required:
                               - namespace
@@ -537,20 +406,15 @@ spec:
                             pattern: ^([0-9]+)([wdhHms]{0,1})$
                             type: string
                           namespaceSpec:
-                            description: The per namespace specification to delete
-                              documents older than a given minimum age
+                            description: The per namespace specification to delete documents older than a given minimum age
                             items:
                               properties:
                                 minAge:
-                                  description: Delete the records matching the namespaces
-                                    which are older than this MinAge (e.g. 1d)
+                                  description: Delete the records matching the namespaces which are older than this MinAge (e.g. 1d)
                                   pattern: ^([0-9]+)([wdhHms]{0,1})$
                                   type: string
                                 namespace:
-                                  description: Target Namespace to delete logs older
-                                    than MinAge (defaults to 7d) Can be one namespace
-                                    name or a prefix (e.g., "openshift-" covers all
-                                    namespaces with this prefix)
+                                  description: Target Namespace to delete logs older than MinAge (defaults to 7d) Can be one namespace name or a prefix (e.g., "openshift-" covers all namespaces with this prefix)
                                   type: string
                               required:
                               - namespace
@@ -569,20 +433,15 @@ spec:
                             pattern: ^([0-9]+)([wdhHms]{0,1})$
                             type: string
                           namespaceSpec:
-                            description: The per namespace specification to delete
-                              documents older than a given minimum age
+                            description: The per namespace specification to delete documents older than a given minimum age
                             items:
                               properties:
                                 minAge:
-                                  description: Delete the records matching the namespaces
-                                    which are older than this MinAge (e.g. 1d)
+                                  description: Delete the records matching the namespaces which are older than this MinAge (e.g. 1d)
                                   pattern: ^([0-9]+)([wdhHms]{0,1})$
                                   type: string
                                 namespace:
-                                  description: Target Namespace to delete logs older
-                                    than MinAge (defaults to 7d) Can be one namespace
-                                    name or a prefix (e.g., "openshift-" covers all
-                                    namespaces with this prefix)
+                                  description: Target Namespace to delete logs older than MinAge (defaults to 7d) Can be one namespace name or a prefix (e.g., "openshift-" covers all namespaces with this prefix)
                                   type: string
                               required:
                               - namespace
@@ -601,15 +460,13 @@ spec:
                 - type
                 type: object
               managementState:
-                description: Indicator if the resource is 'Managed' or 'Unmanaged'
-                  by the operator
+                description: Indicator if the resource is 'Managed' or 'Unmanaged' by the operator
                 enum:
                 - Managed
                 - Unmanaged
                 type: string
               visualization:
-                description: Specification of the Visualization component for the
-                  cluster
+                description: Specification of the Visualization component for the cluster
                 nullable: true
                 properties:
                   kibana:
@@ -625,8 +482,7 @@ spec:
                         description: Specification of the Kibana Proxy component
                         properties:
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
+                            description: ResourceRequirements describes the compute resource requirements.
                             nullable: true
                             properties:
                               limits:
@@ -636,8 +492,7 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -646,11 +501,7 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                             type: object
                         required:
@@ -671,8 +522,7 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                           requests:
                             additionalProperties:
@@ -681,51 +531,28 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                       tolerations:
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -745,16 +572,7 @@ spec:
               clusterConditions:
                 description: Conditions is a set of Condition instances.
                 items:
-                  description: "Condition represents an observation of an object's
-                    state. Conditions are an extension mechanism intended to be used
-                    when the details of an observation are not a priori known or would
-                    not apply to all instances of a given Kind. \n Conditions should
-                    be added to explicitly convey properties that users and components
-                    care about rather than requiring those properties to be inferred
-                    from other observations. Once defined, the meaning of a Condition
-                    can not be changed arbitrarily - it becomes part of the API, and
-                    has the same backwards- and forwards-compatibility concerns of
-                    any other part of the API."
+                  description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                   properties:
                     lastTransitionTime:
                       format: date-time
@@ -762,20 +580,12 @@ spec:
                     message:
                       type: string
                     reason:
-                      description: ConditionReason is intended to be a one-word, CamelCase
-                        representation of the category of cause of the current status.
-                        It is intended to be used in concise output, such as one-line
-                        kubectl get output, and in summarizing occurrences of causes.
+                      description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                       type: string
                     status:
                       type: string
                     type:
-                      description: "ConditionType is the type of the condition and
-                        is typically a CamelCased word or short phrase. \n Condition
-                        types should indicate state in the \"abnormal-true\" polarity.
-                        For example, if the condition indicates when a policy is invalid,
-                        the \"is valid\" case is probably the norm, so the condition
-                        should be called \"Invalid\"."
+                      description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                       type: string
                   required:
                   - status
@@ -790,21 +600,9 @@ spec:
                         properties:
                           clusterCondition:
                             additionalProperties:
-                              description: '`operator-sdk generate crds` does not
-                                allow map-of-slice, must use a named type.'
+                              description: '`operator-sdk generate crds` does not allow map-of-slice, must use a named type.'
                               items:
-                                description: "Condition represents an observation
-                                  of an object's state. Conditions are an extension
-                                  mechanism intended to be used when the details of
-                                  an observation are not a priori known or would not
-                                  apply to all instances of a given Kind. \n Conditions
-                                  should be added to explicitly convey properties
-                                  that users and components care about rather than
-                                  requiring those properties to be inferred from other
-                                  observations. Once defined, the meaning of a Condition
-                                  can not be changed arbitrarily - it becomes part
-                                  of the API, and has the same backwards- and forwards-compatibility
-                                  concerns of any other part of the API."
+                                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                                 properties:
                                   lastTransitionTime:
                                     format: date-time
@@ -812,24 +610,12 @@ spec:
                                   message:
                                     type: string
                                   reason:
-                                    description: ConditionReason is intended to be
-                                      a one-word, CamelCase representation of the
-                                      category of cause of the current status. It
-                                      is intended to be used in concise output, such
-                                      as one-line kubectl get output, and in summarizing
-                                      occurrences of causes.
+                                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                                     type: string
                                   status:
                                     type: string
                                   type:
-                                    description: "ConditionType is the type of the
-                                      condition and is typically a CamelCased word
-                                      or short phrase. \n Condition types should indicate
-                                      state in the \"abnormal-true\" polarity. For
-                                      example, if the condition indicates when a policy
-                                      is invalid, the \"is valid\" case is probably
-                                      the norm, so the condition should be called
-                                      \"Invalid\"."
+                                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                                     type: string
                                 required:
                                 - status
@@ -859,21 +645,9 @@ spec:
                       properties:
                         clusterCondition:
                           additionalProperties:
-                            description: '`operator-sdk generate crds` does not allow
-                              map-of-slice, must use a named type.'
+                            description: '`operator-sdk generate crds` does not allow map-of-slice, must use a named type.'
                             items:
-                              description: "Condition represents an observation of
-                                an object's state. Conditions are an extension mechanism
-                                intended to be used when the details of an observation
-                                are not a priori known or would not apply to all instances
-                                of a given Kind. \n Conditions should be added to
-                                explicitly convey properties that users and components
-                                care about rather than requiring those properties
-                                to be inferred from other observations. Once defined,
-                                the meaning of a Condition can not be changed arbitrarily
-                                - it becomes part of the API, and has the same backwards-
-                                and forwards-compatibility concerns of any other part
-                                of the API."
+                              description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                               properties:
                                 lastTransitionTime:
                                   format: date-time
@@ -881,23 +655,12 @@ spec:
                                 message:
                                   type: string
                                 reason:
-                                  description: ConditionReason is intended to be a
-                                    one-word, CamelCase representation of the category
-                                    of cause of the current status. It is intended
-                                    to be used in concise output, such as one-line
-                                    kubectl get output, and in summarizing occurrences
-                                    of causes.
+                                  description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                                   type: string
                                 status:
                                   type: string
                                 type:
-                                  description: "ConditionType is the type of the condition
-                                    and is typically a CamelCased word or short phrase.
-                                    \n Condition types should indicate state in the
-                                    \"abnormal-true\" polarity. For example, if the
-                                    condition indicates when a policy is invalid,
-                                    the \"is valid\" case is probably the norm, so
-                                    the condition should be called \"Invalid\"."
+                                  description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                                   type: string
                               required:
                               - status
@@ -922,45 +685,37 @@ spec:
                         cluster:
                           properties:
                             activePrimaryShards:
-                              description: The number of Active Primary Shards for
-                                the Elasticsearch Cluster
+                              description: The number of Active Primary Shards for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             activeShards:
-                              description: The number of Active Shards for the Elasticsearch
-                                Cluster
+                              description: The number of Active Shards for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             initializingShards:
-                              description: The number of Initializing Shards for the
-                                Elasticsearch Cluster
+                              description: The number of Initializing Shards for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             numDataNodes:
-                              description: The number of Data Nodes for the Elasticsearch
-                                Cluster
+                              description: The number of Data Nodes for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             numNodes:
-                              description: The number of Nodes for the Elasticsearch
-                                Cluster
+                              description: The number of Nodes for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             pendingTasks:
                               format: int32
                               type: integer
                             relocatingShards:
-                              description: The number of Relocating Shards for the
-                                Elasticsearch Cluster
+                              description: The number of Relocating Shards for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             status:
-                              description: The current Status of the Elasticsearch
-                                Cluster
+                              description: The current Status of the Elasticsearch Cluster
                               type: string
                             unassignedShards:
-                              description: The number of Unassigned Shards for the
-                                Elasticsearch Cluster
+                              description: The number of Unassigned Shards for the Elasticsearch Cluster
                               format: int32
                               type: integer
                           required:
@@ -978,23 +733,19 @@ spec:
                           items:
                             properties:
                               lastTransitionTime:
-                                description: Last time the condition transitioned
-                                  from one status to another.
+                                description: Last time the condition transitioned from one status to another.
                                 format: date-time
                                 type: string
                               message:
-                                description: Human-readable message indicating details
-                                  about last transition.
+                                description: Human-readable message indicating details about last transition.
                                 type: string
                               reason:
-                                description: Unique, one-word, CamelCase reason for
-                                  the condition's last transition.
+                                description: Unique, one-word, CamelCase reason for the condition's last transition.
                                 type: string
                               status:
                                 type: string
                               type:
-                                description: ClusterConditionType is a valid value
-                                  for ClusterCondition.Type
+                                description: ClusterConditionType is a valid value for ClusterCondition.Type
                                 type: string
                             required:
                             - lastTransitionTime
@@ -1015,23 +766,19 @@ spec:
                             items:
                               properties:
                                 lastTransitionTime:
-                                  description: Last time the condition transitioned
-                                    from one status to another.
+                                  description: Last time the condition transitioned from one status to another.
                                   format: date-time
                                   type: string
                                 message:
-                                  description: Human-readable message indicating details
-                                    about last transition.
+                                  description: Human-readable message indicating details about last transition.
                                   type: string
                                 reason:
-                                  description: Unique, one-word, CamelCase reason
-                                    for the condition's last transition.
+                                  description: Unique, one-word, CamelCase reason for the condition's last transition.
                                   type: string
                                 status:
                                   type: string
                                 type:
-                                  description: ClusterConditionType is a valid value
-                                    for ClusterCondition.Type
+                                  description: ClusterConditionType is a valid value for ClusterCondition.Type
                                   type: string
                               required:
                               - lastTransitionTime
@@ -1075,23 +822,19 @@ spec:
                             items:
                               properties:
                                 lastTransitionTime:
-                                  description: Last time the condition transitioned
-                                    from one status to another.
+                                  description: Last time the condition transitioned from one status to another.
                                   format: date-time
                                   type: string
                                 message:
-                                  description: Human-readable message indicating details
-                                    about last transition.
+                                  description: Human-readable message indicating details about last transition.
                                   type: string
                                 reason:
-                                  description: Unique, one-word, CamelCase reason
-                                    for the condition's last transition.
+                                  description: Unique, one-word, CamelCase reason for the condition's last transition.
                                   type: string
                                 status:
                                   type: string
                                 type:
-                                  description: ClusterConditionType is a valid value
-                                    for ClusterCondition.Type
+                                  description: ClusterConditionType is a valid value for ClusterCondition.Type
                                   type: string
                               required:
                               - lastTransitionTime
@@ -1107,8 +850,7 @@ spec:
                             items:
                               type: string
                             type: array
-                          description: The status for each of the Kibana pods for
-                            the Visualization component
+                          description: The status for each of the Kibana pods for the Visualization component
                           type: object
                         replicaSets:
                           items:

--- a/internal/k8shandler/indexmanagement/index_management.go
+++ b/internal/k8shandler/indexmanagement/index_management.go
@@ -29,7 +29,7 @@ var (
 	AliasesInfra = []string{"infra", "logs.infra"}
 	AliasesAudit = []string{"audit", "logs.audit"}
 
-	agePattern = regexp.MustCompile(`^(?P<number>\d+)(?P<unit>[yMwdhHms])$`)
+	agePattern = regexp.MustCompile(`^(?P<number>\d+)(?P<unit>[wdhHms])$`)
 )
 
 func NewSpec(retentionPolicy *logging.RetentionPoliciesSpec) *esapi.IndexManagementSpec {

--- a/internal/k8shandler/indexmanagement/indexmanagement_test.go
+++ b/internal/k8shandler/indexmanagement/indexmanagement_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Indexmanagement", func() {
 		}
 	})
 
-	Describe("IndexManagemet Policy with 0 minutes, hours, days, weeks, months", func() {
+	Describe("IndexManagemet Policy with 0 minutes, hours, days, weeks", func() {
 		It("should correctly parse 0m", func() {
 			retentionPolicy = &logging.RetentionPoliciesSpec{
 				App: &logging.RetentionPolicySpec{
@@ -103,25 +103,6 @@ var _ = Describe("Indexmanagement", func() {
 			Expect(spec.Policies[0].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0w")))
 			Expect(spec.Policies[1].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0w")))
 			Expect(spec.Policies[2].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0w")))
-		})
-		It("should correctly parse 0M", func() {
-			retentionPolicy = &logging.RetentionPoliciesSpec{
-				App: &logging.RetentionPolicySpec{
-					MaxAge: esapi.TimeUnit("0M"),
-				},
-				Infra: &logging.RetentionPolicySpec{
-					MaxAge: esapi.TimeUnit("0M"),
-				},
-				Audit: &logging.RetentionPolicySpec{
-					MaxAge: esapi.TimeUnit("0M"),
-				},
-			}
-			spec := NewSpec(retentionPolicy)
-			Expect(len(spec.Policies)).To(Equal(3))
-			Expect(len(spec.Mappings)).To(Equal(3))
-			Expect(spec.Policies[0].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0M")))
-			Expect(spec.Policies[1].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0M")))
-			Expect(spec.Policies[2].Phases.Delete.MinAge).To(Equal(esapi.TimeUnit("0M")))
 		})
 	})
 
@@ -248,18 +229,6 @@ var _ = Describe("Indexmanagement", func() {
 			err  error
 		)
 		Context("converting to lower units", func() {
-			It("year to days", func() {
-				time, unit, err = convertToLowerUnits(1, 'y')
-				Expect(time).To(Equal(365), "time is incorrect")
-				Expect(unit).To(Equal(byte('d')), "unit is incorrect")
-				Expect(err).To(BeNil(), "error must be nil")
-			})
-			It("month to days", func() {
-				time, unit, err = convertToLowerUnits(1, 'M')
-				Expect(time).To(Equal(30), "time is incorrect")
-				Expect(unit).To(Equal(byte('d')), "unit is incorrect")
-				Expect(err).To(BeNil(), "error must be nil")
-			})
 			It("week to days", func() {
 				time, unit, err = convertToLowerUnits(1, 'w')
 				Expect(time).To(Equal(7), "time is incorrect")

--- a/manifests/5.5/logging.openshift.io_clusterlogforwarders_crd.yaml
+++ b/manifests/5.5/logging.openshift.io_clusterlogforwarders_crd.yaml
@@ -21,25 +21,13 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: "ClusterLogForwarder is an API to configure forwarding logs.
-          \n You configure forwarding by specifying a list of `pipelines`, which forward
-          from a set of named inputs to a set of named outputs. \n There are built-in
-          input names for common log categories, and you can define custom inputs
-          to do additional filtering. \n There is a built-in output name for the default
-          openshift log store, but you can define your own outputs with a URL and
-          other connection information to forward logs to other stores or processors,
-          inside or outside the cluster. \n For more details see the documentation
-          on the API fields."
+        description: "ClusterLogForwarder is an API to configure forwarding logs. \n You configure forwarding by specifying a list of `pipelines`, which forward from a set of named inputs to a set of named outputs. \n There are built-in input names for common log categories, and you can define custom inputs to do additional filtering. \n There is a built-in output name for the default openshift log store, but you can define your own outputs with a URL and other connection information to forward logs to other stores or processors, inside or outside the cluster. \n For more details see the documentation on the API fields."
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -52,53 +40,34 @@ spec:
             description: ClusterLogForwarderSpec defines the desired state of ClusterLogForwarder
             properties:
               inputs:
-                description: "Inputs are named filters for log messages to be forwarded.
-                  \n There are three built-in inputs named `application`, `infrastructure`
-                  and `audit`. You don't need to define inputs here if those are sufficient
-                  for your needs. See `inputRefs` for more."
+                description: "Inputs are named filters for log messages to be forwarded. \n There are three built-in inputs named `application`, `infrastructure` and `audit`. You don't need to define inputs here if those are sufficient for your needs. See `inputRefs` for more."
                 items:
                   description: InputSpec defines a selector of log messages.
                   properties:
                     application:
-                      description: Application, if present, enables `application`
-                        logs.
+                      description: Application, if present, enables `application` logs.
                       properties:
                         namespaces:
-                          description: Namespaces from which to collect application
-                            logs. Only messages from these namespaces are collected.
-                            If absent or empty, logs are collected from all namespaces.
+                          description: Namespaces from which to collect application logs. Only messages from these namespaces are collected. If absent or empty, logs are collected from all namespaces.
                           items:
                             type: string
                           type: array
                         selector:
-                          description: Selector for logs from pods with matching labels.
-                            Only messages from pods with these labels are collected.
-                            If absent or empty, logs are collected regardless of labels.
+                          description: Selector for logs from pods with matching labels. Only messages from pods with these labels are collected. If absent or empty, logs are collected regardless of labels.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
+                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
+                                    description: key is the label key that the selector applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -110,11 +79,7 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                       type: object
@@ -122,8 +87,7 @@ spec:
                       description: Audit, if present, enables `audit` logs.
                       type: object
                     infrastructure:
-                      description: Infrastructure, if present, enables `infrastructure`
-                        logs.
+                      description: Infrastructure, if present, enables `infrastructure` logs.
                       type: object
                     name:
                       description: Name used to refer to the input of a `pipeline`.
@@ -133,49 +97,29 @@ spec:
                   type: object
                 type: array
               outputDefaults:
-                description: OutputDefaults are used to specify default values for
-                  OutputSpec
+                description: OutputDefaults are used to specify default values for OutputSpec
                 properties:
                   elasticsearch:
-                    description: "Elasticsearch OutputSpec default values \n Values
-                      specified here will be used as default values for Elasticsearch
-                      Output spec"
+                    description: "Elasticsearch OutputSpec default values \n Values specified here will be used as default values for Elasticsearch Output spec"
                     properties:
                       enableStructuredContainerLogs:
-                        description: EnableStructuredContainerLogs enables multi-container
-                          structured logs to allow forwarding logs from containers
-                          within a pod to separate indices.  Annotating the pod with
-                          key 'containerType.logging.openshift.io/<container-name>'
-                          and value '<structure-type-name>' will forward those container
-                          logs to an alternate index from that defined by the other
-                          'structured' keys here
+                        description: EnableStructuredContainerLogs enables multi-container structured logs to allow forwarding logs from containers within a pod to separate indices.  Annotating the pod with key 'containerType.logging.openshift.io/<container-name>' and value '<structure-type-name>' will forward those container logs to an alternate index from that defined by the other 'structured' keys here
                         type: boolean
                       structuredTypeKey:
-                        description: StructuredTypeKey specifies the metadata key
-                          to be used as name of elasticsearch index It takes precedence
-                          over StructuredTypeName
+                        description: StructuredTypeKey specifies the metadata key to be used as name of elasticsearch index It takes precedence over StructuredTypeName
                         type: string
                       structuredTypeName:
-                        description: StructuredTypeName specifies the name of elasticsearch
-                          schema
+                        description: StructuredTypeName specifies the name of elasticsearch schema
                         type: string
                     type: object
                 type: object
               outputs:
-                description: "Outputs are named destinations for log messages. \n
-                  There is a built-in output named `default` which forwards to the
-                  default openshift log store. You can define outputs to forward to
-                  other stores or log processors, inside or outside the cluster."
+                description: "Outputs are named destinations for log messages. \n There is a built-in output named `default` which forwards to the default openshift log store. You can define outputs to forward to other stores or log processors, inside or outside the cluster."
                 items:
                   description: Output defines a destination for log messages.
                   properties:
                     cloudwatch:
-                      description: "Cloudwatch provides configuration for the output
-                        type `cloudwatch` \n Note: the cloudwatch output recognizes
-                        the following keys in the Secret: \n `aws_secret_access_key`:
-                        AWS secret access key. `aws_access_key_id`: AWS secret access
-                        key ID. \n Or for sts-enabled clusters `role_arn` key specifying
-                        a properly formatted role arn"
+                      description: "Cloudwatch provides configuration for the output type `cloudwatch` \n Note: the cloudwatch output recognizes the following keys in the Secret: \n `aws_secret_access_key`: AWS secret access key. `aws_access_key_id`: AWS secret access key ID. \n Or for sts-enabled clusters `role_arn` key specifying a properly formatted role arn"
                       properties:
                         groupBy:
                           description: GroupBy defines the strategy for grouping logstreams
@@ -185,10 +129,7 @@ spec:
                           - namespaceUUID
                           type: string
                         groupPrefix:
-                          description: GroupPrefix Add this prefix to all group names.
-                            Useful to avoid group name clashes if an AWS account is
-                            used for multiple clusters and used verbatim (e.g. ""
-                            means no prefix) The default prefix is cluster-name/log-type
+                          description: GroupPrefix Add this prefix to all group names. Useful to avoid group name clashes if an AWS account is used for multiple clusters and used verbatim (e.g. "" means no prefix) The default prefix is cluster-name/log-type
                           type: string
                         region:
                           type: string
@@ -196,178 +137,84 @@ spec:
                     elasticsearch:
                       properties:
                         enableStructuredContainerLogs:
-                          description: EnableStructuredContainerLogs enables multi-container
-                            structured logs to allow forwarding logs from containers
-                            within a pod to separate indices.  Annotating the pod
-                            with key 'containerType.logging.openshift.io/<container-name>'
-                            and value '<structure-type-name>' will forward those container
-                            logs to an alternate index from that defined by the other
-                            'structured' keys here
+                          description: EnableStructuredContainerLogs enables multi-container structured logs to allow forwarding logs from containers within a pod to separate indices.  Annotating the pod with key 'containerType.logging.openshift.io/<container-name>' and value '<structure-type-name>' will forward those container logs to an alternate index from that defined by the other 'structured' keys here
                           type: boolean
                         structuredTypeKey:
-                          description: StructuredTypeKey specifies the metadata key
-                            to be used as name of elasticsearch index It takes precedence
-                            over StructuredTypeName
+                          description: StructuredTypeKey specifies the metadata key to be used as name of elasticsearch index It takes precedence over StructuredTypeName
                           type: string
                         structuredTypeName:
-                          description: StructuredTypeName specifies the name of elasticsearch
-                            schema
+                          description: StructuredTypeName specifies the name of elasticsearch schema
                           type: string
                       type: object
                     fluentdForward:
-                      description: "FluentdForward does not provide additional fields,
-                        but note that the fluentforward output allows this additional
-                        keys in the Secret: \n `shared_key`: (string) Key to enable
-                        fluent-forward shared-key authentication."
+                      description: "FluentdForward does not provide additional fields, but note that the fluentforward output allows this additional keys in the Secret: \n `shared_key`: (string) Key to enable fluent-forward shared-key authentication."
                       type: object
                     kafka:
-                      description: 'Kafka provides optional extra properties for `type:
-                        kafka`'
+                      description: 'Kafka provides optional extra properties for `type: kafka`'
                       properties:
                         brokers:
-                          description: Brokers specifies the list of brokers to register
-                            in addition to the main output URL on initial connect
-                            to enhance reliability.
+                          description: Brokers specifies the list of brokers to register in addition to the main output URL on initial connect to enhance reliability.
                           items:
                             type: string
                           type: array
                         topic:
-                          description: Topic specifies the target topic to send logs
-                            to.
+                          description: Topic specifies the target topic to send logs to.
                           type: string
                       type: object
                     loki:
-                      description: 'Loki provides optional extra properties for `type:
-                        loki`'
+                      description: 'Loki provides optional extra properties for `type: loki`'
                       properties:
                         labelKeys:
-                          description: "LabelKeys is a list of meta-data field keys
-                            to replace the default Loki labels. \n Loki label names
-                            must match the regular expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\".
-                            Illegal characters in meta-data keys are replaced with
-                            \"_\" to form the label name. For example meta-data key
-                            \"kubernetes.labels.foo\" becomes Loki label \"kubernetes_labels_foo\".
-                            \n If LabelKeys is not set, the default keys are `[log_type,
-                            kubernetes.namespace_name, kubernetes.pod_name, kubernetes_host]`
-                            These keys are translated to Loki labels by replacing
-                            '.' with '_' as: `log_type`, `kubernetes_namespace_name`,
-                            `kubernetes_pod_name`, `kubernetes_host` Note that not
-                            all logs will include all of these keys: audit logs and
-                            infrastructure journal logs do not have namespace or pod
-                            name. \n Note: the set of labels should be small, Loki
-                            imposes limits on the size and number of labels allowed.
-                            See https://grafana.com/docs/loki/latest/configuration/#limits_config
-                            for more. You can still query based on any log record
-                            field using query filters."
+                          description: "LabelKeys is a list of meta-data field keys to replace the default Loki labels. \n Loki label names must match the regular expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\". Illegal characters in meta-data keys are replaced with \"_\" to form the label name. For example meta-data key \"kubernetes.labels.foo\" becomes Loki label \"kubernetes_labels_foo\". \n If LabelKeys is not set, the default keys are `[log_type, kubernetes.namespace_name, kubernetes.pod_name, kubernetes_host]` These keys are translated to Loki labels by replacing '.' with '_' as: `log_type`, `kubernetes_namespace_name`, `kubernetes_pod_name`, `kubernetes_host` Note that not all logs will include all of these keys: audit logs and infrastructure journal logs do not have namespace or pod name. \n Note: the set of labels should be small, Loki imposes limits on the size and number of labels allowed. See https://grafana.com/docs/loki/latest/configuration/#limits_config for more. You can still query based on any log record field using query filters."
                           items:
                             type: string
                           type: array
                         tenantKey:
-                          description: 'TenantKey is a meta-data key field to use
-                            as the TenantID, For example: ''TenantKey: kubernetes.namespace_name`
-                            will use the kubernetes namespace as the tenant ID.'
+                          description: 'TenantKey is a meta-data key field to use as the TenantID, For example: ''TenantKey: kubernetes.namespace_name` will use the kubernetes namespace as the tenant ID.'
                           type: string
                       type: object
                     name:
                       description: Name used to refer to the output from a `pipeline`.
                       type: string
                     secret:
-                      description: "Secret for authentication. \n Names a secret in
-                        the same namespace as the ClusterLogForwarder. \n Sensitive
-                        authentication information is stored in a separate Secret
-                        object. A Secret is like a ConfigMap, where the keys are strings
-                        and the values are base64-encoded binary data, for example
-                        TLS certificates. \n Common keys are described here. Some
-                        output types support additional keys, documented with the
-                        output-specific configuration field. All secret keys are optional,
-                        enable the security features you want by setting the relevant
-                        keys. \n Transport Layer Security (TLS) \n Using a TLS URL
-                        ('https://...' or 'tls://...') without any secret enables
-                        basic TLS: client authenticates server using system default
-                        certificate authority. \n Additional TLS features are enabled
-                        by referencing a Secret with the following optional fields
-                        in its spec.data. All data fields are base64 encoded. \n `tls.crt`:
-                        A client certificate, for mutual authentication. Requires
-                        `tls.key`. `tls.key`: Private key to unlock the client certificate.
-                        Requires `tls.crt` `passphrase`: Passphrase to decode an encoded
-                        TLS private key. Requires tls.key. `ca-bundle.crt`: Custom
-                        CA to validate certificates. \n `tls.insecure`: If this key
-                        is present (with any value) accept server certificates that
-                        are self-signed or have an incorrect hostname. This is INSECURE,
-                        the connection is susceptible to man-in-the-middle attacks.
-                        This is ONLY for development and testing when valid certificates
-                        are not available. \n Username and Password \n `username`:
-                        Authentication user name. Requires `password`. `password`:
-                        Authentication password. Requires `username`. \n Simple Authentication
-                        Security Layer (SASL) \n `sasl.enable`: (boolean) Explicitly
-                        enable or disable SASL. If missing, SASL is automatically
-                        enabled if any `sasl.*` keys are set. `sasl.mechanisms`: (array
-                        of string) List of allowed SASL mechanism names. If missing
-                        or empty, the system defaults are used. `sasl.allow-insecure`:
-                        (boolean) Allow mechanisms that send clear-text passwords.
-                        Default false."
+                      description: "Secret for authentication. \n Names a secret in the same namespace as the ClusterLogForwarder. \n Sensitive authentication information is stored in a separate Secret object. A Secret is like a ConfigMap, where the keys are strings and the values are base64-encoded binary data, for example TLS certificates. \n Common keys are described here. Some output types support additional keys, documented with the output-specific configuration field. All secret keys are optional, enable the security features you want by setting the relevant keys. \n Transport Layer Security (TLS) \n Using a TLS URL ('https://...' or 'tls://...') without any secret enables basic TLS: client authenticates server using system default certificate authority. \n Additional TLS features are enabled by referencing a Secret with the following optional fields in its spec.data. All data fields are base64 encoded. \n `tls.crt`: A client certificate, for mutual authentication. Requires `tls.key`. `tls.key`: Private key to unlock the client certificate. Requires `tls.crt` `passphrase`: Passphrase to decode an encoded TLS private key. Requires tls.key. `ca-bundle.crt`: Custom CA to validate certificates. \n `tls.insecure`: If this key is present (with any value) accept server certificates that are self-signed or have an incorrect hostname. This is INSECURE, the connection is susceptible to man-in-the-middle attacks. This is ONLY for development and testing when valid certificates are not available. \n Username and Password \n `username`: Authentication user name. Requires `password`. `password`: Authentication password. Requires `username`. \n Simple Authentication Security Layer (SASL) \n `sasl.enable`: (boolean) Explicitly enable or disable SASL. If missing, SASL is automatically enabled if any `sasl.*` keys are set. `sasl.mechanisms`: (array of string) List of allowed SASL mechanism names. If missing or empty, the system defaults are used. `sasl.allow-insecure`: (boolean) Allow mechanisms that send clear-text passwords. Default false."
                       properties:
                         name:
-                          description: Name of a secret in the namespace configured
-                            for log forwarder secrets.
+                          description: Name of a secret in the namespace configured for log forwarder secrets.
                           type: string
                       required:
                       - name
                       type: object
                     syslog:
-                      description: Syslog provides optional extra properties for output
-                        type `syslog`
+                      description: Syslog provides optional extra properties for output type `syslog`
                       properties:
                         addLogSource:
-                          description: AddLogSource adds log's source information
-                            to the log message If the logs are collected from a process;
-                            namespace_name, pod_name, container_name is added to the
-                            log In addition, it picks the originating process name
-                            and id(known as the `pid`) from the record and injects
-                            them into the header field."
+                          description: AddLogSource adds log's source information to the log message If the logs are collected from a process; namespace_name, pod_name, container_name is added to the log In addition, it picks the originating process name and id(known as the `pid`) from the record and injects them into the header field."
                           type: boolean
                         appName:
-                          description: "AppName is APP-NAME part of the syslog-msg
-                            header \n AppName needs to be specified if using rfc5424"
+                          description: "AppName is APP-NAME part of the syslog-msg header \n AppName needs to be specified if using rfc5424"
                           type: string
                         facility:
-                          description: "Facility to set on outgoing syslog records.
-                            \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
-                            The value can be a decimal integer. Facility keywords
-                            are not standardized, this API recognizes at least the
-                            following case-insensitive keywords (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels):
-                            \n kernel user mail daemon auth syslog lpr news uucp cron
-                            authpriv ftp ntp security console solaris-cron local0
-                            local1 local2 local3 local4 local5 local6 local7"
+                          description: "Facility to set on outgoing syslog records. \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1. The value can be a decimal integer. Facility keywords are not standardized, this API recognizes at least the following case-insensitive keywords (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels): \n kernel user mail daemon auth syslog lpr news uucp cron authpriv ftp ntp security console solaris-cron local0 local1 local2 local3 local4 local5 local6 local7"
                           type: string
                         msgID:
-                          description: "MsgID is MSGID part of the syslog-msg header
-                            \n MsgID needs to be specified if using rfc5424"
+                          description: "MsgID is MSGID part of the syslog-msg header \n MsgID needs to be specified if using rfc5424"
                           type: string
                         payloadKey:
-                          description: PayloadKey specifies record field to use as
-                            payload.
+                          description: PayloadKey specifies record field to use as payload.
                           type: string
                         procID:
-                          description: "ProcID is PROCID part of the syslog-msg header
-                            \n ProcID needs to be specified if using rfc5424"
+                          description: "ProcID is PROCID part of the syslog-msg header \n ProcID needs to be specified if using rfc5424"
                           type: string
                         rfc:
                           default: RFC5424
-                          description: "Rfc specifies the rfc to be used for sending
-                            syslog \n Rfc values can be one of: - RFC3164 (https://tools.ietf.org/html/rfc3164)
-                            - RFC5424 (https://tools.ietf.org/html/rfc5424) \n If
-                            unspecified, RFC5424 will be assumed."
+                          description: "Rfc specifies the rfc to be used for sending syslog \n Rfc values can be one of: - RFC3164 (https://tools.ietf.org/html/rfc3164) - RFC5424 (https://tools.ietf.org/html/rfc5424) \n If unspecified, RFC5424 will be assumed."
                           enum:
                           - RFC3164
                           - RFC5424
                           type: string
                         severity:
-                          description: "Severity to set on outgoing syslog records.
-                            \n Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1
-                            The value can be a decimal integer or one of these case-insensitive
-                            keywords: \n Emergency Alert Critical Error Warning Notice
-                            Informational Debug"
+                          description: "Severity to set on outgoing syslog records. \n Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1 The value can be a decimal integer or one of these case-insensitive keywords: \n Emergency Alert Critical Error Warning Notice Informational Debug"
                           type: string
                         tag:
                           description: Tag specifies a record field to use as tag.
@@ -387,15 +234,7 @@ spec:
                       - loki
                       type: string
                     url:
-                      description: "URL to send log records to. \n An absolute URL,
-                        with a scheme. Valid schemes depend on `type`. Special schemes
-                        `tcp`, `tls`, `udp` and `udps` are used for types that have
-                        no scheme of their own. For example, to send syslog records
-                        using secure UDP: \n { type: syslog, url: udps://syslog.example.com:1234
-                        } \n Basic TLS is enabled if the URL scheme requires it (for
-                        example 'https' or 'tls'). The 'username@password' part of
-                        `url` is ignored. Any additional authentication material is
-                        in the `secret`. See the `secret` field for more details."
+                      description: "URL to send log records to. \n An absolute URL, with a scheme. Valid schemes depend on `type`. Special schemes `tcp`, `tls`, `udp` and `udps` are used for types that have no scheme of their own. For example, to send syslog records using secure UDP: \n { type: syslog, url: udps://syslog.example.com:1234 } \n Basic TLS is enabled if the URL scheme requires it (for example 'https' or 'tls'). The 'username@password' part of `url` is ignored. Any additional authentication material is in the `secret`. See the `secret` field for more details."
                       pattern: ^$|[a-zA-z]+:\/\/.*
                       type: string
                   required:
@@ -404,47 +243,32 @@ spec:
                   type: object
                 type: array
               pipelines:
-                description: Pipelines forward the messages selected by a set of inputs
-                  to a set of outputs.
+                description: Pipelines forward the messages selected by a set of inputs to a set of outputs.
                 items:
                   properties:
                     detectMultilineErrors:
-                      description: DetectMultilineErrors enables multiline error detection
-                        of container logs
+                      description: DetectMultilineErrors enables multiline error detection of container logs
                       type: boolean
                     inputRefs:
-                      description: "InputRefs lists the names (`input.name`) of inputs
-                        to this pipeline. \n The following built-in input names are
-                        always available: \n `application` selects all logs from application
-                        pods. \n `infrastructure` selects logs from openshift and
-                        kubernetes pods and some node logs. \n `audit` selects node
-                        logs related to security audits."
+                      description: "InputRefs lists the names (`input.name`) of inputs to this pipeline. \n The following built-in input names are always available: \n `application` selects all logs from application pods. \n `infrastructure` selects logs from openshift and kubernetes pods and some node logs. \n `audit` selects node logs related to security audits."
                       items:
                         type: string
                       type: array
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels applied to log records passing through this
-                        pipeline. These labels appear in the `openshift.labels` map
-                        in the log record.
+                      description: Labels applied to log records passing through this pipeline. These labels appear in the `openshift.labels` map in the log record.
                       type: object
                     name:
-                      description: Name is optional, but must be unique in the `pipelines`
-                        list if provided.
+                      description: Name is optional, but must be unique in the `pipelines` list if provided.
                       type: string
                     outputRefs:
-                      description: "OutputRefs lists the names (`output.name`) of
-                        outputs from this pipeline. \n The following built-in names
-                        are always available: \n 'default' Output to the default log
-                        store provided by ClusterLogging."
+                      description: "OutputRefs lists the names (`output.name`) of outputs from this pipeline. \n The following built-in names are always available: \n 'default' Output to the default log store provided by ClusterLogging."
                       items:
                         type: string
                       type: array
                     parse:
-                      description: "Parse enables parsing of log entries into structured
-                        logs \n Logs are parsed according to parse value, only `json`
-                        is supported as of now."
+                      description: "Parse enables parsing of log entries into structured logs \n Logs are parsed according to parse value, only `json` is supported as of now."
                       enum:
                       - json
                       type: string
@@ -460,16 +284,7 @@ spec:
               conditions:
                 description: Conditions of the log forwarder.
                 items:
-                  description: "Condition represents an observation of an object's
-                    state. Conditions are an extension mechanism intended to be used
-                    when the details of an observation are not a priori known or would
-                    not apply to all instances of a given Kind. \n Conditions should
-                    be added to explicitly convey properties that users and components
-                    care about rather than requiring those properties to be inferred
-                    from other observations. Once defined, the meaning of a Condition
-                    can not be changed arbitrarily - it becomes part of the API, and
-                    has the same backwards- and forwards-compatibility concerns of
-                    any other part of the API."
+                  description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                   properties:
                     lastTransitionTime:
                       format: date-time
@@ -477,20 +292,12 @@ spec:
                     message:
                       type: string
                     reason:
-                      description: ConditionReason is intended to be a one-word, CamelCase
-                        representation of the category of cause of the current status.
-                        It is intended to be used in concise output, such as one-line
-                        kubectl get output, and in summarizing occurrences of causes.
+                      description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                       type: string
                     status:
                       type: string
                     type:
-                      description: "ConditionType is the type of the condition and
-                        is typically a CamelCased word or short phrase. \n Condition
-                        types should indicate state in the \"abnormal-true\" polarity.
-                        For example, if the condition indicates when a policy is invalid,
-                        the \"is valid\" case is probably the norm, so the condition
-                        should be called \"Invalid\"."
+                      description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                       type: string
                   required:
                   - status
@@ -501,16 +308,7 @@ spec:
                 additionalProperties:
                   description: Conditions is a set of Condition instances.
                   items:
-                    description: "Condition represents an observation of an object's
-                      state. Conditions are an extension mechanism intended to be
-                      used when the details of an observation are not a priori known
-                      or would not apply to all instances of a given Kind. \n Conditions
-                      should be added to explicitly convey properties that users and
-                      components care about rather than requiring those properties
-                      to be inferred from other observations. Once defined, the meaning
-                      of a Condition can not be changed arbitrarily - it becomes part
-                      of the API, and has the same backwards- and forwards-compatibility
-                      concerns of any other part of the API."
+                    description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -518,21 +316,12 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is intended to be a one-word,
-                          CamelCase representation of the category of cause of the
-                          current status. It is intended to be used in concise output,
-                          such as one-line kubectl get output, and in summarizing
-                          occurrences of causes.
+                        description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                         type: string
                       status:
                         type: string
                       type:
-                        description: "ConditionType is the type of the condition and
-                          is typically a CamelCased word or short phrase. \n Condition
-                          types should indicate state in the \"abnormal-true\" polarity.
-                          For example, if the condition indicates when a policy is
-                          invalid, the \"is valid\" case is probably the norm, so
-                          the condition should be called \"Invalid\"."
+                        description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                         type: string
                     required:
                     - status
@@ -545,16 +334,7 @@ spec:
                 additionalProperties:
                   description: Conditions is a set of Condition instances.
                   items:
-                    description: "Condition represents an observation of an object's
-                      state. Conditions are an extension mechanism intended to be
-                      used when the details of an observation are not a priori known
-                      or would not apply to all instances of a given Kind. \n Conditions
-                      should be added to explicitly convey properties that users and
-                      components care about rather than requiring those properties
-                      to be inferred from other observations. Once defined, the meaning
-                      of a Condition can not be changed arbitrarily - it becomes part
-                      of the API, and has the same backwards- and forwards-compatibility
-                      concerns of any other part of the API."
+                    description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -562,21 +342,12 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is intended to be a one-word,
-                          CamelCase representation of the category of cause of the
-                          current status. It is intended to be used in concise output,
-                          such as one-line kubectl get output, and in summarizing
-                          occurrences of causes.
+                        description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                         type: string
                       status:
                         type: string
                       type:
-                        description: "ConditionType is the type of the condition and
-                          is typically a CamelCased word or short phrase. \n Condition
-                          types should indicate state in the \"abnormal-true\" polarity.
-                          For example, if the condition indicates when a policy is
-                          invalid, the \"is valid\" case is probably the norm, so
-                          the condition should be called \"Invalid\"."
+                        description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                         type: string
                     required:
                     - status
@@ -589,16 +360,7 @@ spec:
                 additionalProperties:
                   description: Conditions is a set of Condition instances.
                   items:
-                    description: "Condition represents an observation of an object's
-                      state. Conditions are an extension mechanism intended to be
-                      used when the details of an observation are not a priori known
-                      or would not apply to all instances of a given Kind. \n Conditions
-                      should be added to explicitly convey properties that users and
-                      components care about rather than requiring those properties
-                      to be inferred from other observations. Once defined, the meaning
-                      of a Condition can not be changed arbitrarily - it becomes part
-                      of the API, and has the same backwards- and forwards-compatibility
-                      concerns of any other part of the API."
+                    description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -606,21 +368,12 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is intended to be a one-word,
-                          CamelCase representation of the category of cause of the
-                          current status. It is intended to be used in concise output,
-                          such as one-line kubectl get output, and in summarizing
-                          occurrences of causes.
+                        description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                         type: string
                       status:
                         type: string
                       type:
-                        description: "ConditionType is the type of the condition and
-                          is typically a CamelCased word or short phrase. \n Condition
-                          types should indicate state in the \"abnormal-true\" polarity.
-                          For example, if the condition indicates when a policy is
-                          invalid, the \"is valid\" case is probably the norm, so
-                          the condition should be called \"Invalid\"."
+                        description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                         type: string
                     required:
                     - status

--- a/manifests/5.5/logging.openshift.io_clusterloggings_crd.yaml
+++ b/manifests/5.5/logging.openshift.io_clusterloggings_crd.yaml
@@ -28,14 +28,10 @@ spec:
         description: ClusterLogging is the Schema for the clusterloggings API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             properties:
@@ -60,8 +56,7 @@ spec:
                           nodeSelector:
                             additionalProperties:
                               type: string
-                            description: Define which Nodes the Pods are scheduled
-                              on.
+                            description: Define which Nodes the Pods are scheduled on.
                             nullable: true
                             type: object
                           resources:
@@ -75,8 +70,7 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -85,53 +79,28 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                             type: object
                           tolerations:
                             items:
-                              description: The pod this Toleration is attached to
-                                tolerates any taint that matches the triple <key,value,effect>
-                                using the matching operator <operator>.
+                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                               properties:
                                 effect:
-                                  description: Effect indicates the taint effect to
-                                    match. Empty means match all taint effects. When
-                                    specified, allowed values are NoSchedule, PreferNoSchedule
-                                    and NoExecute.
+                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                   type: string
                                 key:
-                                  description: Key is the taint key that the toleration
-                                    applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists;
-                                    this combination means to match all values and
-                                    all keys.
+                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                   type: string
                                 operator:
-                                  description: Operator represents a key's relationship
-                                    to the value. Valid operators are Exists and Equal.
-                                    Defaults to Equal. Exists is equivalent to wildcard
-                                    for value, so that a pod can tolerate all taints
-                                    of a particular category.
+                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                                   type: string
                                 tolerationSeconds:
-                                  description: TolerationSeconds represents the period
-                                    of time the toleration (which must be of effect
-                                    NoExecute, otherwise this field is ignored) tolerates
-                                    the taint. By default, it is not set, which means
-                                    tolerate the taint forever (do not evict). Zero
-                                    and negative values will be treated as 0 (evict
-                                    immediately) by the system.
+                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                                   format: int64
                                   type: integer
                                 value:
-                                  description: Value is the taint value the toleration
-                                    matches to. If the operator is Exists, the value
-                                    should be empty, otherwise just a regular string.
+                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                   type: string
                               type: object
                             type: array
@@ -167,8 +136,7 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                           requests:
                             additionalProperties:
@@ -177,55 +145,31 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                       schedule:
-                        description: The cron schedule that the Curator job is run.
-                          Defaults to "30 3 * * *"
+                        description: The cron schedule that the Curator job is run. Defaults to "30 3 * * *"
                         type: string
                       tolerations:
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -243,100 +187,65 @@ spec:
                 nullable: true
                 properties:
                   fluentd:
-                    description: FluentdForwarderSpec represents the configuration
-                      for forwarders of type fluentd.
+                    description: FluentdForwarderSpec represents the configuration for forwarders of type fluentd.
                     properties:
                       buffer:
-                        description: "FluentdBufferSpec represents a subset of fluentd
-                          buffer parameters to tune the buffer configuration for all
-                          fluentd outputs. It supports a subset of parameters to configure
-                          buffer and queue sizing, flush operations and retry flushing.
-                          \n For general parameters refer to: https://docs.fluentd.org/configuration/buffer-section#buffering-parameters
-                          \n For flush parameters refer to: https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
-                          \n For retry parameters refer to: https://docs.fluentd.org/configuration/buffer-section#retries-parameters"
+                        description: "FluentdBufferSpec represents a subset of fluentd buffer parameters to tune the buffer configuration for all fluentd outputs. It supports a subset of parameters to configure buffer and queue sizing, flush operations and retry flushing. \n For general parameters refer to: https://docs.fluentd.org/configuration/buffer-section#buffering-parameters \n For flush parameters refer to: https://docs.fluentd.org/configuration/buffer-section#flushing-parameters \n For retry parameters refer to: https://docs.fluentd.org/configuration/buffer-section#retries-parameters"
                         properties:
                           chunkLimitSize:
-                            description: ChunkLimitSize represents the maximum size
-                              of each chunk. Events will be written into chunks until
-                              the size of chunks become this size.
+                            description: ChunkLimitSize represents the maximum size of each chunk. Events will be written into chunks until the size of chunks become this size.
                             pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
                             type: string
                           flushInterval:
-                            description: 'FlushInterval represents the time duration
-                              to wait between two consecutive flush operations. Takes
-                              only effect used together with `flushMode: interval`.'
+                            description: 'FlushInterval represents the time duration to wait between two consecutive flush operations. Takes only effect used together with `flushMode: interval`.'
                             pattern: ^([0-9]+)([smhd]{0,1})$
                             type: string
                           flushMode:
-                            description: FlushMode represents the mode of the flushing
-                              thread to write chunks. The mode allows lazy (if `time`
-                              parameter set), per interval or immediate flushing.
+                            description: FlushMode represents the mode of the flushing thread to write chunks. The mode allows lazy (if `time` parameter set), per interval or immediate flushing.
                             enum:
                             - lazy
                             - interval
                             - immediate
                             type: string
                           flushThreadCount:
-                            description: FlushThreadCount reprents the number of threads
-                              used by the fluentd buffer plugin to flush/write chunks
-                              in parallel.
+                            description: FlushThreadCount reprents the number of threads used by the fluentd buffer plugin to flush/write chunks in parallel.
                             format: int32
                             type: integer
                           overflowAction:
-                            description: 'OverflowAction represents the action for
-                              the fluentd buffer plugin to execute when a buffer queue
-                              is full. (Default: block)'
+                            description: 'OverflowAction represents the action for the fluentd buffer plugin to execute when a buffer queue is full. (Default: block)'
                             enum:
                             - throw_exception
                             - block
                             - drop_oldest_chunk
                             type: string
                           retryMaxInterval:
-                            description: 'RetryMaxInterval represents the maximum
-                              time interval for exponential backoff between retries.
-                              Takes only effect if used together with `retryType:
-                              exponential_backoff`.'
+                            description: 'RetryMaxInterval represents the maximum time interval for exponential backoff between retries. Takes only effect if used together with `retryType: exponential_backoff`.'
                             pattern: ^([0-9]+)([smhd]{0,1})$
                             type: string
                           retryTimeout:
-                            description: RetryTimeout represents the maximum time
-                              interval to attempt retries before giving up and the
-                              record is disguarded.  If unspecified, the default will
-                              be used
+                            description: RetryTimeout represents the maximum time interval to attempt retries before giving up and the record is disguarded.  If unspecified, the default will be used
                             pattern: ^([0-9]+)([smhd]{0,1})$
                             type: string
                           retryType:
-                            description: RetryType represents the type of retrying
-                              flush operations. Flush operations can be retried either
-                              periodically or by applying exponential backoff.
+                            description: RetryType represents the type of retrying flush operations. Flush operations can be retried either periodically or by applying exponential backoff.
                             enum:
                             - exponential_backoff
                             - periodic
                             type: string
                           retryWait:
-                            description: RetryWait represents the time duration between
-                              two consecutive retries to flush buffers for periodic
-                              retries or a constant factor of time on retries with
-                              exponential backoff.
+                            description: RetryWait represents the time duration between two consecutive retries to flush buffers for periodic retries or a constant factor of time on retries with exponential backoff.
                             pattern: ^([0-9]+)([smhd]{0,1})$
                             type: string
                           totalLimitSize:
-                            description: TotalLimitSize represents the threshold of
-                              node space allowed per fluentd buffer to allocate. Once
-                              this threshold is reached, all append operations will
-                              fail with error (and data will be lost).
+                            description: TotalLimitSize represents the threshold of node space allowed per fluentd buffer to allocate. Once this threshold is reached, all append operations will fail with error (and data will be lost).
                             pattern: ^([0-9]+)([kmgtKMGT]{0,1})$
                             type: string
                         type: object
                       inFile:
-                        description: "FluentdInFileSpec represents a subset of fluentd
-                          in-tail plugin parameters to tune the configuration for
-                          all fluentd in-tail inputs. \n For general parameters refer
-                          to: https://docs.fluentd.org/input/tail#parameters"
+                        description: "FluentdInFileSpec represents a subset of fluentd in-tail plugin parameters to tune the configuration for all fluentd in-tail inputs. \n For general parameters refer to: https://docs.fluentd.org/input/tail#parameters"
                         properties:
                           readLinesLimit:
-                            description: ReadLinesLimit represents the number of lines
-                              to read with each I/O operation
+                            description: ReadLinesLimit represents the number of lines to read with each I/O operation
                             type: integer
                         type: object
                     type: object
@@ -362,8 +271,7 @@ spec:
                         description: Specification of the Elasticsearch Proxy component
                         properties:
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
+                            description: ResourceRequirements describes the compute resource requirements.
                             nullable: true
                             properties:
                               limits:
@@ -373,8 +281,7 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -383,19 +290,14 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                             type: object
                         required:
                         - resources
                         type: object
                       redundancyPolicy:
-                        description: The policy towards data redundancy to specify
-                          the number of redundant primary shards
+                        description: The policy towards data redundancy to specify the number of redundant primary shards
                         enum:
                         - FullRedundancy
                         - MultipleRedundancy
@@ -413,8 +315,7 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                           requests:
                             additionalProperties:
@@ -423,69 +324,43 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                       storage:
-                        description: The storage specification for Elasticsearch data
-                          nodes
+                        description: The storage specification for Elasticsearch data nodes
                         nullable: true
                         properties:
                           size:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: The max storage capacity for the node to
-                              provision.
+                            description: The max storage capacity for the node to provision.
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           storageClassName:
-                            description: 'The name of the storage class to use with
-                              creating the node''s PVC. More info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
+                            description: 'The name of the storage class to use with creating the node''s PVC. More info: https://kubernetes.io/docs/concepts/storage/storage-classes/'
                             type: string
                         type: object
                       tolerations:
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -493,8 +368,7 @@ spec:
                     - nodeCount
                     type: object
                   retentionPolicy:
-                    description: Retention policy defines the maximum age for an index
-                      after which it should be deleted
+                    description: Retention policy defines the maximum age for an index after which it should be deleted
                     nullable: true
                     properties:
                       application:
@@ -505,20 +379,15 @@ spec:
                             pattern: ^([0-9]+)([wdhHms]{0,1})$
                             type: string
                           namespaceSpec:
-                            description: The per namespace specification to delete
-                              documents older than a given minimum age
+                            description: The per namespace specification to delete documents older than a given minimum age
                             items:
                               properties:
                                 minAge:
-                                  description: Delete the records matching the namespaces
-                                    which are older than this MinAge (e.g. 1d)
+                                  description: Delete the records matching the namespaces which are older than this MinAge (e.g. 1d)
                                   pattern: ^([0-9]+)([wdhHms]{0,1})$
                                   type: string
                                 namespace:
-                                  description: Target Namespace to delete logs older
-                                    than MinAge (defaults to 7d) Can be one namespace
-                                    name or a prefix (e.g., "openshift-" covers all
-                                    namespaces with this prefix)
+                                  description: Target Namespace to delete logs older than MinAge (defaults to 7d) Can be one namespace name or a prefix (e.g., "openshift-" covers all namespaces with this prefix)
                                   type: string
                               required:
                               - namespace
@@ -537,20 +406,15 @@ spec:
                             pattern: ^([0-9]+)([wdhHms]{0,1})$
                             type: string
                           namespaceSpec:
-                            description: The per namespace specification to delete
-                              documents older than a given minimum age
+                            description: The per namespace specification to delete documents older than a given minimum age
                             items:
                               properties:
                                 minAge:
-                                  description: Delete the records matching the namespaces
-                                    which are older than this MinAge (e.g. 1d)
+                                  description: Delete the records matching the namespaces which are older than this MinAge (e.g. 1d)
                                   pattern: ^([0-9]+)([wdhHms]{0,1})$
                                   type: string
                                 namespace:
-                                  description: Target Namespace to delete logs older
-                                    than MinAge (defaults to 7d) Can be one namespace
-                                    name or a prefix (e.g., "openshift-" covers all
-                                    namespaces with this prefix)
+                                  description: Target Namespace to delete logs older than MinAge (defaults to 7d) Can be one namespace name or a prefix (e.g., "openshift-" covers all namespaces with this prefix)
                                   type: string
                               required:
                               - namespace
@@ -569,20 +433,15 @@ spec:
                             pattern: ^([0-9]+)([wdhHms]{0,1})$
                             type: string
                           namespaceSpec:
-                            description: The per namespace specification to delete
-                              documents older than a given minimum age
+                            description: The per namespace specification to delete documents older than a given minimum age
                             items:
                               properties:
                                 minAge:
-                                  description: Delete the records matching the namespaces
-                                    which are older than this MinAge (e.g. 1d)
+                                  description: Delete the records matching the namespaces which are older than this MinAge (e.g. 1d)
                                   pattern: ^([0-9]+)([wdhHms]{0,1})$
                                   type: string
                                 namespace:
-                                  description: Target Namespace to delete logs older
-                                    than MinAge (defaults to 7d) Can be one namespace
-                                    name or a prefix (e.g., "openshift-" covers all
-                                    namespaces with this prefix)
+                                  description: Target Namespace to delete logs older than MinAge (defaults to 7d) Can be one namespace name or a prefix (e.g., "openshift-" covers all namespaces with this prefix)
                                   type: string
                               required:
                               - namespace
@@ -601,15 +460,13 @@ spec:
                 - type
                 type: object
               managementState:
-                description: Indicator if the resource is 'Managed' or 'Unmanaged'
-                  by the operator
+                description: Indicator if the resource is 'Managed' or 'Unmanaged' by the operator
                 enum:
                 - Managed
                 - Unmanaged
                 type: string
               visualization:
-                description: Specification of the Visualization component for the
-                  cluster
+                description: Specification of the Visualization component for the cluster
                 nullable: true
                 properties:
                   kibana:
@@ -625,8 +482,7 @@ spec:
                         description: Specification of the Kibana Proxy component
                         properties:
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
+                            description: ResourceRequirements describes the compute resource requirements.
                             nullable: true
                             properties:
                               limits:
@@ -636,8 +492,7 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -646,11 +501,7 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                             type: object
                         required:
@@ -671,8 +522,7 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                           requests:
                             additionalProperties:
@@ -681,51 +531,28 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
                         type: object
                       tolerations:
                         items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
+                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
+                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
+                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
+                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
+                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
+                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
@@ -745,16 +572,7 @@ spec:
               clusterConditions:
                 description: Conditions is a set of Condition instances.
                 items:
-                  description: "Condition represents an observation of an object's
-                    state. Conditions are an extension mechanism intended to be used
-                    when the details of an observation are not a priori known or would
-                    not apply to all instances of a given Kind. \n Conditions should
-                    be added to explicitly convey properties that users and components
-                    care about rather than requiring those properties to be inferred
-                    from other observations. Once defined, the meaning of a Condition
-                    can not be changed arbitrarily - it becomes part of the API, and
-                    has the same backwards- and forwards-compatibility concerns of
-                    any other part of the API."
+                  description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                   properties:
                     lastTransitionTime:
                       format: date-time
@@ -762,20 +580,12 @@ spec:
                     message:
                       type: string
                     reason:
-                      description: ConditionReason is intended to be a one-word, CamelCase
-                        representation of the category of cause of the current status.
-                        It is intended to be used in concise output, such as one-line
-                        kubectl get output, and in summarizing occurrences of causes.
+                      description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                       type: string
                     status:
                       type: string
                     type:
-                      description: "ConditionType is the type of the condition and
-                        is typically a CamelCased word or short phrase. \n Condition
-                        types should indicate state in the \"abnormal-true\" polarity.
-                        For example, if the condition indicates when a policy is invalid,
-                        the \"is valid\" case is probably the norm, so the condition
-                        should be called \"Invalid\"."
+                      description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                       type: string
                   required:
                   - status
@@ -790,21 +600,9 @@ spec:
                         properties:
                           clusterCondition:
                             additionalProperties:
-                              description: '`operator-sdk generate crds` does not
-                                allow map-of-slice, must use a named type.'
+                              description: '`operator-sdk generate crds` does not allow map-of-slice, must use a named type.'
                               items:
-                                description: "Condition represents an observation
-                                  of an object's state. Conditions are an extension
-                                  mechanism intended to be used when the details of
-                                  an observation are not a priori known or would not
-                                  apply to all instances of a given Kind. \n Conditions
-                                  should be added to explicitly convey properties
-                                  that users and components care about rather than
-                                  requiring those properties to be inferred from other
-                                  observations. Once defined, the meaning of a Condition
-                                  can not be changed arbitrarily - it becomes part
-                                  of the API, and has the same backwards- and forwards-compatibility
-                                  concerns of any other part of the API."
+                                description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                                 properties:
                                   lastTransitionTime:
                                     format: date-time
@@ -812,24 +610,12 @@ spec:
                                   message:
                                     type: string
                                   reason:
-                                    description: ConditionReason is intended to be
-                                      a one-word, CamelCase representation of the
-                                      category of cause of the current status. It
-                                      is intended to be used in concise output, such
-                                      as one-line kubectl get output, and in summarizing
-                                      occurrences of causes.
+                                    description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                                     type: string
                                   status:
                                     type: string
                                   type:
-                                    description: "ConditionType is the type of the
-                                      condition and is typically a CamelCased word
-                                      or short phrase. \n Condition types should indicate
-                                      state in the \"abnormal-true\" polarity. For
-                                      example, if the condition indicates when a policy
-                                      is invalid, the \"is valid\" case is probably
-                                      the norm, so the condition should be called
-                                      \"Invalid\"."
+                                    description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                                     type: string
                                 required:
                                 - status
@@ -859,21 +645,9 @@ spec:
                       properties:
                         clusterCondition:
                           additionalProperties:
-                            description: '`operator-sdk generate crds` does not allow
-                              map-of-slice, must use a named type.'
+                            description: '`operator-sdk generate crds` does not allow map-of-slice, must use a named type.'
                             items:
-                              description: "Condition represents an observation of
-                                an object's state. Conditions are an extension mechanism
-                                intended to be used when the details of an observation
-                                are not a priori known or would not apply to all instances
-                                of a given Kind. \n Conditions should be added to
-                                explicitly convey properties that users and components
-                                care about rather than requiring those properties
-                                to be inferred from other observations. Once defined,
-                                the meaning of a Condition can not be changed arbitrarily
-                                - it becomes part of the API, and has the same backwards-
-                                and forwards-compatibility concerns of any other part
-                                of the API."
+                              description: "Condition represents an observation of an object's state. Conditions are an extension mechanism intended to be used when the details of an observation are not a priori known or would not apply to all instances of a given Kind. \n Conditions should be added to explicitly convey properties that users and components care about rather than requiring those properties to be inferred from other observations. Once defined, the meaning of a Condition can not be changed arbitrarily - it becomes part of the API, and has the same backwards- and forwards-compatibility concerns of any other part of the API."
                               properties:
                                 lastTransitionTime:
                                   format: date-time
@@ -881,23 +655,12 @@ spec:
                                 message:
                                   type: string
                                 reason:
-                                  description: ConditionReason is intended to be a
-                                    one-word, CamelCase representation of the category
-                                    of cause of the current status. It is intended
-                                    to be used in concise output, such as one-line
-                                    kubectl get output, and in summarizing occurrences
-                                    of causes.
+                                  description: ConditionReason is intended to be a one-word, CamelCase representation of the category of cause of the current status. It is intended to be used in concise output, such as one-line kubectl get output, and in summarizing occurrences of causes.
                                   type: string
                                 status:
                                   type: string
                                 type:
-                                  description: "ConditionType is the type of the condition
-                                    and is typically a CamelCased word or short phrase.
-                                    \n Condition types should indicate state in the
-                                    \"abnormal-true\" polarity. For example, if the
-                                    condition indicates when a policy is invalid,
-                                    the \"is valid\" case is probably the norm, so
-                                    the condition should be called \"Invalid\"."
+                                  description: "ConditionType is the type of the condition and is typically a CamelCased word or short phrase. \n Condition types should indicate state in the \"abnormal-true\" polarity. For example, if the condition indicates when a policy is invalid, the \"is valid\" case is probably the norm, so the condition should be called \"Invalid\"."
                                   type: string
                               required:
                               - status
@@ -922,45 +685,37 @@ spec:
                         cluster:
                           properties:
                             activePrimaryShards:
-                              description: The number of Active Primary Shards for
-                                the Elasticsearch Cluster
+                              description: The number of Active Primary Shards for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             activeShards:
-                              description: The number of Active Shards for the Elasticsearch
-                                Cluster
+                              description: The number of Active Shards for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             initializingShards:
-                              description: The number of Initializing Shards for the
-                                Elasticsearch Cluster
+                              description: The number of Initializing Shards for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             numDataNodes:
-                              description: The number of Data Nodes for the Elasticsearch
-                                Cluster
+                              description: The number of Data Nodes for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             numNodes:
-                              description: The number of Nodes for the Elasticsearch
-                                Cluster
+                              description: The number of Nodes for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             pendingTasks:
                               format: int32
                               type: integer
                             relocatingShards:
-                              description: The number of Relocating Shards for the
-                                Elasticsearch Cluster
+                              description: The number of Relocating Shards for the Elasticsearch Cluster
                               format: int32
                               type: integer
                             status:
-                              description: The current Status of the Elasticsearch
-                                Cluster
+                              description: The current Status of the Elasticsearch Cluster
                               type: string
                             unassignedShards:
-                              description: The number of Unassigned Shards for the
-                                Elasticsearch Cluster
+                              description: The number of Unassigned Shards for the Elasticsearch Cluster
                               format: int32
                               type: integer
                           required:
@@ -978,23 +733,19 @@ spec:
                           items:
                             properties:
                               lastTransitionTime:
-                                description: Last time the condition transitioned
-                                  from one status to another.
+                                description: Last time the condition transitioned from one status to another.
                                 format: date-time
                                 type: string
                               message:
-                                description: Human-readable message indicating details
-                                  about last transition.
+                                description: Human-readable message indicating details about last transition.
                                 type: string
                               reason:
-                                description: Unique, one-word, CamelCase reason for
-                                  the condition's last transition.
+                                description: Unique, one-word, CamelCase reason for the condition's last transition.
                                 type: string
                               status:
                                 type: string
                               type:
-                                description: ClusterConditionType is a valid value
-                                  for ClusterCondition.Type
+                                description: ClusterConditionType is a valid value for ClusterCondition.Type
                                 type: string
                             required:
                             - lastTransitionTime
@@ -1015,23 +766,19 @@ spec:
                             items:
                               properties:
                                 lastTransitionTime:
-                                  description: Last time the condition transitioned
-                                    from one status to another.
+                                  description: Last time the condition transitioned from one status to another.
                                   format: date-time
                                   type: string
                                 message:
-                                  description: Human-readable message indicating details
-                                    about last transition.
+                                  description: Human-readable message indicating details about last transition.
                                   type: string
                                 reason:
-                                  description: Unique, one-word, CamelCase reason
-                                    for the condition's last transition.
+                                  description: Unique, one-word, CamelCase reason for the condition's last transition.
                                   type: string
                                 status:
                                   type: string
                                 type:
-                                  description: ClusterConditionType is a valid value
-                                    for ClusterCondition.Type
+                                  description: ClusterConditionType is a valid value for ClusterCondition.Type
                                   type: string
                               required:
                               - lastTransitionTime
@@ -1075,23 +822,19 @@ spec:
                             items:
                               properties:
                                 lastTransitionTime:
-                                  description: Last time the condition transitioned
-                                    from one status to another.
+                                  description: Last time the condition transitioned from one status to another.
                                   format: date-time
                                   type: string
                                 message:
-                                  description: Human-readable message indicating details
-                                    about last transition.
+                                  description: Human-readable message indicating details about last transition.
                                   type: string
                                 reason:
-                                  description: Unique, one-word, CamelCase reason
-                                    for the condition's last transition.
+                                  description: Unique, one-word, CamelCase reason for the condition's last transition.
                                   type: string
                                 status:
                                   type: string
                                 type:
-                                  description: ClusterConditionType is a valid value
-                                    for ClusterCondition.Type
+                                  description: ClusterConditionType is a valid value for ClusterCondition.Type
                                   type: string
                               required:
                               - lastTransitionTime
@@ -1107,8 +850,7 @@ spec:
                             items:
                               type: string
                             type: array
-                          description: The status for each of the Kibana pods for
-                            the Visualization component
+                          description: The status for each of the Kibana pods for the Visualization component
                           type: object
                         replicaSets:
                           items:


### PR DESCRIPTION
### Description
This PR is a followup to a similar one for Elasticsearch operator, where the support of `y` and `M` time units is removed from the retention policy time fields in CRDs

### Links
- Depending on PR(s): https://github.com/openshift/elasticsearch-operator/pull/874
- JIRA: [LOG-2418](https://issues.redhat.com/browse/LOG-2418)
