### PR TITLE
LOG-2784: checking is symbols valid 'utf-8', if not replace to the valid one

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -655,7 +655,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   

--- a/internal/generator/fluentd/elements/record_modifier.go
+++ b/internal/generator/fluentd/elements/record_modifier.go
@@ -6,12 +6,14 @@ package elements
 // In char_encoding from:to case, it replaces invalid character with safe character.
 // <filter pattern>
 //   @type record_modifier
-//   # change char encoding from 'ASCII-8BIT' to 'UTF-8'
-//   char_encoding ascii-8bit:utf-8
+//   # will check is symbols valid 'utf-8', if not replace to the valid one
+//   # e.g. japanese 'こんにちは' and ukrainian 'привіт' are valid 'utf-8' string, so will be store without modification
+//   # but BINARY will be replaced with '?'
+//   char_encoding utf-8:utf-8
 //  </filter>
 // */
 
-const DefaultCharEncoding = "ascii-8bit:utf-8"
+const DefaultCharEncoding = "utf-8:utf-8"
 const CharEncoding = "charEncoding"
 
 type RecordModifier struct {

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -707,7 +707,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   
@@ -836,7 +836,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   
@@ -1510,7 +1510,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   
@@ -1639,7 +1639,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   
@@ -2317,7 +2317,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   
@@ -2446,7 +2446,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   
@@ -3622,7 +3622,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   
@@ -3751,7 +3751,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   
@@ -3880,7 +3880,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   
@@ -4009,7 +4009,7 @@ var _ = Describe("Generating fluentd config", func() {
   #remove structured field if present
   <filter **>
 	@type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
 	remove_keys structured
   </filter>
   

--- a/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Generating fluentd config", func() {
 <label @MY_CLOUDWATCH>
   <filter ` + source.InfraTagsForMultilineEx + `>
     @type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
     <record>
       cw_group_name foo.infrastructure
       cw_stream_name ${record['hostname']}.${tag}
@@ -238,7 +238,7 @@ var _ = Describe("Generating fluentd config", func() {
   
   <filter ` + source.ApplicationTagsForMultilineEx + `>
     @type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
     <record>
       cw_group_name foo.application
       cw_stream_name ${tag}
@@ -247,7 +247,7 @@ var _ = Describe("Generating fluentd config", func() {
   
   <filter ` + source.AuditTags + `>
     @type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
     <record>
       cw_group_name foo.audit
       cw_stream_name ${record['hostname']}.${tag}

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -1065,7 +1065,7 @@ var _ = Describe("Generate fluentd config", func() {
   #remove structured field if present
   <filter **>
     @type record_modifier
-    char_encoding ascii-8bit:utf-8
+    char_encoding utf-8:utf-8
     remove_keys structured
   </filter>
   

--- a/test/framework/functional/factory.go
+++ b/test/framework/functional/factory.go
@@ -44,7 +44,7 @@ func NewCRIOLogMessage(timestamp, message string, partial bool) string {
 }
 
 // CRIOTime returns the CRIO string format of time t.
-func CRIOTime(t time.Time) string { return time.Now().UTC().Format(time.RFC3339Nano) }
+func CRIOTime(t time.Time) string { return t.UTC().Format(time.RFC3339Nano) }
 
 func CreateAppLogFromJson(jsonstr string) string {
 	jsonMsg := strings.ReplaceAll(jsonstr, "\n", "")

--- a/test/functional/outputs/elasticsearch/forward_to_elasticsearch_test.go
+++ b/test/functional/outputs/elasticsearch/forward_to_elasticsearch_test.go
@@ -8,6 +8,8 @@ import (
 	testfw "github.com/openshift/cluster-logging-operator/test/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"github.com/openshift/cluster-logging-operator/test/matchers"
+	"sort"
+	"time"
 )
 
 var _ = Describe("[Functional][Outputs][ElasticSearch] FluentdForward Output to ElasticSearch", func() {
@@ -26,7 +28,6 @@ var _ = Describe("[Functional][Outputs][ElasticSearch] FluentdForward Output to 
 			FromInput(logging.InputNameApplication).
 			ToElasticSearchOutput()
 		Expect(framework.Deploy()).To(BeNil())
-		Expect(framework.WritesApplicationLogs(1)).To(BeNil())
 	})
 	AfterEach(func() {
 		framework.Cleanup()
@@ -34,6 +35,7 @@ var _ = Describe("[Functional][Outputs][ElasticSearch] FluentdForward Output to 
 
 	Context("when sending to ElasticSearch "+functional.ElasticSearchTag+" protocol", func() {
 		It("should  be compatible", func() {
+			Expect(framework.WritesApplicationLogs(1)).To(BeNil())
 			raw, err := framework.GetLogsFromElasticSearch(logging.OutputTypeElasticsearch, logging.InputNameApplication)
 			Expect(err).To(BeNil(), "Expected no errors reading the logs")
 			Expect(raw).To(Not(BeEmpty()))
@@ -46,6 +48,32 @@ var _ = Describe("[Functional][Outputs][ElasticSearch] FluentdForward Output to 
 			outputTestLog := logs[0]
 			outputLogTemplate.ViaqIndexName = ""
 			Expect(outputTestLog).To(matchers.FitLogFormatTemplate(outputLogTemplate))
+		})
+		It("should work well for valid utf-8 and replace not utf-8", func() {
+			timestamp := functional.CRIOTime(time.Now())
+			ukr := "привіт "
+			jp := "こんにちは "
+			ch := "你好"
+			msg := functional.NewCRIOLogMessage(timestamp, ukr+jp+ch, false)
+			Expect(framework.WriteMessagesToApplicationLog(msg, 1)).To(BeNil())
+
+			Expect(framework.WriteMessagesWithNotUTF8SymbolsToLog()).To(BeNil())
+
+			raw, err := framework.GetLogsFromElasticSearch(logging.OutputTypeElasticsearch, logging.InputNameApplication)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(raw).To(Not(BeEmpty()))
+			// Parse log line
+			var logs []types.ApplicationLog
+			err = types.StrictlyParseLogs(raw, &logs)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+			Expect(len(logs)).To(Equal(2))
+			//sort log by time before matching
+			sort.Slice(logs, func(i, j int) bool {
+				return logs[i].Timestamp.Before(logs[j].Timestamp)
+			})
+
+			Expect(logs[0].Message).To(Equal(ukr + jp + ch))
+			Expect(logs[1].Message).To(Equal("������������"))
 		})
 	})
 })

--- a/test/functional/outputs/loki/audit_logs_test.go
+++ b/test/functional/outputs/loki/audit_logs_test.go
@@ -76,7 +76,7 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 			now := time.Now()
 			nowCrio := functional.CRIOTime(now)
 			openshiftAuditLogs := fmt.Sprintf(functional.OpenShiftAuditLogTemplate, nowCrio, nowCrio)
-			earlier := now.Add(-1 * 3600 * time.Minute)
+			earlier := now.Add(-1 * 30 * time.Minute)
 			earlierLog := functional.NewKubeAuditLog(earlier)
 
 			writeAndVerifyLogs("k8s-audit.log", func() error {


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Checks and replace not valid UTF-8 symbols 
```
<filter pattern>
   @type record_modifier
   # will check is symbol's valid 'utf-8', if not replace to the valid one
   # e.g. japanese 'こんにちは' and ukrainian 'привіт' are valid 'utf-8' string, so will be store without modification
   # but BINARY will be replaced with '?'
   char_encoding utf-8:utf-8
</filter>
```

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @jcantrill <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick release-5.4 <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2784
- Enhancement proposal:
