### PR TITLE
LOG-2677: Update critical normalization to be like others

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -481,7 +481,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
     </level>
     <level>
       name critical
-      match 'Critical|CRITICAL|C[0-9]+|level=critical|Value:critical|"level":"critical"'
+      match 'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'
     </level>
     <level>
       name debug

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -524,7 +524,7 @@ var _ = Describe("Generating fluentd config", func() {
     </level>
     <level>
       name critical
-      match 'Critical|CRITICAL|C[0-9]+|level=critical|Value:critical|"level":"critical"'
+      match 'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'
     </level>
     <level>
       name debug
@@ -1358,7 +1358,7 @@ var _ = Describe("Generating fluentd config", func() {
     </level>
     <level>
       name critical
-      match 'Critical|CRITICAL|C[0-9]+|level=critical|Value:critical|"level":"critical"'
+      match 'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'
     </level>
     <level>
       name debug
@@ -2177,7 +2177,7 @@ var _ = Describe("Generating fluentd config", func() {
     </level>
     <level>
       name critical
-      match 'Critical|CRITICAL|C[0-9]+|level=critical|Value:critical|"level":"critical"'
+      match 'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'
     </level>
     <level>
       name debug
@@ -2941,7 +2941,7 @@ var _ = Describe("Generating fluentd config", func() {
     </level>
     <level>
       name critical
-      match 'Critical|CRITICAL|C[0-9]+|level=critical|Value:critical|"level":"critical"'
+      match 'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'
     </level>
     <level>
       name debug
@@ -3499,7 +3499,7 @@ var _ = Describe("Generating fluentd config", func() {
     </level>
     <level>
       name critical
-      match 'Critical|CRITICAL|C[0-9]+|level=critical|Value:critical|"level":"critical"'
+      match 'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'
     </level>
     <level>
       name debug
@@ -4604,7 +4604,7 @@ inputs:
     </level>
     <level>
       name critical
-      match 'Critical|CRITICAL|C[0-9]+|level=critical|Value:critical|"level":"critical"'
+      match 'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'
     </level>
     <level>
       name debug

--- a/internal/generator/fluentd/ingress.go
+++ b/internal/generator/fluentd/ingress.go
@@ -297,7 +297,7 @@ const ViaQDataModel string = `
   </level>
   <level>
     name critical
-    match 'Critical|CRITICAL|C[0-9]+|level=critical|Value:critical|"level":"critical"'
+    match 'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'
   </level>
   <level>
     name debug

--- a/internal/generator/vector/conf.go
+++ b/internal/generator/vector/conf.go
@@ -63,6 +63,8 @@ source = '''
 	level = "info"
   } else if match(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"'){
 	level = "error"
+  } else if match(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'){
+    level = "critical"
   } else if match(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"'){
 	level = "debug"
   }

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -1,10 +1,8 @@
 package vector
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/openshift/cluster-logging-operator/test/framework/unit"
-	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
@@ -14,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -27,16 +26,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 		e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, testcase.Options))
 		conf, err := g.GenerateConf(e...)
 		Expect(err).To(BeNil())
-		diff := cmp.Diff(
-			strings.Split(strings.TrimSpace(testcase.ExpectedConf), "\n"),
-			strings.Split(strings.TrimSpace(conf), "\n"))
-		if diff != "" {
-			b, _ := json.MarshalIndent(e, "", " ")
-			fmt.Printf("elements:\n%s\n", string(b))
-			fmt.Println(conf)
-			fmt.Printf("diff: %s", diff)
-		}
-		Expect(diff).To(Equal(""))
+		Expect(conf).To(EqualTrimLines(testcase.ExpectedConf))
 	}
 	DescribeTable("Generate full vector.toml", f,
 		Entry("with complex spec", unit.ConfGenerateTest{
@@ -128,13 +118,15 @@ inputs = ["raw_container_logs"]
 source = '''
   level = "unknown"
   if match(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn")'){
-	level = "warn"
+    level = "warn"
   } else if match(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"'){
-	level = "info"
+    level = "info"
   } else if match(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"'){
-	level = "error"
+    level = "error"
+  } else if match(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'){
+    level = "critical"
   } else if match(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"'){
-	level = "debug"
+    level = "debug"
   }
   .level = level
 
@@ -158,6 +150,8 @@ source = '''
 	level = "info"
   } else if match(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"'){
 	level = "error"
+  } else if match(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'){
+    level = "critical"
   } else if match(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"'){
 	level = "debug"
   }
@@ -337,6 +331,8 @@ source = '''
 	level = "info"
   } else if match(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"'){
 	level = "error"
+  } else if match(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'){
+    level = "critical"
   } else if match(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"'){
 	level = "debug"
   }
@@ -362,6 +358,8 @@ source = '''
 	level = "info"
   } else if match(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"'){
 	level = "error"
+  } else if match(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'){
+    level = "critical"
   } else if match(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"'){
 	level = "debug"
   }
@@ -691,6 +689,8 @@ source = '''
 	level = "info"
   } else if match(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"'){
 	level = "error"
+  } else if match(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'){
+    level = "critical"
   } else if match(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"'){
 	level = "debug"
   }
@@ -716,6 +716,8 @@ source = '''
 	level = "info"
   } else if match(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"'){
 	level = "error"
+  } else if match(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'){
+    level = "critical"
   } else if match(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"'){
 	level = "debug"
   }


### PR DESCRIPTION
### Description
This PR:

fixes 'critical' log level eval to expect a match from beginning of capture
adds critical to vector to address for [LOG-2033](https://issues.redhat.com//browse/LOG-2033) for vector
Links
https://issues.redhat.com/browse/LOG-2677