### PR TITLE
LOG-2134: Always send infra logs to infra indices

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -629,7 +629,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -680,7 +680,7 @@ var _ = Describe("Generating fluentd config", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>
@@ -807,7 +807,7 @@ var _ = Describe("Generating fluentd config", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>
@@ -1477,7 +1477,7 @@ var _ = Describe("Generating fluentd config", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>
@@ -1604,7 +1604,7 @@ var _ = Describe("Generating fluentd config", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>
@@ -2278,7 +2278,7 @@ var _ = Describe("Generating fluentd config", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
       static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>
@@ -2405,7 +2405,7 @@ var _ = Describe("Generating fluentd config", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>
@@ -3574,7 +3574,7 @@ var _ = Describe("Generating fluentd config", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>
@@ -3701,7 +3701,7 @@ var _ = Describe("Generating fluentd config", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>
@@ -3828,7 +3828,7 @@ var _ = Describe("Generating fluentd config", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>
@@ -3955,7 +3955,7 @@ var _ = Describe("Generating fluentd config", func() {
 	<elasticsearch_index_name>
 	  enabled 'true'
 	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-	  name_type structured
+	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Generate fluentd config", func() {
     <elasticsearch_index_name>
       enabled 'true'
       tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-      name_type structured
+      name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
     <elasticsearch_index_name>
@@ -200,7 +200,7 @@ var _ = Describe("Generate fluentd config", func() {
     <elasticsearch_index_name>
       enabled 'true'
       tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-      name_type structured
+      name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
     <elasticsearch_index_name>
@@ -343,7 +343,7 @@ var _ = Describe("Generate fluentd config", func() {
     <elasticsearch_index_name>
       enabled 'true'
       tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-      name_type structured
+      name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
     <elasticsearch_index_name>
@@ -475,7 +475,7 @@ var _ = Describe("Generate fluentd config", func() {
     <elasticsearch_index_name>
       enabled 'true'
       tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-      name_type structured
+      name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
     <elasticsearch_index_name>
@@ -619,7 +619,7 @@ var _ = Describe("Generate fluentd config", func() {
     <elasticsearch_index_name>
       enabled 'true'
       tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-      name_type structured
+      name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
     <elasticsearch_index_name>
@@ -760,7 +760,7 @@ var _ = Describe("Generate fluentd config", func() {
     <elasticsearch_index_name>
       enabled 'true'
       tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-      name_type structured
+      name_type static
       static_index_name infra-write
       structured_type_annotation_prefix containerType_logging_openshift_io
     </elasticsearch_index_name>
@@ -896,7 +896,7 @@ var _ = Describe("Generate fluentd config", func() {
     <elasticsearch_index_name>
       enabled 'true'
       tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-      name_type structured
+      name_type static
       static_index_name infra-write
       structured_type_key kubernetes.labels.foo-bar
       structured_type_name my-name

--- a/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
+++ b/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
@@ -69,7 +69,7 @@ func (im IndexModel) Template() string {
   <elasticsearch_index_name>
     enabled 'true'
     tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-    name_type structured
+    name_type static
     static_index_name infra-write
 {{if (ne .StructuredTypeKey "") -}}
     structured_type_key {{ .StructuredTypeKey }}

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Generating fluentd config", func() {
 			<elasticsearch_index_name>
 			  enabled 'true'
 			  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-			  name_type structured
+			  name_type static
 			  static_index_name infra-write
 			</elasticsearch_index_name>
 			<elasticsearch_index_name>
@@ -233,7 +233,7 @@ var _ = Describe("Generating fluentd config", func() {
 			<elasticsearch_index_name>
 			  enabled 'true'
 			  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-			  name_type structured
+			  name_type static
 			  static_index_name infra-write
 			</elasticsearch_index_name>
 			<elasticsearch_index_name>
@@ -360,7 +360,7 @@ var _ = Describe("Generating fluentd config", func() {
 			<elasticsearch_index_name>
 			  enabled 'true'
 			  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
-			  name_type structured
+			  name_type static
 			  static_index_name infra-write
 			</elasticsearch_index_name>
 			<elasticsearch_index_name>

--- a/test/framework/functional/message_templates.go
+++ b/test/framework/functional/message_templates.go
@@ -31,6 +31,22 @@ var (
 		NamespaceLabels:  map[string]string{"*": "*"},
 		Annotations:      map[string]string{"*": "*"},
 	}
+	templateForInfraKubernetes = types.Kubernetes{
+		ContainerName:     "*",
+		PodName:           "*",
+		NamespaceName:     "*",
+		NamespaceID:       "**optional**",
+		OrphanedNamespace: "**optional**",
+		ContainerImage:    "**optional**",
+		ContainerImageID:  "**optional**",
+		PodID:             "**optional**",
+		PodIP:             "**optional**",
+		Host:              "**optional**",
+		MasterURL:         "**optional**",
+		FlatLabels:        []string{"*"},
+		NamespaceLabels:   map[string]string{"*": "*"},
+		Annotations:       map[string]string{"*": "*"},
+	}
 )
 
 func NewApplicationLogTemplate() types.ApplicationLog {
@@ -50,5 +66,24 @@ func NewApplicationLogTemplate() types.ApplicationLog {
 			ContainerID: "*",
 		},
 		Kubernetes: templateForAnyKubernetes,
+	}
+}
+
+// NewContainerInfrastructureLogTemplate creates a generally expected template for infrastructure container logs
+func NewContainerInfrastructureLogTemplate() types.ApplicationLog {
+	return types.ApplicationLog{
+		Timestamp: time.Time{},
+		Message:   "*",
+		LogType:   "infrastructure",
+		Level:     "*",
+		Hostname:  "*",
+		ViaqMsgID: "*",
+		Openshift: types.OpenshiftMeta{
+			Labels:   map[string]string{"*": "*"},
+			Sequence: types.NewOptionalInt(""),
+		},
+		PipelineMetadata: TemplateForAnyPipelineMetadata,
+		Docker:           types.Docker{},
+		Kubernetes:       templateForInfraKubernetes,
 	}
 }

--- a/test/framework/functional/write.go
+++ b/test/framework/functional/write.go
@@ -21,6 +21,9 @@ func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLogForContainer
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
 
+// WriteMessagesInfraContainerLog mocks writing infra container logs for the functional framework.  This may require
+// enabling the mock api adapter to get metadata for infrastructure logs since the path does not match a pod
+// running on the cluster (e.g framework.VisitConfig = functional.TestAPIAdapterConfigVisitor)
 func (f *CollectorFunctionalFramework) WriteMessagesToInfraContainerLog(msg string, numOfLogs int) error {
 	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], "openshift-fake-infra", f.Pod.Name, f.Pod.UID, constants.CollectorName)
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)


### PR DESCRIPTION
### Description
This PR:
* fixes the case where structured logging is enabled and infra source logs are sent to an application structured index

### Links
* https://issues.redhat.com/browse/LOG-2134
