### PR TITLE
LOG-2587: Fix ES functional tests for vector

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -88,6 +88,8 @@ const (
 
 	ContainerLogDir = "/var/log/containers"
 	PodLogDir       = "/var/log/pods"
+
+	EnableMetrics = "enable-metrics"
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 
@@ -21,7 +22,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 	var f = func(testcase generator.ConfGenerateTest) {
 		g := generator.MakeGenerator()
 		if testcase.Options == nil {
-			testcase.Options = generator.Options{}
+			testcase.Options = generator.Options{constants.EnableMetrics: "true"}
 		}
 		e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, testcase.Options))
 		conf, err := g.GenerateConf(e...)
@@ -98,6 +99,8 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -153,6 +156,10 @@ source = """
   del(.stream)
   
   del(.kubernetes.pod_ips)
+  
+  ts = .timestamp
+  del(.timestamp)
+  ."@timestamp" = ts
 """
 
 [transforms.journal_logs]
@@ -292,6 +299,8 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -347,6 +356,10 @@ source = """
   del(.stream)
   
   del(.kubernetes.pod_ips)
+  
+  ts = .timestamp
+  del(.timestamp)
+  ."@timestamp" = ts
 """
 
 [transforms.journal_logs]

--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -36,6 +36,11 @@ del(.stream)
 	RemovePodIPs = `
 del(.kubernetes.pod_ips)
 `
+	FixTimestampField = `
+ts = .timestamp
+del(.timestamp)
+."@timestamp" = ts
+`
 )
 
 func NormalizeLogs(spec *logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
@@ -61,6 +66,7 @@ func NormalizeContainerLogs(inLabel, outLabel string) []generator.Element {
 				RemoveSourceType,
 				RemoveStream,
 				RemovePodIPs,
+				FixTimestampField,
 			}), "\n\n"),
 		},
 	}

--- a/internal/generator/vector/outputs.go
+++ b/internal/generator/vector/outputs.go
@@ -49,7 +49,9 @@ func Outputs(clspec *logging.ClusterLoggingSpec, secrets map[string]*corev1.Secr
 			outputs = generator.MergeElements(outputs, elasticsearch.Conf(o, inputs, secret, op))
 		}
 	}
-	outputs = append(outputs, PrometheusOutput(PrometheusOutputSinkName, []string{InternalMetricsSourceName}))
+	if _, ok := op[constants.EnableMetrics]; ok {
+		outputs = append(outputs, PrometheusOutput(PrometheusOutputSinkName, []string{InternalMetricsSourceName}))
+	}
 	return outputs
 }
 

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -23,5 +23,7 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = {{.ExcludePaths}}
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 {{end}}`
 }

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -35,6 +35,8 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 `,
 		}),
 		Entry("Only Infrastructure", generator.ConfGenerateTest{
@@ -57,6 +59,8 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -123,6 +127,8 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 
 [sources.raw_journal_logs]
 type = "journald"

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -67,6 +67,7 @@ func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config s
 	if debug, ok := clusterRequest.ForwarderRequest.Annotations[AnnotationDebugOutput]; ok && strings.ToLower(debug) == "true" {
 		op[helpers.EnableDebugOutput] = "true"
 	}
+	op[constants.EnableMetrics] = true
 
 	var collectorType = clusterRequest.Cluster.Spec.Collection.Logs.Type
 	g := forwardergenerator.New(collectorType)

--- a/test/framework/functional/fluentd/message_templates.go
+++ b/test/framework/functional/fluentd/message_templates.go
@@ -1,0 +1,91 @@
+package fluentd
+
+import (
+	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
+)
+
+var (
+	TemplateForAnyPipelineMetadata = types.PipelineMetadata{
+		Collector: types.Collector{
+			Ipaddr4:    "*",
+			Inputname:  "*",
+			Name:       "*",
+			Version:    "*",
+			ReceivedAt: time.Time{},
+		},
+	}
+	templateForAnyKubernetes = types.Kubernetes{
+		ContainerName:    "*",
+		PodName:          "*",
+		NamespaceName:    "*",
+		NamespaceID:      "*",
+		ContainerImage:   "*",
+		ContainerImageID: "*",
+		PodID:            "*",
+		PodIP:            "**optional**",
+		Host:             "*",
+		MasterURL:        "*",
+		FlatLabels:       []string{"*"},
+		NamespaceLabels:  map[string]string{"*": "*"},
+		Annotations:      map[string]string{"*": "*"},
+	}
+	templateForInfraKubernetes = types.Kubernetes{
+		ContainerName:     "*",
+		PodName:           "*",
+		NamespaceName:     "*",
+		NamespaceID:       "**optional**",
+		OrphanedNamespace: "**optional**",
+		ContainerImage:    "**optional**",
+		ContainerImageID:  "**optional**",
+		PodID:             "**optional**",
+		PodIP:             "**optional**",
+		Host:              "**optional**",
+		MasterURL:         "**optional**",
+		FlatLabels:        []string{"*"},
+		NamespaceLabels:   map[string]string{"*": "*"},
+		Annotations:       map[string]string{"*": "*"},
+	}
+)
+
+func NewApplicationLogTemplate() types.ApplicationLog {
+	return types.ApplicationLog{
+		Timestamp: time.Time{},
+		Message:   "*",
+		LogType:   "application",
+		Level:     "*",
+		Hostname:  "*",
+		ViaqMsgID: "*",
+		Openshift: types.OpenshiftMeta{
+			Labels:   map[string]string{"*": "*"},
+			Sequence: types.NewOptionalInt(""),
+		},
+		PipelineMetadata: TemplateForAnyPipelineMetadata,
+		Docker: types.Docker{
+			ContainerID: "*",
+		},
+		Kubernetes:    templateForAnyKubernetes,
+		ViaqIndexName: "app-write",
+	}
+}
+
+// NewContainerInfrastructureLogTemplate creates a generally expected template for infrastructure container logs
+func NewContainerInfrastructureLogTemplate() types.ApplicationLog {
+	return types.ApplicationLog{
+		Timestamp: time.Time{},
+		Message:   "*",
+		LogType:   "infrastructure",
+		Level:     "*",
+		Hostname:  "*",
+		ViaqMsgID: "*",
+		Openshift: types.OpenshiftMeta{
+			Labels:   map[string]string{"*": "*"},
+			Sequence: types.NewOptionalInt(""),
+		},
+		PipelineMetadata: TemplateForAnyPipelineMetadata,
+		Docker:           types.Docker{},
+		Kubernetes:       templateForInfraKubernetes,
+		ViaqIndexName:    "infra-write",
+	}
+}

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -2,16 +2,17 @@ package functional
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/certificates"
-	"github.com/openshift/cluster-logging-operator/internal/pkg/generator/forwarder"
-	"github.com/openshift/cluster-logging-operator/internal/runtime"
-	testruntime "github.com/openshift/cluster-logging-operator/test/runtime"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/internal/certificates"
+	"github.com/openshift/cluster-logging-operator/internal/pkg/generator/forwarder"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	testruntime "github.com/openshift/cluster-logging-operator/test/runtime"
 
 	yaml "sigs.k8s.io/yaml"
 

--- a/test/framework/functional/message_template.go
+++ b/test/framework/functional/message_template.go
@@ -1,0 +1,28 @@
+package functional
+
+import (
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional/fluentd"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional/vector"
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
+)
+
+func NewApplicationLogTemplate(collector logging.LogCollectionType) types.ApplicationLog {
+	if collector == logging.LogCollectionTypeFluentd {
+		return fluentd.NewApplicationLogTemplate()
+	}
+	if collector == logging.LogCollectionTypeVector {
+		return vector.NewApplicationLogTemplate()
+	}
+	return types.ApplicationLog{}
+}
+
+func NewContainerInfrastructureLogTemplate(collector logging.LogCollectionType) types.ApplicationLog {
+	if collector == logging.LogCollectionTypeFluentd {
+		return fluentd.NewContainerInfrastructureLogTemplate()
+	}
+	if collector == logging.LogCollectionTypeVector {
+		return vector.NewContainerInfrastructureLogTemplate()
+	}
+	return types.ApplicationLog{}
+}

--- a/test/framework/functional/vector/deploy.go
+++ b/test/framework/functional/vector/deploy.go
@@ -1,12 +1,13 @@
 package vector
 
 import (
+	"strings"
+
 	"github.com/ViaQ/logerr/log"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/test/client"
-	"strings"
 )
 
 const entrypointScript = `#!/bin/bash
@@ -37,10 +38,10 @@ func (c *VectorCollector) DeployConfigMapForConfig(name, config, clfYaml string)
 }
 
 func (c *VectorCollector) BuildCollectorContainer(b *runtime.ContainerBuilder, nodeName string) *runtime.ContainerBuilder {
-	return b.AddEnvVar("LOG_LEVEL", "debug").
+	return b.AddEnvVar("LOG", "debug").
 		AddEnvVarFromFieldRef("POD_IP", "status.podIP").
 		AddEnvVar("NODE_NAME", nodeName).
-		AddEnvVar("VECTOR_SELF_NODE_NAME", nodeName).
+		AddEnvVarFromFieldRef("VECTOR_SELF_NODE_NAME", "spec.nodeName").
 		AddVolumeMount("config", "/etc/vector", "", true).
 		AddVolumeMount("entrypoint", "/opt/app-root/src/run.sh", "run.sh", true).
 		WithCmd([]string{"/opt/app-root/src/run.sh"})

--- a/test/framework/functional/vector/message_templates.go
+++ b/test/framework/functional/vector/message_templates.go
@@ -1,4 +1,4 @@
-package functional
+package vector
 
 import (
 	"time"
@@ -17,32 +17,28 @@ var (
 		},
 	}
 	templateForAnyKubernetes = types.Kubernetes{
-		ContainerName:    "*",
-		PodName:          "*",
-		NamespaceName:    "*",
-		NamespaceID:      "*",
-		ContainerImage:   "*",
-		ContainerImageID: "*",
-		PodID:            "*",
-		PodIP:            "**optional**",
-		Host:             "*",
-		MasterURL:        "*",
-		FlatLabels:       []string{"*"},
-		NamespaceLabels:  map[string]string{"*": "*"},
-		Annotations:      map[string]string{"*": "*"},
+		ContainerName:   "*",
+		PodName:         "*",
+		PodNodeName:     "*",
+		NamespaceName:   "*",
+		ContainerID:     "*",
+		ContainerImage:  "*",
+		PodID:           "*",
+		PodIP:           "**optional**",
+		FlatLabels:      []string{"*"},
+		NamespaceLabels: map[string]string{"*": "*"},
+		Annotations:     map[string]string{"*": "*"},
 	}
 	templateForInfraKubernetes = types.Kubernetes{
 		ContainerName:     "*",
 		PodName:           "*",
+		PodNodeName:       "*",
 		NamespaceName:     "*",
-		NamespaceID:       "**optional**",
+		ContainerID:       "*",
 		OrphanedNamespace: "**optional**",
-		ContainerImage:    "**optional**",
-		ContainerImageID:  "**optional**",
+		ContainerImage:    "*",
 		PodID:             "**optional**",
 		PodIP:             "**optional**",
-		Host:              "**optional**",
-		MasterURL:         "**optional**",
 		FlatLabels:        []string{"*"},
 		NamespaceLabels:   map[string]string{"*": "*"},
 		Annotations:       map[string]string{"*": "*"},
@@ -55,17 +51,16 @@ func NewApplicationLogTemplate() types.ApplicationLog {
 		Message:   "*",
 		LogType:   "application",
 		Level:     "*",
-		Hostname:  "*",
-		ViaqMsgID: "*",
+		Hostname:  "",
+		ViaqMsgID: "",
 		Openshift: types.OpenshiftMeta{
 			Labels:   map[string]string{"*": "*"},
 			Sequence: types.NewOptionalInt(""),
 		},
-		PipelineMetadata: TemplateForAnyPipelineMetadata,
-		Docker: types.Docker{
-			ContainerID: "*",
-		},
-		Kubernetes: templateForAnyKubernetes,
+		PipelineMetadata: types.PipelineMetadata{},
+		Docker:           types.Docker{},
+		Kubernetes:       templateForAnyKubernetes,
+		WriteIndex:       "app-write",
 	}
 }
 
@@ -82,8 +77,9 @@ func NewContainerInfrastructureLogTemplate() types.ApplicationLog {
 			Labels:   map[string]string{"*": "*"},
 			Sequence: types.NewOptionalInt(""),
 		},
-		PipelineMetadata: TemplateForAnyPipelineMetadata,
+		PipelineMetadata: types.PipelineMetadata{},
 		Docker:           types.Docker{},
 		Kubernetes:       templateForInfraKubernetes,
+		WriteIndex:       "infra-write",
 	}
 }

--- a/test/framework/functional/write.go
+++ b/test/framework/functional/write.go
@@ -3,14 +3,19 @@ package functional
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/ViaQ/logerr/log"
-	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"path/filepath"
 	"time"
+
+	"github.com/ViaQ/logerr/log"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+)
+
+const (
+	logGenContainerName = constants.CollectorName
 )
 
 func (f *CollectorFunctionalFramework) WriteMessagesToNamespace(msg, namespace string, numOfLogs int) error {
-	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], namespace, f.Pod.Name, f.Pod.UID, constants.CollectorName)
+	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], namespace, f.Pod.Name, f.Pod.UID, logGenContainerName)
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
 func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLog(msg string, numOfLogs int) error {
@@ -25,7 +30,7 @@ func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLogForContainer
 // enabling the mock api adapter to get metadata for infrastructure logs since the path does not match a pod
 // running on the cluster (e.g framework.VisitConfig = functional.TestAPIAdapterConfigVisitor)
 func (f *CollectorFunctionalFramework) WriteMessagesToInfraContainerLog(msg string, numOfLogs int) error {
-	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], "openshift-fake-infra", f.Pod.Name, f.Pod.UID, constants.CollectorName)
+	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], "openshift-fake-infra", f.Pod.Name, f.Pod.UID, logGenContainerName)
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
 
@@ -99,7 +104,7 @@ func (f *CollectorFunctionalFramework) WritesApplicationLogs(numOfLogs int) erro
 
 func (f *CollectorFunctionalFramework) WritesNApplicationLogsOfSize(numOfLogs, size int) error {
 	msg := "$(date -u +'%Y-%m-%dT%H:%M:%S.%N%:z') stdout F $msg "
-	file := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], f.Pod.Namespace, f.Pod.Name, f.Pod.UID, constants.CollectorName)
+	file := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], f.Pod.Namespace, f.Pod.Name, f.Pod.UID, logGenContainerName)
 	logPath := filepath.Dir(file)
 	result, err := f.RunCommand(constants.CollectorName, "bash", "-c", fmt.Sprintf("bash -c 'mkdir -p %s;msg=$(cat /dev/urandom|tr -dc 'a-zA-Z0-9'|fold -w %d|head -n 1);for n in $(seq 1 %d);do echo %s >> %s; done'", logPath, size, numOfLogs, msg, file))
 	log.V(3).Info("CollectorFunctionalFramework.WritesNApplicationLogsOfSize", "result", result, "err", err)

--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -2,9 +2,11 @@ package normalization
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"strings"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional/fluentd"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -43,7 +45,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 					Level:            "debug",
 					Timestamp:        time.Time{},
 					ViaqMsgID:        "*",
-					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+					PipelineMetadata: fluentd.TemplateForAnyPipelineMetadata,
 				},
 				K8SAuditLevel: "debug",
 			}
@@ -77,7 +79,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				},
 				Timestamp:        testTime,
 				ViaqMsgID:        "*",
-				PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				PipelineMetadata: fluentd.TemplateForAnyPipelineMetadata,
 			}
 			// Write log line as input to fluentd
 			Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
@@ -108,7 +110,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 					Sequence: types.NewOptionalInt(""),
 				},
 				ViaqMsgID:        "*",
-				PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				PipelineMetadata: fluentd.TemplateForAnyPipelineMetadata,
 			}
 			outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
 			// Write log line as input to fluentd

--- a/test/functional/normalization/log_level_test.go
+++ b/test/functional/normalization/log_level_test.go
@@ -1,8 +1,10 @@
 package normalization
 
 import (
-	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional/fluentd"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -37,10 +39,11 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 		nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 
 		// Template expected as output Log
-		var outputLogTemplate = functional.NewApplicationLogTemplate()
+		var outputLogTemplate = fluentd.NewApplicationLogTemplate()
 		outputLogTemplate.Timestamp = nanoTime
 		outputLogTemplate.Message = message
 		outputLogTemplate.Level = expLevel
+		outputLogTemplate.ViaqIndexName = ""
 
 		// Write log line as input to fluentd
 		applicationLogLine := functional.NewCRIOLogMessage(timestamp, message, false)

--- a/test/functional/normalization/message_format_test.go
+++ b/test/functional/normalization/message_format_test.go
@@ -2,8 +2,10 @@ package normalization
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional/fluentd"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -39,10 +41,11 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 		nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 
 		// Template expected as output Log
-		var outputLogTemplate = functional.NewApplicationLogTemplate()
+		var outputLogTemplate = fluentd.NewApplicationLogTemplate()
 		outputLogTemplate.Timestamp = nanoTime
 		outputLogTemplate.Message = message
 		outputLogTemplate.Level = expLevel
+		outputLogTemplate.ViaqIndexName = ""
 
 		// Write log line as input to fluentd
 		applicationLogLine := functional.NewCRIOLogMessage(timestamp, message, false)
@@ -72,10 +75,11 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 		nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 
 		// Template expected as output Log
-		var outputLogTemplate = functional.NewApplicationLogTemplate()
+		var outputLogTemplate = fluentd.NewApplicationLogTemplate()
 		outputLogTemplate.Timestamp = nanoTime
 		outputLogTemplate.Message = fmt.Sprintf("regex:^%s.*$", message)
 		outputLogTemplate.Level = "*"
+		outputLogTemplate.ViaqIndexName = ""
 
 		// Write log line as input to fluentd
 		applicationLogLine := functional.NewCRIOLogMessage(timestamp, message, false)
@@ -103,10 +107,11 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 		nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 
 		// Template expected as output Log
-		var outputLogTemplate = functional.NewApplicationLogTemplate()
+		var outputLogTemplate = fluentd.NewApplicationLogTemplate()
 		outputLogTemplate.Timestamp = nanoTime
 		outputLogTemplate.Message = fmt.Sprintf("regex:^%s.*$", message)
 		outputLogTemplate.Level = "*"
+		outputLogTemplate.ViaqIndexName = ""
 
 		// Write log line as input to fluentd
 		applicationLogLine := fmt.Sprintf("%s stdout F %s $n", timestamp, message)

--- a/test/functional/normalization/multiline_exception_test.go
+++ b/test/functional/normalization/multiline_exception_test.go
@@ -1,6 +1,8 @@
 package normalization
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -8,7 +10,6 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
-	"strings"
 )
 
 // Multiline Detect Exception test to verify proper re-assembly of

--- a/test/functional/outputs/forward_to_logstash_test.go
+++ b/test/functional/outputs/forward_to_logstash_test.go
@@ -1,9 +1,11 @@
 package outputs
 
 import (
+	"path"
+
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
-	"path"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional/fluentd"
 
 	"github.com/ViaQ/logerr/log"
 	. "github.com/onsi/ginkgo"
@@ -78,7 +80,7 @@ output {
 
 		// Template expected as output Log
 		outputLogTemplate = LogstashApplicationLog{
-			ApplicationLog: functional.NewApplicationLogTemplate(),
+			ApplicationLog: fluentd.NewApplicationLogTemplate(),
 			Tags:           []string{},
 			Version:        "1",
 			Host:           "*",
@@ -102,6 +104,7 @@ output {
 
 	Context("when sending to Logstash using fluent's forward protocol", func() {
 		It("should  be compatible", func() {
+			outputLogTemplate.ApplicationLog.ViaqIndexName = ""
 			raw, err := framework.ReadRawApplicationLogsFrom(logging.OutputTypeFluentdForward)
 			Expect(err).To(BeNil(), "Expected no errors reading the logs")
 			Expect(raw).To(Not(BeEmpty()))

--- a/test/helpers/types/types.go
+++ b/test/helpers/types/types.go
@@ -31,7 +31,8 @@ type ContainerLog struct {
 	Hostname         string                 `json:"hostname"`
 	PipelineMetadata PipelineMetadata       `json:"pipeline_metadata"`
 	LogType          string                 `json:"log_type,omitempty"`
-	ViaqIndexName    string                 `json:"viaq_index_name"`
+	ViaqIndexName    string                 `json:"viaq_index_name,omitempty"`
+	WriteIndex       string                 `json:"write_index,omitempty"`
 	ViaqMsgID        string                 `json:"viaq_msg_id"`
 	Openshift        OpenshiftMeta          `json:"openshift"`
 	Structured       map[string]interface{} `json:"structured"`
@@ -44,12 +45,14 @@ type Docker struct {
 type Kubernetes struct {
 	Annotations       map[string]string `json:"annotations,omitempty"`
 	ContainerName     string            `json:"container_name,omitempty"`
+	ContainerID       string            `json:"container_id,omitempty"`
 	NamespaceName     string            `json:"namespace_name,omitempty"`
 	PodName           string            `json:"pod_name,omitempty"`
-	ContainerImage    string            `json:"container_image,omitempty"`
-	ContainerImageID  string            `json:"container_image_id,omitempty"`
+	PodNodeName       string            `json:"pod_node_name,omitempty"`
 	PodID             string            `json:"pod_id,omitempty"`
 	PodIP             string            `json:"pod_ip,omitempty"`
+	ContainerImage    string            `json:"container_image,omitempty"`
+	ContainerImageID  string            `json:"container_image_id,omitempty"`
 	Host              string            `json:"host,omitempty"`
 	MasterURL         string            `json:"master_url,omitempty"`
 	NamespaceID       string            `json:"namespace_id,omitempty"`


### PR DESCRIPTION
### Description
This PR
- fixes functional framework to make kubernetes_logs start scraping application logs created by functional framework
- changes generator to add a flag for metrics, so that functional tests do not generate metrics collection. 
- fixes app log data model to conform to functional test app log template
- refactors functional test to separate the message templates for fluentd and vector
- enables `outputs/elasticsearch` tests to run for both fluentd and vector

/cc @jcantrill @cahartma 
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2587
