### PR TITLE
LOG-2014: Support user defined app inputs for vector

### DIFF
--- a/internal/generator/vector/inputs.go
+++ b/internal/generator/vector/inputs.go
@@ -17,7 +17,7 @@ const (
 	NsDefault   = "default"
 
 	K8sNamespaceName = ".kubernetes.namespace_name"
-	K8sLabelKeyExpr  = ".kubernetes.pod_labels.%s"
+	K8sLabelKeyExpr  = ".kubernetes.labels.%s"
 
 	InputContainerLogs   = "container_logs"
 	InputJournalLogs     = "journal_logs"

--- a/internal/generator/vector/sources_to_pipelines_test.go
+++ b/internal/generator/vector/sources_to_pipelines_test.go
@@ -299,7 +299,7 @@ source = """
 [transforms.route_application_logs]
 type = "route"
 inputs = ["application"]
-route.myapplogs = '((.kubernetes.namespace_name == "myapp1") || (.kubernetes.namespace_name == "myapp2")) && ((.kubernetes.pod_labels.key1 == "value1") && (.kubernetes.pod_labels.key2 == "value2"))'
+route.myapplogs = '((.kubernetes.namespace_name == "myapp1") || (.kubernetes.namespace_name == "myapp2")) && ((.kubernetes.labels.key1 == "value1") && (.kubernetes.labels.key2 == "value2"))'
 
 [transforms.pipeline]
 type = "remap"


### PR DESCRIPTION
### Description
Verify users can forward application logs by specifying a namespace.  
Verify users can forward application logs by specifying pod labels.  
Verify comparable functionality with fluentd.   

Note:
All vector forwarding has been tested using cloudwatch.  We do not currently have a functional test for forwarding by specifying namespace since vector lacks the meta `namespace.uid`.  An upcoming release of vector will contain the additional data needed to write the test.

/assign @vimalk78 @jcantrill @syedriko 

### Links
- https://issues.redhat.com/browse/LOG-2014
