### PR TITLE
Log 2223 support cloudwatch output fixed vrl syntax issues

### DIFF
--- a/hack/cr-vector.yaml
+++ b/hack/cr-vector.yaml
@@ -3,6 +3,8 @@ kind: "ClusterLogging"
 metadata:
   name: "instance"
   namespace: "openshift-logging"
+  annotations:
+    logging.openshift.io/preview-vector-collector: enabled
 spec:
   logStore:
     type: "elasticsearch"

--- a/internal/generator/vector/elements/elements.go
+++ b/internal/generator/vector/elements/elements.go
@@ -37,8 +37,21 @@ type Remap struct {
 	VRL         string
 }
 
+type RemapCW struct {
+	ComponentID    string
+	Desc           string
+	Inputs         string
+	GroupBy        string
+	LogGroupPrefix string
+	VRL            string
+}
+
 func (r Remap) Name() string {
 	return "remapTemplate"
+}
+
+func (r RemapCW) Name() string {
+	return "remapTemplateCW"
 }
 
 func (r Remap) Template() string {
@@ -50,6 +63,23 @@ func (r Remap) Template() string {
 type = "remap"
 inputs = {{.Inputs}}
 source = """
+{{.VRL | indent 2}}
+"""
+{{end}}
+`
+}
+
+func (r RemapCW) Template() string {
+	return `{{define "remapTemplateCW" -}}
+{{if .Desc -}}
+# {{.Desc}}
+{{end -}}
+[transforms.{{.ComponentID}}]
+type = "remap"
+inputs = {{.Inputs}}
+source = """
+.GroupBy = "{{.GroupBy}}"
+.LogGroupPrefix = "{{.LogGroupPrefix}}"
 {{.VRL | indent 2}}
 """
 {{end}}

--- a/internal/generator/vector/output/cloudwatch/basic.go
+++ b/internal/generator/vector/output/cloudwatch/basic.go
@@ -1,0 +1,19 @@
+package cloudwatch
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+)
+
+type BasicAuthConf generator.ConfLiteral
+
+func (t BasicAuthConf) Name() string {
+	return "cloudwatchBasicAuthConf"
+}
+
+func (t BasicAuthConf) Template() string {
+	return `
+{{define "cloudwatchBasicAuthConf" -}}
+# {{.Desc}}
+[sinks.{{.ComponentID}}.auth]
+{{- end}}`
+}

--- a/internal/generator/vector/output/cloudwatch/ca-file.go
+++ b/internal/generator/vector/output/cloudwatch/ca-file.go
@@ -1,0 +1,18 @@
+package cloudwatch
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
+)
+
+type CAFile security.CAFile
+
+func (ca CAFile) Name() string {
+	return "cloudwatchCAFileTemplate"
+}
+
+func (ca CAFile) Template() string {
+	return `{{define "` + ca.Name() + `" -}}
+ca_file = {{.CAFilePath}}
+{{- end}}
+`
+}

--- a/internal/generator/vector/output/cloudwatch/cert-key.go
+++ b/internal/generator/vector/output/cloudwatch/cert-key.go
@@ -11,7 +11,7 @@ func (a AWSKey) Name() string {
 
 func (a AWSKey) Template() string {
 	return `{{define "` + a.Name() + `" -}}
-auth.access_key_id = {{.AWSAccessKeyID}}
-auth.secret_access_key = {{.AWSSecretAccessKey}}
+auth.access_key_id = "{{.AWSAccessKeyID}}"
+auth.secret_access_key = "{{.AWSSecretAccessKey}}"
 {{- end}}`
 }

--- a/internal/generator/vector/output/cloudwatch/cert-key.go
+++ b/internal/generator/vector/output/cloudwatch/cert-key.go
@@ -1,0 +1,17 @@
+package cloudwatch
+
+type AWSKey struct {
+	AWSAccessKeyID     string
+	AWSSecretAccessKey string
+}
+
+func (a AWSKey) Name() string {
+	return "awsKeyTemplate"
+}
+
+func (a AWSKey) Template() string {
+	return `{{define "` + a.Name() + `" -}}
+auth.access_key_id = {{.AWSAccessKeyID}}
+auth.secret_access_key = {{.AWSSecretAccessKey}}
+{{- end}}`
+}

--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -1,0 +1,149 @@
+package cloudwatch
+
+import (
+	"fmt"
+	"strings"
+
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	. "github.com/openshift/cluster-logging-operator/internal/generator"
+	. "github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	vectorhelpers "github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type CloudWatch struct {
+	ID_Key      string
+	Desc        string
+	ComponentID string
+	Inputs      string
+	Endpoint    string
+	Region      string
+	//if Endpoint provided then it overrides  Region         string
+	Host           string
+	GroupBy        string
+	LogGroupPrefix string
+	SecurityConfig Element
+	EndpointConfig Element
+}
+
+func (e CloudWatch) Name() string {
+	return "cloudwatchTemplate"
+}
+
+func (e CloudWatch) Template() string {
+
+	return `{{define "` + e.Name() + `" -}}
+
+[sinks.{{.ComponentID}}]
+type = "aws_cloudwatch_logs"
+inputs = {{.Inputs}}
+region = "{{.Region}}"
+create_missing_group = true
+create_missing_stream = true
+compression = "none"
+encoding.codec = "json"
+request.concurrency = 2
+group_name = "{{"{{ Cw_groupName }}"}}-%h-%m"
+stream_name = "{{"{{ Cw_streamName }}"}}"
+{{- end}}
+`
+}
+
+func AddCwGroupNameCw_streamName(groupbytype string, logGroupPrefix string, id string, inputs []string) Element {
+	return RemapCW{
+		Desc:           "Adding group_name and stream_name field",
+		ComponentID:    id,
+		Inputs:         helpers.MakeInputs(inputs...),
+		GroupBy:        groupbytype,
+		LogGroupPrefix: logGroupPrefix,
+		VRL: strings.TrimSpace(`
+.Cw_groupName =  "{{ LogGroupPrefix }}-{{ log_type }}"
+.Cw_streamName = "{{ LogGroupPrefix }}-{{ log_type }}"
+`),
+	}
+}
+
+func ID(id1, id2 string) string {
+	return fmt.Sprintf("%s_%s", id1, id2)
+}
+
+func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
+
+	logGroupPrefix := ""
+	Region := ""
+	if o.Cloudwatch != nil {
+		prefix := o.Cloudwatch.GroupPrefix
+		if prefix != nil && strings.TrimSpace(*prefix) != "" {
+			logGroupPrefix = *prefix
+		}
+		Region = o.Cloudwatch.Region
+		if Region == "" {
+			Region = "us-east-1"
+		}
+	}
+
+	//need three syncs for individual input logs streams - application, infrastructure, audit
+	outputs := []Element{}
+	outputName := strings.ToLower(vectorhelpers.Replacer.Replace(o.Name))
+	groupbytype := string(o.Cloudwatch.GroupBy)
+
+	outputs = MergeElements(outputs,
+		[]Element{
+			AddCwGroupNameCw_streamName(groupbytype, logGroupPrefix, ID(outputName, "add_grpandstream"), inputs),
+			Output(o, []string{ID(outputName, "add_grpandstream")}, secret, op, Region),
+		},
+		TLSConf(o, secret),
+		BasicAuth(o, secret),
+	)
+
+	return outputs
+}
+
+func Output(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options, region string) Element {
+
+	return CloudWatch{
+		ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
+		Endpoint:    o.URL,
+		Inputs:      vectorhelpers.MakeInputs(inputs...),
+		Region:      region,
+	}
+}
+
+func TLSConf(o logging.OutputSpec, secret *corev1.Secret) []Element {
+	conf := []Element{}
+	if o.Secret != nil {
+		hasTLS := false
+		if o.Name == logging.OutputNameDefault || security.HasAwsCredentials(secret) {
+			hasTLS = true
+			kc := AWSKey{
+				AWSAccessKeyID:     security.GetFromSecret(secret, "aws_access_key_id"),
+				AWSSecretAccessKey: security.GetFromSecret(secret, "aws_secret_access_key"),
+			}
+			conf = append(conf, kc)
+		}
+		if !hasTLS {
+			return []Element{}
+		}
+	}
+	return conf
+}
+
+//not sure if required for cloudwatch?
+func BasicAuth(o logging.OutputSpec, secret *corev1.Secret) []Element {
+	conf := []Element{}
+
+	if o.Secret != nil {
+		hasBasicAuth := false
+		conf = append(conf, BasicAuthConf{
+			Desc:        "Basic Auth Config",
+			ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
+		})
+		if !hasBasicAuth {
+			return []Element{}
+		}
+	}
+
+	return conf
+}

--- a/internal/generator/vector/output/cloudwatch/cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch_test.go
@@ -1,0 +1,129 @@
+package cloudwatch
+
+import (
+	"testing"
+
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Generate Vector config", func() {
+	inputPipeline := []string{"application-logs"}
+	prefix := "all-logs"
+	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
+		return Conf(clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], op)
+	}
+	DescribeTable("For Cloudwatch output", generator.TestGenerateConfWith(f),
+		Entry("with auth.access_key_id auth.secret_access_key auth.credentials_file", generator.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeCloudwatch,
+						Name: "cw",
+						URL:  "https://cw.svc.all.cluster:9200",
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Cloudwatch: &logging.Cloudwatch{
+								Region:      "us-east-1",
+								GroupBy:     "logType",
+								GroupPrefix: &prefix,
+							},
+						},
+
+						Secret: &logging.OutputSecretSpec{
+							Name: "cw",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"cw": {
+					Data: map[string][]byte{
+						"aws_access_key_id":     []byte("xXyYzZ"),
+						"aws_secret_access_key": []byte("sSxXyYzZ"),
+					},
+				},
+			},
+			ExpectedConf: `
+			# Adding group_name and stream_name field
+[transforms.cw_add_grpandstream]
+type = "remap"
+inputs = ["application-logs"]
+source = """
+.GroupBy = "logType"
+.LogGroupPrefix = "all-logs"
+  .Cw_groupName =  "{{ LogGroupPrefix }}-{{ log_type }}"
+  .Cw_streamName = "{{ LogGroupPrefix }}-{{ log_type }}"
+"""
+
+[sinks.cw]
+type = "aws_cloudwatch_logs"
+inputs = ["cw_add_grpandstream"]
+region = "us-east-1"
+create_missing_group = true
+create_missing_stream = true
+compression = "none"
+encoding.codec = "json"
+request.concurrency = 2
+group_name = "{{ Cw_groupName }}-%h-%m"
+stream_name = "{{ Cw_streamName }}"
+auth.access_key_id = xXyYzZ
+auth.secret_access_key = sSxXyYzZ
+`,
+		}),
+		Entry("without security", generator.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeCloudwatch,
+						Name: "cw",
+						URL:  "https://cw.svc.all.cluster:9200",
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Cloudwatch: &logging.Cloudwatch{
+								Region:      "us-east-1",
+								GroupBy:     "logType",
+								GroupPrefix: &prefix,
+							},
+						},
+						Secret: nil,
+					},
+				},
+			},
+			Secrets: security.NoSecrets,
+			ExpectedConf: `
+			# Adding group_name and stream_name field
+[transforms.cw_add_grpandstream]
+type = "remap"
+inputs = ["application-logs"]
+source = """
+.GroupBy = "logType"
+.LogGroupPrefix = "all-logs"
+  .Cw_groupName =  "{{ LogGroupPrefix }}-{{ log_type }}"
+  .Cw_streamName = "{{ LogGroupPrefix }}-{{ log_type }}"
+"""
+
+[sinks.cw]
+type = "aws_cloudwatch_logs"
+inputs = ["cw_add_grpandstream"]
+region = "us-east-1"
+create_missing_group = true
+create_missing_stream = true
+compression = "none"
+encoding.codec = "json"
+request.concurrency = 2
+group_name = "{{ Cw_groupName }}-%h-%m"
+stream_name = "{{ Cw_streamName }}"
+`,
+		}),
+	)
+})
+
+func TestVectorConfGenerator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Vector Conf Generation")
+}

--- a/internal/generator/vector/output/cloudwatch/cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch_test.go
@@ -57,8 +57,44 @@ inputs = ["application-logs"]
 source = """
 .GroupBy = "logType"
 .LogGroupPrefix = "all-logs"
-  .Cw_groupName =  "{{ LogGroupPrefix }}-{{ log_type }}"
-  .Cw_streamName = "{{ LogGroupPrefix }}-{{ log_type }}"
+  if (.GroupBy == "logType") {
+  
+        .Cw_groupName = .log_type
+       
+    
+     } else if ( .GroupBy == "namespaceName" ) {
+     
+  
+         if ( .kubernetes.namespace_name != null ) {
+  
+          .Cw_groupName = ( .kubernetes.namespace_name + "." + .log_type ) ?? {}
+   
+         } else {
+  
+          .Cw_groupName = .log_type
+  
+         }
+       
+         
+     } else if ( .GroupBy == "namespaceUUID" ) {
+     
+  
+         if ( .kubernetes.namespace_name != null ) {
+  
+          .Cw_groupName = ( .LogGroupPrefix + "." + .kubernetes.namespace_name + "." + .log_type ) ?? {}
+  
+         } else {
+  
+           .Cw_groupName = ( .LogGroupPrefix + "." + .log_type ) ?? {}
+  
+         }
+       
+     } else {
+  
+        .Cw_groupName = .log_type
+    
+     } 
+        .Cw_streamName = ( .log_type + "." + .host )  ?? {}
 """
 
 [sinks.cw]
@@ -70,10 +106,10 @@ create_missing_stream = true
 compression = "none"
 encoding.codec = "json"
 request.concurrency = 2
-group_name = "{{ Cw_groupName }}-%h-%m"
+group_name = "{{ Cw_groupName }}-%Y-%m"
 stream_name = "{{ Cw_streamName }}"
-auth.access_key_id = xXyYzZ
-auth.secret_access_key = sSxXyYzZ
+auth.access_key_id = "xXyYzZ"
+auth.secret_access_key = "sSxXyYzZ"
 `,
 		}),
 		Entry("without security", generator.ConfGenerateTest{
@@ -103,8 +139,44 @@ inputs = ["application-logs"]
 source = """
 .GroupBy = "logType"
 .LogGroupPrefix = "all-logs"
-  .Cw_groupName =  "{{ LogGroupPrefix }}-{{ log_type }}"
-  .Cw_streamName = "{{ LogGroupPrefix }}-{{ log_type }}"
+  if (.GroupBy == "logType") {
+  
+        .Cw_groupName = .log_type
+       
+    
+     } else if ( .GroupBy == "namespaceName" ) {
+     
+  
+         if ( .kubernetes.namespace_name != null ) {
+  
+          .Cw_groupName = ( .kubernetes.namespace_name + "." + .log_type ) ?? {}
+   
+         } else {
+  
+          .Cw_groupName = .log_type
+  
+         }
+       
+         
+     } else if ( .GroupBy == "namespaceUUID" ) {
+     
+  
+         if ( .kubernetes.namespace_name != null ) {
+  
+          .Cw_groupName = ( .LogGroupPrefix + "." + .kubernetes.namespace_name + "." + .log_type ) ?? {}
+  
+         } else {
+  
+           .Cw_groupName = ( .LogGroupPrefix + "." + .log_type ) ?? {}
+  
+         }
+       
+     } else {
+  
+        .Cw_groupName = .log_type
+    
+     } 
+        .Cw_streamName = ( .log_type + "." + .host )  ?? {}
 """
 
 [sinks.cw]
@@ -116,7 +188,7 @@ create_missing_stream = true
 compression = "none"
 encoding.codec = "json"
 request.concurrency = 2
-group_name = "{{ Cw_groupName }}-%h-%m"
+group_name = "{{ Cw_groupName }}-%Y-%m"
 stream_name = "{{ Cw_streamName }}"
 `,
 		}),

--- a/internal/generator/vector/output/security/security.go
+++ b/internal/generator/vector/output/security/security.go
@@ -61,6 +61,9 @@ func HasTLSCertAndKey(secret *corev1.Secret) bool {
 	return HasKeys(secret, constants.ClientCertKey, constants.ClientPrivateKey)
 }
 
+func HasAwsCredentials(secret *corev1.Secret) bool {
+	return HasAwsKey(secret, constants.AWSAccessKeyID, constants.AWSSecretAccessKey)
+}
 func HasCABundle(secret *corev1.Secret) bool {
 	return HasKeys(secret, constants.TrustedCABundleKey)
 }
@@ -88,6 +91,17 @@ func GetKey(secret *corev1.Secret, key string) (data []byte, ok bool) {
 
 // HasKeys true if all keys are present.
 func HasKeys(secret *corev1.Secret, keys ...string) bool {
+	for _, k := range keys {
+		_, ok := GetKey(secret, k)
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// HasKeys true if all keys are present.
+func HasAwsKey(secret *corev1.Secret, keys ...string) bool {
 	for _, k := range keys {
 		_, ok := GetKey(secret, k)
 		if !ok {

--- a/internal/generator/vector/outputs.go
+++ b/internal/generator/vector/outputs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/cloudwatch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/elasticsearch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/kafka"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/loki"
@@ -47,6 +48,8 @@ func Outputs(clspec *logging.ClusterLoggingSpec, secrets map[string]*corev1.Secr
 			outputs = generator.MergeElements(outputs, loki.Conf(o, inputs, secret, op))
 		case logging.OutputTypeElasticsearch:
 			outputs = generator.MergeElements(outputs, elasticsearch.Conf(o, inputs, secret, op))
+		case logging.OutputTypeCloudwatch:
+			outputs = generator.MergeElements(outputs, cloudwatch.Conf(o, inputs, secret, op))
 		}
 	}
 	outputs = append(outputs, PrometheusOutput(PrometheusOutputSinkName, []string{InternalMetricsSourceName}))

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -319,8 +319,8 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.Cluster
 			log.V(3).Info("verifyOutputs failed", "reason", "output URL is invalid", "output URL", output.URL)
 		case !clusterRequest.verifyOutputSecret(&output, status.Outputs):
 			log.V(3).Info("verifyOutputs failed", "reason", "output secret is invalid")
-		case output.Type == logging.OutputTypeCloudwatch && output.Cloudwatch == nil:
-			log.V(3).Info("verifyOutputs failed", "reason", "Cloudwatch output requires type spec", "output name", output.Name)
+		case output.Type == logging.OutputTypeCloudwatch && output.Cloudwatch == nil && output.Secret == nil:
+			log.V(3).Info("verifyOutputs failed", "reason", "Cloudwatch output requires type spec and Secret", "output name", output.Name)
 			status.Outputs.Set(output.Name, condInvalid("output %q: Cloudwatch output requires type spec", output.Name))
 		default:
 			status.Outputs.Set(output.Name, condReady)
@@ -335,7 +335,9 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.Cluster
 					output.Cloudwatch.GroupPrefix = &clusterName
 				}
 			}
+
 		}
+
 		names.Insert(output.Name)
 	}
 

--- a/test/framework/functional/cluster_log_forwarder.go
+++ b/test/framework/functional/cluster_log_forwarder.go
@@ -87,6 +87,7 @@ func (p *PipelineBuilder) ToOutputWithVisitor(visit OutputSpecVisiter, outputNam
 	outputs := clf.Spec.OutputMap()
 	var output *logging.OutputSpec
 	var found bool
+
 	if output, found = outputs[outputName]; !found {
 		switch outputName {
 		case logging.OutputTypeFluentdForward:

--- a/test/framework/functional/vector/deploy.go
+++ b/test/framework/functional/vector/deploy.go
@@ -12,7 +12,7 @@ import (
 const entrypointScript = `#!/bin/bash
 mkdir -p /var/lib/vector
 
-/usr/bin/vector
+/usr/bin/vector -v
 `
 
 type VectorCollector struct {
@@ -43,6 +43,7 @@ func (c *VectorCollector) BuildCollectorContainer(b *runtime.ContainerBuilder, n
 		AddEnvVar("VECTOR_SELF_NODE_NAME", nodeName).
 		AddVolumeMount("config", "/etc/vector", "", true).
 		AddVolumeMount("entrypoint", "/opt/app-root/src/run.sh", "run.sh", true).
+		AddVolumeMount("certs", "/etc/fluent/metrics", "", true).
 		WithCmd([]string{"/opt/app-root/src/run.sh"})
 }
 

--- a/test/functional/outputs/cloudwatch/forward_to_cloudwatch_test.go
+++ b/test/functional/outputs/cloudwatch/forward_to_cloudwatch_test.go
@@ -64,7 +64,7 @@ var _ = Describe("[Functional][Outputs][CloudWatch] Forward Output to CloudWatch
 		defaultRetryInterval, _ = time.ParseDuration("10s")
 
 		getRawCloudwatchApplicationLogs = func(f *functional.CollectorFunctionalFramework, cwlClient *cwl.Client) ([]string, error) {
-			log.V(3).Info("Retrieving cloudwatch LogGroups")
+			log.V(2).Info("Retrieving cloudwatch LogGroups")
 			var logGroupsOutput *cwl.DescribeLogGroupsOutput
 			err := wait.PollImmediate(defaultRetryInterval, f.GetMaxReadDuration(), func() (done bool, err error) {
 				logGroupsOutput, err = cwlClient.DescribeLogGroups(context.TODO(), nil)
@@ -77,9 +77,9 @@ var _ = Describe("[Functional][Outputs][CloudWatch] Forward Output to CloudWatch
 			if err != nil {
 				return nil, err
 			}
-			log.V(3).Info("Results", "logGroups", logGroupsOutput.LogGroups)
+			log.V(2).Info("Results", "logGroups", logGroupsOutput.LogGroups)
 
-			log.V(3).Info("Retrieving cloudwatch LogStreams")
+			log.V(2).Info("Retrieving cloudwatch LogStreams")
 			var logStreamsOutput *cwl.DescribeLogStreamsOutput
 			err = wait.PollImmediate(defaultRetryInterval, f.GetMaxReadDuration(), func() (done bool, err error) {
 				logStreamsOutput, err = cwlClient.DescribeLogStreams(
@@ -95,9 +95,9 @@ var _ = Describe("[Functional][Outputs][CloudWatch] Forward Output to CloudWatch
 			if err != nil {
 				return nil, err
 			}
-			log.V(3).Info("Results", "logStreams", logStreamsOutput.LogStreams)
+			log.V(2).Info("Results", "logStreams", logStreamsOutput.LogStreams)
 
-			log.V(3).Info("Retrieving cloudwatch LogEvents")
+			log.V(2).Info("Retrieving cloudwatch LogEvents")
 			var logEventsOutput *cwl.GetLogEventsOutput
 			err = wait.PollImmediate(defaultRetryInterval, f.GetMaxReadDuration(), func() (done bool, err error) {
 				logEventsOutput, err = cwlClient.GetLogEvents(
@@ -168,7 +168,7 @@ var _ = Describe("[Functional][Outputs][CloudWatch] Forward Output to CloudWatch
 				}),
 			})
 
-		log.V(2).Info("Creating secret cloudwatch with AWS example credentials")
+		log.V(0).Info("Creating secret cloudwatch with AWS example credentials")
 		secret := runtime.NewSecret(framework.Namespace, "cloudwatch",
 			map[string][]byte{
 				"aws_access_key_id":     []byte(awsAccessKeyID),


### PR DESCRIPTION
### Description
Cloudwatch support for vector.  Generated conf is base as closed as possible to that of fluentd conf on the aspect of group_name and  stream_name constructs based on hostname, namespace, logtype, groupPrefix provided values. Tested manually in deployed CLO for its working. Unit test cases added to test expected conf vs. generated conf 100% match

/cc @jcantrill 

### Links

- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2223
- Enhancement proposal:
