### PR TITLE
[release-5.4] LOG-2786: Use service CA when using default token in vector Loki output

### DIFF
--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -206,6 +206,17 @@ func TLSConf(o logging.OutputSpec, secret *corev1.Secret) []Element {
 		if !hasTLS {
 			return []Element{}
 		}
+	} else if secret != nil {
+		// Set CA from logcollector ServiceAccount for internal Loki
+		return []Element{
+			security.TLSConf{
+				Desc:        "TLS Config",
+				ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
+			},
+			CAFile{
+				CAFilePath: `"/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"`,
+			},
+		}
 	}
 	return conf
 }

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -227,6 +227,9 @@ kubernetes_namespace_name = "{{kubernetes.pod_namespace}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
 
+# TLS Config
+[sinks.loki_receiver.tls]
+ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 # Bearer Auth Config
 [sinks.loki_receiver.auth]
 strategy = "bearer"


### PR DESCRIPTION
### Description

Cherry-pick of #1531 for `release-5.4`.

### Links

- JIRA: LOG-2786
