### PR TITLE
Default to collector service-account for fluentd Loki output

### DIFF
--- a/internal/generator/fluentd/output/loki/loki.go
+++ b/internal/generator/fluentd/output/loki/loki.go
@@ -131,6 +131,13 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 			}
 			conf = append(conf, bt)
 		}
+	} else if secret != nil {
+		// Use secret of logcollector ServiceAccount as fallback
+		conf = append(conf, CAFile{
+			CAFilePath: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+		}, BearerTokenFile{
+			BearerTokenFilePath: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+		})
 	}
 	return conf
 }

--- a/internal/generator/fluentd/output/loki/output_conf_loki_test.go
+++ b/internal/generator/fluentd/output/loki/output_conf_loki_test.go
@@ -117,7 +117,9 @@ func TestLokiOutput(t *testing.T) {
 		es := Conf(nil, secrets["loki-receiver"], outputs[0], generator.NoOptions)
 		results, err := g.GenerateConf(es...)
 		require.NoError(t, err)
-		config.content = "url https://logs-us-west1.grafana.net"
+		config.content = `url https://logs-us-west1.grafana.net
+ca_cert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+bearer_token_file /var/run/secrets/kubernetes.io/serviceaccount/token`
 		require.Equal(t, test.TrimLines(config.String()), test.TrimLines(results), results)
 	})
 
@@ -152,7 +154,9 @@ func TestLokiOutput(t *testing.T) {
 		es := Conf(nil, secrets["loki-receiver"], outputs[0], generator.NoOptions)
 		results, err := g.GenerateConf(es...)
 		require.NoError(t, err)
-		config.content = `url https://logs-us-west1.grafana.net`
+		config.content = `url https://logs-us-west1.grafana.net
+ca_cert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+bearer_token_file /var/run/secrets/kubernetes.io/serviceaccount/token`
 		// NOTE: kubernetes.host should be added automatically if not present.
 		config.filter = `
       _kubernetes_container_name ${record.dig("kubernetes","container_name")}
@@ -180,6 +184,8 @@ func TestLokiOutput(t *testing.T) {
 		}}
 		config.content = `url https://logs-us-west1.grafana.net/a-tenant
     tenant ${record.dig("foo","bar","baz")}
+ca_cert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+bearer_token_file /var/run/secrets/kubernetes.io/serviceaccount/token
 `
 		es := Conf(nil, secrets["loki-receiver"], outputs[0], generator.NoOptions)
 		results, err := g.GenerateConf(es...)


### PR DESCRIPTION
### Description

There's currently a difference in behavior between the configuration generators for fluentd and vector when generating configuration for a Loki output: When generating the configuration for a Loki output on vector, the cluster-logging-operator will automatically fall back to the credentials in the `logcollector` ServiceAccount when no user-provided secret is available while the fluentd generator will not use credentials at all.

This PR changes the behavior of the fluentd configuration generator to match the one of the vector config generator, so that for both collectors it is possible to use a Loki output and authenticate using the `logcollector` ServiceAccount.

### Links

- JIRA: Related to [LOG-1803](https://issues.redhat.com/browse/LOG-1803)
