### PR TITLE
LOG-2378: Normalize Host Audit Logs

### DIFF
--- a/internal/generator/vector/elements/elements.go
+++ b/internal/generator/vector/elements/elements.go
@@ -49,9 +49,9 @@ func (r Remap) Template() string {
 [transforms.{{.ComponentID}}]
 type = "remap"
 inputs = {{.Inputs}}
-source = """
+source = '''
 {{.VRL | indent 2}}
-"""
+'''
 {{end}}
 `
 }

--- a/internal/generator/vector/inputs.go
+++ b/internal/generator/vector/inputs.go
@@ -24,22 +24,6 @@ const (
 	RouteApplicationLogs = "route_application_logs"
 
 	SrcPassThrough = "."
-
-	HostAuditLogTag = ".linux-audit.log"
-	HostAuditLogID  = "tagged_host_audit_logs"
-
-	K8sAuditLogTag = ".k8s-audit.log"
-	K8sAuditLogID  = "tagged_k8s_audit_logs"
-
-	OpenAuditLogTag = ".openshift-audit.log"
-	OpenAuditLogID  = "tagged_openshift_audit_logs"
-
-	OvnAuditLogTag = ".ovn-audit.log"
-	OvnAuditLogID  = "tagged_ovn_audit_logs"
-
-	ParseAndFlatten = `. = merge(., parse_json!(string!(.message))) ?? .
-del(.message)
-`
 )
 
 var (
@@ -54,11 +38,6 @@ var (
 	AddLogTypeApp   = fmt.Sprintf(".log_type = %q", logging.InputNameApplication)
 	AddLogTypeInfra = fmt.Sprintf(".log_type = %q", logging.InputNameInfrastructure)
 	AddLogTypeAudit = fmt.Sprintf(".log_type = %q", logging.InputNameAudit)
-
-	AddHostAuditTag = fmt.Sprintf(".tag = %q", HostAuditLogTag)
-	AddK8sAuditTag  = fmt.Sprintf(".tag = %q", K8sAuditLogTag)
-	AddOpenAuditTag = fmt.Sprintf(".tag = %q", OpenAuditLogTag)
-	AddOvnAuditTag  = fmt.Sprintf(".tag = %q", OvnAuditLogTag)
 
 	MatchNS = func(ns string) string {
 		return Eq(K8sNamespaceName, ns)
@@ -111,39 +90,9 @@ func Inputs(spec *logging.ClusterLogForwarderSpec, o Options) []Element {
 	if types.Has(logging.InputNameAudit) {
 		el = append(el,
 			Remap{
-				Desc:        `Tag host audit files`,
-				ComponentID: HostAuditLogID,
-				Inputs:      helpers.MakeInputs(HostAuditLogs),
-				VRL:         AddHostAuditTag,
-			},
-			Remap{
-				Desc:        `Tag k8s audit files`,
-				ComponentID: K8sAuditLogID,
-				Inputs:      helpers.MakeInputs(K8sAuditLogs),
-				VRL: strings.Join(helpers.TrimSpaces([]string{
-					AddK8sAuditTag,
-					ParseAndFlatten,
-				}), "\n"),
-			},
-			Remap{
-				Desc:        `Tag openshift audit files`,
-				ComponentID: OpenAuditLogID,
-				Inputs:      helpers.MakeInputs(OpenShiftAuditLogs),
-				VRL: strings.Join(helpers.TrimSpaces([]string{
-					AddOpenAuditTag,
-					ParseAndFlatten,
-				}), "\n"),
-			},
-			Remap{
-				Desc:        `Tag ovn audit files`,
-				ComponentID: OvnAuditLogID,
-				Inputs:      helpers.MakeInputs(OvnAuditLogs),
-				VRL:         AddOvnAuditTag,
-			},
-			Remap{
 				Desc:        `Set log_type to "audit"`,
 				ComponentID: logging.InputNameAudit,
-				Inputs:      helpers.MakeInputs(HostAuditLogID, K8sAuditLogID, OpenAuditLogID, OvnAuditLogID),
+				Inputs:      helpers.MakeInputs(HostAuditLogs, K8sAuditLogs, OpenshiftAuditLogs, OvnAuditLogs),
 				VRL: strings.Join(helpers.TrimSpaces([]string{
 					AddLogTypeAudit,
 					FixTimestampField,

--- a/internal/generator/vector/normalize_test.go
+++ b/internal/generator/vector/normalize_test.go
@@ -1,0 +1,249 @@
+package vector
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Vector Config Generation", func() {
+	var f = func(clspec logging.ClusterLoggingSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
+		return generator.MergeElements(
+			NormalizeLogs(&clfspec, op),
+		)
+	}
+	DescribeTable("NormalizeLogs(s)", helpers.TestGenerateConfWith(f),
+		Entry("Application logs only", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Pipelines: []logging.PipelineSpec{
+					{
+						InputRefs: []string{
+							logging.InputNameApplication,
+						},
+						OutputRefs: []string{logging.OutputNameDefault},
+						Name:       "pipeline",
+					},
+				},
+			},
+			ExpectedConf: `
+[transforms.container_logs]
+type = "remap"
+inputs = ["raw_container_logs"]
+source = '''
+  level = "unknown"
+  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
+    level = "warn"
+  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
+    level = "info"
+  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
+    level = "error"
+  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
+    level = "critical"
+  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
+    level = "debug"
+  }
+  .level = level
+  del(.source_type)
+  del(.stream)
+  del(.kubernetes.pod_ips)
+  ."@timestamp" = del(.timestamp)
+'''
+`,
+		}),
+		Entry("Infrastructure logs only", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Pipelines: []logging.PipelineSpec{
+					{
+						InputRefs: []string{
+							logging.InputNameInfrastructure,
+						},
+						OutputRefs: []string{logging.OutputNameDefault},
+						Name:       "pipeline",
+					},
+				},
+			},
+			ExpectedConf: `
+[transforms.container_logs]
+type = "remap"
+inputs = ["raw_container_logs"]
+source = '''
+  level = "unknown"
+  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
+    level = "warn"
+  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
+    level = "info"
+  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
+    level = "error"
+  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
+    level = "critical"
+  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
+    level = "debug"
+  }
+  .level = level
+  del(.source_type)
+  del(.stream)
+  del(.kubernetes.pod_ips)
+  ."@timestamp" = del(.timestamp)
+'''
+
+[transforms.journal_logs]
+type = "remap"
+inputs = ["raw_journal_logs"]
+source = '''
+  .tag = ".journal.system"
+  
+  del(.source_type)
+  del(._CPU_USAGE_NSEC)
+  del(.__REALTIME_TIMESTAMP)
+  del(.__MONOTONIC_TIMESTAMP)
+  del(._SOURCE_REALTIME_TIMESTAMP)
+  del(.PRIORITY)
+  del(.JOB_RESULT)
+  del(.JOB_TYPE)
+  del(.TIMESTAMP_BOOTTIME)
+  del(.TIMESTAMP_MONOTONIC)
+  
+  level = "unknown"
+  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
+    level = "warn"
+  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
+    level = "info"
+  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
+    level = "error"
+  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
+    level = "critical"
+  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
+    level = "debug"
+  }
+  .level = level
+  
+  .hostname = del(.host)
+  
+  # systemd’s kernel-specific metadata.
+  # .systemd.k = {}
+  if exists(.KERNEL_DEVICE) { .systemd.k.KERNEL_DEVICE = del(.KERNEL_DEVICE) }
+  if exists(.KERNEL_SUBSYSTEM) { .systemd.k.KERNEL_SUBSYSTEM = del(.KERNEL_SUBSYSTEM) }
+  if exists(.UDEV_DEVLINK) { .systemd.k.UDEV_DEVLINK = del(.UDEV_DEVLINK) }
+  if exists(.UDEV_DEVNODE) { .systemd.k.UDEV_DEVNODE = del(.UDEV_DEVNODE) }
+  if exists(.UDEV_SYSNAME) { .systemd.k.UDEV_SYSNAME = del(.UDEV_SYSNAME) }
+  
+  # trusted journal fields, fields that are implicitly added by the journal and cannot be altered by client code.
+  .systemd.t = {}
+  if exists(._AUDIT_LOGINUID) { .systemd.t.AUDIT_LOGINUID = del(._AUDIT_LOGINUID) }
+  if exists(._BOOT_ID) { .systemd.t.BOOT_ID = del(._BOOT_ID) }
+  if exists(._AUDIT_SESSION) { .systemd.t.AUDIT_SESSION = del(._AUDIT_SESSION) }
+  if exists(._CAP_EFFECTIVE) { .systemd.t.CAP_EFFECTIVE = del(._CAP_EFFECTIVE) }
+  if exists(._CMDLINE) { .systemd.t.CMDLINE = del(._CMDLINE) }
+  if exists(._COMM) { .systemd.t.COMM = del(._COMM) }
+  if exists(._EXE) { .systemd.t.EXE = del(._EXE) }
+  if exists(._GID) { .systemd.t.GID = del(._GID) }
+  if exists(._HOSTNAME) { .systemd.t.HOSTNAME = .hostname }
+  if exists(._LINE_BREAK) { .systemd.t.LINE_BREAK = del(._LINE_BREAK) }
+  if exists(._MACHINE_ID) { .systemd.t.MACHINE_ID = del(._MACHINE_ID) }
+  if exists(._PID) { .systemd.t.PID = del(._PID) }
+  if exists(._SELINUX_CONTEXT) { .systemd.t.SELINUX_CONTEXT = del(._SELINUX_CONTEXT) }
+  if exists(._SOURCE_REALTIME_TIMESTAMP) { .systemd.t.SOURCE_REALTIME_TIMESTAMP = del(._SOURCE_REALTIME_TIMESTAMP) }
+  if exists(._STREAM_ID) { .systemd.t.STREAM_ID = ._STREAM_ID }
+  if exists(._SYSTEMD_CGROUP) { .systemd.t.SYSTEMD_CGROUP = del(._SYSTEMD_CGROUP) }
+  if exists(._SYSTEMD_INVOCATION_ID) {.systemd.t.SYSTEMD_INVOCATION_ID = ._SYSTEMD_INVOCATION_ID}
+  if exists(._SYSTEMD_OWNER_UID) { .systemd.t.SYSTEMD_OWNER_UID = del(._SYSTEMD_OWNER_UID) }
+  if exists(._SYSTEMD_SESSION) { .systemd.t.SYSTEMD_SESSION = del(._SYSTEMD_SESSION) }
+  if exists(._SYSTEMD_SLICE) { .systemd.t.SYSTEMD_SLICE = del(._SYSTEMD_SLICE) }
+  if exists(._SYSTEMD_UNIT) { .systemd.t.SYSTEMD_UNIT = del(._SYSTEMD_UNIT) }
+  if exists(._SYSTEMD_USER_UNIT) { .systemd.t.SYSTEMD_USER_UNIT = del(._SYSTEMD_USER_UNIT) }
+  if exists(._TRANSPORT) { .systemd.t.TRANSPORT = del(._TRANSPORT) }
+  if exists(._UID) { .systemd.t.UID = del(._UID) }
+  
+  # fields that are directly passed from clients and stored in the journal.
+  .systemd.u = {}
+  if exists(.CODE_FILE) { .systemd.u.CODE_FILE = del(.CODE_FILE) }
+  if exists(.CODE_FUNC) { .systemd.u.CODE_FUNCTION = del(.CODE_FUNC) }
+  if exists(.CODE_LINE) { .systemd.u.CODE_LINE = del(.CODE_LINE) }
+  if exists(.ERRNO) { .systemd.u.ERRNO = del(.ERRNO) }
+  if exists(.MESSAGE_ID) { .systemd.u.MESSAGE_ID = del(.MESSAGE_ID) }
+  if exists(.SYSLOG_FACILITY) { .systemd.u.SYSLOG_FACILITY = del(.SYSLOG_FACILITY) }
+  if exists(.SYSLOG_IDENTIFIER) { .systemd.u.SYSLOG_IDENTIFIER = del(.SYSLOG_IDENTIFIER) }
+  if exists(.SYSLOG_PID) { .systemd.u.SYSLOG_PID = del(.SYSLOG_PID) }
+  if exists(.RESULT) { .systemd.u.RESULT = del(.RESULT) }
+  if exists(.UNIT) { .systemd.u.UNIT = del(.UNIT) }
+  
+  .time = format_timestamp!(.timestamp, format: "%FT%T%:z")
+  
+  ."@timestamp" = del(.timestamp)
+'''
+
+`,
+		}),
+		Entry("Audit logs only", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Pipelines: []logging.PipelineSpec{
+					{
+						InputRefs: []string{
+							logging.InputNameAudit,
+						},
+						OutputRefs: []string{logging.OutputNameDefault},
+						Name:       "pipeline",
+					},
+				},
+			},
+			ExpectedConf: `
+[transforms.host_audit_logs]
+type = "remap"
+inputs = ["raw_host_audit_logs"]
+source = '''
+  .tag = ".linux-audit.log"
+  
+  match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
+  envelop = {}
+  envelop |= {"type": match1.type}
+  
+  match2, err = parse_regex(.message, r'msg=audit\((?P<ts_record>[^ ]+)\):')
+  if err == null {
+    sp = split(match2.ts_record,":")
+    if length(sp) == 2 {
+        ts = parse_timestamp(sp[0],"%s.%3f") ?? ""
+        envelop |= {"record_id": sp[1]}
+        . |= {"audit.linux" : envelop}
+        . |= {"@timestamp" : format_timestamp(ts,"%+") ?? ""}
+    }
+  } else {
+    log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
+  }
+  hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+  del(.host)
+  . |= {"hostname" : hostname}
+'''
+    
+[transforms.k8s_audit_logs]
+type = "remap"
+inputs = ["raw_k8s_audit_logs"]
+source = '''
+  .tag = ".k8s-audit.log"
+  
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+'''
+
+[transforms.openshift_audit_logs]
+type = "remap"
+inputs = ["raw_openshift_audit_logs"]
+source = '''
+  .tag = ".openshift-audit.log"
+  
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+'''
+
+[transforms.ovn_audit_logs]
+type = "remap"
+inputs = ["raw_ovn_audit_logs"]
+source = '''
+  .tag = ".ovn-audit.log"
+'''
+`,
+		}),
+	)
+})

--- a/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 [transforms.cw_normalize_group_and_streams]
 type = "remap"
 inputs = ["cw-forward"]
-source = """
+source = '''
   .group_name = "default"
   .stream_name = "default"
   
@@ -37,7 +37,7 @@ source = """
   }
   del(.tag)
   del(.source_type)
-"""
+'''
 `
 		cwSink = `
 # Cloudwatch Logs

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -129,7 +129,7 @@ type = "lua"
 inputs = {{.InLabel}}
 version = "2"
 hooks.process = "process"
-source = """
+source = '''
     function process(event, emit)
         if event.log.kubernetes == nil then
             emit(event)
@@ -189,7 +189,7 @@ source = """
             map[k] = v
         end
     end
-"""
+'''
 {{end}}`,
 	}
 }

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -1,8 +1,9 @@
 package elasticsearch
 
 import (
-	"github.com/openshift/cluster-logging-operator/test/helpers"
 	"testing"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
@@ -50,7 +51,7 @@ var _ = Describe("Generate Vector config", func() {
 [transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
-source = """
+source = '''
   index = "default"
   if (.log_type == "application"){
     index = "app"
@@ -66,14 +67,14 @@ source = """
   del(.file)
   del(.tag)
   del(.source_type)
-"""
+'''
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
-source = """
+source = '''
     function process(event, emit)
         if event.log.kubernetes == nil then
             emit(event)
@@ -133,7 +134,7 @@ source = """
             map[k] = v
         end
     end
-"""
+'''
 
 [sinks.es_1]
 type = "elasticsearch"
@@ -178,7 +179,7 @@ password = "testpass"
 [transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
-source = """
+source = '''
   index = "default"
   if (.log_type == "application"){
     index = "app"
@@ -194,14 +195,14 @@ source = """
   del(.file)
   del(.tag)
   del(.source_type)
-"""
+'''
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
-source = """
+source = '''
     function process(event, emit)
         if event.log.kubernetes == nil then
             emit(event)
@@ -261,7 +262,7 @@ source = """
             map[k] = v
         end
     end
-"""
+'''
 
 [sinks.es_1]
 type = "elasticsearch"
@@ -297,7 +298,7 @@ ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 [transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
-source = """
+source = '''
   index = "default"
   if (.log_type == "application"){
     index = "app"
@@ -313,14 +314,14 @@ source = """
   del(.file)
   del(.tag)
   del(.source_type)
-"""
+'''
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
-source = """
+source = '''
     function process(event, emit)
         if event.log.kubernetes == nil then
             emit(event)
@@ -380,7 +381,7 @@ source = """
             map[k] = v
         end
     end
-"""
+'''
 
 [sinks.es_1]
 type = "elasticsearch"
@@ -453,7 +454,7 @@ id_key = "_id"
 [transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
-source = """
+source = '''
   index = "default"
   if (.log_type == "application"){
     index = "app"
@@ -469,14 +470,14 @@ source = """
   del(.file)
   del(.tag)
   del(.source_type)
-"""
+'''
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
-source = """
+source = '''
     function process(event, emit)
         if event.log.kubernetes == nil then
             emit(event)
@@ -536,7 +537,7 @@ source = """
             map[k] = v
         end
     end
-"""
+'''
 
 [sinks.es_1]
 type = "elasticsearch"
@@ -558,7 +559,7 @@ ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 [transforms.es_2_add_es_index]
 type = "remap"
 inputs = ["application"]
-source = """
+source = '''
   index = "default"
   if (.log_type == "application"){
     index = "app"
@@ -574,14 +575,14 @@ source = """
   del(.file)
   del(.tag)
   del(.source_type)
-"""
+'''
 
 [transforms.es_2_dedot_and_flatten]
 type = "lua"
 inputs = ["es_2_add_es_index"]
 version = "2"
 hooks.process = "process"
-source = """
+source = '''
     function process(event, emit)
         if event.log.kubernetes == nil then
             emit(event)
@@ -641,7 +642,7 @@ source = """
             map[k] = v
         end
     end
-"""
+'''
 
 [sinks.es_2]
 type = "elasticsearch"
@@ -682,7 +683,7 @@ ca_file = "/var/run/ocp-collector/secrets/es-2/ca-bundle.crt"
 [transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
-source = """
+source = '''
   index = "default"
   if (.log_type == "application"){
     index = "app"
@@ -704,14 +705,14 @@ source = """
       .write_index, err = "app-" + val + "-write"
     }
   }
-"""
+'''
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
-source = """
+source = '''
     function process(event, emit)
         if event.log.kubernetes == nil then
             emit(event)
@@ -771,7 +772,7 @@ source = """
             map[k] = v
         end
     end
-"""
+'''
 
 [sinks.es_1]
 type = "elasticsearch"
@@ -805,7 +806,7 @@ id_key = "_id"
 [transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
-source = """
+source = '''
   index = "default"
   if (.log_type == "application"){
     index = "app"
@@ -824,14 +825,14 @@ source = """
   if .log_type == "application" && .structured != null {
     .write_index = "app-myindex-write"
   }
-"""
+'''
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
-source = """
+source = '''
     function process(event, emit)
         if event.log.kubernetes == nil then
             emit(event)
@@ -891,7 +892,7 @@ source = """
             map[k] = v
         end
     end
-"""
+'''
 
 [sinks.es_1]
 type = "elasticsearch"
@@ -926,7 +927,7 @@ id_key = "_id"
 [transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
-source = """
+source = '''
   index = "default"
   if (.log_type == "application"){
     index = "app"
@@ -950,14 +951,14 @@ source = """
       .write_index = "app-myindex-write"
     }
   }
-"""
+'''
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
-source = """
+source = '''
     function process(event, emit)
         if event.log.kubernetes == nil then
             emit(event)
@@ -1017,7 +1018,7 @@ source = """
             map[k] = v
         end
     end
-"""
+'''
 
 [sinks.es_1]
 type = "elasticsearch"
@@ -1053,7 +1054,7 @@ id_key = "_id"
 [transforms.es_1_add_es_index]
 type = "remap"
 inputs = ["application"]
-source = """
+source = '''
   index = "default"
   if (.log_type == "application"){
     index = "app"
@@ -1088,14 +1089,14 @@ source = """
        log(err, level: "error")
     }
   }
-"""
+'''
 
 [transforms.es_1_dedot_and_flatten]
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
 hooks.process = "process"
-source = """
+source = '''
     function process(event, emit)
         if event.log.kubernetes == nil then
             emit(event)
@@ -1155,7 +1156,7 @@ source = """
             map[k] = v
         end
     end
-"""
+'''
 
 [sinks.es_1]
 type = "elasticsearch"

--- a/internal/generator/vector/sources.go
+++ b/internal/generator/vector/sources.go
@@ -12,10 +12,17 @@ import (
 )
 
 const (
-	HostAuditLogs      = "host_audit_logs"
-	K8sAuditLogs       = "k8s_audit_logs"
-	OpenShiftAuditLogs = "openshift_audit_logs"
-	OvnAuditLogs       = "ovn_audit_logs"
+	RawHostAuditLogs = "raw_host_audit_logs"
+	HostAuditLogs    = "host_audit_logs"
+
+	RawK8sAuditLogs = "raw_k8s_audit_logs"
+	K8sAuditLogs    = "k8s_audit_logs"
+
+	RawOpenshiftAuditLogs = "raw_openshift_audit_logs"
+	OpenshiftAuditLogs    = "openshift_audit_logs"
+
+	RawOvnAuditLogs = "raw_ovn_audit_logs"
+	OvnAuditLogs    = "ovn_audit_logs"
 )
 
 func Sources(spec *logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
@@ -48,25 +55,25 @@ func LogSources(spec *logging.ClusterLogForwarderSpec, op generator.Options) []g
 	if types.Has(logging.InputNameAudit) {
 		el = append(el,
 			source.HostAuditLog{
-				ComponentID:  HostAuditLogs,
+				ComponentID:  RawHostAuditLogs,
 				Desc:         "Logs from host audit",
 				TemplateName: "inputSourceHostAuditTemplate",
 				TemplateStr:  source.HostAuditLogTemplate,
 			},
 			source.K8sAuditLog{
-				ComponentID:  K8sAuditLogs,
+				ComponentID:  RawK8sAuditLogs,
 				Desc:         "Logs from kubernetes audit",
 				TemplateName: "inputSourceK8sAuditTemplate",
 				TemplateStr:  source.K8sAuditLogTemplate,
 			},
 			source.OpenshiftAuditLog{
-				ComponentID:  OpenShiftAuditLogs,
+				ComponentID:  RawOpenshiftAuditLogs,
 				Desc:         "Logs from openshift audit",
 				TemplateName: "inputSourceOpenShiftAuditTemplate",
 				TemplateStr:  source.OpenshiftAuditLogTemplate,
 			},
 			source.OVNAuditLog{
-				ComponentID:  OvnAuditLogs,
+				ComponentID:  RawOvnAuditLogs,
 				Desc:         "Logs from ovn audit",
 				TemplateName: "inputSourceOVNAuditTemplate",
 				TemplateStr:  source.OVNAuditLogTemplate,

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -84,25 +84,25 @@ journal_directory = "/var/log/journal"
 			},
 			ExpectedConf: `
 # Logs from host audit
-[sources.host_audit_logs]
+[sources.raw_host_audit_logs]
 type = "file"
 ignore_older_secs = 600
 include = ["/var/log/audit/audit.log"]
 
 # Logs from kubernetes audit
-[sources.k8s_audit_logs]
+[sources.raw_k8s_audit_logs]
 type = "file"
 ignore_older_secs = 600
 include = ["/var/log/kube-apiserver/audit.log"]
 
 # Logs from openshift audit
-[sources.openshift_audit_logs]
+[sources.raw_openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 
 # Logs from ovn audit
-[sources.ovn_audit_logs]
+[sources.raw_ovn_audit_logs]
 type = "file"
 ignore_older_secs = 600
 include = ["/var/log/ovn/acl-audit-log.log"]
@@ -139,28 +139,29 @@ type = "journald"
 journal_directory = "/var/log/journal"
 
 # Logs from host audit
-[sources.host_audit_logs]
+[sources.raw_host_audit_logs]
 type = "file"
 ignore_older_secs = 600
 include = ["/var/log/audit/audit.log"]
 
 # Logs from kubernetes audit
-[sources.k8s_audit_logs]
+[sources.raw_k8s_audit_logs]
 type = "file"
 ignore_older_secs = 600
 include = ["/var/log/kube-apiserver/audit.log"]
 
 # Logs from openshift audit
-[sources.openshift_audit_logs]
+[sources.raw_openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 
 # Logs from ovn audit
-[sources.ovn_audit_logs]
+[sources.raw_ovn_audit_logs]
 type = "file"
 ignore_older_secs = 600
 include = ["/var/log/ovn/acl-audit-log.log"]
 `,
-		}))
+		}),
+	)
 })

--- a/internal/generator/vector/sources_to_pipelines_test.go
+++ b/internal/generator/vector/sources_to_pipelines_test.go
@@ -44,69 +44,33 @@ route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_wit
 [transforms.application]
 type = "remap"
 inputs = ["route_container_logs.app"]
-source = """
+source = '''
   .log_type = "application"
-"""
+'''
 
 # Set log_type to "infrastructure"
 [transforms.infrastructure]
 type = "remap"
 inputs = ["route_container_logs.infra","journal_logs"]
-source = """
+source = '''
   .log_type = "infrastructure"
-"""
-
-# Tag host audit files
-[transforms.tagged_host_audit_logs]
-type = "remap"
-inputs = ["host_audit_logs"]
-source = """
-  .tag = ".linux-audit.log"
-"""
-
-# Tag k8s audit files
-[transforms.tagged_k8s_audit_logs]
-type = "remap"
-inputs = ["k8s_audit_logs"]
-source = """
-  .tag = ".k8s-audit.log"
-  . = merge(., parse_json!(string!(.message))) ?? .
-  del(.message)
-"""
-
-# Tag openshift audit files
-[transforms.tagged_openshift_audit_logs]
-type = "remap"
-inputs = ["openshift_audit_logs"]
-source = """
-  .tag = ".openshift-audit.log"
-  . = merge(., parse_json!(string!(.message))) ?? .
-  del(.message)
-"""
-
-# Tag ovn audit files
-[transforms.tagged_ovn_audit_logs]
-type = "remap"
-inputs = ["ovn_audit_logs"]
-source = """
-  .tag = ".ovn-audit.log"
-"""
+'''
 
 # Set log_type to "audit"
 [transforms.audit]
 type = "remap"
-inputs = ["tagged_host_audit_logs","tagged_k8s_audit_logs","tagged_openshift_audit_logs","tagged_ovn_audit_logs"]
-source = """
+inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
+source = '''
   .log_type = "audit"
   ."@timestamp" = del(.timestamp)
-"""
+'''
 
 [transforms.pipeline]
 type = "remap"
 inputs = ["application","infrastructure","audit"]
-source = """
+source = '''
   .
-"""
+'''
 `,
 		}),
 		Entry("Send same logtype to multiple output", helpers.ConfGenerateTest{
@@ -141,76 +105,40 @@ route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_wit
 [transforms.application]
 type = "remap"
 inputs = ["route_container_logs.app"]
-source = """
+source = '''
   .log_type = "application"
-"""
+'''
 
 # Set log_type to "infrastructure"
 [transforms.infrastructure]
 type = "remap"
 inputs = ["route_container_logs.infra","journal_logs"]
-source = """
+source = '''
   .log_type = "infrastructure"
-"""
-
-# Tag host audit files
-[transforms.tagged_host_audit_logs]
-type = "remap"
-inputs = ["host_audit_logs"]
-source = """
-  .tag = ".linux-audit.log"
-"""
-
-# Tag k8s audit files
-[transforms.tagged_k8s_audit_logs]
-type = "remap"
-inputs = ["k8s_audit_logs"]
-source = """
-  .tag = ".k8s-audit.log"
-  . = merge(., parse_json!(string!(.message))) ?? .
-  del(.message)
-"""
-
-# Tag openshift audit files
-[transforms.tagged_openshift_audit_logs]
-type = "remap"
-inputs = ["openshift_audit_logs"]
-source = """
-  .tag = ".openshift-audit.log"
-  . = merge(., parse_json!(string!(.message))) ?? .
-  del(.message)
-"""
-
-# Tag ovn audit files
-[transforms.tagged_ovn_audit_logs]
-type = "remap"
-inputs = ["ovn_audit_logs"]
-source = """
-  .tag = ".ovn-audit.log"
-"""
+'''
 
 # Set log_type to "audit"
 [transforms.audit]
 type = "remap"
-inputs = ["tagged_host_audit_logs","tagged_k8s_audit_logs","tagged_openshift_audit_logs","tagged_ovn_audit_logs"]
-source = """
+inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
+source = '''
   .log_type = "audit"
   ."@timestamp" = del(.timestamp)
-"""
+'''
 
 [transforms.pipeline1]
 type = "remap"
 inputs = ["application","infrastructure","audit"]
-source = """
+source = '''
   .
-"""
+'''
 
 [transforms.pipeline2]
 type = "remap"
 inputs = ["application"]
-source = """
+source = '''
   .
-"""
+'''
 `,
 		}),
 		Entry("Route Logs by Namespace(s)", helpers.ConfGenerateTest{
@@ -241,9 +169,9 @@ route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_wit
 [transforms.application]
 type = "remap"
 inputs = ["route_container_logs.app"]
-source = """
+source = '''
   .log_type = "application"
-"""
+'''
 
 [transforms.route_application_logs]
 type = "route"
@@ -253,9 +181,9 @@ route.myapplogs = '(.kubernetes.namespace_name == "test-ns1") || (.kubernetes.na
 [transforms.pipeline]
 type = "remap"
 inputs = ["route_application_logs.myapplogs"]
-source = """
+source = '''
   .
-"""
+'''
 `,
 		}),
 		Entry("Route Logs by Namespaces(s), and Labels(s)", helpers.ConfGenerateTest{
@@ -292,9 +220,9 @@ route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_wit
 [transforms.application]
 type = "remap"
 inputs = ["route_container_logs.app"]
-source = """
+source = '''
   .log_type = "application"
-"""
+'''
 
 [transforms.route_application_logs]
 type = "route"
@@ -304,9 +232,9 @@ route.myapplogs = '((.kubernetes.namespace_name == "myapp1") || (.kubernetes.nam
 [transforms.pipeline]
 type = "remap"
 inputs = ["route_application_logs.myapplogs"]
-source = """
+source = '''
   .
-"""
+'''
 `,
 		}),
 		Entry("Add Openshift Label(s)", helpers.ConfGenerateTest{
@@ -333,24 +261,24 @@ route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_wit
 [transforms.application]
 type = "remap"
 inputs = ["route_container_logs.app"]
-source = """
+source = '''
   .log_type = "application"
-"""
+'''
 
 # Set log_type to "infrastructure"
 [transforms.infrastructure]
 type = "remap"
 inputs = ["route_container_logs.infra","journal_logs"]
-source = """
+source = '''
   .log_type = "infrastructure"
-"""
+'''
 
 [transforms.pipeline]
 type = "remap"
 inputs = ["application","infrastructure"]
-source = """
+source = '''
   .openshift.labels = {"label1":"value1"}
-"""
+'''
 `,
 		}),
 		Entry("Parse log message as Jaon", helpers.ConfGenerateTest{
@@ -375,27 +303,27 @@ route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_wit
 [transforms.application]
 type = "remap"
 inputs = ["route_container_logs.app"]
-source = """
+source = '''
   .log_type = "application"
-"""
+'''
 
 # Set log_type to "infrastructure"
 [transforms.infrastructure]
 type = "remap"
 inputs = ["route_container_logs.infra","journal_logs"]
-source = """
+source = '''
   .log_type = "infrastructure"
-"""
+'''
 
 [transforms.pipeline]
 type = "remap"
 inputs = ["application","infrastructure"]
-source = """
+source = '''
   parsed, err = parse_json(.message)
   if err == null {
     .structured = parsed
   }
-"""
+'''
 `,
 		}),
 	)

--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -286,24 +286,24 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 			//TODO: fix me when audit formatting is enabled
 			It("should parse ovn audit log correctly", func() {
 				// Log message data
-				//level := "info"
+				level := "info"
 				ovnLogLine := functional.NewOVNAuditLog(time.Now())
 
-				//// Template expected as output Log
-				//var outputLogTemplate = types.OVNAuditLog{
-				//	Message:   ovnLogLine,
-				//	Level:     level,
-				//	Hostname:  functional.FunctionalNodeName,
-				//	Timestamp: time.Time{},
-				//	LogType:   "audit",
-				//	Openshift: types.OpenshiftMeta{
-				//		Sequence: types.NewOptionalInt(""),
-				//	},
-				//	ViaqMsgID:        "*",
-				//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-				//}
-				//outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
-				//// Write log line as input to fluentd
+				// Template expected as output Log
+				var outputLogTemplate = types.OVNAuditLog{
+					Message:   ovnLogLine,
+					Level:     level,
+					Hostname:  functional.FunctionalNodeName,
+					Timestamp: time.Time{},
+					LogType:   "audit",
+					Openshift: types.OpenshiftMeta{
+						Sequence: types.NewOptionalInt(""),
+					},
+					ViaqMsgID:        "*",
+					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				}
+				outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
+				// Write log line as input to fluentd
 				Expect(framework.WriteMessagesToOVNAuditLog(ovnLogLine, 10)).To(BeNil())
 				// Read line from Log Forward output
 				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
@@ -311,7 +311,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				//var logs []types.OVNAuditLog
 				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
 				//ExpectOK(err)
-				//// Compare to expected template
+				// Compare to expected template
 				//outputTestLog := logs[0]
 				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 				results := strings.Join(raw, " ")


### PR DESCRIPTION
### Description
- Added VRL to parse host audit logs
- changed VRL source to use toml multiline literal strings, (delimited with `'''` instead of `"""`)
- some audit logs refactoring 

/cc @jcantrill @cahartma 
/assign 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2378
- Enhancement proposal:
