### PR TITLE
LOG-2772: fix parsing of STS role

### DIFF
--- a/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
@@ -173,7 +173,7 @@ func LogGroupName(o logging.OutputSpec) string {
 func ParseRoleArn(secret *corev1.Secret) string {
 	roleArnString := security.GetFromSecret(secret, constants.AWSWebIdentityRoleKey)
 	if roleArnString != "" {
-		reg := regexp.MustCompile(`(arn:aws:(iam|sts)::\d{12}:role\/\S+)\s?`)
+		reg := regexp.MustCompile(`(arn:aws(.*)?:(iam|sts)::\d{12}:role\/\S+)\s?`)
 		roleArn := reg.FindStringSubmatch(roleArnString)
 		if roleArn != nil {
 			return roleArn[1] // the capturing group is index 1

--- a/internal/generator/fluentd/output/cloudwatch/cloudwatch_secret_test.go
+++ b/internal/generator/fluentd/output/cloudwatch/cloudwatch_secret_test.go
@@ -8,6 +8,7 @@ import (
 
 var _ = Describe("Parsing strings for sts functionality", func() {
 	var (
+		altRoleArn        = "arn:aws-us-gov:iam::225746144451:role/anli-sts-25690-openshift-logging-cloudwatch-credentials"
 		roleArn           = "arn:aws:iam::123456789012:role/my-role-from-secret"
 		credentialsString = "[default]\nrole_arn = " + roleArn + "\nweb_identity_token_file = /var/run/secrets/token"
 		secrets           = map[string]*corev1.Secret{
@@ -24,6 +25,15 @@ var _ = Describe("Parsing strings for sts functionality", func() {
 			It("should return our specified valid role_arn", func() {
 				results := ParseRoleArn(secrets["my-secret"])
 				Expect(results).To(Equal(roleArn))
+			})
+			It("should return our specified valid role_arn when the partion is more than 'aws'", func() {
+				secrets["other"] = &corev1.Secret{
+					Data: map[string][]byte{
+						"role_arn": []byte(altRoleArn),
+					},
+				}
+				results := ParseRoleArn(secrets["other"])
+				Expect(results).To(Equal(altRoleArn))
 			})
 		})
 	})


### PR DESCRIPTION
### Description
This PR:
* fixes parsing of STS arn role when the partition is not 'aws'

### Links
* https://issues.redhat.com/browse/LOG-2772

cc @cahartma 