### PR TITLE
LOG-2169: Fix Kafka sasl-plaintext/sasl-ssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,12 @@ test-functional-fluentd:
 test-functional-vector:
 	VECTOR_IMAGE=$(IMAGE_LOGGING_VECTOR) \
 	LOGFILEMETRICEXPORTER_IMAGE=$(IMAGE_LOGFILEMETRICEXPORTER) \
-	go test --tags=vector -race ./test/functional/outputs/cloudwatch/... ./test/functional/outputs/elasticsearch/... ./test/functional/normalization -ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
+	go test --tags=vector -race \
+		./test/functional/outputs/elasticsearch/... \
+		./test/functional/outputs/kafka/... \
+		./test/functional/outputs/cloudwatch/... \
+		./test/functional/normalization \
+		-ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
 
 .PHONY: test-forwarder-generator
 test-forwarder-generator: bin/forwarder-generator

--- a/internal/generator/forwarder/generator.go
+++ b/internal/generator/forwarder/generator.go
@@ -21,7 +21,10 @@ var (
 	ErrInvalidOutputURL = func(o logging.OutputSpec) error {
 		return fmt.Errorf("Invalid URL in %s output in ClusterLogForwarder", o.Name)
 	}
-	ErrInvalidInput = errors.New("Invalid Input")
+	ErrInvalidInput      = errors.New("Invalid Input")
+	ErrTLSOutputNoSecret = func(o logging.OutputSpec) error {
+		return fmt.Errorf("No secret defined in output %s, but URL has TLS Scheme %s", o.Name, o.URL)
+	}
 )
 
 type ConfigGenerator struct {
@@ -68,7 +71,7 @@ func (cg *ConfigGenerator) Verify(clspec *logging.ClusterLoggingSpec, secrets ma
 		}
 	}
 	for _, o := range clfspec.Outputs {
-		if _, err := url.Parse(o.URL); err != nil {
+		if _, err = url.Parse(o.URL); err != nil {
 			return ErrInvalidOutputURL(o)
 		}
 	}

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -258,10 +258,10 @@ timestamp_format = "rfc3339"
 
 # TLS Config
 [sinks.kafka_receiver.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"
-enabled = true
 
 [sinks.prometheus_output]
 type = "prometheus_exporter"
@@ -574,9 +574,9 @@ id_key = "_id"
 
 # TLS Config
 [sinks.es_1.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
-
 ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 
 # Set Elasticsearch index
@@ -679,9 +679,9 @@ id_key = "_id"
 
 # TLS Config
 [sinks.es_2.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/es-2/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-2/tls.crt"
-
 ca_file = "/var/run/ocp-collector/secrets/es-2/ca-bundle.crt"
 
 [sinks.prometheus_output]

--- a/internal/generator/vector/output/elasticsearch/cert-key.go
+++ b/internal/generator/vector/output/elasticsearch/cert-key.go
@@ -14,5 +14,5 @@ func (kc TLSKeyCert) Template() string {
 	return `{{define "` + kc.Name() + `" -}}
 key_file = {{.KeyPath}}
 crt_file = {{.CertPath}}
-{{end}}`
+{{- end}}`
 }

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -274,9 +274,9 @@ id_key = "_id"
 
 # TLS Config
 [sinks.es_1.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
-
 ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 `,
 		}),
@@ -549,9 +549,9 @@ id_key = "_id"
 
 # TLS Config
 [sinks.es_1.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
-
 ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 
 # Set Elasticsearch index
@@ -654,9 +654,9 @@ id_key = "_id"
 
 # TLS Config
 [sinks.es_2.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/es-2/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-2/tls.crt"
-
 ca_file = "/var/run/ocp-collector/secrets/es-2/ca-bundle.crt"
 `,
 		}),

--- a/internal/generator/vector/output/kafka/ca-file.go
+++ b/internal/generator/vector/output/kafka/ca-file.go
@@ -13,6 +13,6 @@ func (ca CAFile) Name() string {
 func (ca CAFile) Template() string {
 	return `{{define "` + ca.Name() + `" -}}
 ca_file = {{.CAFilePath}}
-{{- end}}
+{{end}}
 `
 }

--- a/internal/generator/vector/output/kafka/sasl.go
+++ b/internal/generator/vector/output/kafka/sasl.go
@@ -1,34 +1,29 @@
 package kafka
 
-import (
-	"fmt"
-
-	"github.com/openshift/cluster-logging-operator/internal/generator"
+const (
+	SASLMechanismPlain = "PLAIN"
+	SASLMechamisnSSL   = "SCRAM-SHA-256"
 )
 
-type Sasl bool
-
-func (s Sasl) Name() string {
-	return "kafkaSaslTemplate"
+type SASL struct {
+	Desc        string
+	ComponentID string
+	Username    string
+	Password    string
+	Mechanism   string
 }
 
-func (s Sasl) Template() string {
-	return fmt.Sprintf(`{{define "kafkaSaslTemplate" -}}
-enabled = %t
-{{end}}
-`, s)
+func (t SASL) Name() string {
+	return "vectorKafkaSasl"
 }
 
-type SaslConf generator.ConfLiteral
-
-func (t SaslConf) Name() string {
-	return "kafkaSasl"
-}
-
-func (t SaslConf) Template() string {
-	return `
-{{define "kafkaSasl" -}}
+func (t SASL) Template() string {
+	return `{{define "vectorKafkaSasl"}}
 # {{.Desc}}
 [sinks.{{.ComponentID}}.sasl]
-{{- end}}`
+enabled = true
+username = "{{.Username}}"
+password = "{{.Password}}"
+mechanism = "{{.Mechanism}}"
+{{end}}`
 }

--- a/internal/generator/vector/output/security/security.go
+++ b/internal/generator/vector/output/security/security.go
@@ -40,14 +40,15 @@ type BearerToken struct {
 type TLSConf generator.ConfLiteral
 
 func (t TLSConf) Name() string {
-	return "kafkaTLS"
+	return "vectorTLS"
 }
 
 func (t TLSConf) Template() string {
 	return `
-{{define "kafkaTLS" -}}
+{{define "vectorTLS" -}}
 # {{.Desc}}
 [sinks.{{.ComponentID}}.tls]
+enabled = true
 {{- end}}`
 }
 

--- a/test/e2e/logforwarding/fluent/fluent_secure_test.go
+++ b/test/e2e/logforwarding/fluent/fluent_secure_test.go
@@ -2,15 +2,17 @@ package fluent_test
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test"
 	"github.com/openshift/cluster-logging-operator/test/client"
+	"github.com/openshift/cluster-logging-operator/test/framework/e2e"
 	"github.com/openshift/cluster-logging-operator/test/helpers/certificate"
 	"github.com/openshift/cluster-logging-operator/test/helpers/fluentd"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
@@ -85,7 +87,10 @@ var _ = Describe("[ClusterLogForwarder]", func() {
 		g.Wait() // Create secrets before creating CLF to pass validation first time
 	})
 
-	AfterEach(func() { c.Close() })
+	AfterEach(func() {
+		c.Close()
+		e2e.RunCleanupScript()
+	})
 
 	It("connects to secure destinations", func() {
 		// Set up the CLF, one output per receiver source.

--- a/test/e2e/logforwarding/fluent/fluent_test.go
+++ b/test/e2e/logforwarding/fluent/fluent_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test/client"
+	"github.com/openshift/cluster-logging-operator/test/framework/e2e"
 	"github.com/openshift/cluster-logging-operator/test/helpers/fluentd"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
@@ -24,7 +25,10 @@ var _ = Describe("[ClusterLogForwarder]", func() {
 		logTypes   = loggingv1.ReservedInputNames.UnsortedList()
 	)
 	BeforeEach(func() { c = client.NewTest(); f = NewFixture(c.NS.Name, message) })
-	AfterEach(func() { c.Close() })
+	AfterEach(func() {
+		c.Close()
+		e2e.RunCleanupScript()
+	})
 
 	Context("with app/infra/audit receiver", func() {
 		BeforeEach(func() {

--- a/test/functional/outputs/kafka/forward_to_kafka_test.go
+++ b/test/functional/outputs/kafka/forward_to_kafka_test.go
@@ -1,4 +1,4 @@
-package outputs
+package kafka
 
 import (
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	testfw "github.com/openshift/cluster-logging-operator/test/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/kafka"
 )
 
@@ -16,7 +17,7 @@ var _ = Describe("[Functional][Outputs][Kafka] Functional tests", func() {
 	)
 
 	BeforeEach(func() {
-		framework = functional.NewCollectorFunctionalFramework()
+		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(testfw.LogCollectionType)
 
 		log.V(2).Info("Creating secret for broker credentials")
 		brokersecret := kafka.NewBrokerSecret(framework.Namespace)

--- a/test/functional/outputs/kafka/suite_test.go
+++ b/test/functional/outputs/kafka/suite_test.go
@@ -1,0 +1,13 @@
+package kafka
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFunctionalKafkaOutput(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[functional][outputs][kafka] Suite")
+}


### PR DESCRIPTION
### Description
Fixes Kafka Sasl for vector.

Tested scenarios
 - sasl
 - sasl + ssl
 - ssl
 - mutual ssl
 - without tls

/cc @alanconway @jcantrill 
/assign @alanconway 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2169, https://issues.redhat.com/browse/LOG-2167

