### PR TITLE
LOG-2635: Remove colon from config parameter

### DIFF
--- a/pkg/generators/forwarding/fluentd/output_cloudwatch_test.go
+++ b/pkg/generators/forwarding/fluentd/output_cloudwatch_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Generating fluentd config", func() {
 					include_time_key true
 					log_rejected_request true
 					<buffer>
-					  disable_chunk_backup: true
+					  disable_chunk_backup true
 					</buffer>
 				</match>
 			</label>`
@@ -156,7 +156,7 @@ var _ = Describe("Generating fluentd config", func() {
 					include_time_key true
 					log_rejected_request true
 					<buffer>
-					  disable_chunk_backup: true
+					  disable_chunk_backup true
 					</buffer>
 				</match>
 			</label>`
@@ -219,7 +219,7 @@ var _ = Describe("Generating fluentd config", func() {
 					include_time_key true
 					log_rejected_request true
 				    <buffer>
-      					disable_chunk_backup: true
+      					disable_chunk_backup true
     				</buffer>
 				</match>
 			</label>`

--- a/pkg/generators/forwarding/fluentd/templates.go
+++ b/pkg/generators/forwarding/fluentd/templates.go
@@ -709,7 +709,7 @@ const outputLabelConfCloudwatch = `{{- define "outputLabelConfCloudwatch" -}}
     include_time_key true
     log_rejected_request true
     <buffer>
-      disable_chunk_backup: true
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>


### PR DESCRIPTION
### Description
This PR corrects the config to remove the colon so it is actually used
https://issues.redhat.com/browse/LOG-2635