### PR TITLE
fix shard number expression in dashboard file

### DIFF
--- a/files/dashboards/openshift-logging-dashboard.json
+++ b/files/dashboards/openshift-logging-dashboard.json
@@ -249,7 +249,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "max(es_cluster_shards_number{type=\"active_primary\"})",
+              "expr": "max(es_cluster_shards_number{type=\"active\"})",
               "instant": true,
               "refId": "A"
             }


### PR DESCRIPTION
### Description
This PR updates the dashboard file to show all active shards instead of only primary ones, to comply with what's described in the [documentation](https://docs.openshift.com/container-platform/4.9/logging/cluster-logging-dashboards.html#:~:text=Table%201.%20OpenShift%20Logging%20charts).

/cc @shwetaap 
/assign @periklis 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2749
