### PR TITLE
LOG-2657:Add ability to encoding bad characters for elasticsearch and cloudwatch

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -643,6 +643,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
   #remove structured field if present
   <filter **>
     @type record_modifier
+    char_encoding ascii-8bit:utf-8
     remove_keys structured
   </filter>
   

--- a/internal/generator/fluentd/elements/record_modifier.go
+++ b/internal/generator/fluentd/elements/record_modifier.go
@@ -1,8 +1,23 @@
 package elements
 
+// Fluentd including some plugins treats logs as a BINARY by default to forward.
+// But sometimes storage can't proceed some chars, eg ElasticSearch.
+// Plugin record_modifier can help resolve such problem.
+// In char_encoding from:to case, it replaces invalid character with safe character.
+// <filter pattern>
+//   @type record_modifier
+//   # change char encoding from 'ASCII-8BIT' to 'UTF-8'
+//   char_encoding ascii-8bit:utf-8
+//  </filter>
+// */
+
+const DefaultCharEncoding = "ascii-8bit:utf-8"
+const CharEncoding = "charEncoding"
+
 type RecordModifier struct {
-	Records    []Record
-	RemoveKeys []string
+	Records      []Record
+	RemoveKeys   []string
+	CharEncoding string
 }
 
 func (rm RecordModifier) Name() string {
@@ -12,6 +27,9 @@ func (rm RecordModifier) Name() string {
 func (rm RecordModifier) Template() string {
 	return `{{define "` + rm.Name() + `"  -}}
 @type record_modifier
+{{if .CharEncoding -}}
+char_encoding {{.CharEncoding}}
+{{end -}}
 {{if .Records -}}
 <record>
 {{- range $Index, $Record := .Records}}

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -693,8 +693,9 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_ES_1>
   #remove structured field if present
   <filter **>
-    @type record_modifier
-    remove_keys structured
+	@type record_modifier
+    char_encoding ascii-8bit:utf-8
+	remove_keys structured
   </filter>
   
   #flatten labels to prevent field explosion in ES
@@ -796,8 +797,9 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_ES_2>
   #remove structured field if present
   <filter **>
-    @type record_modifier
-    remove_keys structured
+	@type record_modifier
+    char_encoding ascii-8bit:utf-8
+	remove_keys structured
   </filter>
   
   #flatten labels to prevent field explosion in ES
@@ -1460,8 +1462,9 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_ES_1>
   #remove structured field if present
   <filter **>
-    @type record_modifier
-    remove_keys structured
+	@type record_modifier
+    char_encoding ascii-8bit:utf-8
+	remove_keys structured
   </filter>
   
   #flatten labels to prevent field explosion in ES
@@ -1563,8 +1566,9 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_ES_2>
   #remove structured field if present
   <filter **>
-    @type record_modifier
-    remove_keys structured
+	@type record_modifier
+    char_encoding ascii-8bit:utf-8
+	remove_keys structured
   </filter>
   
   #flatten labels to prevent field explosion in ES
@@ -2231,8 +2235,9 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_ES_1>
   #remove structured field if present
   <filter **>
-    @type record_modifier
-    remove_keys structured
+	@type record_modifier
+    char_encoding ascii-8bit:utf-8
+	remove_keys structured
   </filter>
   
   #flatten labels to prevent field explosion in ES
@@ -2334,8 +2339,9 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_ES_2>
   #remove structured field if present
   <filter **>
-    @type record_modifier
-    remove_keys structured
+	@type record_modifier
+    char_encoding ascii-8bit:utf-8
+	remove_keys structured
   </filter>
   
   #flatten labels to prevent field explosion in ES
@@ -3515,8 +3521,9 @@ var _ = Describe("Generating fluentd config", func() {
 <label @INFRA_ES>
   #remove structured field if present
   <filter **>
-    @type record_modifier
-    remove_keys structured
+	@type record_modifier
+    char_encoding ascii-8bit:utf-8
+	remove_keys structured
   </filter>
   
   #flatten labels to prevent field explosion in ES
@@ -3618,8 +3625,9 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_ES_1>
   #remove structured field if present
   <filter **>
-    @type record_modifier
-    remove_keys structured
+	@type record_modifier
+    char_encoding ascii-8bit:utf-8
+	remove_keys structured
   </filter>
   
   #flatten labels to prevent field explosion in ES
@@ -3721,8 +3729,9 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_ES_2>
   #remove structured field if present
   <filter **>
-    @type record_modifier
-    remove_keys structured
+	@type record_modifier
+    char_encoding ascii-8bit:utf-8
+	remove_keys structured
   </filter>
   
   #flatten labels to prevent field explosion in ES
@@ -3824,8 +3833,9 @@ var _ = Describe("Generating fluentd config", func() {
 <label @AUDIT_ES>
   #remove structured field if present
   <filter **>
-    @type record_modifier
-    remove_keys structured
+	@type record_modifier
+    char_encoding ascii-8bit:utf-8
+	remove_keys structured
   </filter>
   
   #flatten labels to prevent field explosion in ES

--- a/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
@@ -68,13 +68,13 @@ func Conf(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o logging.O
 			SubElements: []Element{
 				GroupNameStreamName(fmt.Sprintf("%sinfrastructure", logGroupPrefix),
 					"${record['hostname']}.${tag}",
-					source.InfraTagsForMultilineEx),
+					source.InfraTagsForMultilineEx, op),
 				GroupNameStreamName(fmt.Sprintf("%s%s", logGroupPrefix, logGroupName),
 					"${tag}",
-					source.ApplicationTagsForMultilineEx),
+					source.ApplicationTagsForMultilineEx, op),
 				GroupNameStreamName(fmt.Sprintf("%saudit", logGroupPrefix),
 					"${record['hostname']}.${tag}",
-					source.AuditTags),
+					source.AuditTags, op),
 				OutputConf(bufspec, secret, o, op),
 			},
 		},
@@ -108,21 +108,25 @@ func EndpointConfig(o logging.OutputSpec) Element {
 	}
 }
 
-func GroupNameStreamName(groupName, streamName, tag string) Element {
-	return Filter{
-		MatchTags: tag,
-		Element: RecordModifier{
-			Records: []Record{
-				{
-					Key:        "cw_group_name",
-					Expression: groupName,
-				},
-				{
-					Key:        "cw_stream_name",
-					Expression: streamName,
-				},
+func GroupNameStreamName(groupName, streamName, tag string, op Options) Element {
+	recordModifier := RecordModifier{
+		Records: []Record{
+			{
+				Key:        "cw_group_name",
+				Expression: groupName,
+			},
+			{
+				Key:        "cw_stream_name",
+				Expression: streamName,
 			},
 		},
+	}
+	if op[CharEncoding] != nil {
+		recordModifier.CharEncoding = fmt.Sprintf("%v", op[CharEncoding])
+	}
+	return Filter{
+		MatchTags: tag,
+		Element:   recordModifier,
 	}
 }
 

--- a/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -53,7 +54,7 @@ var _ = Describe("Generating fluentd config", func() {
 				expConf := `
 <label @MY_CLOUDWATCH>
   <filter ` + source.InfraTagsForMultilineEx + `>
-     @type record_modifier
+    @type record_modifier
     <record>
       cw_group_name infrastructure
       cw_stream_name ${record['hostname']}.${tag}
@@ -162,7 +163,7 @@ var _ = Describe("Generating fluentd config", func() {
 				expConf := `
 <label @MY_CLOUDWATCH>
   <filter ` + source.InfraTagsForMultilineEx + `>
-   @type record_modifier
+    @type record_modifier
     <record>
       cw_group_name foo.infrastructure
       cw_stream_name ${record['hostname']}.${tag}
@@ -203,6 +204,62 @@ var _ = Describe("Generating fluentd config", func() {
 `
 
 				es := Conf(nil, secrets[output.Secret.Name], output, nil)
+				results, err := g.GenerateConf(es...)
+				Expect(err).To(BeNil())
+				Expect(results).To(EqualTrimLines(expConf))
+			})
+		})
+		Context("with encoding bad char", func() {
+			BeforeEach(func() {
+				output.Cloudwatch.GroupBy = loggingv1.LogGroupByLogType
+			})
+			It("should provide a valid configuration", func() {
+				expConf := `
+<label @MY_CLOUDWATCH>
+  <filter ` + source.InfraTagsForMultilineEx + `>
+    @type record_modifier
+    char_encoding ascii-8bit:utf-8
+    <record>
+      cw_group_name foo.infrastructure
+      cw_stream_name ${record['hostname']}.${tag}
+    </record>
+  </filter>
+  
+  <filter ` + source.ApplicationTagsForMultilineEx + `>
+    @type record_modifier
+    char_encoding ascii-8bit:utf-8
+    <record>
+      cw_group_name foo.application
+      cw_stream_name ${tag}
+    </record>
+  </filter>
+  
+  <filter ` + source.AuditTags + `>
+    @type record_modifier
+    char_encoding ascii-8bit:utf-8
+    <record>
+      cw_group_name foo.audit
+      cw_stream_name ${record['hostname']}.${tag}
+    </record>
+  </filter>
+  
+  <match **>
+    @type cloudwatch_logs
+    auto_create_stream true
+    region anumber1
+    log_group_name_key cw_group_name
+    log_stream_name_key cw_stream_name
+    remove_log_stream_name_key true
+    remove_log_group_name_key true
+    concurrency 2
+    aws_key_id "#{open('/var/run/ocp-collector/secrets/my-secret/aws_access_key_id','r') do |f|f.read.strip end}"
+    aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
+    include_time_key true
+    log_rejected_request true
+  </match>
+</label>
+`
+				es := Conf(nil, secrets[output.Secret.Name], output, map[string]interface{}{elements.CharEncoding: elements.DefaultCharEncoding})
 				results, err := g.GenerateConf(es...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))

--- a/internal/generator/fluentd/outputs.go
+++ b/internal/generator/fluentd/outputs.go
@@ -3,6 +3,7 @@ package fluentd
 import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	. "github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/cloudwatch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/elasticsearch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/fluentdforward"
@@ -27,12 +28,18 @@ func Outputs(clspec *logging.ClusterLoggingSpec, secrets map[string]*corev1.Secr
 		secret := secrets[o.Name]
 		switch o.Type {
 		case logging.OutputTypeElasticsearch:
+			if _, ok := op[elements.CharEncoding]; !ok {
+				op[elements.CharEncoding] = elements.DefaultCharEncoding
+			}
 			outputs = MergeElements(outputs, elasticsearch.Conf(bufspec, secret, o, op))
 		case logging.OutputTypeFluentdForward:
 			outputs = MergeElements(outputs, fluentdforward.Conf(bufspec, secret, o, op))
 		case logging.OutputTypeKafka:
 			outputs = MergeElements(outputs, kafka.Conf(bufspec, secret, o, op))
 		case logging.OutputTypeCloudwatch:
+			if _, ok := op[elements.CharEncoding]; !ok {
+				op[elements.CharEncoding] = elements.DefaultCharEncoding
+			}
 			outputs = MergeElements(outputs, cloudwatch.Conf(bufspec, secret, o, op))
 		case logging.OutputTypeSyslog:
 			outputs = MergeElements(outputs, syslog.Conf(bufspec, secret, o, op))


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Add to the `fluent.conf` for `Elasticsearch` and `Cloudwatch` storage:
```
<filter **>
  @type record_modifier
  char_encoding ascii-8bit:utf-8
</filter>
```
to be ensured  utf8 and replace bad chars


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

Manually cherry-picked https://github.com/openshift/cluster-logging-operator/pull/1465
### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2657
- Enhancement proposal:
