### PR TITLE
Log-2769: Support Elasticsearch 8.x as an output using vector

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder.go
+++ b/apis/logging/v1/cluster_log_forwarder.go
@@ -20,6 +20,8 @@ func IsInputTypeName(s string) bool { return ReservedInputNames.Has(s) }
 
 // Default log store output name.
 const OutputNameDefault = "default"
+const DefaultESVersion = 6
+const LatestESVersion = 8
 
 // IsReservedOutputName returns true if s is a reserved output name.
 func IsReservedOutputName(s string) bool { return s == OutputNameDefault }

--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -197,6 +197,16 @@ type Elasticsearch struct {
 	//
 	// +optional
 	EnableStructuredContainerLogs bool `json:"enableStructuredContainerLogs,omitempty"`
+
+	// Version specifies the version of Elasticsearch to be used.
+	// Must be one of:
+	//  - 6 - Default for internal ES store
+	//  - 7
+	//  - 8 - Default for external ES store
+	//
+	// +kubebuilder:validation:Minimum:=6
+	// +optional
+	Version int `json:"version,omitempty"`
 }
 
 // Loki provides optional extra properties for `type: loki`

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -160,6 +160,12 @@ spec:
                         description: StructuredTypeName specifies the name of elasticsearch
                           schema
                         type: string
+                      version:
+                        description: 'Version specifies the version of Elasticsearch
+                          to be used. Must be one of: - 6 - Default for internal ES
+                          store - 7 - 8 - Default for external ES store'
+                        minimum: 6
+                        type: integer
                     type: object
                 type: object
               outputs:
@@ -214,6 +220,12 @@ spec:
                           description: StructuredTypeName specifies the name of elasticsearch
                             schema
                           type: string
+                        version:
+                          description: 'Version specifies the version of Elasticsearch
+                            to be used. Must be one of: - 6 - Default for internal
+                            ES store - 7 - 8 - Default for external ES store'
+                          minimum: 6
+                          type: integer
                       type: object
                     fluentdForward:
                       description: "FluentdForward does not provide additional fields,

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -156,6 +156,12 @@ spec:
                         description: StructuredTypeName specifies the name of elasticsearch
                           schema
                         type: string
+                      version:
+                        description: 'Version specifies the version of Elasticsearch
+                          to be used. Must be one of: - 6 - Default for internal ES
+                          store - 7 - 8 - Default for external ES store'
+                        minimum: 6
+                        type: integer
                     type: object
                 type: object
               outputs:
@@ -210,6 +216,12 @@ spec:
                           description: StructuredTypeName specifies the name of elasticsearch
                             schema
                           type: string
+                        version:
+                          description: 'Version specifies the version of Elasticsearch
+                            to be used. Must be one of: - 6 - Default for internal
+                            ES store - 7 - 8 - Default for external ES store'
+                          minimum: 6
+                          type: integer
                       type: object
                     fluentdForward:
                       description: "FluentdForward does not provide additional fields,

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -766,6 +766,7 @@ bulk.index = "{{ write_index }}"
 bulk.action = "create"
 request.timeout_secs = 2147483648
 id_key = "_id"
+suppress_type_name = true
 
 [sinks.es_1.tls]
 enabled = true
@@ -848,6 +849,503 @@ bulk.index = "{{ write_index }}"
 bulk.action = "create"
 request.timeout_secs = 2147483648
 id_key = "_id"
+suppress_type_name = true
+
+[sinks.es_2.tls]
+enabled = true
+key_file = "/var/run/ocp-collector/secrets/es-2/tls.key"
+crt_file = "/var/run/ocp-collector/secrets/es-2/tls.crt"
+ca_file = "/var/run/ocp-collector/secrets/es-2/ca-bundle.crt"
+
+[sinks.prometheus_output]
+type = "prometheus_exporter"
+inputs = ["internal_metrics"]
+address = "0.0.0.0:24231"
+default_namespace = "collector"
+
+[sinks.prometheus_output.tls]
+enabled = true
+key_file = "/etc/collector/metrics/tls.key"
+crt_file = "/etc/collector/metrics/tls.crt"
+`,
+		}),
+		Entry("with complex spec for elasticsearch default v6 & latest version", testhelpers.ConfGenerateTest{
+			CLSpec: logging.CollectionSpec{},
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Pipelines: []logging.PipelineSpec{
+					{
+						InputRefs: []string{
+							logging.InputNameApplication,
+							logging.InputNameInfrastructure,
+							logging.InputNameAudit},
+						OutputRefs: []string{"es-1", "es-2"},
+						Name:       "pipeline",
+					},
+				},
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeElasticsearch,
+						Name: "es-1",
+						URL:  "https://es-1.svc.messaging.cluster.local:9200",
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Elasticsearch: &logging.Elasticsearch{
+								Version: logging.DefaultESVersion,
+							},
+						},
+						Secret: &logging.OutputSecretSpec{
+							Name: "es-1",
+						},
+					},
+					{
+						Type: logging.OutputTypeElasticsearch,
+						Name: "es-2",
+						URL:  "https://es-2.svc.messaging.cluster.local:9200",
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Elasticsearch: &logging.Elasticsearch{
+								Version: logging.LatestESVersion,
+							},
+						},
+						Secret: &logging.OutputSecretSpec{
+							Name: "es-2",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"es-1": {
+					Data: map[string][]byte{
+						"tls.key":       []byte("junk"),
+						"tls.crt":       []byte("junk"),
+						"ca-bundle.crt": []byte("junk"),
+					},
+				},
+				"es-2": {
+					Data: map[string][]byte{
+						"tls.key":       []byte("junk"),
+						"tls.crt":       []byte("junk"),
+						"ca-bundle.crt": []byte("junk"),
+					},
+				},
+			},
+			ExpectedConf: `
+# Logs from containers (including openshift containers)
+[sources.raw_container_logs]
+type = "kubernetes_logs"
+glob_minimum_cooldown_ms = 15000
+auto_partial_merge = true
+exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
+pod_annotation_fields.pod_labels = "kubernetes.labels"
+pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
+
+[sources.raw_journal_logs]
+type = "journald"
+journal_directory = "/var/log/journal"
+
+# Logs from host audit
+[sources.raw_host_audit_logs]
+type = "file"
+include = ["/var/log/audit/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+# Logs from kubernetes audit
+[sources.raw_k8s_audit_logs]
+type = "file"
+include = ["/var/log/kube-apiserver/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+# Logs from openshift audit
+[sources.raw_openshift_audit_logs]
+type = "file"
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+# Logs from ovn audit
+[sources.raw_ovn_audit_logs]
+type = "file"
+include = ["/var/log/ovn/acl-audit-log.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[transforms.container_logs]
+type = "remap"
+inputs = ["raw_container_logs"]
+source = '''
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+      .level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    }
+  }
+  del(.source_type)
+  del(.stream)
+  del(.kubernetes.pod_ips)
+  ."@timestamp" = del(.timestamp)
+'''
+
+[transforms.journal_logs]
+type = "remap"
+inputs = ["raw_journal_logs"]
+source = '''
+  .tag = ".journal.system"
+  
+  del(.source_type)
+  del(._CPU_USAGE_NSEC)
+  del(.__REALTIME_TIMESTAMP)
+  del(.__MONOTONIC_TIMESTAMP)
+  del(._SOURCE_REALTIME_TIMESTAMP)
+  del(.PRIORITY)
+  del(.JOB_RESULT)
+  del(.JOB_TYPE)
+  del(.TIMESTAMP_BOOTTIME)
+  del(.TIMESTAMP_MONOTONIC)
+  
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+      .level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    }
+  }
+  
+  .hostname = del(.host)
+  
+  # systemd’s kernel-specific metadata.
+  # .systemd.k = {}
+  if exists(.KERNEL_DEVICE) { .systemd.k.KERNEL_DEVICE = del(.KERNEL_DEVICE) }
+  if exists(.KERNEL_SUBSYSTEM) { .systemd.k.KERNEL_SUBSYSTEM = del(.KERNEL_SUBSYSTEM) }
+  if exists(.UDEV_DEVLINK) { .systemd.k.UDEV_DEVLINK = del(.UDEV_DEVLINK) }
+  if exists(.UDEV_DEVNODE) { .systemd.k.UDEV_DEVNODE = del(.UDEV_DEVNODE) }
+  if exists(.UDEV_SYSNAME) { .systemd.k.UDEV_SYSNAME = del(.UDEV_SYSNAME) }
+  
+  # trusted journal fields, fields that are implicitly added by the journal and cannot be altered by client code.
+  .systemd.t = {}
+  if exists(._AUDIT_LOGINUID) { .systemd.t.AUDIT_LOGINUID = del(._AUDIT_LOGINUID) }
+  if exists(._BOOT_ID) { .systemd.t.BOOT_ID = del(._BOOT_ID) }
+  if exists(._AUDIT_SESSION) { .systemd.t.AUDIT_SESSION = del(._AUDIT_SESSION) }
+  if exists(._CAP_EFFECTIVE) { .systemd.t.CAP_EFFECTIVE = del(._CAP_EFFECTIVE) }
+  if exists(._CMDLINE) { .systemd.t.CMDLINE = del(._CMDLINE) }
+  if exists(._COMM) { .systemd.t.COMM = del(._COMM) }
+  if exists(._EXE) { .systemd.t.EXE = del(._EXE) }
+  if exists(._GID) { .systemd.t.GID = del(._GID) }
+  if exists(._HOSTNAME) { .systemd.t.HOSTNAME = .hostname }
+  if exists(._LINE_BREAK) { .systemd.t.LINE_BREAK = del(._LINE_BREAK) }
+  if exists(._MACHINE_ID) { .systemd.t.MACHINE_ID = del(._MACHINE_ID) }
+  if exists(._PID) { .systemd.t.PID = del(._PID) }
+  if exists(._SELINUX_CONTEXT) { .systemd.t.SELINUX_CONTEXT = del(._SELINUX_CONTEXT) }
+  if exists(._SOURCE_REALTIME_TIMESTAMP) { .systemd.t.SOURCE_REALTIME_TIMESTAMP = del(._SOURCE_REALTIME_TIMESTAMP) }
+  if exists(._STREAM_ID) { .systemd.t.STREAM_ID = ._STREAM_ID }
+  if exists(._SYSTEMD_CGROUP) { .systemd.t.SYSTEMD_CGROUP = del(._SYSTEMD_CGROUP) }
+  if exists(._SYSTEMD_INVOCATION_ID) {.systemd.t.SYSTEMD_INVOCATION_ID = ._SYSTEMD_INVOCATION_ID}
+  if exists(._SYSTEMD_OWNER_UID) { .systemd.t.SYSTEMD_OWNER_UID = del(._SYSTEMD_OWNER_UID) }
+  if exists(._SYSTEMD_SESSION) { .systemd.t.SYSTEMD_SESSION = del(._SYSTEMD_SESSION) }
+  if exists(._SYSTEMD_SLICE) { .systemd.t.SYSTEMD_SLICE = del(._SYSTEMD_SLICE) }
+  if exists(._SYSTEMD_UNIT) { .systemd.t.SYSTEMD_UNIT = del(._SYSTEMD_UNIT) }
+  if exists(._SYSTEMD_USER_UNIT) { .systemd.t.SYSTEMD_USER_UNIT = del(._SYSTEMD_USER_UNIT) }
+  if exists(._TRANSPORT) { .systemd.t.TRANSPORT = del(._TRANSPORT) }
+  if exists(._UID) { .systemd.t.UID = del(._UID) }
+  
+  # fields that are directly passed from clients and stored in the journal.
+  .systemd.u = {}
+  if exists(.CODE_FILE) { .systemd.u.CODE_FILE = del(.CODE_FILE) }
+  if exists(.CODE_FUNC) { .systemd.u.CODE_FUNCTION = del(.CODE_FUNC) }
+  if exists(.CODE_LINE) { .systemd.u.CODE_LINE = del(.CODE_LINE) }
+  if exists(.ERRNO) { .systemd.u.ERRNO = del(.ERRNO) }
+  if exists(.MESSAGE_ID) { .systemd.u.MESSAGE_ID = del(.MESSAGE_ID) }
+  if exists(.SYSLOG_FACILITY) { .systemd.u.SYSLOG_FACILITY = del(.SYSLOG_FACILITY) }
+  if exists(.SYSLOG_IDENTIFIER) { .systemd.u.SYSLOG_IDENTIFIER = del(.SYSLOG_IDENTIFIER) }
+  if exists(.SYSLOG_PID) { .systemd.u.SYSLOG_PID = del(.SYSLOG_PID) }
+  if exists(.RESULT) { .systemd.u.RESULT = del(.RESULT) }
+  if exists(.UNIT) { .systemd.u.UNIT = del(.UNIT) }
+  
+  .time = format_timestamp!(.timestamp, format: "%FT%T%:z")
+  
+  ."@timestamp" = del(.timestamp)
+'''
+
+[transforms.host_audit_logs]
+type = "remap"
+inputs = ["raw_host_audit_logs"]
+source = '''
+  .tag = ".linux-audit.log"
+  
+  match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
+  envelop = {}
+  envelop |= {"type": match1.type}
+  
+  match2, err = parse_regex(.message, r'msg=audit\((?P<ts_record>[^ ]+)\):')
+  if err == null {
+    sp = split(match2.ts_record,":")
+    if length(sp) == 2 {
+        ts = parse_timestamp(sp[0],"%s.%3f") ?? ""
+        envelop |= {"record_id": sp[1]}
+        . |= {"audit.linux" : envelop}
+        . |= {"@timestamp" : format_timestamp(ts,"%+") ?? ""}
+    }
+  } else {
+    log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
+  }
+'''
+
+[transforms.k8s_audit_logs]
+type = "remap"
+inputs = ["raw_k8s_audit_logs"]
+source = '''
+  .tag = ".k8s-audit.log"
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+'''
+
+[transforms.openshift_audit_logs]
+type = "remap"
+inputs = ["raw_openshift_audit_logs"]
+source = '''
+  .tag = ".openshift-audit.log"
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+'''
+
+[transforms.ovn_audit_logs]
+type = "remap"
+inputs = ["raw_ovn_audit_logs"]
+source = '''
+  .tag = ".ovn-audit.log"
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+      .level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    }
+  }
+'''
+
+[transforms.route_container_logs]
+type = "route"
+inputs = ["container_logs"]
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
+route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube")'
+
+# Set log_type to "application"
+[transforms.application]
+type = "remap"
+inputs = ["route_container_logs.app"]
+source = '''
+  .log_type = "application"
+'''
+
+# Set log_type to "infrastructure"
+[transforms.infrastructure]
+type = "remap"
+inputs = ["route_container_logs.infra","journal_logs"]
+source = '''
+  .log_type = "infrastructure"
+'''
+
+# Set log_type to "audit"
+[transforms.audit]
+type = "remap"
+inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
+source = '''
+  .log_type = "audit"
+  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+  ."@timestamp" = del(.timestamp)
+'''
+
+[transforms.pipeline]
+type = "remap"
+inputs = ["application","infrastructure","audit"]
+source = '''
+  .
+'''
+
+# Set Elasticsearch index
+[transforms.es_1_add_es_index]
+type = "remap"
+inputs = ["pipeline"]
+source = '''
+  index = "default"
+  if (.log_type == "application"){
+    index = "app"
+  }
+  if (.log_type == "infrastructure"){
+    index = "infra"
+  }
+  if (.log_type == "audit"){
+    index = "audit"
+  }
+  .write_index = index + "-write"
+  ._id = encode_base64(uuid_v4())
+  del(.file)
+  del(.tag)
+  del(.source_type)
+'''
+
+[transforms.es_1_dedot_and_flatten]
+type = "lua"
+inputs = ["es_1_add_es_index"]
+version = "2"
+hooks.process = "process"
+source = '''
+    function process(event, emit)
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+        flatten_labels(event)
+        prune_labels(event)
+        emit(event)
+    end
+
+    function flatten_labels(event)
+        -- create "flat_labels" key
+        event.log.kubernetes.flat_labels = {}
+        i = 1
+        -- flatten the labels
+        for k,v in pairs(event.log.kubernetes.labels) do
+          event.log.kubernetes.flat_labels[i] = k.."="..v
+          i=i+1
+        end
+    end 
+
+	function prune_labels(event)
+		local exclusions = {"app.kubernetes.io/name", "app.kubernetes.io/instance", "app.kubernetes.io/version", "app.kubernetes.io/component", "app.kubernetes.io/part-of", "app.kubernetes.io/managed-by", "app.kubernetes.io/created-by"}
+		local keys = {}
+		for k,v in pairs(event.log.kubernetes.labels) do
+			for index, e in pairs(exclusions) do
+				if k == e then
+					keys[k] = v
+				end
+			end
+		end
+		event.log.kubernetes.labels = keys
+	end
+'''
+
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["es_1_dedot_and_flatten"]
+endpoint = "https://es-1.svc.messaging.cluster.local:9200"
+bulk.index = "{{ write_index }}"
+bulk.action = "create"
+request.timeout_secs = 2147483648
+id_key = "_id"
+
+[sinks.es_1.tls]
+enabled = true
+key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
+crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
+ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
+
+# Set Elasticsearch index
+[transforms.es_2_add_es_index]
+type = "remap"
+inputs = ["pipeline"]
+source = '''
+  index = "default"
+  if (.log_type == "application"){
+    index = "app"
+  }
+  if (.log_type == "infrastructure"){
+    index = "infra"
+  }
+  if (.log_type == "audit"){
+    index = "audit"
+  }
+  .write_index = index + "-write"
+  ._id = encode_base64(uuid_v4())
+  del(.file)
+  del(.tag)
+  del(.source_type)
+'''
+
+[transforms.es_2_dedot_and_flatten]
+type = "lua"
+inputs = ["es_2_add_es_index"]
+version = "2"
+hooks.process = "process"
+source = '''
+    function process(event, emit)
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+        flatten_labels(event)
+        prune_labels(event)
+        emit(event)
+    end
+
+    function flatten_labels(event)
+        -- create "flat_labels" key
+        event.log.kubernetes.flat_labels = {}
+        i = 1
+        -- flatten the labels
+        for k,v in pairs(event.log.kubernetes.labels) do
+          event.log.kubernetes.flat_labels[i] = k.."="..v
+          i=i+1
+        end
+    end 
+
+	function prune_labels(event)
+		local exclusions = {"app.kubernetes.io/name", "app.kubernetes.io/instance", "app.kubernetes.io/version", "app.kubernetes.io/component", "app.kubernetes.io/part-of", "app.kubernetes.io/managed-by", "app.kubernetes.io/created-by"}
+		local keys = {}
+		for k,v in pairs(event.log.kubernetes.labels) do
+			for index, e in pairs(exclusions) do
+				if k == e then
+					keys[k] = v
+				end
+			end
+		end
+		event.log.kubernetes.labels = keys
+	end
+'''
+
+[sinks.es_2]
+type = "elasticsearch"
+inputs = ["es_2_dedot_and_flatten"]
+endpoint = "https://es-2.svc.messaging.cluster.local:9200"
+bulk.index = "{{ write_index }}"
+bulk.action = "create"
+request.timeout_secs = 2147483648
+id_key = "_id"
+suppress_type_name = true
 
 [sinks.es_2.tls]
 enabled = true

--- a/internal/k8shandler/forwarding_test.go
+++ b/internal/k8shandler/forwarding_test.go
@@ -515,6 +515,7 @@ var _ = Describe("Normalizing forwarder", func() {
 				spec, status := request.NormalizeForwarder()
 				Expect(status.Outputs["aName"]).To(HaveCondition("Ready", true, "", ""), fmt.Sprintf("status: %+v", status))
 				Expect(spec.Outputs).To(HaveLen(len(request.ForwarderSpec.Outputs)), fmt.Sprintf("status: %+v", status))
+				Expect(spec.Outputs[0].Elasticsearch.Version).To(Equal(logging.LatestESVersion))
 			})
 
 			Context("with outputDefaults specified", func() {
@@ -546,6 +547,7 @@ var _ = Describe("Normalizing forwarder", func() {
 					Expect(len(request.ForwarderSpec.Outputs) == 1).To(BeTrue())
 					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch).ToNot(BeNil(), "Expected an Elasticsearch specific config")
 					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.StructuredTypeKey).To(Equal("kubernetes.labels.mylabel"))
+					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.Version).To(Equal(logging.DefaultESVersion))
 
 				})
 				It("should setup values for elasticsearch output", func() {
@@ -582,7 +584,52 @@ var _ = Describe("Normalizing forwarder", func() {
 
 					Expect(len(request.ForwarderSpec.Outputs) == 1).To(BeTrue())
 					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.StructuredTypeKey).To(Equal("kubernetes.labels.mylabel"))
+					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.Version).To(Equal(logging.LatestESVersion))
+				})
 
+				It("should not change elasticsearch version to latest if defined in outputs", func() {
+					cluster.Spec = logging.ClusterLoggingSpec{
+						Collection: &logging.CollectionSpec{
+							Type: "fluentd",
+							Logs: logging.LogCollectionSpec{
+								Type: "fluentd",
+							},
+						},
+						LogStore: &logging.LogStoreSpec{
+							Type: logging.LogStoreTypeElasticsearch,
+						},
+					}
+					request.ForwarderSpec = logging.ClusterLogForwarderSpec{
+						OutputDefaults: &logging.OutputDefaults{
+							Elasticsearch: &logging.Elasticsearch{
+								StructuredTypeKey: "kubernetes.labels.mylabel",
+							},
+						},
+						Outputs: []logging.OutputSpec{
+							{
+								Type: logging.OutputTypeElasticsearch,
+								Name: "es-out",
+								URL:  "http://some-url",
+								OutputTypeSpec: logging.OutputTypeSpec{
+									Elasticsearch: &logging.Elasticsearch{
+										Version: logging.DefaultESVersion,
+									},
+								},
+							},
+						},
+						Pipelines: []logging.PipelineSpec{
+							{
+								InputRefs:  []string{"application"},
+								OutputRefs: []string{"es-out"},
+								Name:       "mypipe",
+							},
+						},
+					}
+					_, _ = request.generateCollectorConfig()
+
+					Expect(len(request.ForwarderSpec.Outputs) == 1).To(BeTrue())
+					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.StructuredTypeKey).To(Equal("kubernetes.labels.mylabel"))
+					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.Version).To(Equal(logging.DefaultESVersion))
 				})
 			})
 
@@ -610,11 +657,14 @@ var _ = Describe("Normalizing forwarder", func() {
 			spec, status := request.NormalizeForwarder()
 			Expect(YAMLString(spec)).To(EqualLines(`
 outputs:
-- name: default
+- elasticsearch:
+	version: 6
+	name: default
 	secret:
 		name: collector
 	type: elasticsearch
 	url: https://` + constants.ElasticsearchFQDN + `:9200
+
 pipelines:
 - inputRefs:
 	- application
@@ -628,6 +678,7 @@ pipelines:
 			Expect(status.Outputs["default"]).To(HaveCondition("Ready", true, "", ""))
 			Expect(status.Inputs[logging.InputNameApplication]).To(HaveCondition("Ready", true, "", ""))
 			Expect(status.Inputs[logging.InputNameInfrastructure]).To(HaveCondition("Ready", true, "", ""))
+			Expect(spec.Outputs[0].Elasticsearch.Version).To(Equal(logging.DefaultESVersion))
 		})
 
 		It("generates default configuration for empty spec with LokiStack log store", func() {
@@ -710,6 +761,7 @@ pipelines:
 			Expect(spec.Outputs[0].URL).To(Equal("https://" + constants.ElasticsearchFQDN + ":9200"))
 			Expect(spec.Outputs[0].Secret.Name).To(Equal(constants.CollectorSecretName))
 			Expect(spec.Outputs[0].Type).To(Equal("elasticsearch"))
+			Expect(spec.Outputs[0].Elasticsearch.Version).To(Equal(logging.DefaultESVersion))
 
 			Expect(status.Conditions).To(HaveCondition("Ready", true, "", ""))
 			Expect(status.Pipelines).To(HaveLen(1))
@@ -752,6 +804,11 @@ var _ = Describe("#applyOutputDefaults", func() {
 		esOutput      = logging.OutputSpec{
 			Name: "external-elasticsearch",
 			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					Version: logging.LatestESVersion,
+				},
+			},
 			Secret: &logging.OutputSecretSpec{
 				Name: "log-forward-secret",
 			},
@@ -761,6 +818,70 @@ var _ = Describe("#applyOutputDefaults", func() {
 	It("should do nothing when no OutputDefaults are defined", func() {
 		Expect(applyOutputDefaults(nil, esOutput)).To(Equal(esOutput))
 	})
+
+	It("should only set elasticsearch version when no OutputDefaults are defined and no version is defined", func() {
+		esOut := logging.OutputSpec{
+			Name: "external-elasticsearch",
+			Type: logging.OutputTypeElasticsearch,
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		act := applyOutputDefaults(nil, esOut)
+
+		esOutFinal := logging.OutputSpec{
+			Name: "external-elasticsearch",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					Version: logging.LatestESVersion,
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+
+		Expect(act).To(Equal(esOutFinal))
+		Expect(act.Elasticsearch.Version).To(Equal(logging.LatestESVersion))
+	})
+
+	It("should set elasticsearch version to latest version if version is not defined in output defaults", func() {
+		outputDefault2 := &logging.OutputDefaults{
+			Elasticsearch: &logging.Elasticsearch{
+				StructuredTypeKey:  "some.other.label.value",
+				StructuredTypeName: "anotherTypeName",
+			},
+		}
+		act := applyOutputDefaults(outputDefault2, esOutput)
+
+		esOutput.Elasticsearch = &logging.Elasticsearch{
+			StructuredTypeKey:  "some.other.label.value",
+			StructuredTypeName: "anotherTypeName",
+			Version:            logging.LatestESVersion,
+		}
+		Expect(act).To(Equal(esOutput))
+	})
+
+	It("should set elasticsearch version to latest version if not set to DefaultESVersion or greater", func() {
+		outputDefault3 := &logging.OutputDefaults{
+			Elasticsearch: &logging.Elasticsearch{
+				StructuredTypeKey:  "some.other.label.value",
+				StructuredTypeName: "anotherTypeName",
+				Version:            4,
+			},
+		}
+		act := applyOutputDefaults(outputDefault3, esOutput)
+
+		esOutput.Elasticsearch = &logging.Elasticsearch{
+			StructuredTypeKey:  "some.other.label.value",
+			StructuredTypeName: "anotherTypeName",
+			Version:            logging.LatestESVersion,
+		}
+
+		Expect(act).To(Equal(esOutput))
+	})
+
 	Context("when Elasticsearch OutputDefaults are defined", func() {
 
 		BeforeEach(func() {
@@ -768,29 +889,225 @@ var _ = Describe("#applyOutputDefaults", func() {
 				Elasticsearch: &logging.Elasticsearch{
 					StructuredTypeKey:  "kubernetes.labels.app",
 					StructuredTypeName: "nologformat",
+					Version:            logging.DefaultESVersion,
 				},
 			}
 		})
 
 		It("should set the values on the output from the default when the output does not define them", func() {
-			act := applyOutputDefaults(outputDefault, esOutput)
+			esOutputNoES := logging.OutputSpec{
+				Name: "external-elasticsearch",
+				Type: logging.OutputTypeElasticsearch,
+				Secret: &logging.OutputSecretSpec{
+					Name: "log-forward-secret",
+				},
+			}
+			act := applyOutputDefaults(outputDefault, esOutputNoES)
 			esOutput.Elasticsearch = &logging.Elasticsearch{
 				StructuredTypeKey:  "kubernetes.labels.app",
 				StructuredTypeName: "nologformat",
+				Version:            logging.DefaultESVersion,
 			}
 			Expect(act).To(Equal(esOutput))
+			Expect(act.Elasticsearch.Version).To(Equal(logging.DefaultESVersion))
+			Expect(act.Elasticsearch.StructuredTypeKey).To(Equal("kubernetes.labels.app"))
 		})
 
 		It("should not set the values on the output from the default when the output defines them", func() {
 			esOutput.Elasticsearch = &logging.Elasticsearch{
 				StructuredTypeKey:  "some.label.value",
 				StructuredTypeName: "someTypeName",
+				Version:            logging.LatestESVersion,
 			}
 			act := applyOutputDefaults(outputDefault, esOutput)
 			Expect(act).To(Equal(esOutput))
+			Expect(act.Elasticsearch.Version).To(Equal(logging.LatestESVersion))
+			Expect(act.Elasticsearch.StructuredTypeKey).To(Equal("some.label.value"))
 		})
-
 	})
+
+})
+
+var _ = Describe("setESVersion", func() {
+	It("Should set Elasticsearch version to latest if no ES OutputTypeSpec is defined", func() {
+		esDeclared := logging.OutputSpec{
+			Name: "external-elasticsearch",
+			Type: logging.OutputTypeElasticsearch,
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		act := setESVersion(esDeclared)
+
+		esExpected := logging.OutputSpec{
+			Name: "external-elasticsearch",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					Version: logging.LatestESVersion,
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		Expect(act).To(Equal(esExpected))
+		Expect(act.Elasticsearch.Version).To(Equal(logging.LatestESVersion))
+		Expect(act.Elasticsearch.StructuredTypeKey).To(Equal(""))
+	})
+
+	It("Should set Elasticsearch version to latest if StructuredTypeKey is defined and no ES version is defined and not default log store", func() {
+		esDeclared := logging.OutputSpec{
+			Name: "external-elasticsearch",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					StructuredTypeKey: "some.label",
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		act := setESVersion(esDeclared)
+
+		esExpected := logging.OutputSpec{
+			Name: "external-elasticsearch",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					StructuredTypeKey: "some.label",
+					Version:           logging.LatestESVersion,
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		Expect(act).To(Equal(esExpected))
+		Expect(act.Elasticsearch.Version).To(Equal(logging.LatestESVersion))
+		Expect(act.Elasticsearch.StructuredTypeKey).To(Equal("some.label"))
+	})
+
+	It("Should set Elasticsearch version to default if default log store and version not defined", func() {
+		esDeclared := logging.OutputSpec{
+			Name: "default",
+			Type: logging.OutputTypeElasticsearch,
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		act := setESVersion(esDeclared)
+
+		esExpected := logging.OutputSpec{
+			Name: "default",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					Version: logging.DefaultESVersion,
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		Expect(act).To(Equal(esExpected))
+		Expect(act.Elasticsearch.Version).To(Equal(logging.DefaultESVersion))
+	})
+
+	It("Should not set ES version if version is defined & version >= default ES version", func() {
+		esDeclared := logging.OutputSpec{
+			Name: "external-elasticsearch",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					Version: 7,
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		act := setESVersion(esDeclared)
+
+		esExpected := logging.OutputSpec{
+			Name: "external-elasticsearch",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					Version: 7,
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		Expect(act).To(Equal(esExpected))
+		Expect(act.Elasticsearch.Version).To(Equal(7))
+	})
+
+	It("Should set Elasticsearch version to latest if defined version is < DefautlESVersion", func() {
+		esDeclared := logging.OutputSpec{
+			Name: "external-elasticsearch",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					Version: 4,
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		act := setESVersion(esDeclared)
+
+		esExpected := logging.OutputSpec{
+			Name: "external-elasticsearch",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					Version: logging.LatestESVersion,
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		Expect(act).To(Equal(esExpected))
+		Expect(act.Elasticsearch.Version).To(Equal(logging.LatestESVersion))
+	})
+
+	It("Should set Elasticsearch version to default version if defined version is < defaultESVersion & default log store", func() {
+		esDeclared := logging.OutputSpec{
+			Name: "default",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					Version: 2,
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		act := setESVersion(esDeclared)
+
+		esExpected := logging.OutputSpec{
+			Name: "default",
+			Type: logging.OutputTypeElasticsearch,
+			OutputTypeSpec: logging.OutputTypeSpec{
+				Elasticsearch: &logging.Elasticsearch{
+					Version: logging.DefaultESVersion,
+				},
+			},
+			Secret: &logging.OutputSecretSpec{
+				Name: "log-forward-secret",
+			},
+		}
+		Expect(act).To(Equal(esExpected))
+		Expect(act.Elasticsearch.Version).To(Equal(logging.DefaultESVersion))
+	})
+
 })
 
 var _ = DescribeTable("#generateCollectorConfig",
@@ -880,10 +1197,14 @@ var _ = DescribeTable("Normalizing round trip of valid YAML specs",
 	},
 	Entry("simple", `
 outputs:
-- name: myOutput
+- elasticsearch:
+    version: 8
+  name: myOutput
   type: elasticsearch
   url: http://here
-- name: someothername
+- elasticsearch:
+    version: 8
+  name: someothername
   type: elasticsearch
   url: http://there
 pipelines:


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

#### Summary:
- Added optional `Elasticsearch.Version` field to types.
- Added `suppress_type_name = true` if forwarding to `Elasticsearch 7.x` or higher.
- Can forward both to `default` and external `Elasticsearch` store at the same time with a `ClusterLogForwarder` custom resource.

#### Details:

This PR addresses an issue with forwarding logs using `vector` to `Elasticsearch 8.x` (ES). Forwarding logs to ES 8.x produced the following error in the logs: `Action/metadata line [1] contains an unknown parameter [_type]`.

To fix the error, in the `vector.toml` config file, `[sinks - <ES>]` section, `suppress_type_name = true` needs to be added for ES versions 7.x and higher. However, we cannot suppress the type name for ES 6.x, which is our internally managed ES.

To distinguish between ES versions, in the `output_types.go` file I added the `Version` field under `Elasticsearch`. This field is optional and will default to the latest ES version (right now that is 8.x) if not specified by the end user when defining a `ClusterLogForwarder` custom resource. The internal `default` store will be ES 6.x.

With this field, the `suppress_type_name = true` will only be added to `vector.toml` ES sink configurations using version 7.x or higher.

/cc @cahartma   <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- https://issues.redhat.com/browse/LOG-2769
