### PR TITLE
LOG-2588: fix alerting rule for CLF

### DIFF
--- a/files/fluentd/fluentd_prometheus_alerts.yaml
+++ b/files/fluentd/fluentd_prometheus_alerts.yaml
@@ -13,10 +13,10 @@
       "severity": "critical"
   - "alert": "FluentdQueueLengthIncreasing"
     "annotations":
-      "message": "For the last hour, fluentd {{ $labels.instance }} average buffer queue length has increased continuously."
-      "summary": "Fluentd unable to keep up with traffic over time."
+      "message": "For the last hour, fluentd {{ $labels.instance }} output '{{ $labels.plugin_id }}' average buffer queue length has increased continuously."
+      "summary": "Fluentd unable to keep up with traffic over time for forwarding output {{ $labels.plugin_id }}."
     "expr": |
-      ( 0 * (kube_pod_start_time{pod=~".*fluentd.*"} < time() - 3600 ) )  + on(pod)  label_replace( ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 ), "pod", "$1", "hostname", "(.*)")
+      ( 0 * (kube_pod_start_time{pod=~".*collector-.*"} < time() - 3600 ) )  + on(pod,plugin_id)  label_replace( ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 ), "pod", "$1", "hostname", "(.*)")
     "for": "1h"
     "labels":
       "service": "fluentd"


### PR DESCRIPTION
### Description
This PR:
* fixes the alerting rule for clusterlogforwarder to take into account the output

### Links
* https://issues.redhat.com/browse/LOG-2588

Note without fix the metrics console shows:

![image](https://user-images.githubusercontent.com/4548408/168678944-eceb6cc5-fbd7-49d8-bc9d-c71b332c860a.png)



