### PR TITLE
LOG-2746: Disable chunk backup for all outputs

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -699,6 +699,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
       total_limit_size 800000000
       chunk_limit_size 8m
       overflow_action throw_exception
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -742,6 +743,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
       total_limit_size 800000000
       chunk_limit_size 8m
       overflow_action throw_exception
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -749,6 +749,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -792,6 +793,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -872,6 +874,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -915,6 +918,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -1539,6 +1543,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -1582,6 +1587,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -1662,6 +1668,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -1705,6 +1712,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -2333,6 +2341,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -2376,6 +2385,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -2456,6 +2466,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -2499,6 +2510,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -2975,6 +2987,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -3623,6 +3636,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -3666,6 +3680,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -3746,6 +3761,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -3789,6 +3805,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -3869,6 +3886,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -3912,6 +3930,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -3992,6 +4011,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -4035,6 +4055,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/buffer_conf.go
+++ b/internal/generator/fluentd/output/buffer_conf.go
@@ -21,6 +21,7 @@ func (bc BufferConf) Template() string {
 <buffer>
 {{- end}}
 {{compose_one .BufferConfData | indent 2}}
+  disable_chunk_backup true
 </buffer>
 {{end}}`
 }

--- a/internal/generator/fluentd/output/buffer_conf_test.go
+++ b/internal/generator/fluentd/output/buffer_conf_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Generate fluentd conf", func() {
   total_limit_size 800000000
   chunk_limit_size 8m
   overflow_action throw_exception
+  disable_chunk_backup true
 </buffer>`,
 		}),
 		Entry("when tuning flush_mode other then interval", ConfGenerateTest{
@@ -96,6 +97,7 @@ var _ = Describe("Generate fluentd conf", func() {
   total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
   chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
   overflow_action block
+  disable_chunk_backup true
 </buffer>`,
 		}),
 	)
@@ -148,6 +150,7 @@ var _ = Describe("Generate fluentd conf", func() {
   total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
   chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
   overflow_action block
+  disable_chunk_backup true
 </buffer>`,
 		}))
 })

--- a/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
@@ -59,6 +59,9 @@ concurrency 2
 include_time_key true
 log_rejected_request true
 {{compose_one .EndpointConfig}}
+<buffer>
+  disable_chunk_backup true
+</buffer>
 {{end}}`
 }
 

--- a/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
@@ -92,6 +92,9 @@ var _ = Describe("Generating fluentd config", func() {
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `
@@ -145,6 +148,9 @@ var _ = Describe("Generating fluentd config", func() {
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `
@@ -201,6 +207,9 @@ var _ = Describe("Generating fluentd config", func() {
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `
@@ -258,6 +267,9 @@ var _ = Describe("Generating fluentd config", func() {
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `
@@ -349,6 +361,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     </web_identity_credentials>    
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `
@@ -405,6 +420,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     </web_identity_credentials>      
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `
@@ -464,6 +482,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     </web_identity_credentials>     
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -161,6 +162,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -264,6 +266,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -307,6 +310,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -398,6 +402,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -437,6 +442,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -526,6 +532,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -566,6 +573,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -666,6 +674,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -707,6 +716,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -797,6 +807,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -837,6 +848,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -930,6 +942,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -970,6 +983,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -1063,6 +1077,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -1102,6 +1117,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
@@ -82,6 +82,7 @@ var _ = Describe("fluentd conf generation", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -140,6 +141,7 @@ var _ = Describe("fluentd conf generation", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -186,6 +188,7 @@ var _ = Describe("fluentd conf generation", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/fluentdforward/output_conf_forward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/output_conf_forward_test.go
@@ -86,6 +86,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -126,6 +127,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -173,6 +175,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -219,6 +222,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/kafka/kafka_test.go
+++ b/internal/generator/fluentd/output/kafka/kafka_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -135,6 +136,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -176,6 +178,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/kafka/output_conf_kafka_test.go
+++ b/internal/generator/fluentd/output/kafka/output_conf_kafka_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Generating external kafka server output store config block", f
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -111,6 +112,7 @@ var _ = Describe("Generating external kafka server output store config block", f
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -181,6 +183,7 @@ var _ = Describe("Generating external kafka server output store config block", f
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/loki/loki_conf_test.go
+++ b/internal/generator/fluentd/output/loki/loki_conf_test.go
@@ -115,6 +115,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -183,6 +184,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/loki/output_conf_loki_test.go
+++ b/internal/generator/fluentd/output/loki/output_conf_loki_test.go
@@ -84,6 +84,7 @@ func TestLokiOutput(t *testing.T) {
      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
      overflow_action block
+     disable_chunk_backup true
 `,
 			}
 			secrets = map[string]*corev1.Secret{

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -156,6 +156,7 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
                 overflow_action block
+                disable_chunk_backup true
               </buffer>
           </match>
           <match **>
@@ -195,6 +196,7 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
                 overflow_action block
+                disable_chunk_backup true
               </buffer>
           </match>
         </label>`
@@ -293,6 +295,7 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
                 overflow_action block
+                disable_chunk_backup true
               </buffer>
           </match>
           <match **>
@@ -332,6 +335,7 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
                 overflow_action block
+                disable_chunk_backup true
               </buffer>
           </match>
         </label>`
@@ -415,7 +419,8 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size 512m
                 chunk_limit_size 256m
                 overflow_action drop_oldest_chunk
-              </buffer>
+                disable_chunk_backup true
+             </buffer>
           </match>
           <match **>
               @type elasticsearch
@@ -453,6 +458,7 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size 512m
                 chunk_limit_size 256m
                 overflow_action drop_oldest_chunk
+                disable_chunk_backup true
               </buffer>
           </match>
         </label>`
@@ -504,6 +510,7 @@ var _ = Describe("Generating fluentd config", func() {
             total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
             chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
             overflow_action block
+            disable_chunk_backup true
             </buffer>
 
            </match>
@@ -542,6 +549,7 @@ var _ = Describe("Generating fluentd config", func() {
           total_limit_size 512m
           chunk_limit_size 256m
           overflow_action drop_oldest_chunk
+          disable_chunk_backup true
           </buffer>
 
         </match>
@@ -610,7 +618,8 @@ var _ = Describe("Generating fluentd config", func() {
 		                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
 		                chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
 		                overflow_action block
-		              </buffer>
+		                disable_chunk_backup true
+                    </buffer>
 		          </match>
 		        </label>`
 
@@ -662,6 +671,7 @@ var _ = Describe("Generating fluentd config", func() {
 		                total_limit_size 512m
 		                chunk_limit_size 256m
 		                overflow_action drop_oldest_chunk
+                        disable_chunk_backup true
 		              </buffer>
 		          </match>
 		        </label>`
@@ -712,6 +722,7 @@ var _ = Describe("Generating fluentd config", func() {
                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
                chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
                overflow_action block
+               disable_chunk_backup true
            </buffer>
         </match>
         </label>`
@@ -746,6 +757,7 @@ var _ = Describe("Generating fluentd config", func() {
                total_limit_size 512m
                chunk_limit_size 256m
                overflow_action drop_oldest_chunk
+               disable_chunk_backup true
            </buffer>
         </match>
         </label>`

--- a/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
+++ b/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
@@ -174,6 +174,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -215,6 +216,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -265,6 +267,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -309,6 +312,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -460,6 +464,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -499,6 +504,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -595,6 +601,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -635,6 +642,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -732,6 +740,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -771,6 +780,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>


### PR DESCRIPTION
### Description
This PR:
* Disables chunk backup for all output types in order to not fill the node disk

### Links
* https://issues.redhat.com/browse/LOG-2746
