### PR TITLE
code cleanup: remove redundant(duplicate) line

### DIFF
--- a/internal/k8shandler/indexmanagement/index_management.go
+++ b/internal/k8shandler/indexmanagement/index_management.go
@@ -162,8 +162,6 @@ func newPolicySpec(name string, retentionPolicy *logging.RetentionPolicySpec, ho
 		policySpec.Phases.Delete.Namespaces = retentionPolicy.Namespaces
 	}
 
-	policySpec.Phases.Delete.DiskThresholdPercent = retentionPolicy.DiskThresholdPercent
-
 	return policySpec
 }
 


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description

Remove redundant line  [index_management.go#L165](https://github.com/openshift/cluster-logging-operator/blob/e8965fc78962fe67352c8d80ebc1c972bd04c5fb/internal/k8shandler/indexmanagement/index_management.go#L165) because value already set in [index_management.go#L156](https://github.com/openshift/cluster-logging-operator/blob/e8965fc78962fe67352c8d80ebc1c972bd04c5fb/internal/k8shandler/indexmanagement/index_management.go#L156)

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
