### PR TITLE
LOG-2609: fluentd and vector are unable to ship logs to elasticsearch when cluster-wide proxy is in effect

### DIFF
--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 
 				verifyEnvVar(collector, "HTTP_PROXY", httpproxy)
 				verifyEnvVar(collector, "HTTPS_PROXY", httpproxy)
-				verifyEnvVar(collector, "NO_PROXY", noproxy)
+				verifyEnvVar(collector, "NO_PROXY", "elasticsearch,"+noproxy)
 				verifyProxyVolumesAndVolumeMounts(collector, podSpec, constants.CollectorTrustedCAName)
 			})
 		})

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -91,3 +91,4 @@ const (
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}
+var ExtraNoProxyList = []string{ElasticsearchFQDN}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -457,6 +457,11 @@ func GetProxyEnvVars() []v1.EnvVar {
 	envVars := []v1.EnvVar{}
 	for _, envvar := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"} {
 		if value := os.Getenv(envvar); value != "" {
+			if envvar == "NO_PROXY" || envvar == "no_proxy" {
+				if len(constants.ExtraNoProxyList) > 0 {
+					value = strings.Join(constants.ExtraNoProxyList, ",") + "," + value
+				}
+			}
 			envVars = append(envVars, v1.EnvVar{
 				Name:  envvar,
 				Value: value,

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -159,7 +159,11 @@ var _ = Describe("GetProxyEnvVars", func() {
 		envvars := GetProxyEnvVars()
 		Expect(envvars).To(HaveLen(6)) //proxy,noproxy vars
 		for _, envvar := range envvars {
-			Expect(envvar.Name).To(Equal(envvar.Value), "Exp. the value to be set to the name for the test")
+			if envvar.Name == "NO_PROXY" || envvar.Name == "no_proxy" {
+				Expect(envvar.Value).To(Equal("elasticsearch,"+envvar.Name), "Exp. the value to be set to the name for the test with elasticsearch prepended")
+			} else {
+				Expect(envvar.Name).To(Equal(envvar.Value), "Exp. the value to be set to the name for the test")
+			}
 		}
 	})
 })


### PR DESCRIPTION
### Description
fluentd and vector are unable to ship logs to elasticsearch when cluster-wide proxy is in effect. This is due to https://github.com/openshift/cluster-logging-operator/pull/1407. The fix is to add `elasticsearch,` to the `NO_PROXY` and `no_proxy` env variables in case those are set and make sure we do not try to talk to elasticsearch through the proxy.

/cc @alanconway 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2609

