### PR TITLE
Log 2568: Removing stable annotations

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable,stable-5.3
+  operators.operatorframework.io.bundle.channel.default.v1: stable-5.3
+  operators.operatorframework.io.bundle.channels.v1: stable-5.3
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
Removes the stable annotation from the 5.3 release.

/cc @syedriko 
/assign @jcantrill 


### Links
- JIRA: https://issues.redhat.com/browse/LOG-2568
