### PR TITLE
LOG-2596: Fix the condition in [transforms.route_container_logs] in the configuration file for Vector 

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -537,7 +537,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
   </filter>
   
   # Include Infrastructure logs
-  <match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+  <match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
     @type relabel
     @label @_INFRASTRUCTURE
   </match>
@@ -628,7 +628,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -567,7 +567,7 @@ var _ = Describe("Generating fluentd config", func() {
   </filter>
   
   # Discard Infrastructure logs
-  <match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+  <match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
     @type null
   </match>
   
@@ -679,7 +679,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -807,7 +807,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -1383,7 +1383,7 @@ var _ = Describe("Generating fluentd config", func() {
   </filter>
   
   # Discard Infrastructure logs
-  <match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+  <match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
     @type null
   </match>
   
@@ -1478,7 +1478,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -1606,7 +1606,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -2184,7 +2184,7 @@ var _ = Describe("Generating fluentd config", func() {
   </filter>
   
   # Discard Infrastructure logs
-  <match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+  <match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
     @type null
   </match>
   
@@ -2281,7 +2281,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
       static_index_name infra-write
 	</elasticsearch_index_name>
@@ -2409,7 +2409,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -2930,7 +2930,7 @@ var _ = Describe("Generating fluentd config", func() {
   </filter>
   
   # Discard Infrastructure logs
-  <match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+  <match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
     @type null
   </match>
   
@@ -3470,7 +3470,7 @@ var _ = Describe("Generating fluentd config", func() {
   </filter>
   
   # Include Infrastructure logs
-  <match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+  <match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
     @type relabel
     @label @_INFRASTRUCTURE
   </match>
@@ -3579,7 +3579,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -3707,7 +3707,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -3835,7 +3835,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -3963,7 +3963,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -4557,7 +4557,7 @@ inputs:
   </filter>
   
   # Discard Infrastructure logs
-  <match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+  <match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
     @type null
   </match>
   

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
@@ -200,7 +200,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
@@ -343,7 +343,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
@@ -475,7 +475,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
@@ -619,7 +619,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
@@ -760,7 +760,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
       structured_type_annotation_prefix containerType_logging_openshift_io
@@ -896,7 +896,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
       structured_type_key kubernetes.labels.foo-bar
@@ -1032,7 +1032,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>

--- a/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
+++ b/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
@@ -72,7 +72,7 @@ func (im IndexModel) Template() string {
   elasticsearch_index_prefix_field 'viaq_index_name'
   <elasticsearch_index_name>
     enabled 'true'
-    tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+    tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
     name_type static
     static_index_name infra-write
 {{if (ne .StructuredTypeKey "") -}}

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Generating fluentd config", func() {
 			elasticsearch_index_prefix_field 'viaq_index_name'
 			<elasticsearch_index_name>
 			  enabled 'true'
-			  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+			  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 			  name_type static
 			  static_index_name infra-write
 			</elasticsearch_index_name>
@@ -232,7 +232,7 @@ var _ = Describe("Generating fluentd config", func() {
 			elasticsearch_index_prefix_field 'viaq_index_name'
 			<elasticsearch_index_name>
 			  enabled 'true'
-			  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+			  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 			  name_type static
 			  static_index_name infra-write
 			</elasticsearch_index_name>
@@ -359,7 +359,7 @@ var _ = Describe("Generating fluentd config", func() {
 			elasticsearch_index_prefix_field 'viaq_index_name'
 			<elasticsearch_index_name>
 			  enabled 'true'
-			  tag "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+			  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
 			  name_type static
 			  static_index_name infra-write
 			</elasticsearch_index_name>

--- a/internal/generator/fluentd/source/tags.go
+++ b/internal/generator/fluentd/source/tags.go
@@ -4,7 +4,7 @@ const (
 	ApplicationTags               = "kubernetes.**"
 	ApplicationTagsForMultilineEx = "/^(?!(kubernetes\\.|)var\\.log\\.pods\\.openshift-.+_|(kubernetes\\.|)var\\.log\\.pods\\.default_|(kubernetes\\.|)var\\.log\\.pods\\.kube-.+_|journal\\.|system\\.var\\.log|linux-audit\\.log|k8s-audit\\.log|openshift-audit\\.log|ovn-audit\\.log).+/"
 	JournalTags                   = "journal.** system.var.log**"
-	InfraContainerTags            = "kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_**"
+	InfraContainerTags            = "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_**"
 	InfraTags                     = InfraContainerTags + " " + JournalTags
 	InfraTagsForMultilineEx       = InfraTags + " var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_**"
 	AuditTags                     = "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"

--- a/internal/generator/fluentd/sources_to_pipelines_test.go
+++ b/internal/generator/fluentd/sources_to_pipelines_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Testing Config Generation", func() {
 			},
 			ExpectedConf: `
 # Include Infrastructure logs
-<match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+<match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
   @type relabel
   @label @_INFRASTRUCTURE
 </match>
@@ -126,7 +126,7 @@ var _ = Describe("Testing Config Generation", func() {
 			},
 			ExpectedConf: `
 # Include Infrastructure logs
-<match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+<match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
   @type relabel
   @label @_INFRASTRUCTURE
 </match>
@@ -222,7 +222,7 @@ var _ = Describe("Testing Config Generation", func() {
 			},
 			ExpectedConf: `
 # Discard Infrastructure logs
-<match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+<match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
   @type null
 </match>
 
@@ -287,7 +287,7 @@ var _ = Describe("Testing Config Generation", func() {
 			},
 			ExpectedConf: `
 # Discard Infrastructure logs
-<match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+<match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
   @type null
 </match>
 
@@ -353,7 +353,7 @@ var _ = Describe("Testing Config Generation", func() {
 			},
 			ExpectedConf: `
 # Discard Infrastructure logs
-<match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+<match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
   @type null
 </match>
 
@@ -425,7 +425,7 @@ var _ = Describe("Testing Config Generation", func() {
 			},
 			ExpectedConf: `
 # Discard Infrastructure logs
-<match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+<match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
   @type null
 </match>
 
@@ -527,7 +527,7 @@ var _ = Describe("Testing Config Generation", func() {
 			},
 			ExpectedConf: `
 # Discard Infrastructure logs
-<match kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+<match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
   @type null
 </match>
 

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -170,8 +170,8 @@ source = """
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!((starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default"))'
-route.infra = '(starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default")'
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
+route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube")'
 
 # Rename log stream to "application"
 [transforms.application]
@@ -369,8 +369,8 @@ source = """
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!((starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default"))'
-route.infra = '(starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default")'
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
+route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube")'
 
 # Rename log stream to "application"
 [transforms.application]

--- a/internal/generator/vector/inputs.go
+++ b/internal/generator/vector/inputs.go
@@ -2,12 +2,11 @@ package vector
 
 import (
 	"fmt"
-	"sort"
-
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 	. "github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"sort"
 )
 
 const (
@@ -15,8 +14,8 @@ const (
 	NsOpenshift = "openshift"
 	NsDefault   = "default"
 
-	K8sPodNamespace = ".kubernetes.namespace_name"
-	K8sLabelKeyExpr = ".kubernetes.pod_labels.%s"
+	K8sNamespaceName = ".kubernetes.namespace_name"
+	K8sLabelKeyExpr  = ".kubernetes.pod_labels.%s"
 
 	InputContainerLogs   = "container_logs"
 	InputJournalLogs     = "journal_logs"
@@ -27,9 +26,11 @@ const (
 
 var (
 	InfraContainerLogs = OR(
-		StartWith(K8sPodNamespace, NsKube),
-		StartWith(K8sPodNamespace, NsOpenshift),
-		Eq(K8sPodNamespace, NsDefault))
+		StartWith(K8sNamespaceName, NsKube+"-"),
+		StartWith(K8sNamespaceName, NsOpenshift+"-"),
+		Eq(K8sNamespaceName, NsDefault),
+		Eq(K8sNamespaceName, NsOpenshift),
+		Eq(K8sNamespaceName, NsKube))
 	AppContainerLogs = Neg(Paren(InfraContainerLogs))
 
 	AddLogTypeApp   = fmt.Sprintf(".log_type = %q", logging.InputNameApplication)
@@ -37,7 +38,7 @@ var (
 	AddLogTypeAudit = fmt.Sprintf(".log_type = %q", logging.InputNameAudit)
 
 	MatchNS = func(ns string) string {
-		return Eq(K8sPodNamespace, ns)
+		return Eq(K8sNamespaceName, ns)
 	}
 	K8sLabelKey = func(k string) string {
 		return fmt.Sprintf(K8sLabelKeyExpr, k)

--- a/internal/generator/vector/sources_to_pipelines_test.go
+++ b/internal/generator/vector/sources_to_pipelines_test.go
@@ -36,8 +36,8 @@ var _ = Describe("Testing Config Generation", func() {
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!((starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default"))'
-route.infra = '(starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default")'
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
+route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube")'
 
 # Rename log stream to "application"
 [transforms.application]
@@ -96,8 +96,8 @@ source = """
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!((starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default"))'
-route.infra = '(starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default")'
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
+route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube")'
 
 # Rename log stream to "application"
 [transforms.application]
@@ -160,7 +160,7 @@ source = """
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!((starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default"))'
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
 
 # Rename log stream to "application"
 [transforms.application]
@@ -211,7 +211,7 @@ source = """
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!((starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default"))'
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
 
 # Rename log stream to "application"
 [transforms.application]
@@ -251,8 +251,8 @@ source = """
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!((starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default"))'
-route.infra = '(starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default")'
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
+route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube")'
 
 # Rename log stream to "application"
 [transforms.application]
@@ -293,8 +293,8 @@ source = """
 [transforms.route_container_logs]
 type = "route"
 inputs = ["container_logs"]
-route.app = '!((starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default"))'
-route.infra = '(starts_with!(.kubernetes.namespace_name,"kube")) || (starts_with!(.kubernetes.namespace_name,"openshift")) || (.kubernetes.namespace_name == "default")'
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
+route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube")'
 
 # Rename log stream to "application"
 [transforms.application]


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Fix the condition in [transforms.route_container_logs] in the configuration file for Vector. 
All container logs from namespaces which name start with  `kube-`, `openshift-` or equals `default`, `openshift` should be treated as infra logs,  otherwise are application logs.



<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @jcantrill <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @vimalk78 <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2596
- Enhancement proposal:
