### PR TITLE
LOG-2203:Add ability to encoding bad characters for elasticsearch and cloudwatch

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -649,6 +649,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   

--- a/internal/generator/fluentd/elements/record_modifier.go
+++ b/internal/generator/fluentd/elements/record_modifier.go
@@ -1,8 +1,23 @@
 package elements
 
+// Fluentd including some plugins treats logs as a BINARY by default to forward.
+// But sometimes storage can't proceed some chars, eg ElasticSearch.
+// Plugin record_modifier can help resolve such problem.
+// In char_encoding from:to case, it replaces invalid character with safe character.
+// <filter pattern>
+//   @type record_modifier
+//   # change char encoding from 'ASCII-8BIT' to 'UTF-8'
+//   char_encoding ascii-8bit:utf-8
+//  </filter>
+// */
+
+const DefaultCharEncoding = "ascii-8bit:utf-8"
+const CharEncoding = "charEncoding"
+
 type RecordModifier struct {
-	Records    []Record
-	RemoveKeys []string
+	Records      []Record
+	RemoveKeys   []string
+	CharEncoding string
 }
 
 func (rm RecordModifier) Name() string {
@@ -12,6 +27,9 @@ func (rm RecordModifier) Name() string {
 func (rm RecordModifier) Template() string {
 	return `{{define "` + rm.Name() + `"  -}}
 @type record_modifier
+{{if .CharEncoding -}}
+char_encoding {{.CharEncoding}}
+{{end -}}
 {{if .Records -}}
 <record>
 {{- range $Index, $Record := .Records}}

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -700,6 +700,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   
@@ -827,6 +828,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   
@@ -1497,6 +1499,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   
@@ -1624,6 +1627,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   
@@ -2298,6 +2302,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   
@@ -2425,6 +2430,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   
@@ -3594,6 +3600,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   
@@ -3721,6 +3728,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   
@@ -3848,6 +3856,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   
@@ -3975,6 +3984,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
+    char_encoding ascii-8bit:utf-8
 	remove_keys structured
   </filter>
   

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
 	"github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 	corev1 "k8s.io/api/core/v1"
@@ -18,7 +19,7 @@ var _ = Describe("Generate fluentd config", func() {
 			clspec.Forwarder.Fluentd.Buffer != nil {
 			bufspec = clspec.Forwarder.Fluentd.Buffer
 		}
-		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], generator.NoOptions)
+		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], op)
 	}
 	DescribeTable("for Elasticsearch output", generator.TestGenerateConfAndFormatWith(f, helpers.FormatFluentConf),
 		Entry("with username,password", generator.ConfGenerateTest{
@@ -974,6 +975,143 @@ var _ = Describe("Generate fluentd config", func() {
     verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    type_name _doc
+    retry_tag retry_es_1
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/es_1'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+    </buffer>
+  </match>
+</label>
+`,
+		}),
+		Entry("with char encoding", generator.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeElasticsearch,
+						Name: "es-1",
+						URL:  "http://es.svc.infra.cluster:9999",
+						Secret: &logging.OutputSecretSpec{
+							Name: "es-1",
+						},
+					},
+				},
+			},
+			Secrets: security.NoSecrets,
+			Options: map[string]interface{}{elements.CharEncoding: elements.DefaultCharEncoding},
+			ExpectedConf: `
+<label @ES_1>
+  # Viaq Data Model
+  <filter **>
+    @type viaq_data_model
+    elasticsearch_index_prefix_field 'viaq_index_name'
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      name_type static
+      static_index_name infra-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+      name_type static
+      static_index_name audit-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "**"
+      name_type structured
+      static_index_name app-write
+    </elasticsearch_index_name>
+  </filter>
+  
+  #remove structured field if present
+  <filter **>
+    @type record_modifier
+    char_encoding ascii-8bit:utf-8
+    remove_keys structured
+  </filter>
+  
+  #flatten labels to prevent field explosion in ES
+  <filter **>
+    @type record_transformer
+    enable_ruby true
+    <record>
+      kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+    </record>
+    remove_keys $.kubernetes.labels
+  </filter>
+  
+  <match retry_es_1>
+    @type elasticsearch
+    @id retry_es_1
+    host es.svc.infra.cluster
+    port 9999
+    verify_es_version_at_startup false
+    scheme http
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    type_name _doc
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/retry_es_1'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+    </buffer>
+  </match>
+  
+  <match **>
+    @type elasticsearch
+    @id es_1
+    host es.svc.infra.cluster
+    port 9999
+    verify_es_version_at_startup false
+    scheme http
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name

--- a/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
+++ b/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
@@ -1,11 +1,11 @@
 package elasticsearch
 
 import (
+	"fmt"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
-	corev1 "k8s.io/api/core/v1"
-
 	. "github.com/openshift/cluster-logging-operator/internal/generator"
 	. "github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type IndexModel struct {
@@ -26,12 +26,16 @@ func ViaqDataModel(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o 
 		},
 	}
 	if o.Elasticsearch == nil || (o.Elasticsearch.StructuredTypeKey == "" && o.Elasticsearch.StructuredTypeName == "" && !o.Elasticsearch.EnableStructuredContainerLogs) {
+		recordModifier := RecordModifier{
+			RemoveKeys: []string{KeyStructured},
+		}
+		if op[CharEncoding] != nil {
+			recordModifier.CharEncoding = fmt.Sprintf("%v", op[CharEncoding])
+		}
 		elements = append(elements, Filter{
 			Desc:      "remove structured field if present",
 			MatchTags: "**",
-			Element: RecordModifier{
-				RemoveKeys: []string{KeyStructured},
-			},
+			Element:   recordModifier,
 		})
 	}
 	return elements

--- a/internal/generator/fluentd/outputs.go
+++ b/internal/generator/fluentd/outputs.go
@@ -3,6 +3,7 @@ package fluentd
 import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	. "github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/cloudwatch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/elasticsearch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/fluentdforward"
@@ -27,12 +28,18 @@ func Outputs(clspec *logging.ClusterLoggingSpec, secrets map[string]*corev1.Secr
 		secret := secrets[o.Name]
 		switch o.Type {
 		case logging.OutputTypeElasticsearch:
+			if _, ok := op[elements.CharEncoding]; !ok {
+				op[elements.CharEncoding] = elements.DefaultCharEncoding
+			}
 			outputs = MergeElements(outputs, elasticsearch.Conf(bufspec, secret, o, op))
 		case logging.OutputTypeFluentdForward:
 			outputs = MergeElements(outputs, fluentdforward.Conf(bufspec, secret, o, op))
 		case logging.OutputTypeKafka:
 			outputs = MergeElements(outputs, kafka.Conf(bufspec, secret, o, op))
 		case logging.OutputTypeCloudwatch:
+			if _, ok := op[elements.CharEncoding]; !ok {
+				op[elements.CharEncoding] = elements.DefaultCharEncoding
+			}
 			outputs = MergeElements(outputs, cloudwatch.Conf(bufspec, secret, o, op))
 		case logging.OutputTypeSyslog:
 			outputs = MergeElements(outputs, syslog.Conf(bufspec, secret, o, op))


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Add to the `fluent.conf` for `Elasticsearch` and `Cloudwatch` storage:
```
<filter **>
  @type record_modifier
  char_encoding ascii-8bit:utf-8
</filter>
```
to be ensured  utf8 and replace bad chars
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2203
- Enhancement proposal:
