### PR TITLE
LOG-2589: fix infra logs showing in app group 

### DIFF
--- a/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
@@ -51,7 +51,6 @@ log_group_name_key cw_group_name
 log_stream_name_key cw_stream_name
 remove_log_stream_name_key true
 remove_log_group_name_key true
-auto_create_stream true
 concurrency 2
 {{compose_one .SecurityConfig}}
 include_time_key true

--- a/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
@@ -9,6 +9,7 @@ import (
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/source"
 
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
@@ -51,7 +52,7 @@ var _ = Describe("Generating fluentd config", func() {
 			It("should provide a valid configuration", func() {
 				expConf := `
 <label @MY_CLOUDWATCH>
- <filter kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_**>
+  <filter ` + source.InfraTagsForMultilineEx + `>
      @type record_modifier
     <record>
       cw_group_name infrastructure
@@ -59,7 +60,7 @@ var _ = Describe("Generating fluentd config", func() {
     </record>
   </filter>
   
-  <filter kubernetes.** var.log.pods.**>
+  <filter ` + source.ApplicationTagsForMultilineEx + `>
     @type record_modifier
     <record>
       cw_group_name application
@@ -67,7 +68,7 @@ var _ = Describe("Generating fluentd config", func() {
     </record>
   </filter>
   
-  <filter linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**>
+  <filter ` + source.AuditTags + `>
     @type record_modifier
     <record>
       cw_group_name audit
@@ -83,7 +84,6 @@ var _ = Describe("Generating fluentd config", func() {
     log_stream_name_key cw_stream_name
     remove_log_stream_name_key true
     remove_log_group_name_key true
-    auto_create_stream true
     concurrency 2
     aws_key_id "#{open('/var/run/ocp-collector/secrets/my-secret/aws_access_key_id','r') do |f|f.read.strip end}"
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
@@ -105,7 +105,7 @@ var _ = Describe("Generating fluentd config", func() {
 			It("should provide a valid configuration", func() {
 				expConf := `
 <label @MY_CLOUDWATCH>
-  <filter kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_**>
+  <filter ` + source.InfraTagsForMultilineEx + `>
     @type record_modifier
     <record>
       cw_group_name infrastructure
@@ -113,7 +113,7 @@ var _ = Describe("Generating fluentd config", func() {
     </record>
   </filter>
 
-  <filter kubernetes.** var.log.pods.**>
+  <filter ` + source.ApplicationTagsForMultilineEx + `>
     @type record_modifier
     <record>
       cw_group_name ${record['kubernetes']['namespace_name']}
@@ -121,7 +121,7 @@ var _ = Describe("Generating fluentd config", func() {
     </record>
   </filter>
 
-  <filter linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**>
+  <filter ` + source.AuditTags + `>
     @type record_modifier
     <record>
       cw_group_name audit
@@ -137,7 +137,6 @@ var _ = Describe("Generating fluentd config", func() {
     log_stream_name_key cw_stream_name
     remove_log_stream_name_key true
     remove_log_group_name_key true
-    auto_create_stream true
     concurrency 2
     aws_key_id "#{open('/var/run/ocp-collector/secrets/my-secret/aws_access_key_id','r') do |f|f.read.strip end}"
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
@@ -162,15 +161,15 @@ var _ = Describe("Generating fluentd config", func() {
 			It("should provide a valid configuration", func() {
 				expConf := `
 <label @MY_CLOUDWATCH>
-  <filter kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_**>
-    @type record_modifier
+  <filter ` + source.InfraTagsForMultilineEx + `>
+   @type record_modifier
     <record>
       cw_group_name foo.infrastructure
       cw_stream_name ${record['hostname']}.${tag}
     </record>
   </filter>
 
-  <filter kubernetes.** var.log.pods.**>
+  <filter ` + source.ApplicationTagsForMultilineEx + `>
     @type record_modifier
     <record>
       cw_group_name foo.${record['kubernetes']['namespace_id']}
@@ -178,7 +177,7 @@ var _ = Describe("Generating fluentd config", func() {
     </record>
   </filter>
 
-  <filter linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**>
+  <filter ` + source.AuditTags + `>
     @type record_modifier
     <record>
       cw_group_name foo.audit
@@ -194,7 +193,6 @@ var _ = Describe("Generating fluentd config", func() {
     log_stream_name_key cw_stream_name
     remove_log_stream_name_key true
     remove_log_group_name_key true
-    auto_create_stream true
     concurrency 2
     aws_key_id "#{open('/var/run/ocp-collector/secrets/my-secret/aws_access_key_id','r') do |f|f.read.strip end}"
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"

--- a/internal/generator/fluentd/source/tags.go
+++ b/internal/generator/fluentd/source/tags.go
@@ -2,7 +2,7 @@ package source
 
 const (
 	ApplicationTags               = "kubernetes.**"
-	ApplicationTagsForMultilineEx = ApplicationTags + " var.log.pods.**"
+	ApplicationTagsForMultilineEx = "/^(?!(kubernetes\\.|)var\\.log\\.pods\\.openshift-.+_|(kubernetes\\.|)var\\.log\\.pods\\.default_|(kubernetes\\.|)var\\.log\\.pods\\.kube-.+_|journal\\.|system\\.var\\.log|linux-audit\\.log|k8s-audit\\.log|openshift-audit\\.log|ovn-audit\\.log).+/"
 	JournalTags                   = "journal.** system.var.log**"
 	InfraContainerTags            = "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_**"
 	InfraTags                     = InfraContainerTags + " " + JournalTags

--- a/test/framework/functional/output_cloudwatch.go
+++ b/test/framework/functional/output_cloudwatch.go
@@ -1,0 +1,138 @@
+package functional
+
+import (
+	"context"
+	"github.com/ViaQ/logerr/log"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func (f *CollectorFunctionalFramework) GetAllCloudwatchGroups(svc *cwl.Client) ([]string, error) {
+	var (
+		allGroups       []string
+		logGroupsOutput *cwl.DescribeLogGroupsOutput
+	)
+	err := wait.PollImmediate(defaultRetryInterval, f.GetMaxReadDuration(), func() (done bool, err error) {
+		logGroupsOutput, err = svc.DescribeLogGroups(context.TODO(), &cwl.DescribeLogGroupsInput{})
+		if err != nil || len(logGroupsOutput.LogGroups) == 0 {
+			return false, err
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	log.V(3).Info("Results", "logGroups", logGroupsOutput.LogGroups)
+
+	for _, l := range logGroupsOutput.LogGroups {
+		allGroups = append(allGroups, *l.LogGroupName)
+	}
+	return allGroups, nil
+}
+
+func (f *CollectorFunctionalFramework) GetLogGroupsByType(client *cwl.Client, inputName string) ([]string, error) {
+	var (
+		myGroups        []string
+		logGroupsOutput *cwl.DescribeLogGroupsOutput
+	)
+	err := wait.PollImmediate(defaultRetryInterval, f.GetMaxReadDuration(), func() (done bool, err error) {
+		logGroupsOutput, err = client.DescribeLogGroups(context.TODO(), &cwl.DescribeLogGroupsInput{})
+		if err != nil || len(logGroupsOutput.LogGroups) == 0 {
+			return false, err
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	log.V(3).Info("Results", "logGroups", logGroupsOutput.LogGroups)
+
+	for _, l := range logGroupsOutput.LogGroups {
+		// Filter by type and get all
+		if *l.LogGroupName == "group-prefix."+inputName {
+			myGroups = append(myGroups, *l.LogGroupName)
+		}
+	}
+	return myGroups, nil
+}
+
+func (f *CollectorFunctionalFramework) GetLogStreamsByGroup(client *cwl.Client, groupName string) ([]string, error) {
+	var (
+		myStreams        []string
+		logStreamsOutput *cwl.DescribeLogStreamsOutput
+	)
+	err := wait.PollImmediate(defaultRetryInterval, f.GetMaxReadDuration(), func() (done bool, err error) {
+		// TODO: need to query for log group or get more log group info above
+		logStreamsOutput, err = client.DescribeLogStreams(
+			context.TODO(),
+			&cwl.DescribeLogStreamsInput{LogGroupName: &groupName},
+		)
+		if err != nil || len(logStreamsOutput.LogStreams) == 0 {
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, stream := range logStreamsOutput.LogStreams {
+		myStreams = append(myStreams, *stream.LogStreamName)
+	}
+	return myStreams, nil
+}
+
+func (f *CollectorFunctionalFramework) GetLogMessagesByGroupAndStream(client *cwl.Client, groupName string, streamName string) ([]string, error) {
+	var (
+		myMessages      []string
+		logEventsOutput *cwl.GetLogEventsOutput
+	)
+	err := wait.PollImmediate(defaultRetryInterval, f.GetMaxReadDuration(), func() (done bool, err error) {
+		// NOTE:  This is assuming only one stream is created for this group
+		logEventsOutput, err = client.GetLogEvents(
+			context.TODO(),
+			&cwl.GetLogEventsInput{
+				LogGroupName:  &groupName,
+				LogStreamName: &streamName,
+			})
+		if err != nil || len(logEventsOutput.Events) == 0 {
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, event := range logEventsOutput.Events {
+		myMessages = append(myMessages, *event.Message)
+	}
+	return myMessages, nil
+}
+
+func (f *CollectorFunctionalFramework) ReadLogsFromCloudwatch(client *cwl.Client, inputName string) ([]string, error) {
+	log.V(3).Info("Retrieving cloudwatch LogGroups ----------", "LogGroupName:", inputName)
+	logGroupNames, err := f.GetLogGroupsByType(client, inputName)
+	if err != nil {
+		return nil, err
+	}
+	log.V(3).Info("Results", "logGroups", logGroupNames)
+
+	log.V(3).Info("Retrieving cloudwatch LogStreams ----------")
+	logStreams, e := f.GetLogStreamsByGroup(client, logGroupNames[0])
+	if e != nil {
+		return nil, e
+	}
+	log.V(3).Info("Results", "logStreams", logStreams)
+
+	log.V(3).Info("Retrieving cloudwatch LogEvents  ----------")
+	myMessages, er := f.GetLogMessagesByGroupAndStream(client, logGroupNames[0], logStreams[0])
+	if er != nil {
+		return nil, er
+	}
+	log.V(3).Info("Results", "myMessages", myMessages)
+
+	return myMessages, nil
+}

--- a/test/framework/functional/write.go
+++ b/test/framework/functional/write.go
@@ -9,16 +9,19 @@ import (
 	"time"
 )
 
-func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLogInNamespace(msg, namespace string, numOfLogs int) error {
+func (f *CollectorFunctionalFramework) WriteMessagesToNamespace(msg, namespace string, numOfLogs int) error {
 	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], namespace, f.Pod.Name, f.Pod.UID, constants.CollectorName)
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
 func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLog(msg string, numOfLogs int) error {
-	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], f.Pod.Namespace, f.Pod.Name, f.Pod.UID, constants.CollectorName)
+	return f.WriteMessagesToApplicationLogForContainer(msg, constants.CollectorName, numOfLogs)
+}
+func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLogForContainer(msg, container string, numOfLogs int) error {
+	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], f.Pod.Namespace, f.Pod.Name, f.Pod.UID, container)
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
 
-func (f *CollectorFunctionalFramework) WriteMessagesInfraContainerLog(msg string, numOfLogs int) error {
+func (f *CollectorFunctionalFramework) WriteMessagesToInfraContainerLog(msg string, numOfLogs int) error {
 	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], "openshift-fake-infra", f.Pod.Name, f.Pod.UID, constants.CollectorName)
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
@@ -27,6 +30,7 @@ func (f *CollectorFunctionalFramework) WriteMessagesToAuditLog(msg string, numOf
 	filename := fmt.Sprintf("%s/audit.log", fluentdLogPath[auditLog])
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
+
 func (f *CollectorFunctionalFramework) WriteAuditHostLog(numOfLogs int) error {
 	filename := fmt.Sprintf("%s/audit.log", fluentdLogPath[auditLog])
 	msg := NewAuditHostLog(time.Now())
@@ -37,6 +41,7 @@ func (f *CollectorFunctionalFramework) WriteMessagesTok8sAuditLog(msg string, nu
 	filename := fmt.Sprintf("%s/audit.log", fluentdLogPath[k8sAuditLog])
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
+
 func (f *CollectorFunctionalFramework) WriteK8sAuditLog(numOfLogs int) error {
 	filename := fmt.Sprintf("%s/audit.log", fluentdLogPath[k8sAuditLog])
 	for numOfLogs > 0 {
@@ -48,6 +53,7 @@ func (f *CollectorFunctionalFramework) WriteK8sAuditLog(numOfLogs int) error {
 	}
 	return nil
 }
+
 func (f *CollectorFunctionalFramework) WriteOpenshiftAuditLog(numOfLogs int) error {
 	filename := fmt.Sprintf("%s/audit.log", fluentdLogPath[OpenshiftAuditLog])
 	for numOfLogs > 0 {
@@ -71,6 +77,7 @@ func (f *CollectorFunctionalFramework) WriteMessagesToOVNAuditLog(msg string, nu
 	filename := fmt.Sprintf("%s/acl-audit-log.log", fluentdLogPath[ovnAuditLog])
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
+
 func (f *CollectorFunctionalFramework) WriteOVNAuditLog(numOfLogs int) error {
 	filename := fmt.Sprintf("%s/acl-audit-log.log", fluentdLogPath[ovnAuditLog])
 	for numOfLogs > 0 {

--- a/test/functional/normalization/multiline_exception_test.go
+++ b/test/functional/normalization/multiline_exception_test.go
@@ -81,7 +81,8 @@ created by main.main
 			crioLine := functional.NewCRIOLogMessage(timestamp, line, false)
 			buffer = append(buffer, crioLine)
 		}
-		Expect(framework.WriteMessagesToApplicationLogInNamespace(strings.Join(buffer, "\n"), appNamespace, 1)).To(Succeed())
+		// Application log in namespace
+		Expect(framework.WriteMessagesToNamespace(strings.Join(buffer, "\n"), appNamespace, 1)).To(Succeed())
 
 		for _, output := range framework.Forwarder.Spec.Outputs {
 			outputType := output.Type

--- a/test/functional/outputs/syslog/rfc3164_test.go
+++ b/test/functional/outputs/syslog/rfc3164_test.go
@@ -83,7 +83,7 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 	})
 
 	DescribeTable("configured to addLogSourceToMessage should add namespace, pod, container name", func(source string) {
-		writeLogs := framework.WriteMessagesInfraContainerLog
+		writeLogs := framework.WriteMessagesToInfraContainerLog
 		readLogsFrom := framework.ReadInfrastructureLogsFrom
 		if source == logging.InputNameApplication {
 			writeLogs = framework.WriteMessagesToApplicationLog


### PR DESCRIPTION
### Description
5.4 version of fix for issue where infra container logs were being captured by the application log group - clone of [LOG-2455](https://issues.redhat.com//browse/LOG-2455)

/assign @vimalk78 @jcantrill 

### Links
- clone of: https://issues.redhat.com/browse/LOG-2455
- related to: https://issues.redhat.com/browse/LOG-2160
- related to: https://issues.redhat.com/browse/LOG-2275 

Additional Note:
 This includes the same 7 files as the PR we just merged for [LOG-2455](https://issues.redhat.com//browse/LOG-2455):  https://github.com/openshift/cluster-logging-operator/pull/1431   The only difference should be the absence of sts cloudwatch tests.
