### PR TITLE
LOG-2587: Fix ES functional tests for vector, using go tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,16 +166,22 @@ undeploy-elasticsearch-operator:
 deploy-example: deploy
 	oc create -n $(NAMESPACE) -f hack/cr.yaml
 
-test-functional: test-functional-benchmarker
-	VECTOR_IMAGE=$(IMAGE_LOGGING_VECTOR) \
-	FLUENTD_IMAGE=$(IMAGE_LOGGING_FLUENTD) \
-	LOGFILEMETRICEXPORTER_IMAGE=$(IMAGE_LOGFILEMETRICEXPORTER) \
-	go test -race ./test/functional/... -ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
+test-functional: test-functional-benchmarker test-functional-fluentd test-functional-vector
 	VECTOR_IMAGE=$(IMAGE_LOGGING_VECTOR) \
 	FLUENTD_IMAGE=$(IMAGE_LOGGING_FLUENTD) \
 	LOGFILEMETRICEXPORTER_IMAGE=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	go test -cover -race ./test/helpers/...
 .PHONY: test-functional
+
+test-functional-fluentd:
+	FLUENTD_IMAGE=$(IMAGE_LOGGING_FLUENTD) \
+	LOGFILEMETRICEXPORTER_IMAGE=$(IMAGE_LOGFILEMETRICEXPORTER) \
+	go test --tags=fluentd -race ./test/functional/... -ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
+
+test-functional-vector:
+	VECTOR_IMAGE=$(IMAGE_LOGGING_VECTOR) \
+	LOGFILEMETRICEXPORTER_IMAGE=$(IMAGE_LOGFILEMETRICEXPORTER) \
+	go test --tags=vector -race ./test/functional/outputs/elasticsearch/... -ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
 
 test-forwarder-generator: bin/forwarder-generator
 	@bin/forwarder-generator --file hack/logforwarder.yaml --collector=fluentd > /dev/null

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -98,6 +98,9 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -153,6 +156,8 @@ source = """
   del(.stream)
   
   del(.kubernetes.pod_ips)
+  
+  ."@timestamp" = del(.timestamp)
 """
 
 [transforms.journal_logs]
@@ -292,6 +297,9 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -347,6 +355,8 @@ source = """
   del(.stream)
   
   del(.kubernetes.pod_ips)
+  
+  ."@timestamp" = del(.timestamp)
 """
 
 [transforms.journal_logs]

--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -36,6 +36,9 @@ del(.stream)
 	RemovePodIPs = `
 del(.kubernetes.pod_ips)
 `
+	FixTimestampField = `
+."@timestamp" = del(.timestamp)
+`
 )
 
 func NormalizeLogs(spec *logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
@@ -61,6 +64,7 @@ func NormalizeContainerLogs(inLabel, outLabel string) []generator.Element {
 				RemoveSourceType,
 				RemoveStream,
 				RemovePodIPs,
+				FixTimestampField,
 			}), "\n\n"),
 		},
 	}

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -23,5 +23,8 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = {{.ExcludePaths}}
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
 {{end}}`
 }

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -35,6 +35,9 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
 `,
 		}),
 		Entry("Only Infrastructure", generator.ConfGenerateTest{
@@ -57,6 +60,9 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -123,6 +129,9 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
 
 [sources.raw_journal_logs]
 type = "journald"

--- a/internal/runtime/pod.go
+++ b/internal/runtime/pod.go
@@ -100,7 +100,7 @@ func (builder *PodBuilder) AddContainer(name, image string) *ContainerBuilder {
 			Name:            strings.ToLower(name),
 			Image:           image,
 			Env:             []corev1.EnvVar{},
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 		},
 		podBuilder: builder,
 	}

--- a/test/framework/functional/message_templates.go
+++ b/test/framework/functional/message_templates.go
@@ -9,24 +9,25 @@ import (
 var (
 	TemplateForAnyPipelineMetadata = types.PipelineMetadata{
 		Collector: types.Collector{
-			Ipaddr4:    "*",
-			Inputname:  "*",
-			Name:       "*",
-			Version:    "*",
+			Ipaddr4:    "**optional**",
+			Inputname:  "**optional**",
+			Name:       "**optional**",
+			Version:    "**optional**",
 			ReceivedAt: time.Time{},
 		},
 	}
 	templateForAnyKubernetes = types.Kubernetes{
 		ContainerName:    "*",
+		ContainerID:      "**optional**",
 		PodName:          "*",
 		NamespaceName:    "*",
-		NamespaceID:      "*",
+		NamespaceID:      "**optional**",
 		ContainerImage:   "*",
-		ContainerImageID: "*",
+		ContainerImageID: "**optional**",
 		PodID:            "*",
 		PodIP:            "**optional**",
-		Host:             "*",
-		MasterURL:        "*",
+		Host:             "**optional**",
+		MasterURL:        "**optional**",
 		FlatLabels:       []string{"*"},
 		NamespaceLabels:  map[string]string{"*": "*"},
 		Annotations:      map[string]string{"*": "*"},
@@ -51,19 +52,20 @@ var (
 
 func NewApplicationLogTemplate() types.ApplicationLog {
 	return types.ApplicationLog{
-		Timestamp: time.Time{},
-		Message:   "*",
-		LogType:   "application",
-		Level:     "*",
-		Hostname:  "*",
-		ViaqMsgID: "*",
+		Timestamp:  time.Time{},
+		Message:    "*",
+		LogType:    "application",
+		Level:      "*",
+		Hostname:   "*",
+		ViaqMsgID:  "**optional**",
+		WriteIndex: "**optional**",
 		Openshift: types.OpenshiftMeta{
 			Labels:   map[string]string{"*": "*"},
 			Sequence: types.NewOptionalInt(""),
 		},
 		PipelineMetadata: TemplateForAnyPipelineMetadata,
 		Docker: types.Docker{
-			ContainerID: "*",
+			ContainerID: "**optional**",
 		},
 		Kubernetes: templateForAnyKubernetes,
 	}

--- a/test/framework/functional/output_cloudwatch.go
+++ b/test/framework/functional/output_cloudwatch.go
@@ -2,6 +2,8 @@ package functional
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/ViaQ/logerr/log"
 	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -49,11 +51,16 @@ func (f *CollectorFunctionalFramework) GetLogGroupsByType(client *cwl.Client, in
 	}
 	log.V(3).Info("Results", "logGroups", logGroupsOutput.LogGroups)
 
+	found := false
 	for _, l := range logGroupsOutput.LogGroups {
 		// Filter by type and get all
 		if *l.LogGroupName == "group-prefix."+inputName {
+			found = true
 			myGroups = append(myGroups, *l.LogGroupName)
 		}
+	}
+	if !found {
+		return nil, fmt.Errorf("%s log type not found", inputName)
 	}
 	return myGroups, nil
 }

--- a/test/framework/functional/vector/deploy.go
+++ b/test/framework/functional/vector/deploy.go
@@ -1,12 +1,13 @@
 package vector
 
 import (
+	"strings"
+
 	"github.com/ViaQ/logerr/log"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/test/client"
-	"strings"
 )
 
 const entrypointScript = `#!/bin/bash
@@ -37,10 +38,10 @@ func (c *VectorCollector) DeployConfigMapForConfig(name, config, clfYaml string)
 }
 
 func (c *VectorCollector) BuildCollectorContainer(b *runtime.ContainerBuilder, nodeName string) *runtime.ContainerBuilder {
-	return b.AddEnvVar("LOG_LEVEL", "debug").
+	return b.AddEnvVar("LOG", "debug").
 		AddEnvVarFromFieldRef("POD_IP", "status.podIP").
 		AddEnvVar("NODE_NAME", nodeName).
-		AddEnvVar("VECTOR_SELF_NODE_NAME", nodeName).
+		AddEnvVarFromFieldRef("VECTOR_SELF_NODE_NAME", "spec.nodeName").
 		AddVolumeMount("config", "/etc/vector", "", true).
 		AddVolumeMount("entrypoint", "/opt/app-root/src/run.sh", "run.sh", true).
 		WithCmd([]string{"/opt/app-root/src/run.sh"})

--- a/test/functional/doc.go
+++ b/test/functional/doc.go
@@ -1,0 +1,1 @@
+package functional

--- a/test/functional/fluentd.go
+++ b/test/functional/fluentd.go
@@ -1,0 +1,12 @@
+//go:build fluentd
+// +build fluentd
+
+package functional
+
+import (
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+)
+
+func init() {
+	LogCollectionType = logging.LogCollectionTypeFluentd
+}

--- a/test/functional/functional.go
+++ b/test/functional/functional.go
@@ -1,0 +1,5 @@
+package functional
+
+import logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+
+var LogCollectionType = logging.LogCollectionTypeFluentd

--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -2,14 +2,16 @@ package normalization
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"strings"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
+	testfw "github.com/openshift/cluster-logging-operator/test/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
@@ -21,298 +23,302 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 	)
 
 	Context("with fluentd", func() {
-		BeforeEach(func() {
-			framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeFluentd)
-			functional.NewClusterLogForwarderBuilder(framework.Forwarder).
-				FromInput(logging.InputNameAudit).
-				ToFluentForwardOutput()
-			Expect(framework.Deploy()).To(BeNil())
-		})
+		if testfw.LogCollectionType == logging.LogCollectionTypeFluentd {
+			BeforeEach(func() {
+				framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeFluentd)
+				functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+					FromInput(logging.InputNameAudit).
+					ToFluentForwardOutput()
+				Expect(framework.Deploy()).To(BeNil())
+			})
 
-		It("should parse k8s audit log format correctly", func() {
-			// Log message data
-			timestamp := "2013-03-28T14:36:03.243000+00:00"
-			nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+			It("should parse k8s audit log format correctly", func() {
+				// Log message data
+				timestamp := "2013-03-28T14:36:03.243000+00:00"
+				nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 
-			// Define a template for test format (used for input, and expected output)
-			var outputLogTemplate = types.K8sAuditLog{
-				AuditLogCommon: types.AuditLogCommon{
-					Kind:             "Event",
-					Hostname:         functional.FunctionalNodeName,
-					LogType:          "audit",
-					Level:            "debug",
-					Timestamp:        time.Time{},
+				// Define a template for test format (used for input, and expected output)
+				var outputLogTemplate = types.K8sAuditLog{
+					AuditLogCommon: types.AuditLogCommon{
+						Kind:             "Event",
+						Hostname:         functional.FunctionalNodeName,
+						LogType:          "audit",
+						Level:            "debug",
+						Timestamp:        time.Time{},
+						ViaqMsgID:        "*",
+						PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+					},
+					K8SAuditLevel: "debug",
+				}
+				// Template expected as output Log
+				k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
+				Expect(framework.WriteMessagesTok8sAuditLog(k8sAuditLogLine, 10)).To(BeNil())
+				// Read line from Log Forward output
+				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeFluentdForward)
+				Expect(err).To(BeNil(), "Expected no errors reading the logs")
+				var logs []types.K8sAuditLog
+				err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+				// Compare to expected template
+				outputTestLog := logs[0]
+				Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+			})
+
+			It("should parse linux audit log format correctly", func() {
+				// Log message data
+				timestamp := "2013-03-28T14:36:03.243000+00:00"
+				testTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+				auditLogLine := functional.NewAuditHostLog(testTime)
+				// Template expected as output Log
+				var outputLogTemplate = types.LinuxAuditLog{
+					Message:  auditLogLine,
+					LogType:  "audit",
+					Hostname: functional.FunctionalNodeName,
+					AuditLinux: types.AuditLinux{
+						Type:     "DAEMON_START",
+						RecordID: "*",
+					},
+					Timestamp:        testTime,
 					ViaqMsgID:        "*",
 					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-				},
-				K8SAuditLevel: "debug",
-			}
-			// Template expected as output Log
-			k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
-			Expect(framework.WriteMessagesTok8sAuditLog(k8sAuditLogLine, 10)).To(BeNil())
-			// Read line from Log Forward output
-			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeFluentdForward)
-			Expect(err).To(BeNil(), "Expected no errors reading the logs")
-			var logs []types.K8sAuditLog
-			err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
-			// Compare to expected template
-			outputTestLog := logs[0]
-			Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-		})
+				}
+				// Write log line as input to fluentd
+				Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
+				// Read line from Log Forward output
+				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeFluentdForward)
+				Expect(err).To(BeNil(), "Expected no errors reading the logs")
+				var logs []types.LinuxAuditLog
+				err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+				// Compare to expected template
+				outputTestLog := logs[0]
+				Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+			})
 
-		It("should parse linux audit log format correctly", func() {
-			// Log message data
-			timestamp := "2013-03-28T14:36:03.243000+00:00"
-			testTime, _ := time.Parse(time.RFC3339Nano, timestamp)
-			auditLogLine := functional.NewAuditHostLog(testTime)
-			// Template expected as output Log
-			var outputLogTemplate = types.LinuxAuditLog{
-				Message:  auditLogLine,
-				LogType:  "audit",
-				Hostname: functional.FunctionalNodeName,
-				AuditLinux: types.AuditLinux{
-					Type:     "DAEMON_START",
-					RecordID: "*",
-				},
-				Timestamp:        testTime,
-				ViaqMsgID:        "*",
-				PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-			}
-			// Write log line as input to fluentd
-			Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
-			// Read line from Log Forward output
-			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeFluentdForward)
-			Expect(err).To(BeNil(), "Expected no errors reading the logs")
-			var logs []types.LinuxAuditLog
-			err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
-			// Compare to expected template
-			outputTestLog := logs[0]
-			Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-		})
+			It("should parse ovn audit log correctly", func() {
+				// Log message data
+				level := "info"
+				ovnLogLine := functional.NewOVNAuditLog(time.Now())
 
-		It("should parse ovn audit log correctly", func() {
-			// Log message data
-			level := "info"
-			ovnLogLine := functional.NewOVNAuditLog(time.Now())
+				// Template expected as output Log
+				var outputLogTemplate = types.OVNAuditLog{
+					Message:   ovnLogLine,
+					Level:     level,
+					Hostname:  functional.FunctionalNodeName,
+					Timestamp: time.Time{},
+					LogType:   "audit",
+					Openshift: types.OpenshiftMeta{
+						Sequence: types.NewOptionalInt(""),
+					},
+					ViaqMsgID:        "*",
+					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				}
+				outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
+				// Write log line as input to fluentd
+				Expect(framework.WriteMessagesToOVNAuditLog(ovnLogLine, 10)).To(BeNil())
+				// Read line from Log Forward output
+				raw, err := framework.ReadOvnAuditLogsFrom(logging.OutputTypeFluentdForward)
+				Expect(err).To(BeNil(), "Expected no errors reading the logs")
+				var logs []types.OVNAuditLog
+				err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				ExpectOK(err)
+				// Compare to expected template
+				outputTestLog := logs[0]
+				Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+			})
 
-			// Template expected as output Log
-			var outputLogTemplate = types.OVNAuditLog{
-				Message:   ovnLogLine,
-				Level:     level,
-				Hostname:  functional.FunctionalNodeName,
-				Timestamp: time.Time{},
-				LogType:   "audit",
-				Openshift: types.OpenshiftMeta{
-					Sequence: types.NewOptionalInt(""),
-				},
-				ViaqMsgID:        "*",
-				PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-			}
-			outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
-			// Write log line as input to fluentd
-			Expect(framework.WriteMessagesToOVNAuditLog(ovnLogLine, 10)).To(BeNil())
-			// Read line from Log Forward output
-			raw, err := framework.ReadOvnAuditLogsFrom(logging.OutputTypeFluentdForward)
-			Expect(err).To(BeNil(), "Expected no errors reading the logs")
-			var logs []types.OVNAuditLog
-			err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-			ExpectOK(err)
-			// Compare to expected template
-			outputTestLog := logs[0]
-			Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-		})
-
-		AfterEach(func() {
-			framework.Cleanup()
-		})
+			AfterEach(func() {
+				framework.Cleanup()
+			})
+		}
 	})
 
 	Context("with vector", func() {
-		BeforeEach(func() {
-			framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
-			functional.NewClusterLogForwarderBuilder(framework.Forwarder).
-				FromInput(logging.InputNameAudit).
-				ToElasticSearchOutput()
-			Expect(framework.Deploy()).To(BeNil())
-		})
+		if testfw.LogCollectionType == logging.LogCollectionTypeVector {
+			BeforeEach(func() {
+				framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
+				functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+					FromInput(logging.InputNameAudit).
+					ToElasticSearchOutput()
+				Expect(framework.Deploy()).To(BeNil())
+			})
 
-		//TODO: fix me when audit formatting is enabled
-		It("should parse k8s audit log format correctly", func() {
-			// Log message data
-			timestamp := "2013-03-28T14:36:03.243000+00:00"
-			nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+			//TODO: fix me when audit formatting is enabled
+			It("should parse k8s audit log format correctly", func() {
+				// Log message data
+				timestamp := "2013-03-28T14:36:03.243000+00:00"
+				nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 
-			// Define a template for test format (used for input, and expected output)
-			//var outputLogTemplate = types.K8sAuditLog{
-			//AuditLogCommon: types.AuditLogCommon{
-			//	Kind:             "Event",
-			//	Hostname:         functional.FunctionalNodeName,
-			//	LogType:          "audit",
-			//	Level:            "debug",
-			//	Timestamp:        time.Time{},
-			//	ViaqMsgID:        "*",
-			//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-			//},
-			//K8SAuditLevel: "debug",
-			//}
-			// Template expected as output Log
-			k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
-			Expect(framework.WriteMessagesTok8sAuditLog(k8sAuditLogLine, 10)).To(BeNil())
-			// Read line from Log Forward output
-			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
-			Expect(err).To(BeNil(), "Expected no errors reading the logs")
-			//var logs []types.K8sAuditLog
-			//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-			//Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
-			//// Compare to expected template
-			//outputTestLog := logs[0]
-			//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-			results := strings.Join(raw, " ")
-			Expect(results).To(MatchRegexp("kind.*Event.*level.*debug"), "Message should contain the audit log: %v", raw)
+				// Define a template for test format (used for input, and expected output)
+				//var outputLogTemplate = types.K8sAuditLog{
+				//AuditLogCommon: types.AuditLogCommon{
+				//	Kind:             "Event",
+				//	Hostname:         functional.FunctionalNodeName,
+				//	LogType:          "audit",
+				//	Level:            "debug",
+				//	Timestamp:        time.Time{},
+				//	ViaqMsgID:        "*",
+				//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				//},
+				//K8SAuditLevel: "debug",
+				//}
+				// Template expected as output Log
+				k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
+				Expect(framework.WriteMessagesTok8sAuditLog(k8sAuditLogLine, 10)).To(BeNil())
+				// Read line from Log Forward output
+				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
+				Expect(err).To(BeNil(), "Expected no errors reading the logs")
+				//var logs []types.K8sAuditLog
+				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				//Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
+				//// Compare to expected template
+				//outputTestLog := logs[0]
+				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+				results := strings.Join(raw, " ")
+				Expect(results).To(MatchRegexp("kind.*Event.*level.*debug"), "Message should contain the audit log: %v", raw)
 
-		})
-		//TODO: fix me when audit formatting is enabled
-		It("should parse openshift audit log format correctly", func() {
-			// Log message data
-			timestamp := "2013-03-28T14:36:03.243000+00:00"
-			nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+			})
+			//TODO: fix me when audit formatting is enabled
+			It("should parse openshift audit log format correctly", func() {
+				// Log message data
+				timestamp := "2013-03-28T14:36:03.243000+00:00"
+				nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 
-			// Define a template for test format (used for input, and expected output)
-			//var outputLogTemplate = types.K8sAuditLog{
-			//AuditLogCommon: types.AuditLogCommon{
-			//	Kind:             "Event",
-			//	Hostname:         functional.FunctionalNodeName,
-			//	LogType:          "audit",
-			//	Level:            "debug",
-			//	Timestamp:        time.Time{},
-			//	ViaqMsgID:        "*",
-			//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-			//},
-			//K8SAuditLevel: "debug",
-			//}
-			// Template expected as output Log
-			auditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
-			Expect(framework.WriteMessagesToOpenshiftAuditLog(auditLogLine, 10)).To(BeNil())
-			// Read line from Log Forward output
-			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
-			Expect(err).To(BeNil(), "Expected no errors reading the logs")
-			//var logs []types.K8sAuditLog
-			//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-			//Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
-			//// Compare to expected template
-			//outputTestLog := logs[0]
-			//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-			results := strings.Join(raw, " ")
-			Expect(results).To(MatchRegexp("kind.*Event.*level.*debug"), "Message should contain the audit log: %v", raw)
+				// Define a template for test format (used for input, and expected output)
+				//var outputLogTemplate = types.K8sAuditLog{
+				//AuditLogCommon: types.AuditLogCommon{
+				//	Kind:             "Event",
+				//	Hostname:         functional.FunctionalNodeName,
+				//	LogType:          "audit",
+				//	Level:            "debug",
+				//	Timestamp:        time.Time{},
+				//	ViaqMsgID:        "*",
+				//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				//},
+				//K8SAuditLevel: "debug",
+				//}
+				// Template expected as output Log
+				auditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
+				Expect(framework.WriteMessagesToOpenshiftAuditLog(auditLogLine, 10)).To(BeNil())
+				// Read line from Log Forward output
+				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
+				Expect(err).To(BeNil(), "Expected no errors reading the logs")
+				//var logs []types.K8sAuditLog
+				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				//Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
+				//// Compare to expected template
+				//outputTestLog := logs[0]
+				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+				results := strings.Join(raw, " ")
+				Expect(results).To(MatchRegexp("kind.*Event.*level.*debug"), "Message should contain the audit log: %v", raw)
 
-		})
-		It("should parse oauth audit log format correctly", func() {
-			// Log message data
-			timestamp := "2013-03-28T14:36:03.243000+00:00"
-			nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+			})
+			It("should parse oauth audit log format correctly", func() {
+				// Log message data
+				timestamp := "2013-03-28T14:36:03.243000+00:00"
+				nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 
-			// Define a template for test format (used for input, and expected output)
-			//var outputLogTemplate = types.K8sAuditLog{
-			//AuditLogCommon: types.AuditLogCommon{
-			//	Kind:             "Event",
-			//	Hostname:         functional.FunctionalNodeName,
-			//	LogType:          "audit",
-			//	Level:            "debug",
-			//	Timestamp:        time.Time{},
-			//	ViaqMsgID:        "*",
-			//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-			//},
-			//K8SAuditLevel: "debug",
-			//}
-			// Template expected as output Log
-			auditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
-			Expect(framework.WriteMessagesToOAuthAuditLog(auditLogLine, 10)).To(BeNil())
-			// Read line from Log Forward output
-			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
-			Expect(err).To(BeNil(), "Expected no errors reading the logs")
-			//var logs []types.K8sAuditLog
-			//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-			//Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
-			//// Compare to expected template
-			//outputTestLog := logs[0]
-			//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-			results := strings.Join(raw, " ")
-			Expect(results).To(MatchRegexp("kind.*Event.*level.*debug"), "Message should contain the audit log: %v", raw)
+				// Define a template for test format (used for input, and expected output)
+				//var outputLogTemplate = types.K8sAuditLog{
+				//AuditLogCommon: types.AuditLogCommon{
+				//	Kind:             "Event",
+				//	Hostname:         functional.FunctionalNodeName,
+				//	LogType:          "audit",
+				//	Level:            "debug",
+				//	Timestamp:        time.Time{},
+				//	ViaqMsgID:        "*",
+				//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				//},
+				//K8SAuditLevel: "debug",
+				//}
+				// Template expected as output Log
+				auditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
+				Expect(framework.WriteMessagesToOAuthAuditLog(auditLogLine, 10)).To(BeNil())
+				// Read line from Log Forward output
+				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
+				Expect(err).To(BeNil(), "Expected no errors reading the logs")
+				//var logs []types.K8sAuditLog
+				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				//Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
+				//// Compare to expected template
+				//outputTestLog := logs[0]
+				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+				results := strings.Join(raw, " ")
+				Expect(results).To(MatchRegexp("kind.*Event.*level.*debug"), "Message should contain the audit log: %v", raw)
 
-		})
-		//TODO: fix me when audit formatting is enabled
-		It("should parse linux audit log format correctly", func() {
-			// Log message data
-			timestamp := "2013-03-28T14:36:03.243000+00:00"
-			testTime, _ := time.Parse(time.RFC3339Nano, timestamp)
-			auditLogLine := functional.NewAuditHostLog(testTime)
-			//// Template expected as output Log
-			//var outputLogTemplate = types.LinuxAuditLog{
-			//	Message:  auditLogLine,
-			//	LogType:  "audit",
-			//	Hostname: functional.FunctionalNodeName,
-			//	AuditLinux: types.AuditLinux{
-			//		Type:     "DAEMON_START",
-			//		RecordID: "*",
-			//	},
-			//	Timestamp:        testTime,
-			//	ViaqMsgID:        "*",
-			//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-			//}
-			// Write log line as input to fluentd
-			Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
-			// Read line from Log Forward output
-			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
-			Expect(err).To(BeNil(), "Expected no errors reading the logs")
-			//var logs []types.LinuxAuditLog
-			//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-			//Expect(err).To(BeNil(), "Expected no errors parsing the logs")
-			//// Compare to expected template
-			//outputTestLog := logs[0]
-			//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-			results := strings.Join(raw, " ")
-			Expect(results).To(MatchRegexp("format=enriched kernel="), "Message should contain the audit log: %v", raw)
-		})
-		//TODO: fix me when audit formatting is enabled
-		It("should parse ovn audit log correctly", func() {
-			// Log message data
-			//level := "info"
-			ovnLogLine := functional.NewOVNAuditLog(time.Now())
+			})
+			//TODO: fix me when audit formatting is enabled
+			It("should parse linux audit log format correctly", func() {
+				// Log message data
+				timestamp := "2013-03-28T14:36:03.243000+00:00"
+				testTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+				auditLogLine := functional.NewAuditHostLog(testTime)
+				//// Template expected as output Log
+				//var outputLogTemplate = types.LinuxAuditLog{
+				//	Message:  auditLogLine,
+				//	LogType:  "audit",
+				//	Hostname: functional.FunctionalNodeName,
+				//	AuditLinux: types.AuditLinux{
+				//		Type:     "DAEMON_START",
+				//		RecordID: "*",
+				//	},
+				//	Timestamp:        testTime,
+				//	ViaqMsgID:        "*",
+				//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				//}
+				// Write log line as input to fluentd
+				Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
+				// Read line from Log Forward output
+				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
+				Expect(err).To(BeNil(), "Expected no errors reading the logs")
+				//var logs []types.LinuxAuditLog
+				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				//Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+				//// Compare to expected template
+				//outputTestLog := logs[0]
+				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+				results := strings.Join(raw, " ")
+				Expect(results).To(MatchRegexp("format=enriched kernel="), "Message should contain the audit log: %v", raw)
+			})
+			//TODO: fix me when audit formatting is enabled
+			It("should parse ovn audit log correctly", func() {
+				// Log message data
+				//level := "info"
+				ovnLogLine := functional.NewOVNAuditLog(time.Now())
 
-			//// Template expected as output Log
-			//var outputLogTemplate = types.OVNAuditLog{
-			//	Message:   ovnLogLine,
-			//	Level:     level,
-			//	Hostname:  functional.FunctionalNodeName,
-			//	Timestamp: time.Time{},
-			//	LogType:   "audit",
-			//	Openshift: types.OpenshiftMeta{
-			//		Sequence: types.NewOptionalInt(""),
-			//	},
-			//	ViaqMsgID:        "*",
-			//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-			//}
-			//outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
-			//// Write log line as input to fluentd
-			Expect(framework.WriteMessagesToOVNAuditLog(ovnLogLine, 10)).To(BeNil())
-			// Read line from Log Forward output
-			raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
-			Expect(err).To(BeNil(), "Expected no errors reading the logs")
-			//var logs []types.OVNAuditLog
-			//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-			//ExpectOK(err)
-			//// Compare to expected template
-			//outputTestLog := logs[0]
-			//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-			results := strings.Join(raw, " ")
-			Expect(results).To(MatchRegexp("name=verify-audit-logging_deny-all"), "Message should contain the audit log: %v", raw)
-		})
+				//// Template expected as output Log
+				//var outputLogTemplate = types.OVNAuditLog{
+				//	Message:   ovnLogLine,
+				//	Level:     level,
+				//	Hostname:  functional.FunctionalNodeName,
+				//	Timestamp: time.Time{},
+				//	LogType:   "audit",
+				//	Openshift: types.OpenshiftMeta{
+				//		Sequence: types.NewOptionalInt(""),
+				//	},
+				//	ViaqMsgID:        "*",
+				//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				//}
+				//outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
+				//// Write log line as input to fluentd
+				Expect(framework.WriteMessagesToOVNAuditLog(ovnLogLine, 10)).To(BeNil())
+				// Read line from Log Forward output
+				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
+				Expect(err).To(BeNil(), "Expected no errors reading the logs")
+				//var logs []types.OVNAuditLog
+				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				//ExpectOK(err)
+				//// Compare to expected template
+				//outputTestLog := logs[0]
+				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+				results := strings.Join(raw, " ")
+				Expect(results).To(MatchRegexp("name=verify-audit-logging_deny-all"), "Message should contain the audit log: %v", raw)
+			})
 
-		AfterEach(func() {
-			framework.Cleanup()
-		})
+			AfterEach(func() {
+				framework.Cleanup()
+			})
+		}
 	})
 
 })

--- a/test/functional/normalization/crio_partial_log_test.go
+++ b/test/functional/normalization/crio_partial_log_test.go
@@ -1,11 +1,12 @@
 package normalization
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"github.com/openshift/cluster-logging-operator/test/matchers"
-	"strings"
 
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 )
@@ -79,6 +80,7 @@ var _ = Describe("[Functional][Normalization]Reassembly split by CRI-O logs ", f
 
 		logs, err := framework.ReadApplicationLogsFrom(logging.OutputTypeFluentdForward)
 		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+		Expect(len(logs)).To(Equal(2))
 		Expect(logs[0].Message).Should(Equal("Run, Forest, Run!"))
 		Expect(logs[1].Message).Should(Equal("Freedom!!!"))
 	})

--- a/test/functional/outputs/elasticsearch/forward_to_elasticsearch_index_test.go
+++ b/test/functional/outputs/elasticsearch/forward_to_elasticsearch_index_test.go
@@ -2,12 +2,14 @@ package elasticsearch
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	testfw "github.com/openshift/cluster-logging-operator/test/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"github.com/openshift/cluster-logging-operator/test/matchers"
 )
@@ -39,7 +41,7 @@ var _ = Describe("[Functional][Outputs][ElasticSearch][Index] FluentdForward Out
 		// Template expected as output Log
 		outputLogTemplate = functional.NewApplicationLogTemplate()
 		outputLogTemplate.ViaqIndexName = "app-write"
-		framework = functional.NewCollectorFunctionalFramework()
+		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(testfw.LogCollectionType)
 	})
 	AfterEach(func() {
 		framework.Cleanup()
@@ -94,6 +96,9 @@ var _ = Describe("[Functional][Outputs][ElasticSearch][Index] FluentdForward Out
 			Expect(outputTestLog).To(matchers.FitLogFormatTemplate(outputLogTemplate))
 		})
 		It("should not send logs to structuredTypeName for infrastructure sources", func() {
+			if testfw.LogCollectionType == logging.LogCollectionTypeVector {
+				Skip("infrastructure logs tests not supported for vector")
+			}
 			outputLogTemplate = functional.NewContainerInfrastructureLogTemplate()
 			outputLogTemplate.ViaqIndexName = "infra-write"
 			clfb := functional.NewClusterLogForwarderBuilder(framework.Forwarder).
@@ -120,6 +125,9 @@ var _ = Describe("[Functional][Outputs][ElasticSearch][Index] FluentdForward Out
 			Expect(outputTestLog).To(matchers.FitLogFormatTemplate(outputLogTemplate))
 		})
 		It("should not send to k8s label structuredTypeKey for infrastructure sources", func() {
+			if testfw.LogCollectionType == logging.LogCollectionTypeVector {
+				Skip("infrastructure logs tests not supported for vector")
+			}
 			outputLogTemplate = functional.NewContainerInfrastructureLogTemplate()
 			outputLogTemplate.ViaqIndexName = "infra-write"
 			clfb := functional.NewClusterLogForwarderBuilder(framework.Forwarder).
@@ -197,6 +205,9 @@ var _ = Describe("[Functional][Outputs][ElasticSearch][Index] FluentdForward Out
 		})
 		Context("and enabling sending each container log to different indices", func() {
 			It("should send one container's log as defined by the annotation and the other defined by structuredTypeKey", func() {
+				if testfw.LogCollectionType == logging.LogCollectionTypeVector {
+					Skip("sending each container log to different indices not supported for vector")
+				}
 				clfb := functional.NewClusterLogForwarderBuilder(framework.Forwarder).
 					FromInput(logging.InputNameApplication).
 					ToOutputWithVisitor(func(spec *logging.OutputSpec) {

--- a/test/functional/outputs/elasticsearch/forward_to_elasticsearch_test.go
+++ b/test/functional/outputs/elasticsearch/forward_to_elasticsearch_test.go
@@ -5,11 +5,12 @@ import (
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	testfw "github.com/openshift/cluster-logging-operator/test/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
-var _ = Describe("[VECTOR_READY][Functional][Outputs][ElasticSearch] FluentdForward Output to ElasticSearch", func() {
+var _ = Describe("[Functional][Outputs][ElasticSearch] FluentdForward Output to ElasticSearch", func() {
 
 	var (
 		framework *functional.CollectorFunctionalFramework
@@ -20,7 +21,7 @@ var _ = Describe("[VECTOR_READY][Functional][Outputs][ElasticSearch] FluentdForw
 
 	BeforeEach(func() {
 		outputLogTemplate.ViaqIndexName = "app-write"
-		framework = functional.NewCollectorFunctionalFramework()
+		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(testfw.LogCollectionType)
 		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
 			FromInput(logging.InputNameApplication).
 			ToElasticSearchOutput()

--- a/test/functional/vector.go
+++ b/test/functional/vector.go
@@ -1,0 +1,12 @@
+//go:build vector
+// +build vector
+
+package functional
+
+import (
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+)
+
+func init() {
+	LogCollectionType = logging.LogCollectionTypeVector
+}

--- a/test/helpers/types/types.go
+++ b/test/helpers/types/types.go
@@ -33,6 +33,7 @@ type ContainerLog struct {
 	LogType          string                 `json:"log_type,omitempty"`
 	ViaqIndexName    string                 `json:"viaq_index_name"`
 	ViaqMsgID        string                 `json:"viaq_msg_id"`
+	WriteIndex       string                 `json:"write_index"`
 	Openshift        OpenshiftMeta          `json:"openshift"`
 	Structured       map[string]interface{} `json:"structured"`
 }
@@ -46,6 +47,7 @@ type Kubernetes struct {
 	ContainerName     string            `json:"container_name,omitempty"`
 	NamespaceName     string            `json:"namespace_name,omitempty"`
 	PodName           string            `json:"pod_name,omitempty"`
+	ContainerID       string            `json:"container_id,omitempty"`
 	ContainerImage    string            `json:"container_image,omitempty"`
 	ContainerImageID  string            `json:"container_image_id,omitempty"`
 	PodID             string            `json:"pod_id,omitempty"`


### PR DESCRIPTION
### Description
This PR

  - fixes functional framework to make `kubernetes_logs` start scraping application logs created by functional framework, enables debug logs for vector
  - adds go test tags based selection of collector for functional test framework.
    - use `go test --tag=fluentd` to set a global variable `"FrameworkType"` to "fluentd"
    - use `go test --tag=vector` to set a global variable `"FrameworkType"` to "vector"
    which can be used to create framework in the tests.
  - fixes app log data model to conform to functional test app log template
  - relaxes message template to accommodate both fluentd and vector based record creation
  - enables outputs/elasticsearch tests to run for both fluentd and vector


/cc @jcantrill @cahartma 

/assign @vimalk78 


### Links
- JIRA: https://issues.redhat.com/browse/LOG-2587
