### PR TITLE
LOG-2172: fix ovn and oauthapi audit log collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,20 +166,11 @@ deploy-example: deploy
 	oc create -n $(NAMESPACE) -f hack/cr.yaml
 
 test-functional: test-functional-benchmarker
+	VECTOR_IMAGE=$(IMAGE_LOGGING_VECTOR) \
 	FLUENTD_IMAGE=$(IMAGE_LOGGING_FLUENTD) \
-	LOGGING_SHARE_DIR=$(CURDIR)/files \
-	SCRIPTS_DIR=$(CURDIR)/scripts \
 	go test -race ./test/functional/... -ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
 	FLUENTD_IMAGE=$(IMAGE_LOGGING_FLUENTD) go test -cover -race ./test/helpers/...
 .PHONY: test-functional
-
-test-functional-vector:
-	VECTOR_IMAGE=$(IMAGE_LOGGING_VECTOR) \
-	LOGGING_SHARE_DIR=$(CURDIR)/files \
-	SCRIPTS_DIR=$(CURDIR)/scripts \
-	COLLECTOR_IMPL=vector \
-	go test -race ./test/functional/... -ginkgo.noColor -timeout=40m -ginkgo.focus '\[VECTOR_READY\]'
-.PHONY: test-functional-vector
 
 test-forwarder-generator: bin/forwarder-generator
 	@bin/forwarder-generator --file hack/logforwarder.yaml --collector=fluentd > /dev/null

--- a/internal/cmd/functional-benchmarker/runners/cluster/cluster_runner.go
+++ b/internal/cmd/functional-benchmarker/runners/cluster/cluster_runner.go
@@ -42,7 +42,7 @@ func (r *ClusterRunner) Pod() string {
 
 func (r *ClusterRunner) Deploy() {
 	testclient := client.NewNamesapceClient()
-	r.framework = functional.NewCollectorFunctionalFrameworkUsing(&testclient.Test, testclient.Close, r.Verbosity)
+	r.framework = functional.NewCollectorFunctionalFrameworkUsing(&testclient.Test, testclient.Close, r.Verbosity, logging.LogCollectionTypeFluentd)
 	r.framework.Conf = r.CollectorConfig
 
 	functional.NewClusterLogForwarderBuilder(r.framework.Forwarder).

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -116,7 +116,13 @@ include = ["/var/log/kube-apiserver/audit.log"]
 [sources.openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log"]
+
+# Logs from ovn audit
+[sources.ovn_audit_logs]
+type = "file"
+ignore_older_secs = 600
+include = ["/var/log/ovn/acl-audit-log.log"]
 
 [sources.internal_metrics]
 type = "internal_metrics"
@@ -182,7 +188,7 @@ source = """
 # Rename log stream to "audit"
 [transforms.audit]
 type = "remap"
-inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs"]
+inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
 source = """
   .log_type = "audit"
 """
@@ -305,7 +311,13 @@ include = ["/var/log/kube-apiserver/audit.log"]
 [sources.openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log"]
+
+# Logs from ovn audit
+[sources.ovn_audit_logs]
+type = "file"
+ignore_older_secs = 600
+include = ["/var/log/ovn/acl-audit-log.log"]
 
 [sources.internal_metrics]
 type = "internal_metrics"
@@ -371,7 +383,7 @@ source = """
 # Rename log stream to "audit"
 [transforms.audit]
 type = "remap"
-inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs"]
+inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
 source = """
   .log_type = "audit"
 """

--- a/internal/generator/vector/inputs.go
+++ b/internal/generator/vector/inputs.go
@@ -90,7 +90,7 @@ func Inputs(spec *logging.ClusterLogForwarderSpec, o generator.Options) []genera
 		r := Remap{
 			Desc:        `Rename log stream to "audit"`,
 			ComponentID: logging.InputNameAudit,
-			Inputs:      helpers.MakeInputs("host_audit_logs", "k8s_audit_logs", "openshift_audit_logs"),
+			Inputs:      helpers.MakeInputs("host_audit_logs", "k8s_audit_logs", "openshift_audit_logs", "ovn_audit_logs"),
 			VRL:         AddLogTypeAudit,
 		}
 		el = append(el, r)

--- a/internal/generator/vector/source/audit_logs.go
+++ b/internal/generator/vector/source/audit_logs.go
@@ -21,7 +21,7 @@ const OpenshiftAuditLogTemplate = `
 [sources.{{.ComponentID}}]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log"]
 {{end}}
 `
 
@@ -34,6 +34,18 @@ const K8sAuditLogTemplate = `
 type = "file"
 ignore_older_secs = 600
 include = ["/var/log/kube-apiserver/audit.log"]
+{{end}}
+`
+
+type OVNAuditLog = generator.ConfLiteral
+
+const OVNAuditLogTemplate = `
+{{define "inputSourceOVNAuditTemplate" -}}
+# {{.Desc}}
+[sources.{{.ComponentID}}]
+type = "file"
+ignore_older_secs = 600
+include = ["/var/log/ovn/acl-audit-log.log"]
 {{end}}
 `
 

--- a/internal/generator/vector/sources.go
+++ b/internal/generator/vector/sources.go
@@ -57,6 +57,12 @@ func LogSources(spec *logging.ClusterLogForwarderSpec, op generator.Options) []g
 				Desc:         "Logs from openshift audit",
 				TemplateName: "inputSourceOpenShiftAuditTemplate",
 				TemplateStr:  source.OpenshiftAuditLogTemplate,
+			},
+			source.OVNAuditLog{
+				ComponentID:  "ovn_audit_logs",
+				Desc:         "Logs from ovn audit",
+				TemplateName: "inputSourceOVNAuditTemplate",
+				TemplateStr:  source.OVNAuditLogTemplate,
 			})
 	}
 	return el

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -87,7 +87,13 @@ include = ["/var/log/kube-apiserver/audit.log"]
 [sources.openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log"]
+
+# Logs from ovn audit
+[sources.ovn_audit_logs]
+type = "file"
+ignore_older_secs = 600
+include = ["/var/log/ovn/acl-audit-log.log"]
 `,
 		}),
 		Entry("All Log Sources", generator.ConfGenerateTest{
@@ -130,7 +136,13 @@ include = ["/var/log/kube-apiserver/audit.log"]
 [sources.openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log"]
+
+# Logs from ovn audit
+[sources.ovn_audit_logs]
+type = "file"
+ignore_older_secs = 600
+include = ["/var/log/ovn/acl-audit-log.log"]
 `,
 		}))
 })

--- a/internal/generator/vector/sources_to_pipelines_test.go
+++ b/internal/generator/vector/sources_to_pipelines_test.go
@@ -58,7 +58,7 @@ source = """
 # Rename log stream to "audit"
 [transforms.audit]
 type = "remap"
-inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs"]
+inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
 source = """
   .log_type = "audit"
 """
@@ -118,7 +118,7 @@ source = """
 # Rename log stream to "audit"
 [transforms.audit]
 type = "remap"
-inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs"]
+inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
 source = """
   .log_type = "audit"
 """

--- a/test/framework/functional/elasticsearch.go
+++ b/test/framework/functional/elasticsearch.go
@@ -12,7 +12,8 @@ import (
 
 var ElasticIndex = map[string]string{
 	logging.InputNameApplication:    "app-write",
-	logging.InputNameInfrastructure: "app-infra",
+	logging.InputNameAudit:          "audit-write",
+	logging.InputNameInfrastructure: "infra-write",
 }
 
 func (f *CollectorFunctionalFramework) GetLogsFromElasticSearch(outputName string, outputLogType string) (result string, err error) {

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -68,28 +68,33 @@ type CollectorFunctionalFramework struct {
 
 func NewCollectorFunctionalFramework() *CollectorFunctionalFramework {
 	test := client.NewTest()
-	return NewCollectorFunctionalFrameworkUsing(test, test.Close, 0)
+	return NewCollectorFunctionalFrameworkUsing(test, test.Close, 0, logging.LogCollectionTypeFluentd)
+}
+
+func NewCollectorFunctionalFrameworkUsingCollector(logCollectorType logging.LogCollectionType) *CollectorFunctionalFramework {
+	test := client.NewTest()
+	return NewCollectorFunctionalFrameworkUsing(test, test.Close, 0, logCollectorType)
 }
 
 func NewFluentdFunctionalFrameworkForTest(t *testing.T) *CollectorFunctionalFramework {
-	return NewCollectorFunctionalFrameworkUsing(client.ForTest(t), func() {}, 0)
+	return NewCollectorFunctionalFrameworkUsing(client.ForTest(t), func() {}, 0, logging.LogCollectionTypeFluentd)
 }
 
-func NewCollectorFunctionalFrameworkUsing(t *client.Test, fnClose func(), verbosity int) *CollectorFunctionalFramework {
+func NewCollectorFunctionalFrameworkUsing(t *client.Test, fnClose func(), verbosity int, collectorType logging.LogCollectionType) *CollectorFunctionalFramework {
 	if level, found := os.LookupEnv("LOG_LEVEL"); found {
 		if i, err := strconv.Atoi(level); err == nil {
 			verbosity = i
 		}
 	}
-
 	var collectorImpl CollectorFramework = &frameworkfluent.FluentdCollector{
 		Test: t,
 	}
-	if collectorType, found := os.LookupEnv("COLLECTOR_IMPL"); found && collectorType == string(logging.LogCollectionTypeVector) {
+	if collectorType == logging.LogCollectionTypeVector {
 		collectorImpl = &frameworkvector.VectorCollector{
 			Test: t,
 		}
 	}
+
 	log.Info("Using collector", "impl", collectorImpl.String())
 
 	log.MustInit("functional-framework")

--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -1,0 +1,249 @@
+package normalization
+
+import (
+	"fmt"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+)
+
+var _ = Describe("[Functional][LogForwarding][Normalization] message format tests for audit logs", func() {
+
+	var (
+		framework *functional.CollectorFunctionalFramework
+	)
+
+	Context("with fluentd", func() {
+		BeforeEach(func() {
+			framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeFluentd)
+			functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(logging.InputNameAudit).
+				ToFluentForwardOutput()
+			Expect(framework.Deploy()).To(BeNil())
+		})
+
+		It("should parse k8s audit log format correctly", func() {
+			// Log message data
+			timestamp := "2013-03-28T14:36:03.243000+00:00"
+			nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+
+			// Define a template for test format (used for input, and expected output)
+			var outputLogTemplate = types.K8sAuditLog{
+				AuditLogCommon: types.AuditLogCommon{
+					Kind:             "Event",
+					Hostname:         functional.FunctionalNodeName,
+					LogType:          "audit",
+					Level:            "debug",
+					Timestamp:        time.Time{},
+					ViaqMsgID:        "*",
+					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				},
+				K8SAuditLevel: "debug",
+			}
+			// Template expected as output Log
+			k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
+			Expect(framework.WriteMessagesTok8sAuditLog(k8sAuditLogLine, 10)).To(BeNil())
+			// Read line from Log Forward output
+			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeFluentdForward)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			var logs []types.K8sAuditLog
+			err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+			// Compare to expected template
+			outputTestLog := logs[0]
+			Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+		})
+
+		It("should parse linux audit log format correctly", func() {
+			// Log message data
+			timestamp := "2013-03-28T14:36:03.243000+00:00"
+			testTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+			auditLogLine := functional.NewAuditHostLog(testTime)
+			// Template expected as output Log
+			var outputLogTemplate = types.LinuxAuditLog{
+				Message:  auditLogLine,
+				LogType:  "audit",
+				Hostname: functional.FunctionalNodeName,
+				AuditLinux: types.AuditLinux{
+					Type:     "DAEMON_START",
+					RecordID: "*",
+				},
+				Timestamp:        testTime,
+				ViaqMsgID:        "*",
+				PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+			}
+			// Write log line as input to fluentd
+			Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
+			// Read line from Log Forward output
+			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeFluentdForward)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			var logs []types.LinuxAuditLog
+			err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+			// Compare to expected template
+			outputTestLog := logs[0]
+			Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+		})
+
+		It("should parse ovn audit log correctly", func() {
+			// Log message data
+			level := "info"
+			ovnLogLine := functional.NewOVNAuditLog(time.Now())
+
+			// Template expected as output Log
+			var outputLogTemplate = types.OVNAuditLog{
+				Message:   ovnLogLine,
+				Level:     level,
+				Hostname:  functional.FunctionalNodeName,
+				Timestamp: time.Time{},
+				LogType:   "audit",
+				Openshift: types.OpenshiftMeta{
+					Sequence: types.NewOptionalInt(""),
+				},
+				ViaqMsgID:        "*",
+				PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+			}
+			outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
+			// Write log line as input to fluentd
+			Expect(framework.WriteMessagesToOVNAuditLog(ovnLogLine, 10)).To(BeNil())
+			// Read line from Log Forward output
+			raw, err := framework.ReadOvnAuditLogsFrom(logging.OutputTypeFluentdForward)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			var logs []types.OVNAuditLog
+			err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+			ExpectOK(err)
+			// Compare to expected template
+			outputTestLog := logs[0]
+			Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+		})
+
+		AfterEach(func() {
+			framework.Cleanup()
+		})
+	})
+
+	Context("with vector", func() {
+		BeforeEach(func() {
+			framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
+			functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(logging.InputNameAudit).
+				ToElasticSearchOutput()
+			Expect(framework.Deploy()).To(BeNil())
+		})
+
+		//TODO: fix me when audit formatting is enabled
+		It("should parse k8s audit log format correctly", func() {
+			// Log message data
+			timestamp := "2013-03-28T14:36:03.243000+00:00"
+			nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+
+			// Define a template for test format (used for input, and expected output)
+			//var outputLogTemplate = types.K8sAuditLog{
+			//AuditLogCommon: types.AuditLogCommon{
+			//	Kind:             "Event",
+			//	Hostname:         functional.FunctionalNodeName,
+			//	LogType:          "audit",
+			//	Level:            "debug",
+			//	Timestamp:        time.Time{},
+			//	ViaqMsgID:        "*",
+			//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+			//},
+			//K8SAuditLevel: "debug",
+			//}
+			// Template expected as output Log
+			k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
+			Expect(framework.WriteMessagesTok8sAuditLog(k8sAuditLogLine, 10)).To(BeNil())
+			// Read line from Log Forward output
+			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			//var logs []types.K8sAuditLog
+			//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+			//Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
+			//// Compare to expected template
+			//outputTestLog := logs[0]
+			//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+			results := strings.Join(raw, " ")
+			Expect(results).To(MatchRegexp("kind.*Event.*level.*debug"), "Message should contain the audit log: %v", raw)
+
+		})
+		//TODO: fix me when audit formatting is enabled
+		It("should parse linux audit log format correctly", func() {
+			// Log message data
+			timestamp := "2013-03-28T14:36:03.243000+00:00"
+			testTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+			auditLogLine := functional.NewAuditHostLog(testTime)
+			//// Template expected as output Log
+			//var outputLogTemplate = types.LinuxAuditLog{
+			//	Message:  auditLogLine,
+			//	LogType:  "audit",
+			//	Hostname: functional.FunctionalNodeName,
+			//	AuditLinux: types.AuditLinux{
+			//		Type:     "DAEMON_START",
+			//		RecordID: "*",
+			//	},
+			//	Timestamp:        testTime,
+			//	ViaqMsgID:        "*",
+			//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+			//}
+			// Write log line as input to fluentd
+			Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
+			// Read line from Log Forward output
+			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			//var logs []types.LinuxAuditLog
+			//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+			//Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+			//// Compare to expected template
+			//outputTestLog := logs[0]
+			//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+			results := strings.Join(raw, " ")
+			Expect(results).To(MatchRegexp("format=enriched kernel="), "Message should contain the audit log: %v", raw)
+		})
+		//TODO: fix me when audit formatting is enabled
+		It("should parse ovn audit log correctly", func() {
+			// Log message data
+			//level := "info"
+			ovnLogLine := functional.NewOVNAuditLog(time.Now())
+
+			//// Template expected as output Log
+			//var outputLogTemplate = types.OVNAuditLog{
+			//	Message:   ovnLogLine,
+			//	Level:     level,
+			//	Hostname:  functional.FunctionalNodeName,
+			//	Timestamp: time.Time{},
+			//	LogType:   "audit",
+			//	Openshift: types.OpenshiftMeta{
+			//		Sequence: types.NewOptionalInt(""),
+			//	},
+			//	ViaqMsgID:        "*",
+			//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+			//}
+			//outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
+			//// Write log line as input to fluentd
+			Expect(framework.WriteMessagesToOVNAuditLog(ovnLogLine, 10)).To(BeNil())
+			// Read line from Log Forward output
+			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			//var logs []types.OVNAuditLog
+			//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+			//ExpectOK(err)
+			//// Compare to expected template
+			//outputTestLog := logs[0]
+			//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+			results := strings.Join(raw, " ")
+			Expect(results).To(MatchRegexp("name=verify-audit-logging_deny-all"), "Message should contain the audit log: %v", raw)
+		})
+
+		AfterEach(func() {
+			framework.Cleanup()
+		})
+	})
+
+})

--- a/test/functional/normalization/message_format_test.go
+++ b/test/functional/normalization/message_format_test.go
@@ -33,69 +33,6 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 		framework.Cleanup()
 	})
 
-	It("should parse k8s audit log format correctly", func() {
-		// Log message data
-		timestamp := "2013-03-28T14:36:03.243000+00:00"
-		nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
-
-		// Define a template for test format (used for input, and expected output)
-		var outputLogTemplate = types.K8sAuditLog{
-			AuditLogCommon: types.AuditLogCommon{
-				Kind:             "Event",
-				Hostname:         functional.FunctionalNodeName,
-				LogType:          "audit",
-				Level:            "debug",
-				Timestamp:        time.Time{},
-				ViaqMsgID:        "*",
-				PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-			},
-			K8SAuditLevel: "debug",
-		}
-		// Template expected as output Log
-		k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
-		Expect(framework.WriteMessagesTok8sAuditLog(k8sAuditLogLine, 10)).To(BeNil())
-		// Read line from Log Forward output
-		raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeFluentdForward)
-		Expect(err).To(BeNil(), "Expected no errors reading the logs")
-		var logs []types.K8sAuditLog
-		err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
-		// Compare to expected template
-		outputTestLog := logs[0]
-		Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-	})
-
-	It("should parse linux audit log format correctly", func() {
-		// Log message data
-		timestamp := "2013-03-28T14:36:03.243000+00:00"
-		testTime, _ := time.Parse(time.RFC3339Nano, timestamp)
-		auditLogLine := functional.NewAuditHostLog(testTime)
-		// Template expected as output Log
-		var outputLogTemplate = types.LinuxAuditLog{
-			Message:  auditLogLine,
-			LogType:  "audit",
-			Hostname: functional.FunctionalNodeName,
-			AuditLinux: types.AuditLinux{
-				Type:     "DAEMON_START",
-				RecordID: "*",
-			},
-			Timestamp:        testTime,
-			ViaqMsgID:        "*",
-			PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-		}
-		// Write log line as input to fluentd
-		Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
-		// Read line from Log Forward output
-		raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeFluentdForward)
-		Expect(err).To(BeNil(), "Expected no errors reading the logs")
-		var logs []types.LinuxAuditLog
-		err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
-		// Compare to expected template
-		outputTestLog := logs[0]
-		Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-	})
-
 	DescribeTable("when evaluating an application message", func(expLevel, message string) {
 		// Log message data
 		timestamp := "2020-11-04T18:13:59.061892+00:00"
@@ -181,38 +118,6 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 		var logs []types.ApplicationLog
 		err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
 		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
-		// Compare to expected template
-		outputTestLog := logs[0]
-		Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-	})
-
-	It("should parse ovn audit log correctly", func() {
-		// Log message data
-		level := "info"
-		ovnLogLine := functional.NewOVNAuditLog(time.Now())
-
-		// Template expected as output Log
-		var outputLogTemplate = types.OVNAuditLog{
-			Message:   ovnLogLine,
-			Level:     level,
-			Hostname:  functional.FunctionalNodeName,
-			Timestamp: time.Time{},
-			LogType:   "audit",
-			Openshift: types.OpenshiftMeta{
-				Sequence: types.NewOptionalInt(""),
-			},
-			ViaqMsgID:        "*",
-			PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-		}
-		outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
-		// Write log line as input to fluentd
-		Expect(framework.WriteMessagesToOVNAuditLog(ovnLogLine, 10)).To(BeNil())
-		// Read line from Log Forward output
-		raw, err := framework.ReadOvnAuditLogsFrom(logging.OutputTypeFluentdForward)
-		Expect(err).To(BeNil(), "Expected no errors reading the logs")
-		var logs []types.OVNAuditLog
-		err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-		ExpectOK(err)
 		// Compare to expected template
 		outputTestLog := logs[0]
 		Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))


### PR DESCRIPTION
### Description
This PR:
* fixes the path used by oauthapi audit logs
* adds ovn audit logs to log collection

cc @vimalk78 

### Links
*https://issues.redhat.com/browse/LOG-2172
