### PR TITLE
LOG-2063: fix deploying a collector with no CLF

### DIFF
--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -35,6 +35,9 @@ var _ = Describe("Reconciling", func() {
 			},
 			Spec: loggingv1.ClusterLoggingSpec{
 				ManagementState: loggingv1.ManagementStateManaged,
+				LogStore: &loggingv1.LogStoreSpec{
+					Type: loggingv1.LogStoreTypeElasticsearch,
+				},
 				Collection: &loggingv1.CollectionSpec{
 					Logs: loggingv1.LogCollectionSpec{
 						Type:        loggingv1.LogCollectionTypeFluentd,


### PR DESCRIPTION
### Description
This PR:
* fixes collector deployment when only a collector is defined and there is no CLF
* Stops deployment of either fluent or vector 
* Refactors one test to be ginkgo table driven

### Links
* https://issues.redhat.com/browse/LOG-2063