### PR TITLE
LOG-2767: sts cloudwatch secret should accept format from credrequest

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -37,7 +37,7 @@ type OutputTypeSpec struct {
 //	`aws_secret_access_key`: AWS secret access key.
 // 	`aws_access_key_id`: AWS secret access key ID.
 //
-// Or for sts-enabled clusters `role_arn` key specifying a properly formatted role arn
+// Or for sts-enabled clusters `credentials` or `role_arn` key specifying a properly formatted role arn
 //
 type Cloudwatch struct {
 	// +required

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -33,7 +33,8 @@ const (
 	AWSSecretAccessKey          = "aws_secret_access_key" //nolint:gosec
 	AWSAccessKeyID              = "aws_access_key_id"
 	AWSRoleSessionName          = "cluster-logging" // identifier for role logging session
-	AWSWebIdentityRoleKey       = "role_arn"        // key to expect for sts-formatted secret
+	AWSCredentialsKey           = "credentials"     // credrequest key to check for sts-formatted secret
+	AWSWebIdentityRoleKey       = "role_arn"        // manual key to check for sts-formatted secret
 	AWSWebIdentityTokenName     = "collector-sts-token"
 	AWSWebIdentityTokenMount    = "/var/run/secrets/openshift/serviceaccount" //nolint:gosec // default location for volume mount
 	AWSWebIdentityTokenFilePath = "token"                                     // file containing token relative to mount

--- a/internal/generator/fluentd/output/cloudwatch/aws.go
+++ b/internal/generator/fluentd/output/cloudwatch/aws.go
@@ -13,7 +13,7 @@ func (a AWSKey) Name() string {
 }
 
 func (a AWSKey) Template() string {
-	// First check for the role key in the secret
+	// First check if we found a value for role
 	if len(a.KeyRoleArn) > 0 {
 		return `{{define "` + a.Name() + `" -}}
 <web_identity_credentials>
@@ -23,7 +23,7 @@ func (a AWSKey) Template() string {
 </web_identity_credentials>
 {{end}}`
 	}
-	// Use ID/Secret
+	// Otherwise use ID/Secret
 	return `{{define "` + a.Name() + `" -}}
 aws_key_id "#{open({{ .KeyIDPath }},'r') do |f|f.read.strip end}"
 aws_sec_key "#{open({{ .KeySecretPath }},'r') do |f|f.read.strip end}"

--- a/internal/generator/fluentd/output/cloudwatch/cloudwatch_secret_test.go
+++ b/internal/generator/fluentd/output/cloudwatch/cloudwatch_secret_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Parsing strings for sts functionality", func() {
 				results := ParseRoleArn(secrets["my-secret"])
 				Expect(results).To(Equal(roleArn))
 			})
-			It("should return our specified valid role_arn when the partion is more than 'aws'", func() {
+			It("should return our specified valid role_arn when the partition is more than 'aws'", func() {
 				secrets["other"] = &corev1.Secret{
 					Data: map[string][]byte{
 						"role_arn": []byte(altRoleArn),
@@ -41,13 +41,16 @@ var _ = Describe("Parsing strings for sts functionality", func() {
 	Context("pass a fully formatted sts secret with 'credentials' as key", func() {
 		BeforeEach(func() {
 			delete(secrets["my-secret"].Data, "role_arn")
-			secrets["my-secret"].Data["credentials"] = []byte(credentialsString)
+			secrets["my-secret"] = &corev1.Secret{
+				Data: map[string][]byte{
+					"credentials": []byte(credentialsString),
+				},
+			}
 		})
 		Context("to ParseRoleArn() helper", func() {
-			It("should return an empty string since the key 'role_arn' is not found", func() {
-				//results := ParseRoleArn(secrets["cred-secret"])
+			It("should be able to parse and return our specified valid role_arn value", func() {
 				results := ParseRoleArn(secrets["my-secret"])
-				Expect(results).To(BeEmpty())
+				Expect(results).To(Equal(roleArn))
 			})
 		})
 	})
@@ -67,8 +70,16 @@ var _ = Describe("Parsing strings for sts functionality", func() {
 
 	Context("pass an incorrectly formatted role_arn", func() {
 		BeforeEach(func() {
+			delete(secrets["my-secret"].Data, "credentials")
 			roleArn = "arn:aws:iam::12345:role/my-role-from-secret" // incorrect format since not "arn:aws:iam::<12-digit-account-id>:"
 			secrets["my-secret"].Data["role_arn"] = []byte(roleArn)
+
+			//delete(secrets["my-secret"].Data, "role_arn")
+			//secrets["my-secret"] = &corev1.Secret{
+			//	Data: map[string][]byte{
+			//		"role_arn": []byte("arn:aws:iam::12345:role/my-role-from-secret"),
+			//	},
+			//}
 		})
 		Context("to ParseRoleArn() helper", func() {
 			It("should return an empty string since arn is not in valid format", func() {

--- a/internal/generator/fluentd/output/security/security.go
+++ b/internal/generator/fluentd/output/security/security.go
@@ -68,6 +68,10 @@ func HasAwsRoleArnKey(secret *corev1.Secret) bool {
 	return HasKeys(secret, constants.AWSWebIdentityRoleKey)
 }
 
+func HasAwsCredentialsKey(secret *corev1.Secret) bool {
+	return HasKeys(secret, constants.AWSCredentialsKey)
+}
+
 // GetKey if found return value and ok=true, else ok=false
 func GetKey(secret *corev1.Secret, key string) (data []byte, ok bool) {
 	if secret == nil {

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -489,12 +489,13 @@ func verifySecretKeysForCloudwatch(output *logging.OutputSpec, conds logging.Nam
 	hasKeyID := len(secret.Data[constants.AWSAccessKeyID]) > 0
 	hasSecretKey := len(secret.Data[constants.AWSSecretAccessKey]) > 0
 	hasRoleArnKey := security.HasAwsRoleArnKey(secret)
+	hasCredentialsKey := security.HasAwsCredentialsKey(secret)
 	hasValidRoleArn := len(cloudwatch.ParseRoleArn(secret)) > 0
 	switch {
 	case hasValidRoleArn: // Sts secret format is the first check
 		return true
-	case hasRoleArnKey && !hasValidRoleArn:
-		return fail(condMissing("auth keys: a 'role_arn' key is required containing a valid arn value"))
+	case hasRoleArnKey && !hasValidRoleArn, hasCredentialsKey && !hasValidRoleArn:
+		return fail(condMissing("auth keys: a 'role_arn' or 'credentials' key is required containing a valid arn value"))
 	case !hasKeyID || !hasSecretKey:
 		return fail(condMissing("auth keys: " + constants.AWSAccessKeyID + " and " + constants.AWSSecretAccessKey + " are required"))
 	}


### PR DESCRIPTION
### Description
When using sts to authenticate with cloudwatch, we should additionally accept the secret format created from a credential request.   We will  accept `credentials` as a valid secret key.    The original story and feature implementation only accepted the `role_arn` as a valid key.  (must also contain a correctly formatted valid role arn)

/assign @jcantrill @vimalk78 
/cc @syedriko 

### Links
- https://issues.redhat.com/browse/LOG-2767
