### PR TITLE
LOG-2768: Disable chunk backup

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -707,6 +707,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
       total_limit_size 800000000
       chunk_limit_size 8m
       overflow_action throw_exception
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -750,6 +751,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
       total_limit_size 800000000
       chunk_limit_size 8m
       overflow_action throw_exception
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -771,6 +771,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -814,7 +815,8 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
-    </buffer>
+      disable_chunk_backup true
+   </buffer>
   </match>
 </label>
 
@@ -899,6 +901,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -942,6 +945,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -1588,6 +1592,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -1631,6 +1636,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -1716,6 +1722,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -1759,6 +1766,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -2409,6 +2417,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -2452,6 +2461,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -2537,6 +2547,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -2580,6 +2591,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -3073,6 +3085,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -3743,6 +3756,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -3786,6 +3800,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -3871,6 +3886,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -3914,6 +3930,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -3999,6 +4016,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -4042,6 +4060,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -4127,6 +4146,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -4170,6 +4190,7 @@ var _ = Describe("Generating fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/buffer_conf.go
+++ b/internal/generator/fluentd/output/buffer_conf.go
@@ -21,6 +21,7 @@ func (bc BufferConf) Template() string {
 <buffer>
 {{- end}}
 {{compose_one .BufferConfData | indent 2}}
+  disable_chunk_backup true
 </buffer>
 {{end}}`
 }

--- a/internal/generator/fluentd/output/buffer_conf_test.go
+++ b/internal/generator/fluentd/output/buffer_conf_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Generate fluentd conf", func() {
   total_limit_size 800000000
   chunk_limit_size 8m
   overflow_action throw_exception
+  disable_chunk_backup true
 </buffer>`,
 		}),
 		Entry("when tuning flush_mode other then interval", ConfGenerateTest{
@@ -96,6 +97,7 @@ var _ = Describe("Generate fluentd conf", func() {
   total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
   chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
   overflow_action block
+  disable_chunk_backup true
 </buffer>`,
 		}),
 	)
@@ -148,6 +150,7 @@ var _ = Describe("Generate fluentd conf", func() {
   total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
   chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
   overflow_action block
+  disable_chunk_backup true
 </buffer>`,
 		}))
 })

--- a/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
@@ -56,6 +56,9 @@ concurrency 2
 include_time_key true
 log_rejected_request true
 {{compose_one .EndpointConfig}}
+<buffer>
+  disable_chunk_backup true
+</buffer>
 {{end}}`
 }
 

--- a/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
@@ -90,6 +90,9 @@ var _ = Describe("Generating fluentd config", func() {
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `
@@ -143,6 +146,9 @@ var _ = Describe("Generating fluentd config", func() {
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `
@@ -199,6 +205,9 @@ var _ = Describe("Generating fluentd config", func() {
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `
@@ -256,6 +265,9 @@ var _ = Describe("Generating fluentd config", func() {
     aws_sec_key "#{open('/var/run/ocp-collector/secrets/my-secret/aws_secret_access_key','r') do |f|f.read.strip end}"
     include_time_key true
     log_rejected_request true
+	<buffer>
+	  disable_chunk_backup true
+	</buffer>
   </match>
 </label>
 `

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -127,6 +127,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -169,6 +170,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -277,6 +279,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -320,6 +323,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -416,6 +420,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -455,6 +460,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -549,7 +555,8 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
-    </buffer>
+      disable_chunk_backup true
+   </buffer>
   </match>
   
   <match **>
@@ -589,6 +596,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -696,6 +704,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -737,6 +746,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -833,6 +843,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -873,6 +884,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/elasticsearch/output_conf_es_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/output_conf_es_test.go
@@ -178,6 +178,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -221,6 +222,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>`))
@@ -334,6 +336,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -375,6 +378,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
@@ -82,7 +82,8 @@ var _ = Describe("fluentd conf generation", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
-    </buffer>
+      disable_chunk_backup true
+   </buffer>
   </match>
 </label>
 `,
@@ -140,6 +141,7 @@ var _ = Describe("fluentd conf generation", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -186,6 +188,7 @@ var _ = Describe("fluentd conf generation", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/fluentdforward/output_conf_forward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/output_conf_forward_test.go
@@ -86,6 +86,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -126,6 +127,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -173,6 +175,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -219,6 +222,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/kafka/kafka_test.go
+++ b/internal/generator/fluentd/output/kafka/kafka_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -135,6 +136,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -176,6 +178,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/kafka/output_conf_kafka_test.go
+++ b/internal/generator/fluentd/output/kafka/output_conf_kafka_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Generating external kafka server output store config block", f
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -111,6 +112,7 @@ var _ = Describe("Generating external kafka server output store config block", f
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -181,6 +183,7 @@ var _ = Describe("Generating external kafka server output store config block", f
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/loki/loki_conf_test.go
+++ b/internal/generator/fluentd/output/loki/loki_conf_test.go
@@ -115,6 +115,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -183,6 +184,7 @@ var _ = Describe("Generate fluentd config", func() {
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>

--- a/internal/generator/fluentd/output/loki/output_conf_loki_test.go
+++ b/internal/generator/fluentd/output/loki/output_conf_loki_test.go
@@ -84,6 +84,7 @@ func TestLokiOutput(t *testing.T) {
      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
      overflow_action block
+     disable_chunk_backup true
 `,
 			}
 			secrets = map[string]*corev1.Secret{

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -159,6 +159,7 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
                 overflow_action block
+                disable_chunk_backup true
               </buffer>
           </match>
           <match **>
@@ -198,6 +199,7 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
                 overflow_action block
+                disable_chunk_backup true
               </buffer>
           </match>
         </label>`
@@ -299,6 +301,7 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
                 overflow_action block
+                disable_chunk_backup true
               </buffer>
           </match>
           <match **>
@@ -338,6 +341,7 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
                 chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
                 overflow_action block
+                disable_chunk_backup true
               </buffer>
           </match>
         </label>`
@@ -427,6 +431,7 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size 512m
                 chunk_limit_size 256m
                 overflow_action drop_oldest_chunk
+                disable_chunk_backup true
               </buffer>
           </match>
           <match **>
@@ -465,7 +470,8 @@ var _ = Describe("Generating fluentd config", func() {
                 total_limit_size 512m
                 chunk_limit_size 256m
                 overflow_action drop_oldest_chunk
-              </buffer>
+                disable_chunk_backup true
+             </buffer>
           </match>
         </label>`
 
@@ -516,6 +522,7 @@ var _ = Describe("Generating fluentd config", func() {
             total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
             chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
             overflow_action block
+            disable_chunk_backup true
             </buffer>
 
            </match>
@@ -554,6 +561,7 @@ var _ = Describe("Generating fluentd config", func() {
           total_limit_size 512m
           chunk_limit_size 256m
           overflow_action drop_oldest_chunk
+          disable_chunk_backup true
           </buffer>
 
         </match>
@@ -622,6 +630,7 @@ var _ = Describe("Generating fluentd config", func() {
 		                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
 		                chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
 		                overflow_action block
+                        disable_chunk_backup true
 		              </buffer>
 		          </match>
 		        </label>`
@@ -674,6 +683,7 @@ var _ = Describe("Generating fluentd config", func() {
 		                total_limit_size 512m
 		                chunk_limit_size 256m
 		                overflow_action drop_oldest_chunk
+                        disable_chunk_backup true
 		              </buffer>
 		          </match>
 		        </label>`
@@ -724,6 +734,7 @@ var _ = Describe("Generating fluentd config", func() {
                total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
                chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
                overflow_action block
+               disable_chunk_backup true
            </buffer>
         </match>
         </label>`
@@ -758,6 +769,7 @@ var _ = Describe("Generating fluentd config", func() {
                total_limit_size 512m
                chunk_limit_size 256m
                overflow_action drop_oldest_chunk
+               disable_chunk_backup true
            </buffer>
         </match>
         </label>`

--- a/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
+++ b/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
@@ -174,6 +174,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -215,6 +216,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -264,6 +266,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -307,6 +310,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -458,6 +462,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -497,6 +502,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -593,6 +599,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -633,6 +640,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>
@@ -730,6 +738,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
   
@@ -769,6 +778,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
       total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
       chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
       overflow_action block
+      disable_chunk_backup true
     </buffer>
   </match>
 </label>


### PR DESCRIPTION
### Description
This PR:
* Disables chunk backup for all output types in order to not fill the node disk

### Links
* https://issues.redhat.com/browse/LOG-2768
* backport of #1520 
