### PR TITLE
Do not treat token as path in fluentd Loki config generator

### DIFF
--- a/internal/generator/fluentd/output/loki/bearer-token-file.go
+++ b/internal/generator/fluentd/output/loki/bearer-token-file.go
@@ -12,7 +12,7 @@ func (bt BearerTokenFile) Name() string {
 
 func (bt BearerTokenFile) Template() string {
 	return `{{define "` + bt.Name() + `" -}}
-bearer_token_file "{{ .BearerTokenFilePath }}"
+bearer_token_file {{ .BearerTokenFilePath }}
 {{- end}}
 `
 }

--- a/internal/generator/fluentd/output/loki/loki.go
+++ b/internal/generator/fluentd/output/loki/loki.go
@@ -127,7 +127,7 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 		}
 		if security.HasBearerTokenFileKey(secret) {
 			bt := BearerTokenFile{
-				BearerTokenFilePath: security.GetFromSecret(secret, constants.BearerTokenFileKey),
+				BearerTokenFilePath: security.SecretPath(o.Secret.Name, constants.BearerTokenFileKey),
 			}
 			conf = append(conf, bt)
 		}

--- a/internal/generator/fluentd/output/loki/output_conf_loki_test.go
+++ b/internal/generator/fluentd/output/loki/output_conf_loki_test.go
@@ -98,7 +98,7 @@ func TestLokiOutput(t *testing.T) {
 					}},
 				"loki-receiver-token": {
 					Data: map[string][]byte{
-						"token": []byte("/path/to/token"),
+						"token": []byte("bearer-token-value"),
 					}}}
 
 			var err error
@@ -198,7 +198,7 @@ func TestLokiOutput(t *testing.T) {
 		results, err := g.GenerateConf(es...)
 		require.NoError(t, err)
 		config.content = `url https://logs-us-west1.grafana.net
-    bearer_token_file "/path/to/token"`
+    bearer_token_file '/var/run/ocp-collector/secrets/a-secret-ref/token'`
 		require.Equal(t, test.TrimLines(config.String()), test.TrimLines(results), results)
 	})
 


### PR DESCRIPTION
### Description

Currently the fluentd and vector config generators for the Loki output treat the contents of the `token` value of the provided secret differently. The vector generator treats the value as the literal token, while the fluentd generator treats it as a path to a file containing the token.

Looking at how secrets are usually used, the approach the vector configuration generator uses seems more adequate, making it possible to give the collector a secret without having additional files in the container. It also makes the secret configuration compatible with secrets backed by a ServiceAccount which, to me, sounds like a often-used use-case.

As this changes existing behaviour it might be problematic to be backported to 5.4, but I'd like to open discussion on that topic anyway, because I would see this as an improvement of usability over the current behaviour.

### Links

- JIRA: Related to [LOG-1803](https://issues.redhat.com/browse/LOG-1803)