### PR TITLE
LOG-643: Add metric test when fluent output is down

### DIFF
--- a/test/functional/metrics/fluentd_test.go
+++ b/test/functional/metrics/fluentd_test.go
@@ -2,11 +2,12 @@ package metrics
 
 import (
 	"fmt"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 )
 
@@ -20,22 +21,26 @@ var _ = Describe("[Functional][Metrics]Function testing of fluentd metrics", fun
 		framework *functional.CollectorFunctionalFramework
 	)
 
+	AfterEach(func() {
+		framework.Cleanup()
+	})
+
 	BeforeEach(func() {
 		framework = functional.NewCollectorFunctionalFramework()
 		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
 			FromInput(logging.InputNameApplication).
 			ToFluentForwardOutput()
-		Expect(framework.Deploy()).To(BeNil())
 	})
-	AfterEach(func() {
-		framework.Cleanup()
+	It("when using a service address should return successfully", func() {
+		Expect(framework.Deploy()).To(BeNil())
+		metrics, _ := framework.RunCommand(constants.CollectorName, "curl", "-ksv", fmt.Sprintf("https://%s.%s:24231/metrics", framework.Name, framework.Namespace))
+		Expect(metrics).To(ContainSubstring(sampleMetric))
 	})
 
-	Context("when using a service address", func() {
-		It("should return successfully", func() {
-			metrics, _ := framework.RunCommand(constants.CollectorName, "curl", "-ksv", fmt.Sprintf("https://%s.%s:24231/metrics", framework.Name, framework.Namespace))
-			Expect(metrics).To(ContainSubstring(sampleMetric))
-		})
+	It("should return successfully even when the output is down", func() {
+		Expect(framework.DeployWithVisitor(func(builder *runtime.PodBuilder) error { return nil })).To(BeNil())
+		metrics, _ := framework.RunCommand(constants.CollectorName, "curl", "-ksv", fmt.Sprintf("https://%s.%s:24231/metrics", framework.Name, framework.Namespace))
+		Expect(metrics).To(ContainSubstring(sampleMetric))
 	})
 
 })


### PR DESCRIPTION
### Description
This PR:
* Adds a test to verify metrics are available even when outputs are down

### Links
* https://issues.redhat.com/browse/LOG-2557
