### PR TITLE
LOG-2223: Vector cloudwatch support fix stream names for infra log group

### DIFF
--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -110,7 +110,6 @@ func NormalizeGroupAndStreamName(logGroupNameField string, logGroupPrefix string
 	vrl := strings.TrimSpace(`
 .group_name = "default"
 .stream_name = "default"
-.hostname = del(.host)
 
 if (.file != null) {
  .file = "kubernetes" + replace!(.file, "/", ".")
@@ -126,11 +125,12 @@ if ( .log_type == "audit" ) {
 }
 if ( .log_type == "infrastructure" ) {
  .group_name = "` + infraGroupName + `"
- .stream_name = ( .kubernetes.pod_node_name + "." + .stream_name ) ?? .stream_name
+ .stream_name = ( .hostname + "." + .stream_name ) ?? .stream_name
 }
 if ( .tag == ".journal.system" ) {
- .stream_name =  ( .hostname + .tag ) ?? .stream_name
+ .stream_name =  ( .host + .tag ) ?? .stream_name
 }
+del(.host)
 del(.tag)
 del(.source_type)
 	`)

--- a/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
@@ -25,7 +25,6 @@ inputs = ["cw-forward"]
 source = """
   .group_name = "default"
   .stream_name = "default"
-  .hostname = del(.host)
   
   if (.file != null) {
    .file = "kubernetes" + replace!(.file, "/", ".")
@@ -34,8 +33,9 @@ source = """
 `
 		transformEnd = `
   if ( .tag == ".journal.system" ) {
-   .stream_name =  ( .hostname + .tag ) ?? .stream_name
+   .stream_name =  ( .host + .tag ) ?? .stream_name
   }
+  del(.host)
   del(.tag)
   del(.source_type)
 """
@@ -110,7 +110,7 @@ request.concurrency = 2
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "` + groupPrefix + `.infrastructure"
-   .stream_name = ( .kubernetes.pod_node_name + "." + .stream_name ) ?? .stream_name
+   .stream_name = ( .hostname + "." + .stream_name ) ?? .stream_name
   }
 
 ` + transformEnd + `
@@ -142,7 +142,7 @@ request.concurrency = 2
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "` + groupPrefix + `.infrastructure"
-   .stream_name = ( .kubernetes.pod_node_name + "." + .stream_name ) ?? .stream_name
+   .stream_name = ( .hostname + "." + .stream_name ) ?? .stream_name
   }
 
 ` + transformEnd + `
@@ -174,7 +174,7 @@ request.concurrency = 2
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "` + groupPrefix + `.infrastructure"
-   .stream_name = ( .kubernetes.pod_node_name + "." + .stream_name ) ?? .stream_name
+   .stream_name = ( .hostname + "." + .stream_name ) ?? .stream_name
   }
 
 ` + transformEnd + `
@@ -213,7 +213,7 @@ request.concurrency = 2
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "infrastructure"
-   .stream_name = ( .kubernetes.pod_node_name + "." + .stream_name ) ?? .stream_name
+   .stream_name = ( .hostname + "." + .stream_name ) ?? .stream_name
   }
 
 ` + transformEnd + `
@@ -247,7 +247,7 @@ request.concurrency = 2
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "infrastructure"
-   .stream_name = ( .kubernetes.pod_node_name + "." + .stream_name ) ?? .stream_name
+   .stream_name = ( .hostname + "." + .stream_name ) ?? .stream_name
   }
 
 ` + transformEnd + `


### PR DESCRIPTION
### Description
Fixes an issue found shortly after merge of the feature.   Infrastructure logs need to include and use `hostname` rather than the removed `kubernetes.pod_node_name` annotation.

/assign @jcantrill 
/assign @vimalk78 

### Links

- https://issues.redhat.com/browse/LOG-2223
