### PR TITLE
Use service CA when using default token in vector Loki output

### DIFF
--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -206,6 +206,17 @@ func TLSConf(o logging.OutputSpec, secret *corev1.Secret) []Element {
 		if !hasTLS {
 			return []Element{}
 		}
+	} else if secret != nil {
+		// Set CA from logcollector ServiceAccount for internal Loki
+		return []Element{
+			security.TLSConf{
+				Desc:        "TLS Config",
+				ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
+			},
+			CAFile{
+				CAFilePath: `"/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"`,
+			},
+		}
 	}
 	return conf
 }

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -227,6 +227,10 @@ kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
 
+# TLS Config
+[sinks.loki_receiver.tls]
+enabled = true
+ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 # Bearer Auth Config
 [sinks.loki_receiver.auth]
 strategy = "bearer"


### PR DESCRIPTION
### Description

Currently the cluster-logging-operator automatically uses the logcollector ServiceAccount's token when no custom secret is specified in the Loki output configuration. This PR extends this behaviour by also injecting the CA-bundle that is present by default on the ServiceAccount, enabling vector to validate certificates issued by the internal service CA.

### Links

- JIRA: References [LOG-2323](https://issues.redhat.com/browse/LOG-2323)
