### PR TITLE
OCPBUGSM-44068: Fix missing labels.instance in messages

### DIFF
--- a/files/fluentd/fluentd_prometheus_alerts.yaml
+++ b/files/fluentd/fluentd_prometheus_alerts.yaml
@@ -6,7 +6,7 @@
       "message": "Prometheus could not scrape fluentd {{ $labels.instance }} for more than 10m."
       "summary": "Fluentd cannot be scraped"
     "expr": |
-      absent(up{job="collector"} == 1)
+      up{job="collector"} == 0 or absent(up{job="collector"}) == 1
     "for": "10m"
     "labels":
       "service": "fluentd"


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc jcantrill
/assign jcantrill

When firing the "FluentdNodeDown" alert, the instance label is always empty in the messages due to "absent()" function which eliminates the label. As adding a condition for partial failures, the messages can show the partial failure instances instead of empty one.

Version:
```
$ oc get csv 
NAME                                     DISPLAY                                          VERSION     REPLACES                                 PHASE
cluster-logging.5.4.0-138                Red Hat OpenShift Logging                        5.4.0-138   cluster-logging.5.3.5-20                 Succeeded
elasticsearch-operator.5.4.0-152         OpenShift Elasticsearch Operator                 5.4.0-152   elasticsearch-operator.5.3.5-20          Succeeded
```

Definition of messages:
```
message: Prometheus could not scrape fluentd {{ $labels.instance }} for more
```

Before changes, the `$labels.instance` is always empty when firing the alert.
```
Prometheus could not scrape fluentd for more than 10m.
```

After changes, the `$labels.instance` is shown when partial pods are in failure.
Only if all collector pods are not in running, then the instance label is empty in the messages.
```
// For example, if partial collector pods are in failures, the instance label is included in the messages
Prometheus could not scrape fluentd 10.130.2.8:2112 for more than 10m.
Prometheus could not scrape fluentd 10.130.2.8:24231 for more than 10m.

// Only if all collector pods are gone, and unable to collect the metrics, then the instance is empty.
Prometheus could not scrape fluentd for more than 10m.
```

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2083076
- JIRA: https://issues.redhat.com/browse/OCPBUGSM-44068 
- https://issues.redhat.com/browse/LOG-2605
