### PR TITLE
LOG-2549: Fix journal logs in vector v0.21-rh

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -101,6 +101,7 @@ pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
 
 [sources.raw_journal_logs]
 type = "journald"
+journal_directory = "/var/log/journal"
 
 # Logs from host audit
 [sources.host_audit_logs]
@@ -288,6 +289,7 @@ pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
 
 [sources.raw_journal_logs]
 type = "journald"
+journal_directory = "/var/log/journal"
 
 # Logs from host audit
 [sources.host_audit_logs]

--- a/internal/generator/vector/source/journal_log.go
+++ b/internal/generator/vector/source/journal_log.go
@@ -8,6 +8,7 @@ const JournalLogTemplate = `
 {{define "inputSourceJournalTemplate" -}}
 [sources.{{.ComponentID}}]
 type = "journald"
+journal_directory = "/var/log/journal"
 {{end}}`
 
 type JournalLog = generator.ConfLiteral

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -60,6 +60,7 @@ pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
 
 [sources.raw_journal_logs]
 type = "journald"
+journal_directory = "/var/log/journal"
 `,
 		}),
 		Entry("Only Audit", generator.ConfGenerateTest{
@@ -119,6 +120,7 @@ pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
 
 [sources.raw_journal_logs]
 type = "journald"
+journal_directory = "/var/log/journal"
 
 # Logs from host audit
 [sources.host_audit_logs]


### PR DESCRIPTION
### Description
set the path of journal logs for `journalctl` to scrape.


/cc @cahartma @jcantrill 
/assign 



### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue: https://issues.redhat.com/browse/LOG-2549
- JIRA:
- Enhancement proposal:
