### PR TITLE
LOG-2454: Add keepalive_timeout to fluent forward output

### DIFF
--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -2979,6 +2979,7 @@ var _ = Describe("Generating fluentd config", func() {
     </server>
     heartbeat_type none
     keepalive true
+    keepalive_timeout 30s
     
     <buffer>
       @type file

--- a/internal/generator/fluentd/output/fluentdforward/fluentdforward.go
+++ b/internal/generator/fluentd/output/fluentdforward/fluentdforward.go
@@ -45,6 +45,7 @@ func (ff FluentdForward) Template() string {
 </server>
 heartbeat_type none
 keepalive true
+keepalive_timeout 30s
 {{compose .SecurityConfig}}
 {{compose .BufferConfig}}
 {{- end}}

--- a/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
@@ -60,6 +60,7 @@ var _ = Describe("fluentd conf generation", func() {
     </server>
     heartbeat_type none
     keepalive true
+    keepalive_timeout 30s
     transport tls
     tls_verify_hostname false
     tls_version 'TLSv1_2'
@@ -116,6 +117,7 @@ var _ = Describe("fluentd conf generation", func() {
     </server>
     heartbeat_type none
     keepalive true
+    keepalive_timeout 30s
     transport tls
     tls_verify_hostname false
     tls_version 'TLSv1_2'
@@ -167,6 +169,7 @@ var _ = Describe("fluentd conf generation", func() {
     </server>
     heartbeat_type none
     keepalive true
+    keepalive_timeout 30s
     
     <buffer>
       @type file

--- a/internal/generator/fluentd/output/fluentdforward/output_conf_forward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/output_conf_forward_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
     </server>
     heartbeat_type none
     keepalive true
+    keepalive_timeout 30s
     transport tls
     tls_verify_hostname false
     tls_version 'TLSv1_2'
@@ -106,6 +107,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
     </server>
     heartbeat_type none
     keepalive true
+    keepalive_timeout 30s
     transport tls
     tls_verify_hostname false
     tls_version 'TLSv1_2'
@@ -145,6 +147,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
     </server>
     heartbeat_type none
     keepalive true
+    keepalive_timeout 30s
     transport tls
     tls_verify_hostname false
     tls_version 'TLSv1_2'
@@ -201,7 +204,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
     </server>
     heartbeat_type none
     keepalive true
-    
+    keepalive_timeout 30s
     <buffer>
       @type file
       path '/var/lib/fluentd/secureforward_receiver'

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -502,6 +502,7 @@ var _ = Describe("Generating fluentd config", func() {
             </server>
             heartbeat_type none
             keepalive true
+            keepalive_timeout 30s
             <buffer>
             @type file
             path '/var/lib/fluentd/secureforward_receiver'
@@ -539,6 +540,7 @@ var _ = Describe("Generating fluentd config", func() {
           </server>
           heartbeat_type none
           keepalive true
+          keepalive_timeout 30s
 
           <buffer>
           @type file


### PR DESCRIPTION
### Description
This PR:
* Adds a keepalive timeout of 30s to fluent forward outputs

### Links
* https://issues.redhat.com/browse/LOG-2454
