### PR TITLE
LOG-2553: Always send infra logs to infra indices

### DIFF
--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -439,8 +439,8 @@ var _ = Describe("Generating fluentd config", func() {
 	@id kubernetes-metadata
     @type kubernetes_metadata
     kubernetes_url 'https://kubernetes.default.svc'
+    allow_orphans false
     cache_size '1000'
-    watch 'false'
     use_journal 'nil'
     ssl_partial_chain 'true'
   </filter>
@@ -691,6 +691,30 @@ var _ = Describe("Generating fluentd config", func() {
 
 # Ship logs to specific outputs
 <label @APPS_ES_1>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
 	@type record_modifier
@@ -795,6 +819,30 @@ var _ = Describe("Generating fluentd config", func() {
 </label>
 
 <label @APPS_ES_2>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
 	@type record_modifier
@@ -1225,8 +1273,8 @@ var _ = Describe("Generating fluentd config", func() {
 	@id kubernetes-metadata
     @type kubernetes_metadata
     kubernetes_url 'https://kubernetes.default.svc'
+    allow_orphans false
     cache_size '1000'
-    watch 'false'
     use_journal 'nil'
     ssl_partial_chain 'true'
   </filter>
@@ -1460,6 +1508,30 @@ var _ = Describe("Generating fluentd config", func() {
 
 # Ship logs to specific outputs
 <label @APPS_ES_1>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
 	@type record_modifier
@@ -1564,6 +1636,30 @@ var _ = Describe("Generating fluentd config", func() {
 </label>
 
 <label @APPS_ES_2>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
 	@type record_modifier
@@ -1996,8 +2092,8 @@ var _ = Describe("Generating fluentd config", func() {
 	@id kubernetes-metadata
     @type kubernetes_metadata
     kubernetes_url 'https://kubernetes.default.svc'
+    allow_orphans false
     cache_size '1000'
-    watch 'false'
     use_journal 'nil'
     ssl_partial_chain 'true'
   </filter>
@@ -2233,6 +2329,30 @@ var _ = Describe("Generating fluentd config", func() {
 
 # Ship logs to specific outputs
 <label @APPS_ES_1>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+      static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
 	@type record_modifier
@@ -2337,6 +2457,30 @@ var _ = Describe("Generating fluentd config", func() {
 </label>
 
 <label @APPS_ES_2>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
 	@type record_modifier
@@ -2712,8 +2856,8 @@ var _ = Describe("Generating fluentd config", func() {
 	@id kubernetes-metadata
     @type kubernetes_metadata
     kubernetes_url 'https://kubernetes.default.svc'
+    allow_orphans false
     cache_size '1000'
-    watch 'false'
     use_journal 'nil'
     ssl_partial_chain 'true'
   </filter>
@@ -3270,8 +3414,8 @@ var _ = Describe("Generating fluentd config", func() {
 	@id kubernetes-metadata
     @type kubernetes_metadata
     kubernetes_url 'https://kubernetes.default.svc'
+    allow_orphans false
     cache_size '1000'
-    watch 'false'
     use_journal 'nil'
     ssl_partial_chain 'true'
   </filter>
@@ -3519,6 +3663,30 @@ var _ = Describe("Generating fluentd config", func() {
 
 # Ship logs to specific outputs
 <label @INFRA_ES>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
 	@type record_modifier
@@ -3623,6 +3791,30 @@ var _ = Describe("Generating fluentd config", func() {
 </label>
 
 <label @APPS_ES_1>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
 	@type record_modifier
@@ -3727,6 +3919,30 @@ var _ = Describe("Generating fluentd config", func() {
 </label>
 
 <label @APPS_ES_2>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
 	@type record_modifier
@@ -3831,6 +4047,30 @@ var _ = Describe("Generating fluentd config", func() {
 </label>
 
 <label @AUDIT_ES>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
 	@type record_modifier
@@ -4279,8 +4519,8 @@ inputs:
 	@id kubernetes-metadata
     @type kubernetes_metadata
     kubernetes_url 'https://kubernetes.default.svc'
+	allow_orphans false
     cache_size '1000'
-    watch 'false'
     use_journal 'nil'
     ssl_partial_chain 'true'
   </filter>

--- a/internal/generator/fluentd/ingress.go
+++ b/internal/generator/fluentd/ingress.go
@@ -196,8 +196,8 @@ const KubernetesMetadataPlugin string = `
   @id kubernetes-metadata
   @type kubernetes_metadata
   kubernetes_url 'https://kubernetes.default.svc'
+  allow_orphans false
   cache_size '1000'
-  watch 'false'
   use_journal 'nil'
   ssl_partial_chain 'true'
 </filter>

--- a/internal/generator/fluentd/output/buffer_conf_test.go
+++ b/internal/generator/fluentd/output/buffer_conf_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/openshift/cluster-logging-operator/internal/generator"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output"
+	. "github.com/openshift/cluster-logging-operator/test/framework/unit"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
@@ -1,9 +1,6 @@
 package elasticsearch
 
 import (
-	"fmt"
-	"strings"
-
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	corev1 "k8s.io/api/core/v1"
@@ -72,7 +69,7 @@ func Conf(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o logging.O
 		FromLabel{
 			InLabel: helpers.LabelName(o.Name),
 			SubElements: MergeElements(
-				ChangeESIndex(bufspec, secret, o, op),
+				ViaqDataModel(bufspec, secret, o, op),
 				FlattenLabels(bufspec, secret, o, op),
 				OutputConf(bufspec, secret, o, op),
 			),
@@ -125,51 +122,6 @@ func RetryOutput(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o lo
 	return es
 }
 
-func ChangeESIndex(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o logging.OutputSpec, op Options) []Element {
-	if o.Elasticsearch != nil && (o.Elasticsearch.StructuredTypeKey != "" || o.Elasticsearch.StructuredTypeName != "") {
-		recordModifier := RecordModifier{
-			Records: []Record{
-				{
-					Key:        "typeFromKey",
-					Expression: (fmt.Sprintf("${record.dig(%s)}", generateRubyDigArgs(o.Elasticsearch.StructuredTypeKey))),
-				},
-				{
-					Key:        "hasStructuredTypeName",
-					Expression: o.Elasticsearch.StructuredTypeName,
-				},
-				{
-					Key:        "viaq_index_name",
-					Expression: `${ if !record['structured'].nil? && record['structured'] != {}; if !record['typeFromKey'].nil?; "app-"+record['typeFromKey']+"-write"; elsif record['hasStructuredTypeName'] != ""; "app-"+record['hasStructuredTypeName']+"-write"; else record['viaq_index_name']; end; else record['viaq_index_name']; end;}`,
-				},
-			},
-			RemoveKeys: []string{"typeFromKey", "hasStructuredTypeName"},
-		}
-		if op[CharEncoding] != nil {
-			recordModifier.CharEncoding = fmt.Sprintf("%v", op[CharEncoding])
-		}
-		return []Element{
-			Filter{
-				MatchTags: "**",
-				Element:   recordModifier,
-			},
-		}
-	} else {
-		recordModifier := RecordModifier{
-			RemoveKeys: []string{KeyStructured},
-		}
-		if op[CharEncoding] != nil {
-			recordModifier.CharEncoding = fmt.Sprintf("%v", op[CharEncoding])
-		}
-		return []Element{
-			Filter{
-				Desc:      "remove structured field if present",
-				MatchTags: "**",
-				Element:   recordModifier,
-			},
-		}
-	}
-}
-
 func FlattenLabels(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o logging.OutputSpec, op Options) []Element {
 	return []Element{
 		Filter{
@@ -215,12 +167,4 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 		}
 	}
 	return conf
-}
-
-func generateRubyDigArgs(path string) string {
-	var args []string
-	for _, s := range strings.Split(path, ".") {
-		args = append(args, fmt.Sprintf("%q", s))
-	}
-	return strings.Join(args, ",")
 }

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -2,6 +2,7 @@ package elasticsearch
 
 import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -24,8 +25,8 @@ var _ = Describe("Generate fluentd config", func() {
 		}
 		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], op)
 	}
-	DescribeTable("for Elasticsearch output", generator.TestGenerateConfWith(f),
-		Entry("with username,password", generator.ConfGenerateTest{
+	DescribeTable("for Elasticsearch output", unit.TestGenerateConfWith(f),
+		Entry("with username,password", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -48,6 +49,30 @@ var _ = Describe("Generate fluentd config", func() {
 			},
 			ExpectedConf: `
 <label @ES_1>
+  # Viaq Data Model
+  <filter **>
+    @type viaq_data_model
+    elasticsearch_index_prefix_field 'viaq_index_name'
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      name_type static
+      static_index_name infra-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+      name_type static
+      static_index_name audit-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "**"
+      name_type structured
+      static_index_name app-write
+    </elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
     @type record_modifier
@@ -149,7 +174,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+		Entry("with tls key,cert,ca-bundle", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -173,6 +198,30 @@ var _ = Describe("Generate fluentd config", func() {
 			},
 			ExpectedConf: `
 <label @ES_1>
+  # Viaq Data Model
+  <filter **>
+    @type viaq_data_model
+    elasticsearch_index_prefix_field 'viaq_index_name'
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      name_type static
+      static_index_name infra-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+      name_type static
+      static_index_name audit-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "**"
+      name_type structured
+      static_index_name app-write
+    </elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
     @type record_modifier
@@ -276,7 +325,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("without security", generator.ConfGenerateTest{
+		Entry("without security", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -292,6 +341,30 @@ var _ = Describe("Generate fluentd config", func() {
 			Secrets: security.NoSecrets,
 			ExpectedConf: `
 <label @ES_1>
+  # Viaq Data Model
+  <filter **>
+    @type viaq_data_model
+    elasticsearch_index_prefix_field 'viaq_index_name'
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      name_type static
+      static_index_name infra-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+      name_type static
+      static_index_name audit-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "**"
+      name_type structured
+      static_index_name app-write
+    </elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
     @type record_modifier
@@ -387,7 +460,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with https but without a secret", generator.ConfGenerateTest{
+		Entry("with https but without a secret", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -400,6 +473,30 @@ var _ = Describe("Generate fluentd config", func() {
 			Secrets: security.NoSecrets,
 			ExpectedConf: `
 <label @ES_1>
+  # Viaq Data Model
+  <filter **>
+    @type viaq_data_model
+    elasticsearch_index_prefix_field 'viaq_index_name'
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      name_type static
+      static_index_name infra-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+      name_type static
+      static_index_name audit-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "**"
+      name_type structured
+      static_index_name app-write
+    </elasticsearch_index_name>
+  </filter>
+  
   #remove structured field if present
   <filter **>
     @type record_modifier
@@ -497,7 +594,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with char encoding", generator.ConfGenerateTest{
+		Entry("with http and username/password", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -510,17 +607,48 @@ var _ = Describe("Generate fluentd config", func() {
 					},
 				},
 			},
-			Secrets: security.NoSecrets,
+			Secrets: map[string]*corev1.Secret{
+				"es-1": {
+					Data: map[string][]byte{
+						"username": []byte("junk"),
+						"password": []byte("junk"),
+					},
+				},
+			},
 			Options: map[string]interface{}{elements.CharEncoding: elements.DefaultCharEncoding},
 			ExpectedConf: `
 <label @ES_1>
-  #remove structured field if present
+  # Viaq Data Model
+  <filter **>
+    @type viaq_data_model
+    elasticsearch_index_prefix_field 'viaq_index_name'
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      name_type static
+      static_index_name infra-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+      name_type static
+      static_index_name audit-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "**"
+      name_type structured
+      static_index_name app-write
+    </elasticsearch_index_name>
+  </filter>
+
+   #remove structured field if present
   <filter **>
     @type record_modifier
     char_encoding ascii-8bit:utf-8
     remove_keys structured
   </filter>
-  
+ 
   #flatten labels to prevent field explosion in ES
   <filter **>
     @type record_transformer
@@ -538,6 +666,8 @@ var _ = Describe("Generate fluentd config", func() {
     port 9999
     verify_es_version_at_startup false
     scheme http
+    user "#{File.exists?('/var/run/ocp-collector/secrets/es-1/username') ? open('/var/run/ocp-collector/secrets/es-1/username','r') do |f|f.read end : ''}"
+    password "#{File.exists?('/var/run/ocp-collector/secrets/es-1/password') ? open('/var/run/ocp-collector/secrets/es-1/password','r') do |f|f.read end : ''}"
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
@@ -576,6 +706,144 @@ var _ = Describe("Generate fluentd config", func() {
     port 9999
     verify_es_version_at_startup false
     scheme http
+    user "#{File.exists?('/var/run/ocp-collector/secrets/es-1/username') ? open('/var/run/ocp-collector/secrets/es-1/username','r') do |f|f.read end : ''}"
+    password "#{File.exists?('/var/run/ocp-collector/secrets/es-1/password') ? open('/var/run/ocp-collector/secrets/es-1/password','r') do |f|f.read end : ''}"
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    type_name _doc
+    retry_tag retry_es_1
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/es_1'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+    </buffer>
+  </match>
+</label>
+`,
+		}),
+		Entry("with structured types enabled", unit.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeElasticsearch,
+						Name: "es-1",
+						URL:  "https://es.svc.infra.cluster:9999",
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Elasticsearch: &logging.Elasticsearch{
+								StructuredTypeKey:  "kubernetes.labels.foo-bar",
+								StructuredTypeName: "my-name",
+							},
+						},
+					},
+				},
+			},
+			Secrets: security.NoSecrets,
+			ExpectedConf: `
+<label @ES_1>
+  # Viaq Data Model
+  <filter **>
+    @type viaq_data_model
+    elasticsearch_index_prefix_field 'viaq_index_name'
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      name_type static
+      static_index_name infra-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+      name_type static
+      static_index_name audit-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "**"
+      name_type structured
+      static_index_name app-write
+      structured_type_key kubernetes.labels.foo-bar
+      structured_type_name my-name
+    </elasticsearch_index_name>
+  </filter>
+  
+  #flatten labels to prevent field explosion in ES
+  <filter **>
+    @type record_transformer
+    enable_ruby true
+    <record>
+      kubernetes ${!record['kubernetes'].nil? ? record['kubernetes'].merge({"flat_labels": (record['kubernetes']['labels']||{}).map{|k,v| "#{k}=#{v}"}}) : {} }
+    </record>
+    remove_keys $.kubernetes.labels
+  </filter>
+  
+  <match retry_es_1>
+    @type elasticsearch
+    @id retry_es_1
+    host es.svc.infra.cluster
+    port 9999
+    verify_es_version_at_startup false
+    scheme https
+    ssl_version TLSv1_2
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    type_name _doc
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/retry_es_1'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+    </buffer>
+  </match>
+  
+  <match **>
+    @type elasticsearch
+    @id es_1
+    host es.svc.infra.cluster
+    port 9999
+    verify_es_version_at_startup false
+    scheme https
+    ssl_version TLSv1_2
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name

--- a/internal/generator/fluentd/output/elasticsearch/output_conf_es_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/output_conf_es_test.go
@@ -99,6 +99,30 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(`
 <label @ONCLUSTER_ELASTICSEARCH>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+
   #remove structured field if present
   <filter **>
     @type record_modifier
@@ -233,6 +257,30 @@ var _ = Describe("Generating fluentd config blocks", func() {
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(`
 <label @OTHER_ELASTICSEARCH>
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+
   #remove structured field if present
   <filter **>
     @type record_modifier

--- a/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
+++ b/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
@@ -1,0 +1,88 @@
+package elasticsearch
+
+import (
+	"fmt"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/openshift/cluster-logging-operator/internal/generator"
+	. "github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
+)
+
+type IndexModel struct {
+	Elasticsearch *logging.Elasticsearch
+}
+
+func ViaqDataModel(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o logging.OutputSpec, op Options) []Element {
+	elements := []Element{
+		IndexModel{
+			Elasticsearch: o.Elasticsearch,
+		},
+	}
+	if o.Elasticsearch == nil || (o.Elasticsearch.StructuredTypeKey == "" && o.Elasticsearch.StructuredTypeName == "") {
+		recordModifier := RecordModifier{
+			RemoveKeys: []string{KeyStructured},
+		}
+		if op[CharEncoding] != nil {
+			recordModifier.CharEncoding = fmt.Sprintf("%v", op[CharEncoding])
+		}
+		elements = append(elements, Filter{
+			Desc:      "remove structured field if present",
+			MatchTags: "**",
+			Element:   recordModifier,
+		})
+	}
+	return elements
+}
+
+func (im IndexModel) StructuredTypeKey() string {
+	if im.Elasticsearch != nil && im.Elasticsearch.StructuredTypeKey != "" {
+		return im.Elasticsearch.StructuredTypeKey
+	}
+	return ""
+}
+func (im IndexModel) StructuredTypeName() string {
+	if im.Elasticsearch != nil && im.Elasticsearch.StructuredTypeName != "" {
+		return im.Elasticsearch.StructuredTypeName
+	}
+	return ""
+}
+
+func (im IndexModel) Name() string {
+	return "viaqDataIndexModel"
+}
+
+func (im IndexModel) Template() string {
+	return `{{define "viaqDataIndexModel" -}}
+# Viaq Data Model
+<filter **>
+  @type viaq_data_model
+  elasticsearch_index_prefix_field 'viaq_index_name'
+  <elasticsearch_index_name>
+    enabled 'true'
+    tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+    name_type static
+    static_index_name infra-write
+  </elasticsearch_index_name>
+  <elasticsearch_index_name>
+    enabled 'true'
+    tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+    name_type static
+    static_index_name audit-write
+  </elasticsearch_index_name>
+  <elasticsearch_index_name>
+    enabled 'true'
+    tag "**"
+    name_type structured
+    static_index_name app-write
+{{if (ne .StructuredTypeKey "") -}}
+    structured_type_key {{ .StructuredTypeKey }}
+{{ end -}}
+{{if (ne .StructuredTypeName "") -}}
+    structured_type_name {{ .StructuredTypeName }}
+{{ end -}}
+  </elasticsearch_index_name>
+</filter>
+{{end}}
+`
+}

--- a/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
@@ -1,6 +1,7 @@
 package fluentdforward
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -23,8 +24,8 @@ var _ = Describe("fluentd conf generation", func() {
 		}
 		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], op)
 	}
-	DescribeTable("for fluentdforward output", generator.TestGenerateConfWith(f),
-		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+	DescribeTable("for fluentdforward output", unit.TestGenerateConfWith(f),
+		Entry("with tls key,cert,ca-bundle", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -86,7 +87,7 @@ var _ = Describe("fluentd conf generation", func() {
 </label>
 `,
 		}),
-		Entry("with shared_key", generator.ConfGenerateTest{
+		Entry("with shared_key", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -144,7 +145,7 @@ var _ = Describe("fluentd conf generation", func() {
 </label>
 `,
 		}),
-		Entry("with unsecured, and default port", generator.ConfGenerateTest{
+		Entry("with unsecured, and default port", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/fluentd/output/kafka/kafka_test.go
+++ b/internal/generator/fluentd/output/kafka/kafka_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -23,8 +24,8 @@ var _ = Describe("Generate fluentd config", func() {
 		}
 		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], op)
 	}
-	DescribeTable("for kafka output", generator.TestGenerateConfWith(f),
-		Entry("with username,password to single topic", generator.ConfGenerateTest{
+	DescribeTable("for kafka output", unit.TestGenerateConfWith(f),
+		Entry("with username,password to single topic", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -83,7 +84,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+		Entry("with tls key,cert,ca-bundle", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -139,7 +140,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("without security", generator.ConfGenerateTest{
+		Entry("without security", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/fluentd/output/loki/loki_conf_test.go
+++ b/internal/generator/fluentd/output/loki/loki_conf_test.go
@@ -1,6 +1,7 @@
 package loki
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	"sort"
 	"testing"
 
@@ -49,8 +50,8 @@ var _ = Describe("Generate fluentd config", func() {
 		}
 		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], generator.NoOptions)
 	}
-	DescribeTable("for Loki output", generator.TestGenerateConfWith(f),
-		Entry("with default labels", generator.ConfGenerateTest{
+	DescribeTable("for Loki output", unit.TestGenerateConfWith(f),
+		Entry("with default labels", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -119,7 +120,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with custom labels", generator.ConfGenerateTest{
+		Entry("with custom labels", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -85,6 +85,30 @@ var _ = Describe("Generating fluentd config", func() {
 		It("should provide a default buffer configuration", func() {
 			esConf := `
         <label @OTHER_ELASTICSEARCH>
+		  # Viaq Data Model
+		  <filter **>
+			@type viaq_data_model
+			elasticsearch_index_prefix_field 'viaq_index_name'
+			<elasticsearch_index_name>
+			  enabled 'true'
+			  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+			  name_type static
+			  static_index_name infra-write
+			</elasticsearch_index_name>
+			<elasticsearch_index_name>
+			  enabled 'true'
+			  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+			  name_type static
+			  static_index_name audit-write
+			</elasticsearch_index_name>
+			<elasticsearch_index_name>
+			  enabled 'true'
+			  tag "**"
+			  name_type structured
+			  static_index_name app-write
+			</elasticsearch_index_name>
+		  </filter>
+		  
 		  #remove structured field if present
 		  <filter **>
 		    @type record_modifier
@@ -201,6 +225,30 @@ var _ = Describe("Generating fluentd config", func() {
 		It("should provide a default buffer configuration", func() {
 			esConf := `
         <label @OTHER_ELASTICSEARCH>
+		  # Viaq Data Model
+		  <filter **>
+			@type viaq_data_model
+			elasticsearch_index_prefix_field 'viaq_index_name'
+			<elasticsearch_index_name>
+			  enabled 'true'
+			  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+			  name_type static
+			  static_index_name infra-write
+			</elasticsearch_index_name>
+			<elasticsearch_index_name>
+			  enabled 'true'
+			  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+			  name_type static
+			  static_index_name audit-write
+			</elasticsearch_index_name>
+			<elasticsearch_index_name>
+			  enabled 'true'
+			  tag "**"
+			  name_type structured
+			  static_index_name app-write
+			</elasticsearch_index_name>
+		  </filter>
+		  
 		  #remove structured field if present
 		  <filter **>
 		    @type record_modifier
@@ -303,11 +351,37 @@ var _ = Describe("Generating fluentd config", func() {
 		It("should override buffer configuration for given tuning parameters", func() {
 			esConf := `
         <label @OTHER_ELASTICSEARCH>
-		#remove structured field if present
-		<filter **>
-		  @type record_modifier
-		  remove_keys structured
-		</filter>
+
+		  # Viaq Data Model
+		  <filter **>
+			@type viaq_data_model
+			elasticsearch_index_prefix_field 'viaq_index_name'
+			<elasticsearch_index_name>
+			  enabled 'true'
+			  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+			  name_type static
+			  static_index_name infra-write
+			</elasticsearch_index_name>
+			<elasticsearch_index_name>
+			  enabled 'true'
+			  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+			  name_type static
+			  static_index_name audit-write
+			</elasticsearch_index_name>
+			<elasticsearch_index_name>
+			  enabled 'true'
+			  tag "**"
+			  name_type structured
+			  static_index_name app-write
+			</elasticsearch_index_name>
+		  </filter>
+		  
+		  #remove structured field if present
+		  <filter **>
+			@type record_modifier
+			remove_keys structured
+		  </filter>
+		  
 		  #flatten labels to prevent field explosion in ES
 		  <filter **>
 			  @type record_transformer

--- a/internal/generator/fluentd/pipeline_to_output_test.go
+++ b/internal/generator/fluentd/pipeline_to_output_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -12,8 +13,8 @@ var _ = Describe("Testing Config Generation", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return PipelineToOutputs(&clfspec, generator.NoOptions)
 	}
-	DescribeTable("Pipelines(s) to Output(s)", generator.TestGenerateConfWith(f),
-		Entry("Application to single output", generator.ConfGenerateTest{
+	DescribeTable("Pipelines(s) to Output(s)", unit.TestGenerateConfWith(f),
+		Entry("Application to single output", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -32,7 +33,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Application to multiple outputs", generator.ConfGenerateTest{
+		Entry("Application to multiple outputs", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -82,7 +83,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Application to default output with Labels", generator.ConfGenerateTest{
+		Entry("Application to default output with Labels", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -122,7 +123,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Application to default output with Json Parsing, and Labels", generator.ConfGenerateTest{
+		Entry("Application to default output with Json Parsing, and Labels", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{

--- a/internal/generator/fluentd/sources_test.go
+++ b/internal/generator/fluentd/sources_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -16,8 +17,8 @@ var _ = Describe("Testing Config Generation", func() {
 		}
 		return LogSources(&clfspec, tuning, op)
 	}
-	DescribeTable("Source(s)", generator.TestGenerateConfWith(f),
-		Entry("Only Application", generator.ConfGenerateTest{
+	DescribeTable("Source(s)", unit.TestGenerateConfWith(f),
+		Entry("Only Application", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -60,7 +61,7 @@ var _ = Describe("Testing Config Generation", func() {
 </source>
 `,
 		}),
-		Entry("Only Application with InTail tuning", generator.ConfGenerateTest{
+		Entry("Only Application with InTail tuning", unit.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{
 					Fluentd: &logging.FluentdForwarderSpec{
@@ -113,7 +114,7 @@ var _ = Describe("Testing Config Generation", func() {
 </source>
 `,
 		}),
-		Entry("Only Infrastructure", generator.ConfGenerateTest{
+		Entry("Only Infrastructure", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -174,7 +175,7 @@ var _ = Describe("Testing Config Generation", func() {
 </source>
 `,
 		}),
-		Entry("Only Audit", generator.ConfGenerateTest{
+		Entry("Only Audit", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -251,7 +252,7 @@ var _ = Describe("Testing Config Generation", func() {
 </source>
 `,
 		}),
-		Entry("Only Audit with InTail tuning", generator.ConfGenerateTest{
+		Entry("Only Audit with InTail tuning", unit.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{
 					Fluentd: &logging.FluentdForwarderSpec{
@@ -341,7 +342,7 @@ var _ = Describe("Testing Config Generation", func() {
 </source>
 `,
 		}),
-		Entry("All Log Sources", generator.ConfGenerateTest{
+		Entry("All Log Sources", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -476,8 +477,8 @@ var _ = Describe("Testing Config Generation", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return MetricSources(&clfspec, op)
 	}
-	DescribeTable("Metric Source(s)", generator.TestGenerateConfWith(f),
-		Entry("Any Input", generator.ConfGenerateTest{
+	DescribeTable("Metric Source(s)", unit.TestGenerateConfWith(f),
+		Entry("Any Input", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{

--- a/internal/generator/fluentd/sources_to_pipelines_test.go
+++ b/internal/generator/fluentd/sources_to_pipelines_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,8 +20,8 @@ var _ = Describe("Testing Config Generation", func() {
 			InputsToPipeline(&clfspec, op),
 		)
 	}
-	DescribeTable("Source(s) to Pipeline(s)", generator.TestGenerateConfWith(f),
-		Entry("Send all log types to output by name", generator.ConfGenerateTest{
+	DescribeTable("Source(s) to Pipeline(s)", unit.TestGenerateConfWith(f),
+		Entry("Send all log types to output by name", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -103,7 +104,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Send same logtype to multiple output", generator.ConfGenerateTest{
+		Entry("Send same logtype to multiple output", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -202,7 +203,7 @@ var _ = Describe("Testing Config Generation", func() {
 </label>
 `,
 		}),
-		Entry("Route Logs by Namespace(s)", generator.ConfGenerateTest{
+		Entry("Route Logs by Namespace(s)", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -262,7 +263,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Route Logs by Labels(s)", generator.ConfGenerateTest{
+		Entry("Route Logs by Labels(s)", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -327,7 +328,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Route Logs by Namespaces(s), and Labels(s)", generator.ConfGenerateTest{
+		Entry("Route Logs by Namespaces(s), and Labels(s)", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -394,7 +395,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Send Logs by custom selection, and direct", generator.ConfGenerateTest{
+		Entry("Send Logs by custom selection, and direct", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -481,7 +482,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Complex Case", generator.ConfGenerateTest{
+		Entry("Complex Case", unit.ConfGenerateTest{
 			Desc: "Complex Case",
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -3,6 +3,7 @@ package vector
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -18,7 +19,7 @@ import (
 
 //TODO: Use a detailed CLF spec
 var _ = Describe("Testing Complete Config Generation", func() {
-	var f = func(testcase generator.ConfGenerateTest) {
+	var f = func(testcase unit.ConfGenerateTest) {
 		g := generator.MakeGenerator()
 		if testcase.Options == nil {
 			testcase.Options = generator.Options{}
@@ -38,7 +39,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 		Expect(diff).To(Equal(""))
 	}
 	DescribeTable("Generate full vector.toml", f,
-		Entry("with complex spec", generator.ConfGenerateTest{
+		Entry("with complex spec", unit.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{
 					Fluentd: &logging.FluentdForwarderSpec{
@@ -244,7 +245,7 @@ address = "0.0.0.0:24231"
 default_namespace = "collector"
 `,
 		}),
-		Entry("with complex spec for elastic-search", generator.ConfGenerateTest{
+		Entry("with complex spec for elastic-search", unit.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{},
 			},
@@ -592,7 +593,7 @@ address = "0.0.0.0:24231"
 default_namespace = "collector"
 `,
 		}),
-		Entry("with multiple pipelines for elastic-search", generator.ConfGenerateTest{
+		Entry("with multiple pipelines for elastic-search", unit.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{},
 			},

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -1,6 +1,7 @@
 package elasticsearch
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -18,8 +19,8 @@ var _ = Describe("Generate Vector config", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return Conf(clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], op)
 	}
-	DescribeTable("For Elasticsearch output", generator.TestGenerateConfWith(f),
-		Entry("with username,password", generator.ConfGenerateTest{
+	DescribeTable("For Elasticsearch output", unit.TestGenerateConfWith(f),
+		Entry("with username,password", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -126,7 +127,7 @@ user = "testuser"
 password = "testpass"
 `,
 		}),
-		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+		Entry("with tls key,cert,ca-bundle", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -234,7 +235,7 @@ crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 `,
 		}),
-		Entry("without security", generator.ConfGenerateTest{
+		Entry("without security", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/vector/output/kafka/kafka_test.go
+++ b/internal/generator/vector/output/kafka/kafka_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -17,8 +18,8 @@ var _ = Describe("Generate vector config", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return Conf(clfspec.Outputs[0], []string{"pipeline_1", "pipeline_2"}, secrets[clfspec.Outputs[0].Name], op)
 	}
-	DescribeTable("for kafka output", generator.TestGenerateConfWith(f),
-		Entry("with username,password to single topic", generator.ConfGenerateTest{
+	DescribeTable("for kafka output", unit.TestGenerateConfWith(f),
+		Entry("with username,password to single topic", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -64,7 +65,7 @@ password = "testpass"
 enabled = true
 `,
 		}),
-		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+		Entry("with tls key,cert,ca-bundle", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -106,7 +107,7 @@ ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"
 enabled = true
 `,
 		}),
-		Entry("without security", generator.ConfGenerateTest{
+		Entry("without security", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -1,6 +1,7 @@
 package loki
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	"sort"
 	"testing"
 
@@ -45,8 +46,8 @@ var _ = Describe("Generate vector config", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return Conf(clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], generator.NoOptions)
 	}
-	DescribeTable("for Loki output", generator.TestGenerateConfWith(f),
-		Entry("with default labels", generator.ConfGenerateTest{
+	DescribeTable("for Loki output", unit.TestGenerateConfWith(f),
+		Entry("with default labels", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -90,7 +91,7 @@ user = "username"
 password = "password"
 `,
 		}),
-		Entry("with custom labels", generator.ConfGenerateTest{
+		Entry("with custom labels", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -135,7 +136,7 @@ user = "username"
 password = "password"
 `,
 		}),
-		Entry("with tenant id", generator.ConfGenerateTest{
+		Entry("with tenant id", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -192,8 +193,8 @@ var _ = Describe("Generate vector config for in cluster loki", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return Conf(clfspec.Outputs[0], inputPipeline, secrets[constants.LogCollectorToken], generator.NoOptions)
 	}
-	DescribeTable("for Loki output", generator.TestGenerateConfWith(f),
-		Entry("with bearer token", generator.ConfGenerateTest{
+	DescribeTable("for Loki output", unit.TestGenerateConfWith(f),
+		Entry("with bearer token", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -14,8 +15,8 @@ var _ = Describe("Vector Config Generation", func() {
 			LogSources(&clfspec, op),
 		)
 	}
-	DescribeTable("Source(s)", generator.TestGenerateConfWith(f),
-		Entry("Only Application", generator.ConfGenerateTest{
+	DescribeTable("Source(s)", unit.TestGenerateConfWith(f),
+		Entry("Only Application", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -35,7 +36,7 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 `,
 		}),
-		Entry("Only Infrastructure", generator.ConfGenerateTest{
+		Entry("Only Infrastructure", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -58,7 +59,7 @@ exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.
 type = "journald"
 `,
 		}),
-		Entry("Only Audit", generator.ConfGenerateTest{
+		Entry("Only Audit", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -90,7 +91,7 @@ ignore_older_secs = 600
 include = ["/var/log/oauth-apiserver.audit.log"]
 `,
 		}),
-		Entry("All Log Sources", generator.ConfGenerateTest{
+		Entry("All Log Sources", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{

--- a/internal/generator/vector/sources_to_pipelines_test.go
+++ b/internal/generator/vector/sources_to_pipelines_test.go
@@ -3,9 +3,9 @@ package vector
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
-
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/test/framework/unit"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,8 +17,8 @@ var _ = Describe("Testing Config Generation", func() {
 			InputsToPipelines(&clfspec, op),
 		)
 	}
-	DescribeTable("Source(s) to Pipeline(s)", generator.TestGenerateConfWith(f),
-		Entry("Send all log types to output by name", generator.ConfGenerateTest{
+	DescribeTable("Source(s) to Pipeline(s)", unit.TestGenerateConfWith(f),
+		Entry("Send all log types to output by name", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -75,7 +75,7 @@ source = """
 """
 `,
 		}),
-		Entry("Send same logtype to multiple output", generator.ConfGenerateTest{
+		Entry("Send same logtype to multiple output", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -147,7 +147,7 @@ source = """
 """
 `,
 		}),
-		Entry("Route Logs by Namespace(s)", generator.ConfGenerateTest{
+		Entry("Route Logs by Namespace(s)", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -195,7 +195,7 @@ source = """
 """
 `,
 		}),
-		Entry("Route Logs by Namespaces(s), and Labels(s)", generator.ConfGenerateTest{
+		Entry("Route Logs by Namespaces(s), and Labels(s)", unit.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{

--- a/internal/k8shandler/fluentd.go
+++ b/internal/k8shandler/fluentd.go
@@ -116,6 +116,7 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *v1.Co
 		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "spec.nodeName"}}},
 		{Name: "METRICS_CERT", Value: "/etc/fluent/metrics/tls.crt"},
 		{Name: "METRICS_KEY", Value: "/etc/fluent/metrics/tls.key"},
+		{Name: "K8S_NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "spec.nodeName"}}},
 		{Name: "NODE_IPV4", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.hostIP"}}},
 		{Name: "POD_IP", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"}}},
 	}

--- a/internal/runtime/core.go
+++ b/internal/runtime/core.go
@@ -70,6 +70,15 @@ func NewRole(namespace, name string, rules ...rbacv1.PolicyRule) *rbacv1.Role {
 	return role
 }
 
+//NewClusterRole returns a role with namespace, names, rules
+func NewClusterRole(name string, rules ...rbacv1.PolicyRule) *rbacv1.ClusterRole {
+	role := &rbacv1.ClusterRole{
+		Rules: rules,
+	}
+	Initialize(role, "", name)
+	return role
+}
+
 //NewRoleBinding returns a role with namespace, names, rules
 func NewRoleBinding(namespace, name string, roleRef rbacv1.RoleRef, subjects ...rbacv1.Subject) *rbacv1.RoleBinding {
 	binding := &rbacv1.RoleBinding{
@@ -77,5 +86,15 @@ func NewRoleBinding(namespace, name string, roleRef rbacv1.RoleRef, subjects ...
 		Subjects: subjects,
 	}
 	Initialize(binding, namespace, name)
+	return binding
+}
+
+//NewClusterRoleBinding returns a role with namespace, names, rules
+func NewClusterRoleBinding(name string, roleRef rbacv1.RoleRef, subjects ...rbacv1.Subject) *rbacv1.ClusterRoleBinding {
+	binding := &rbacv1.ClusterRoleBinding{
+		RoleRef:  roleRef,
+		Subjects: subjects,
+	}
+	Initialize(binding, "", name)
 	return binding
 }

--- a/test/framework/functional/fluentd/deploy.go
+++ b/test/framework/functional/fluentd/deploy.go
@@ -42,6 +42,7 @@ mkdir -p /var/log/pods/%s_functional_123456789-0/loader-0
 func (c *FluentdCollector) BuildCollectorContainer(b *runtime.ContainerBuilder, nodeName string) *runtime.ContainerBuilder {
 	return b.AddEnvVar("LOG_LEVEL", adaptLogLevel()).
 		AddEnvVarFromFieldRef("POD_IP", "status.podIP").
+		AddEnvVarFromFieldRef("K8S_NODE_NAME", "spec.nodeName").
 		AddEnvVar("NODE_NAME", nodeName).
 		AddVolumeMount("config", "/etc/fluent/configs.d/user", "", true).
 		AddVolumeMount("entrypoint", "/opt/app-root/src/run.sh", "run.sh", true).

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -190,9 +190,9 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 		return err
 	}
 
-	role := runtime.NewRole(f.Test.NS.Name, f.Name,
+	role := runtime.NewClusterRole(fmt.Sprintf("%s-%s", f.Test.NS.Name, f.Name),
 		v1.PolicyRule{
-			Verbs:     []string{"list", "get"},
+			Verbs:     []string{"list", "get", "watch"},
 			Resources: []string{"pods", "namespaces"},
 			APIGroups: []string{""},
 		},
@@ -200,15 +200,16 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 	if err = f.Test.Client.Create(role); err != nil {
 		return err
 	}
-	rolebinding := runtime.NewRoleBinding(f.Test.NS.Name, f.Name,
+	rolebinding := runtime.NewClusterRoleBinding(fmt.Sprintf("%s-%s", f.Test.NS.Name, f.Name),
 		v1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
+			Kind:     "ClusterRole",
 			Name:     role.Name,
 		},
 		v1.Subject{
-			Kind: "ServiceAccount",
-			Name: "default",
+			Kind:      "ServiceAccount",
+			Name:      "default",
+			Namespace: f.Test.NS.Name,
 		},
 	)
 	if err = f.Test.Client.Create(rolebinding); err != nil {

--- a/test/framework/functional/message_templates.go
+++ b/test/framework/functional/message_templates.go
@@ -30,6 +30,21 @@ var (
 		FlatLabels:       []string{"*"},
 		NamespaceLabels:  map[string]string{"*": "*"},
 	}
+	templateForInfraKubernetes = types.Kubernetes{
+		ContainerName:     "*",
+		PodName:           "*",
+		NamespaceName:     "*",
+		NamespaceID:       "**optional**",
+		OrphanedNamespace: "**optional**",
+		ContainerImage:    "**optional**",
+		ContainerImageID:  "**optional**",
+		PodID:             "**optional**",
+		PodIP:             "**optional**",
+		Host:              "**optional**",
+		MasterURL:         "**optional**",
+		FlatLabels:        []string{"*"},
+		NamespaceLabels:   map[string]string{"*": "*"},
+	}
 )
 
 func NewApplicationLogTemplate() types.ApplicationLog {
@@ -50,5 +65,24 @@ func NewApplicationLogTemplate() types.ApplicationLog {
 			ContainerID: "*",
 		},
 		Kubernetes: templateForAnyKubernetes,
+	}
+}
+
+// NewContainerInfrastructureLogTemplate creates a generally expected template for infrastructure container logs
+func NewContainerInfrastructureLogTemplate() types.ApplicationLog {
+	return types.ApplicationLog{
+		Timestamp: time.Time{},
+		Message:   "*",
+		LogType:   "infrastructure",
+		Level:     "*",
+		Hostname:  "*",
+		ViaqMsgID: "*",
+		Openshift: types.OpenshiftMeta{
+			Labels:   map[string]string{"*": "*"},
+			Sequence: types.NewOptionalInt(""),
+		},
+		PipelineMetadata: TemplateForAnyPipelineMetadata,
+		Docker:           types.Docker{},
+		Kubernetes:       templateForInfraKubernetes,
 	}
 }

--- a/test/framework/functional/write.go
+++ b/test/framework/functional/write.go
@@ -21,6 +21,9 @@ func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLogForContainer
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
 
+// WriteMessagesInfraContainerLog mocks writing infra container logs for the functional framework.  This may require
+// enabling the mock api adapter to get metadata for infrastructure logs since the path does not match a pod
+// running on the cluster (e.g framework.VisitConfig = functional.TestAPIAdapterConfigVisitor)
 func (f *CollectorFunctionalFramework) WriteMessagesToInfraContainerLog(msg string, numOfLogs int) error {
 	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], "openshift-fake-infra", f.Pod.Name, f.Pod.UID, constants.CollectorName)
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)

--- a/test/functional/normalization/json_parsing_test.go
+++ b/test/functional/normalization/json_parsing_test.go
@@ -234,7 +234,7 @@ var _ = Describe("[Functional][Normalization]Json log parsing", func() {
 		ExpectOK(framework.Deploy())
 
 		// Log message data
-		sample := `{"@timestamp":"2021-12-14T15:12:47.645Z","message":"Building mime message for recipient 'auser@somedomain.com' and sender 'Sympany <no-reply@somedomain>'.","level":"DEBUG","logger_name":"ch.sympany.backend.notificationservice.mail.MailServiceBean","thread_name":"default task-4","mdc":{}}`
+		sample := `{"@timestamp":"2021-12-14T15:12:47.645Z","message":"Building mime message for recipient 'auser@somedomain.com' and sender 'Sympany <no-reply@somedomain>'.","level":"DEBUG","logger_name":"ch.sympany.backend.notificationservice.mail.MailServiceBean","thread_name":"default task-4"}`
 		expectedMessage = normalizeJson(sample)
 		expected = map[string]interface{}{}
 		_ = json.Unmarshal([]byte(sample), &expected)

--- a/test/functional/outputs/forward_to_elasticsearch_index_test.go
+++ b/test/functional/outputs/forward_to_elasticsearch_index_test.go
@@ -30,13 +30,14 @@ var _ = Describe("[Functional][Outputs][ElasticSearch][Index] FluentdForward Out
 	)
 
 	var (
-		framework *functional.CollectorFunctionalFramework
-
-		// Template expected as output Log
-		outputLogTemplate = functional.NewApplicationLogTemplate()
+		framework         *functional.CollectorFunctionalFramework
+		outputLogTemplate types.ApplicationLog
 	)
 
 	BeforeEach(func() {
+		// Template expected as output Log
+		outputLogTemplate = functional.NewApplicationLogTemplate()
+		outputLogTemplate.ViaqIndexName = "app-write"
 		framework = functional.NewCollectorFunctionalFramework()
 	})
 	AfterEach(func() {
@@ -79,6 +80,57 @@ var _ = Describe("[Functional][Outputs][ElasticSearch][Index] FluentdForward Out
 			Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 10)).To(BeNil())
 
 			raw, err := framework.GetLogsFromElasticSearchIndex(logging.OutputTypeElasticsearch, ESIndexName)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(raw).To(Not(BeEmpty()))
+
+			// Parse log line
+			var logs []types.ApplicationLog
+			err = types.StrictlyParseLogs(raw, &logs)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+			// Compare to expected template
+			outputTestLog := logs[0]
+			outputLogTemplate.ViaqIndexName = ""
+			Expect(outputTestLog).To(matchers.FitLogFormatTemplate(outputLogTemplate))
+		})
+		It("should not send logs to structuredTypeName for infrastructure sources", func() {
+			outputLogTemplate = functional.NewContainerInfrastructureLogTemplate()
+			outputLogTemplate.ViaqIndexName = "infra-write"
+			clfb := functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(logging.InputNameInfrastructure).
+				ToOutputWithVisitor(withStructuredTypeName,
+					logging.OutputTypeElasticsearch)
+			clfb.Forwarder.Spec.Pipelines[0].Parse = "json"
+			Expect(framework.Deploy()).To(BeNil())
+
+			applicationLogLine := functional.CreateAppLogFromJson(jsonLog)
+			Expect(framework.WriteMessagesToInfraContainerLog(applicationLogLine, 10)).To(BeNil())
+
+			raw, err := framework.GetLogsFromElasticSearchIndex(logging.OutputTypeElasticsearch, outputLogTemplate.ViaqIndexName)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(raw).To(Not(BeEmpty()))
+
+			// Parse log line
+			var logs []types.ApplicationLog
+			err = types.StrictlyParseLogs(raw, &logs)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+			// Compare to expected template
+			outputTestLog := logs[0]
+			outputLogTemplate.ViaqIndexName = ""
+			Expect(outputTestLog).To(matchers.FitLogFormatTemplate(outputLogTemplate))
+		})
+		It("should not send to k8s label structuredTypeKey for infrastructure sources", func() {
+			outputLogTemplate = functional.NewContainerInfrastructureLogTemplate()
+			outputLogTemplate.ViaqIndexName = "infra-write"
+			clfb := functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(logging.InputNameInfrastructure).
+				ToOutputWithVisitor(withK8sLabelsTypeKey, logging.OutputTypeElasticsearch)
+			clfb.Forwarder.Spec.Pipelines[0].Parse = "json"
+			visitors := append(framework.AddOutputContainersVisitors(), setPodLabelsVisitor)
+			Expect(framework.DeployWithVisitors(visitors)).To(BeNil())
+
+			applicationLogLine := functional.CreateAppLogFromJson(jsonLog)
+			Expect(framework.WriteMessagesToInfraContainerLog(applicationLogLine, 10)).To(BeNil())
+			raw, err := framework.GetLogsFromElasticSearchIndex(logging.OutputTypeElasticsearch, "infra-write")
 			Expect(err).To(BeNil(), "Expected no errors reading the logs")
 			Expect(raw).To(Not(BeEmpty()))
 

--- a/test/matchers/diff.go
+++ b/test/matchers/diff.go
@@ -52,6 +52,7 @@ func (m *lineMatcher) NegatedFailureMessage(actual interface{}) (message string)
 }
 
 func (m *lineMatcher) normalize(in string) []string {
+
 	out := []string{}
 	for _, line := range strings.Split(in, "\n") {
 		if m.trim {


### PR DESCRIPTION
### Description
This PR:
* fixes the case where structured logging is enabled and infra source logs are sent to an application structured index
* enables watch of the api server
* disables allowing_orphan

ref: https://issues.redhat.com/browse/LOG-2553