### PR TITLE
Fix handling of custom bearer token for vector Loki output

### DIFF
--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -237,20 +237,16 @@ func BasicAuth(o logging.OutputSpec, secret *corev1.Secret) []Element {
 
 func BearerTokenAuth(o logging.OutputSpec, secret *corev1.Secret) []Element {
 	conf := []Element{}
-	if o.Secret == nil {
-		// internal loki, use bearer token of logcollector service account
-		// the secret contains the token itself
-		if secret != nil && security.HasBearerTokenFileKey(secret) {
+	if secret != nil {
+		// Inject token from secret, either provided by user using a custom secret
+		// or from the default logcollector service account.
+		if security.HasBearerTokenFileKey(secret) {
 			conf = append(conf, BasicAuthConf{
 				Desc:        "Bearer Auth Config",
 				ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
-			})
-			bt := BearerToken{
+			}, BearerToken{
 				Token: security.GetFromSecret(secret, constants.BearerTokenFileKey),
-			}
-			conf = append(conf, bt)
-		} else {
-			return []Element{}
+			})
 		}
 	}
 	return conf


### PR DESCRIPTION
### Description

Currently the vector configuration generator for the Loki output does not provide an option for setting a custom bearer token. The only way of setting a bearer-token to authenticate to Loki is to leave the secret blank and use the token issues to the `logcollector` ServiceAccount.

This PR enables the use of bearer-tokens with custom secrets.

### Links

- JIRA: Related to [LOG-2323](https://issues.redhat.com/browse/LOG-2323)

