### PR TITLE
LOG-2545: forward container logs to separate indices for vector

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/openshift/cluster-logging-operator/internal/generator/helpers"
+	testhelpers "github.com/openshift/cluster-logging-operator/test/helpers"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -17,7 +18,7 @@ import (
 
 //TODO: Use a detailed CLF spec
 var _ = Describe("Testing Complete Config Generation", func() {
-	var f = func(testcase generator.ConfGenerateTest) {
+	var f = func(testcase testhelpers.ConfGenerateTest) {
 		g := generator.MakeGenerator()
 		e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, generator.NoOptions))
 		conf, err := g.GenerateConf(e...)
@@ -34,7 +35,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 		Expect(diff).To(Equal(""))
 	}
 	DescribeTable("Generate full fluent.conf", f,
-		Entry("with complex spec", generator.ConfGenerateTest{
+		Entry("with complex spec", testhelpers.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{
 					Fluentd: &logging.FluentdForwarderSpec{

--- a/internal/generator/fluentd/output/buffer_conf_test.go
+++ b/internal/generator/fluentd/output/buffer_conf_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/openshift/cluster-logging-operator/internal/generator"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output"
+	. "github.com/openshift/cluster-logging-operator/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
 	"github.com/openshift/cluster-logging-operator/internal/generator/helpers"
+	testhelpers "github.com/openshift/cluster-logging-operator/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -21,8 +22,8 @@ var _ = Describe("Generate fluentd config", func() {
 		}
 		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], op)
 	}
-	DescribeTable("for Elasticsearch output", generator.TestGenerateConfAndFormatWith(f, helpers.FormatFluentConf),
-		Entry("with username,password", generator.ConfGenerateTest{
+	DescribeTable("for Elasticsearch output", testhelpers.TestGenerateConfAndFormatWith(f, helpers.FormatFluentConf),
+		Entry("with username,password", testhelpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -165,7 +166,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+		Entry("with tls key,cert,ca-bundle", testhelpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -311,7 +312,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("without security", generator.ConfGenerateTest{
+		Entry("without security", testhelpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -441,7 +442,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with https but without a secret", generator.ConfGenerateTest{
+		Entry("with https but without a secret", testhelpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -570,7 +571,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with http and username/password", generator.ConfGenerateTest{
+		Entry("with http and username/password", testhelpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -711,7 +712,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with structured container logs enabled", generator.ConfGenerateTest{
+		Entry("with structured container logs enabled", testhelpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -841,7 +842,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with structured types enabled", generator.ConfGenerateTest{
+		Entry("with structured types enabled", testhelpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -974,7 +975,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with char encoding", generator.ConfGenerateTest{
+		Entry("with char encoding", testhelpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
@@ -1,6 +1,7 @@
 package fluentdforward
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -23,8 +24,8 @@ var _ = Describe("fluentd conf generation", func() {
 		}
 		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], op)
 	}
-	DescribeTable("for fluentdforward output", generator.TestGenerateConfWith(f),
-		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+	DescribeTable("for fluentdforward output", helpers.TestGenerateConfWith(f),
+		Entry("with tls key,cert,ca-bundle", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -86,7 +87,7 @@ var _ = Describe("fluentd conf generation", func() {
 </label>
 `,
 		}),
-		Entry("with shared_key", generator.ConfGenerateTest{
+		Entry("with shared_key", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -144,7 +145,7 @@ var _ = Describe("fluentd conf generation", func() {
 </label>
 `,
 		}),
-		Entry("with unsecured, and default port", generator.ConfGenerateTest{
+		Entry("with unsecured, and default port", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/fluentd/output/kafka/kafka_test.go
+++ b/internal/generator/fluentd/output/kafka/kafka_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -23,8 +24,8 @@ var _ = Describe("Generate fluentd config", func() {
 		}
 		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], op)
 	}
-	DescribeTable("for kafka output", generator.TestGenerateConfWith(f),
-		Entry("with username,password to single topic", generator.ConfGenerateTest{
+	DescribeTable("for kafka output", helpers.TestGenerateConfWith(f),
+		Entry("with username,password to single topic", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -83,7 +84,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+		Entry("with tls key,cert,ca-bundle", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -139,7 +140,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("without security", generator.ConfGenerateTest{
+		Entry("without security", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/fluentd/output/loki/loki_conf_test.go
+++ b/internal/generator/fluentd/output/loki/loki_conf_test.go
@@ -1,6 +1,7 @@
 package loki
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	"sort"
 	"testing"
 
@@ -49,8 +50,8 @@ var _ = Describe("Generate fluentd config", func() {
 		}
 		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], generator.NoOptions)
 	}
-	DescribeTable("for Loki output", generator.TestGenerateConfWith(f),
-		Entry("with default labels", generator.ConfGenerateTest{
+	DescribeTable("for Loki output", helpers.TestGenerateConfWith(f),
+		Entry("with default labels", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -119,7 +120,7 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
-		Entry("with custom labels", generator.ConfGenerateTest{
+		Entry("with custom labels", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/fluentd/pipeline_to_output_test.go
+++ b/internal/generator/fluentd/pipeline_to_output_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -12,8 +13,8 @@ var _ = Describe("Testing Config Generation", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return PipelineToOutputs(&clfspec, generator.NoOptions)
 	}
-	DescribeTable("Pipelines(s) to Output(s)", generator.TestGenerateConfWith(f),
-		Entry("Application to single output", generator.ConfGenerateTest{
+	DescribeTable("Pipelines(s) to Output(s)", helpers.TestGenerateConfWith(f),
+		Entry("Application to single output", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -32,7 +33,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Application to multiple outputs", generator.ConfGenerateTest{
+		Entry("Application to multiple outputs", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -82,7 +83,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Application to default output with Labels", generator.ConfGenerateTest{
+		Entry("Application to default output with Labels", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -122,7 +123,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Application to default output with Json Parsing, and Labels", generator.ConfGenerateTest{
+		Entry("Application to default output with Json Parsing, and Labels", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{

--- a/internal/generator/fluentd/sources_test.go
+++ b/internal/generator/fluentd/sources_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -16,8 +17,8 @@ var _ = Describe("Testing Config Generation", func() {
 		}
 		return LogSources(&clfspec, tuning, op)
 	}
-	DescribeTable("Source(s)", generator.TestGenerateConfWith(f),
-		Entry("Only Application", generator.ConfGenerateTest{
+	DescribeTable("Source(s)", helpers.TestGenerateConfWith(f),
+		Entry("Only Application", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -60,7 +61,7 @@ var _ = Describe("Testing Config Generation", func() {
 </source>
 `,
 		}),
-		Entry("Only Application with InTail tuning", generator.ConfGenerateTest{
+		Entry("Only Application with InTail tuning", helpers.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{
 					Fluentd: &logging.FluentdForwarderSpec{
@@ -113,7 +114,7 @@ var _ = Describe("Testing Config Generation", func() {
 </source>
 `,
 		}),
-		Entry("Only Infrastructure", generator.ConfGenerateTest{
+		Entry("Only Infrastructure", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -174,7 +175,7 @@ var _ = Describe("Testing Config Generation", func() {
 </source>
 `,
 		}),
-		Entry("Only Audit", generator.ConfGenerateTest{
+		Entry("Only Audit", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -251,7 +252,7 @@ var _ = Describe("Testing Config Generation", func() {
 </source>
 `,
 		}),
-		Entry("Only Audit with InTail tuning", generator.ConfGenerateTest{
+		Entry("Only Audit with InTail tuning", helpers.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{
 					Fluentd: &logging.FluentdForwarderSpec{
@@ -341,7 +342,7 @@ var _ = Describe("Testing Config Generation", func() {
 </source>
 `,
 		}),
-		Entry("All Log Sources", generator.ConfGenerateTest{
+		Entry("All Log Sources", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -476,8 +477,8 @@ var _ = Describe("Testing Config Generation", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return MetricSources(&clfspec, op)
 	}
-	DescribeTable("Metric Source(s)", generator.TestGenerateConfWith(f),
-		Entry("Any Input", generator.ConfGenerateTest{
+	DescribeTable("Metric Source(s)", helpers.TestGenerateConfWith(f),
+		Entry("Any Input", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{

--- a/internal/generator/fluentd/sources_to_pipelines_test.go
+++ b/internal/generator/fluentd/sources_to_pipelines_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,8 +20,8 @@ var _ = Describe("Testing Config Generation", func() {
 			InputsToPipeline(&clfspec, op),
 		)
 	}
-	DescribeTable("Source(s) to Pipeline(s)", generator.TestGenerateConfWith(f),
-		Entry("Send all log types to output by name", generator.ConfGenerateTest{
+	DescribeTable("Source(s) to Pipeline(s)", helpers.TestGenerateConfWith(f),
+		Entry("Send all log types to output by name", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -103,7 +104,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Send same logtype to multiple output", generator.ConfGenerateTest{
+		Entry("Send same logtype to multiple output", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -202,7 +203,7 @@ var _ = Describe("Testing Config Generation", func() {
 </label>
 `,
 		}),
-		Entry("Route Logs by Namespace(s)", generator.ConfGenerateTest{
+		Entry("Route Logs by Namespace(s)", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -262,7 +263,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Route Logs by Labels(s)", generator.ConfGenerateTest{
+		Entry("Route Logs by Labels(s)", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -327,7 +328,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Route Logs by Namespaces(s), and Labels(s)", generator.ConfGenerateTest{
+		Entry("Route Logs by Namespaces(s), and Labels(s)", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -394,7 +395,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Send Logs by custom selection, and direct", generator.ConfGenerateTest{
+		Entry("Send Logs by custom selection, and direct", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -481,7 +482,7 @@ var _ = Describe("Testing Config Generation", func() {
   </match>
 </label>`,
 		}),
-		Entry("Complex Case", generator.ConfGenerateTest{
+		Entry("Complex Case", helpers.ConfGenerateTest{
 			Desc: "Complex Case",
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -3,6 +3,7 @@ package vector
 import (
 	"encoding/json"
 	"fmt"
+	testhelpers "github.com/openshift/cluster-logging-operator/test/helpers"
 	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -18,7 +19,7 @@ import (
 
 //TODO: Use a detailed CLF spec
 var _ = Describe("Testing Complete Config Generation", func() {
-	var f = func(testcase generator.ConfGenerateTest) {
+	var f = func(testcase testhelpers.ConfGenerateTest) {
 		g := generator.MakeGenerator()
 		if testcase.Options == nil {
 			testcase.Options = generator.Options{}
@@ -38,7 +39,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 		Expect(diff).To(Equal(""))
 	}
 	DescribeTable("Generate full vector.toml", f,
-		Entry("with complex spec", generator.ConfGenerateTest{
+		Entry("with complex spec", testhelpers.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{
 					Fluentd: &logging.FluentdForwarderSpec{
@@ -98,7 +99,7 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
-pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 
@@ -274,7 +275,7 @@ key_file = "/etc/collector/metrics/tls.key"
 crt_file = "/etc/collector/metrics/tls.crt"
 `,
 		}),
-		Entry("with complex spec for elasticsearch", generator.ConfGenerateTest{
+		Entry("with complex spec for elasticsearch", testhelpers.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{},
 			},
@@ -332,7 +333,7 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
-pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -95,6 +95,19 @@ if .log_type == "application" && .structured != null {
 `
 			vrls = append(vrls, fmt.Sprintf(changeIndexName, o.Elasticsearch.StructuredTypeKey, o.Elasticsearch.StructuredTypeName))
 		}
+		if es.EnableStructuredContainerLogs {
+			vrls = append(vrls, `
+  if .log_type == "application"  && .structured != null && .kubernetes.container_name != null && .kubernetes.annotations != null && length!(.kubernetes.annotations) > 0{
+	key = join!(["containerType.logging.openshift.io", .kubernetes.container_name], separator: "/")
+    index, err = get(value: .kubernetes.annotations, path: [key])
+    if index != null && err == null {
+      .write_index = join!(["app-",index,"-write"])
+    } else {
+       log(err, level: "error")
+    }
+  }
+`)
+		}
 	}
 
 	return Remap{

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -1,6 +1,7 @@
 package elasticsearch
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -22,8 +23,8 @@ var _ = Describe("Generate Vector config", func() {
 		}
 		return e
 	}
-	DescribeTable("For Elasticsearch output", generator.TestGenerateConfWith(f),
-		Entry("with username,password", generator.ConfGenerateTest{
+	DescribeTable("For Elasticsearch output", helpers.TestGenerateConfWith(f),
+		Entry("with username,password", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -150,7 +151,7 @@ user = "testuser"
 password = "testpass"
 `,
 		}),
-		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+		Entry("with tls key,cert,ca-bundle", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -279,7 +280,7 @@ crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 `,
 		}),
-		Entry("without security", generator.ConfGenerateTest{
+		Entry("without security", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -391,7 +392,7 @@ request.timeout_secs = 2147483648
 id_key = "_id"
 `,
 		}),
-		Entry("with multiple pipelines for elastic-search", generator.ConfGenerateTest{
+		Entry("with multiple pipelines for elastic-search", helpers.ConfGenerateTest{
 			CLSpec: logging.ClusterLoggingSpec{
 				Forwarder: &logging.ForwarderSpec{},
 			},
@@ -659,7 +660,7 @@ crt_file = "/var/run/ocp-collector/secrets/es-2/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/es-2/ca-bundle.crt"
 `,
 		}),
-		Entry("with Elasticsearch StructuredTypeKey", generator.ConfGenerateTest{
+		Entry("with StructuredTypeKey", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -782,7 +783,7 @@ request.timeout_secs = 2147483648
 id_key = "_id"
 `,
 		}),
-		Entry("with Elasticsearch StructuredTypeName", generator.ConfGenerateTest{
+		Entry("with StructuredTypeName", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -902,7 +903,7 @@ request.timeout_secs = 2147483648
 id_key = "_id"
 `,
 		}),
-		Entry("with both Elasticsearch StructuredTypeKey and StructuredTypeName", generator.ConfGenerateTest{
+		Entry("with both StructuredTypeKey and StructuredTypeName", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -947,6 +948,144 @@ source = """
       .write_index, err = "app-" + val + "-write"
     } else {
       .write_index = "app-myindex-write"
+    }
+  }
+"""
+
+[transforms.es_1_dedot_and_flatten]
+type = "lua"
+inputs = ["es_1_add_es_index"]
+version = "2"
+hooks.process = "process"
+source = """
+    function process(event, emit)
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+        dedot(event.log.kubernetes.labels)
+        flatten_labels(event)
+        prune_labels(event)
+        emit(event)
+    end
+
+    function flatten_labels(event)
+        -- create "flat_labels" key
+        event.log.kubernetes.flat_labels = {}
+        i = 1
+        -- flatten the labels
+        for k,v in pairs(event.log.kubernetes.labels) do
+          event.log.kubernetes.flat_labels[i] = k.."="..v
+          i=i+1
+        end
+    end 
+
+	function prune_labels(event)
+		local exclusions = {"app_kubernetes_io/name", "app_kubernetes_io/instance", "app_kubernetes_io/version", "app_kubernetes_io/component", "app_kubernetes_io/part-of", "app_kubernetes_io/managed-by", "app_kubernetes_io/created-by"}
+		local keys = {}
+		for k,v in pairs(event.log.kubernetes.labels) do
+			for index, e in pairs(exclusions) do
+				if k == e then
+					keys[k] = v
+				end
+			end
+		end
+		event.log.kubernetes.labels = keys
+	end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+"""
+
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["es_1_dedot_and_flatten"]
+endpoint = "http://es.svc.infra.cluster:9200"
+bulk.index = "{{ write_index }}"
+bulk.action = "create"
+request.timeout_secs = 2147483648
+id_key = "_id"
+`,
+		}),
+		Entry("with StructuredTypeKey, StructuredTypeName, container annotations enabled", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type:   logging.OutputTypeElasticsearch,
+						Name:   "es-1",
+						URL:    "http://es.svc.infra.cluster:9200",
+						Secret: nil,
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Elasticsearch: &logging.Elasticsearch{
+								StructuredTypeKey:             "kubernetes.labels.mylabel",
+								StructuredTypeName:            "myindex",
+								EnableStructuredContainerLogs: true,
+							},
+						},
+					},
+				},
+			},
+			Secrets: security.NoSecrets,
+			ExpectedConf: `
+# Set Elasticsearch index
+[transforms.es_1_add_es_index]
+type = "remap"
+inputs = ["application"]
+source = """
+  index = "default"
+  if (.log_type == "application"){
+    index = "app"
+  }
+  if (.log_type == "infrastructure"){
+    index = "infra"
+  }
+  if (.log_type == "audit"){
+    index = "audit"
+  }
+  .write_index = index + "-write"
+  
+  ._id = encode_base64(uuid_v4())
+  del(.file)
+  del(.tag)
+  del(.source_type)
+  if .log_type == "application" && .structured != null {
+    val = .kubernetes.labels.mylabel
+    if val != null {
+      .write_index, err = "app-" + val + "-write"
+    } else {
+      .write_index = "app-myindex-write"
+    }
+  }
+
+  if .log_type == "application"  && .structured != null && .kubernetes.container_name != null && .kubernetes.annotations != null && length!(.kubernetes.annotations) > 0{
+	key = join!(["containerType.logging.openshift.io", .kubernetes.container_name], separator: "/")
+    index, err = get(value: .kubernetes.annotations, path: [key])
+    if index != null && err == null {
+      .write_index = join!(["app-",index,"-write"])
+    } else {
+       log(err, level: "error")
     }
   }
 """

--- a/internal/generator/vector/output/kafka/kafka_test.go
+++ b/internal/generator/vector/output/kafka/kafka_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -17,8 +18,8 @@ var _ = Describe("Generate vector config", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return Conf(clfspec.Outputs[0], []string{"pipeline_1", "pipeline_2"}, secrets[clfspec.Outputs[0].Name], op)
 	}
-	DescribeTable("for kafka output", generator.TestGenerateConfWith(f),
-		Entry("with username, password, no tls to single topic", generator.ConfGenerateTest{
+	DescribeTable("for kafka output", helpers.TestGenerateConfWith(f),
+		Entry("with username, password, no tls to single topic", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -64,7 +65,7 @@ password = "testpass"
 enabled = true
 `,
 		}),
-		Entry("with tls key,cert,ca-bundle", generator.ConfGenerateTest{
+		Entry("with tls key,cert,ca-bundle", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -106,7 +107,7 @@ ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"
 enabled = true
 `,
 		}),
-		Entry("with TLS and tls.insecure", generator.ConfGenerateTest{
+		Entry("with TLS and tls.insecure", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -151,7 +152,7 @@ verify_hostname = false
 enabled = true
 `,
 		}),
-		Entry("with basic TLS", generator.ConfGenerateTest{
+		Entry("with basic TLS", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -179,7 +180,7 @@ timestamp_format = "rfc3339"
 enabled = true
 `,
 		}),
-		Entry("with plain TLS - no secret", generator.ConfGenerateTest{
+		Entry("with plain TLS - no secret", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -207,7 +208,7 @@ timestamp_format = "rfc3339"
 enabled = true
 `,
 		}),
-		Entry("without security", generator.ConfGenerateTest{
+		Entry("without security", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -1,6 +1,7 @@
 package loki
 
 import (
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	"sort"
 	"testing"
 
@@ -45,8 +46,8 @@ var _ = Describe("Generate vector config", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return Conf(clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], generator.NoOptions)
 	}
-	DescribeTable("for Loki output", generator.TestGenerateConfWith(f),
-		Entry("with default labels", generator.ConfGenerateTest{
+	DescribeTable("for Loki output", helpers.TestGenerateConfWith(f),
+		Entry("with default labels", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -90,7 +91,7 @@ user = "username"
 password = "password"
 `,
 		}),
-		Entry("with custom labels", generator.ConfGenerateTest{
+		Entry("with custom labels", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -135,7 +136,7 @@ user = "username"
 password = "password"
 `,
 		}),
-		Entry("with tenant id", generator.ConfGenerateTest{
+		Entry("with tenant id", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{
@@ -192,8 +193,8 @@ var _ = Describe("Generate vector config for in cluster loki", func() {
 	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		return Conf(clfspec.Outputs[0], inputPipeline, secrets[constants.LogCollectorToken], generator.NoOptions)
 	}
-	DescribeTable("for Loki output", generator.TestGenerateConfWith(f),
-		Entry("with bearer token", generator.ConfGenerateTest{
+	DescribeTable("for Loki output", helpers.TestGenerateConfWith(f),
+		Entry("with bearer token", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{
 					{

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -23,7 +23,7 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = {{.ExcludePaths}}
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
-pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 {{end}}`

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -14,8 +15,8 @@ var _ = Describe("Vector Config Generation", func() {
 			LogSources(&clfspec, op),
 		)
 	}
-	DescribeTable("Source(s)", generator.TestGenerateConfWith(f),
-		Entry("Only Application", generator.ConfGenerateTest{
+	DescribeTable("Source(s)", helpers.TestGenerateConfWith(f),
+		Entry("Only Application", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -35,12 +36,12 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
-pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 `,
 		}),
-		Entry("Only Infrastructure", generator.ConfGenerateTest{
+		Entry("Only Infrastructure", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -60,7 +61,7 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
-pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 
@@ -69,7 +70,7 @@ type = "journald"
 journal_directory = "/var/log/journal"
 `,
 		}),
-		Entry("Only Audit", generator.ConfGenerateTest{
+		Entry("Only Audit", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -107,7 +108,7 @@ ignore_older_secs = 600
 include = ["/var/log/ovn/acl-audit-log.log"]
 `,
 		}),
-		Entry("All Log Sources", generator.ConfGenerateTest{
+		Entry("All Log Sources", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -129,7 +130,7 @@ auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
-pod_annotation_fields.pod_annotations = ""
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 

--- a/internal/generator/vector/sources_to_pipelines_test.go
+++ b/internal/generator/vector/sources_to_pipelines_test.go
@@ -3,6 +3,7 @@ package vector
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
@@ -17,8 +18,8 @@ var _ = Describe("Testing Config Generation", func() {
 			Pipelines(&clfspec, op),
 		)
 	}
-	DescribeTable("Source(s) to Pipeline(s)", generator.TestGenerateConfWith(f),
-		Entry("Send all log types to output by name", generator.ConfGenerateTest{
+	DescribeTable("Source(s) to Pipeline(s)", helpers.TestGenerateConfWith(f),
+		Entry("Send all log types to output by name", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -108,7 +109,7 @@ source = """
 """
 `,
 		}),
-		Entry("Send same logtype to multiple output", generator.ConfGenerateTest{
+		Entry("Send same logtype to multiple output", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -212,7 +213,7 @@ source = """
 """
 `,
 		}),
-		Entry("Route Logs by Namespace(s)", generator.ConfGenerateTest{
+		Entry("Route Logs by Namespace(s)", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -257,7 +258,7 @@ source = """
 """
 `,
 		}),
-		Entry("Route Logs by Namespaces(s), and Labels(s)", generator.ConfGenerateTest{
+		Entry("Route Logs by Namespaces(s), and Labels(s)", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -308,7 +309,7 @@ source = """
 """
 `,
 		}),
-		Entry("Add Openshift Label(s)", generator.ConfGenerateTest{
+		Entry("Add Openshift Label(s)", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -352,7 +353,7 @@ source = """
 """
 `,
 		}),
-		Entry("Parse log message as Jaon", generator.ConfGenerateTest{
+		Entry("Parse log message as Jaon", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{

--- a/test/functional/outputs/elasticsearch/forward_to_elasticsearch_index_test.go
+++ b/test/functional/outputs/elasticsearch/forward_to_elasticsearch_index_test.go
@@ -1,3 +1,6 @@
+//go:build fluentd || vector
+// +build fluentd vector
+
 package elasticsearch
 
 import (
@@ -207,9 +210,6 @@ var _ = Describe("[Functional][Outputs][ElasticSearch] forwarding to specific in
 		})
 		Context("and enabling sending each container log to different indices", func() {
 			It("should send one container's log as defined by the annotation and the other defined by structuredTypeKey", func() {
-				if testfw.LogCollectionType == logging.LogCollectionTypeVector {
-					Skip("sending each container log to different indices not supported for vector")
-				}
 				clfb := functional.NewClusterLogForwarderBuilder(framework.Forwarder).
 					FromInput(logging.InputNameApplication).
 					ToOutputWithVisitor(func(spec *logging.OutputSpec) {
@@ -231,7 +231,7 @@ var _ = Describe("[Functional][Outputs][ElasticSearch] forwarding to specific in
 
 				applicationLogLine := functional.CreateAppLogFromJson(jsonLog)
 				Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 1)).To(BeNil())
-				Expect(framework.WriteMessagesToApplicationLogForContainer(applicationLogLine, "other", 1)).To(BeNil())
+				Expect(framework.WriteMessagesToApplicationLogForContainer(functional.CreateAppLogFromJson(`{"foo":"bar"}`), "other", 1)).To(BeNil())
 
 				for index, containerName := range map[string]string{fmt.Sprintf("app-%s-write", containerStructuredIndexValue): constants.CollectorName, "app-write": "other"} {
 					raw, err := framework.GetLogsFromElasticSearchIndex(logging.OutputTypeElasticsearch, index)


### PR DESCRIPTION
### Description
This PR:
* Enables forward container logs to separate indices for vector

### Links
* https://issues.redhat.com/browse/LOG-2545

/assign @cahartma 
/assign @vimalk78 