### PR TITLE
Generate version file compatible with formatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ $(GEN_TIMESTAMP): $(shell find apis -name '*.go')  $(OPERATOR_SDK) $(CONTROLLER_
 	@$(CONTROLLER_GEN) object paths="./apis/..."
 	@$(CONTROLLER_GEN) crd:crdVersions=v1 rbac:roleName=clusterlogging-operator paths="./..." output:crd:artifacts:config=config/crd/bases
 	@bash ./hack/generate-crd.sh
-	echo 'package version; var Version = "$(or $(CI_CONTAINER_VERSION),$(LOGGING_VERSION), DEFAULT_VERSION)"' > version/version.go
+	echo -e "package version\n\nvar Version = \"$(or $(CI_CONTAINER_VERSION),$(LOGGING_VERSION), DEFAULT_VERSION)\"" > version/version.go
 	@touch $@
 
 .PHONY: regenerate


### PR DESCRIPTION
### Description

It seems the linter got more strict recently, which made it fix the `version/version.go` file automatically generated by the `make generate` task. The Make target wants to generate a different file than what the formatter expects, so the format of the file depends on which target was run last.

This change fixes the generation of the file in the Makefile to use the same format as the formatter would output, so that both targets now produce the same file.

