### PR TITLE
Remove check on DiskThresholdPercent in index management

### DIFF
--- a/internal/k8shandler/indexmanagement/index_management.go
+++ b/internal/k8shandler/indexmanagement/index_management.go
@@ -162,11 +162,7 @@ func newPolicySpec(name string, retentionPolicy *logging.RetentionPolicySpec, ho
 		policySpec.Phases.Delete.Namespaces = retentionPolicy.Namespaces
 	}
 
-	if retentionPolicy.DiskThresholdPercent > 0 {
-		policySpec.Phases.Delete.DiskThresholdPercent = retentionPolicy.DiskThresholdPercent
-	} else {
-		log.Info("DiskThresholdPercent must be an integer higher than 0")
-	}
+	policySpec.Phases.Delete.DiskThresholdPercent = retentionPolicy.DiskThresholdPercent
 
 	return policySpec
 }


### PR DESCRIPTION
### Description
A little modification on #1508 to remove the check on `DiskThresholdPercent`, since it's already done in EO.

/cc @vimalk78 
/assign @periklis 

### Links
- Depending on PR(s): #1508 
- JIRA: https://issues.redhat.com/browse/LOG-2429
