### PR TITLE
LOG-2785: Replace all collector instances at once

### DIFF
--- a/internal/factory/daemonset.go
+++ b/internal/factory/daemonset.go
@@ -4,6 +4,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 //NewDaemonSet stubs an instance of a daemonset
@@ -39,8 +40,13 @@ func NewDaemonSet(daemonsetName, namespace, loggingComponent, component string, 
 				Spec: podSpec,
 			},
 			UpdateStrategy: apps.DaemonSetUpdateStrategy{
-				Type:          apps.RollingUpdateDaemonSetStrategyType,
-				RollingUpdate: &apps.RollingUpdateDaemonSet{},
+				Type: apps.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &apps.RollingUpdateDaemonSet{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "100%",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### Description

The cluster-logging-operator uses a DaemonSet to manage the collector instances running on all cluster nodes.

Currently the default deployment strategy of the DaemonSet is used, which only allows a single instance to be "unavailable" at once, similar to a Deployment rollout.

While this strategy does make sense for deployments with more than once instance for high-availability reasons, it's unnecessary for the DaemonSet as each collector is responsible for its own node and no HA is done between the instances. The current strategy effectively only slows down the application of a new configuration.

The aim of this change is to replace the current configuration of the deployment strategy used by the DaemonSet with one that allows all instances to be replaced at once.

### Links

- JIRA: [LOG-2785](https://issues.redhat.com/browse/LOG-2785)
