### PR TITLE
LOG-2664: suppress type_name deprecation warnings

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -676,6 +676,8 @@ var _ = Describe("Testing Complete Config Generation", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -720,6 +722,8 @@ var _ = Describe("Testing Complete Config Generation", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -728,6 +728,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -772,6 +774,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -853,6 +857,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -897,6 +903,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1523,6 +1531,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1567,6 +1577,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1648,6 +1660,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1692,6 +1706,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2322,6 +2338,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2366,6 +2384,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2447,6 +2467,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2491,6 +2513,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3619,6 +3643,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3663,6 +3689,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_infra_es
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3744,6 +3772,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3788,6 +3818,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3869,6 +3901,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3913,6 +3947,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3994,6 +4030,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -4038,6 +4076,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_audit_es
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
@@ -51,6 +51,8 @@ type_name _doc
 {{ kv .RetryTag -}}
 http_backend typhoeus
 write_operation create
+# https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+suppress_type_name 'true'
 reload_connections 'true'
 # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 reload_after '200'

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -96,6 +96,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -139,6 +141,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -243,6 +247,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -287,6 +293,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -379,6 +387,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -419,6 +429,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -509,6 +521,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -550,6 +564,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -651,6 +667,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -693,6 +711,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -784,6 +804,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -825,6 +847,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -919,6 +943,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -960,6 +986,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1054,6 +1082,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1094,6 +1124,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -134,6 +134,8 @@ var _ = Describe("Generating fluentd config", func() {
               type_name _doc
               http_backend typhoeus
               write_operation create
+              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -174,6 +176,8 @@ var _ = Describe("Generating fluentd config", func() {
               retry_tag retry_other_elasticsearch
               http_backend typhoeus
               write_operation create
+			  # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+			  suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -273,6 +277,8 @@ var _ = Describe("Generating fluentd config", func() {
               type_name _doc
               http_backend typhoeus
               write_operation create
+              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -313,6 +319,8 @@ var _ = Describe("Generating fluentd config", func() {
               retry_tag retry_other_elasticsearch
               http_backend typhoeus
               write_operation create
+              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+			  suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -398,6 +406,8 @@ var _ = Describe("Generating fluentd config", func() {
               type_name _doc
               http_backend typhoeus
               write_operation create
+              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -437,6 +447,8 @@ var _ = Describe("Generating fluentd config", func() {
               retry_tag retry_other_elasticsearch
               http_backend typhoeus
               write_operation create
+              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>
### Description
Suppress high number of type deprecation logs, like:
`[types removal] Specifying types in bulk requests is deprecated.`

More details here: https://github.com/uken/fluent-plugin-elasticsearch/issues/766

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2664
- Enhancement proposal:
