### PR TITLE
[release-5.4] LOG-2664: suppress type_name deprecation warnings

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -685,6 +685,8 @@ var _ = Describe("Testing Complete Config Generation", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -729,6 +731,8 @@ var _ = Describe("Testing Complete Config Generation", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -749,6 +749,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -793,6 +795,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -879,6 +883,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -923,6 +929,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1570,6 +1578,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1614,6 +1624,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1700,6 +1712,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1744,6 +1758,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2395,6 +2411,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2439,6 +2457,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2525,6 +2545,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2569,6 +2591,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3734,6 +3758,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3778,6 +3804,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_infra_es
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3864,6 +3892,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3908,6 +3938,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3994,6 +4026,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -4038,6 +4072,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -4124,6 +4160,8 @@ var _ = Describe("Generating fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -4168,6 +4206,8 @@ var _ = Describe("Generating fluentd config", func() {
     retry_tag retry_audit_es
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
@@ -51,6 +51,8 @@ type_name _doc
 {{ kv .RetryTag -}}
 http_backend typhoeus
 write_operation create
+# https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+suppress_type_name 'true'
 reload_connections 'true'
 # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
 reload_after '200'

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -105,6 +105,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -148,6 +150,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -257,6 +261,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -301,6 +307,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -398,6 +406,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -438,6 +448,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -533,6 +545,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -574,6 +588,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -682,6 +698,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -724,6 +742,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -821,6 +841,8 @@ var _ = Describe("Generate fluentd config", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -862,6 +884,8 @@ var _ = Describe("Generate fluentd config", func() {
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'

--- a/internal/generator/fluentd/output/elasticsearch/output_conf_es_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/output_conf_es_test.go
@@ -156,6 +156,8 @@ var _ = Describe("Generating fluentd config blocks", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -200,6 +202,8 @@ var _ = Describe("Generating fluentd config blocks", func() {
     retry_tag retry_oncluster_elasticsearch
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -314,6 +318,8 @@ var _ = Describe("Generating fluentd config blocks", func() {
     type_name _doc
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -356,6 +362,8 @@ var _ = Describe("Generating fluentd config blocks", func() {
     retry_tag retry_other_elasticsearch
     http_backend typhoeus
     write_operation create
+    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -137,6 +137,8 @@ var _ = Describe("Generating fluentd config", func() {
               type_name _doc
               http_backend typhoeus
               write_operation create
+              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -177,6 +179,8 @@ var _ = Describe("Generating fluentd config", func() {
               retry_tag retry_other_elasticsearch
               http_backend typhoeus
               write_operation create
+			  # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+			  suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -279,6 +283,8 @@ var _ = Describe("Generating fluentd config", func() {
               type_name _doc
               http_backend typhoeus
               write_operation create
+              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -319,6 +325,8 @@ var _ = Describe("Generating fluentd config", func() {
               retry_tag retry_other_elasticsearch
               http_backend typhoeus
               write_operation create
+              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+			  suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -410,6 +418,8 @@ var _ = Describe("Generating fluentd config", func() {
               type_name _doc
               http_backend typhoeus
               write_operation create
+              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -449,6 +459,8 @@ var _ = Describe("Generating fluentd config", func() {
               retry_tag retry_other_elasticsearch
               http_backend typhoeus
               write_operation create
+              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
+              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Suppress high number of type deprecation logs, like:
`[types removal] Specifying types in bulk requests is deprecated.`

More details here: https://github.com/uken/fluent-plugin-elasticsearch/issues/766

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
