### PR TITLE
LOG-2662: Losing audit logs may happen when using Vector

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -106,28 +106,24 @@ journal_directory = "/var/log/journal"
 # Logs from host audit
 [sources.raw_host_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 
 # Logs from kubernetes audit
 [sources.raw_k8s_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 host_key = "hostname"
 
 # Logs from ovn audit
 [sources.raw_ovn_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 
@@ -442,28 +438,24 @@ journal_directory = "/var/log/journal"
 # Logs from host audit
 [sources.raw_host_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 
 # Logs from kubernetes audit
 [sources.raw_k8s_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 host_key = "hostname"
 
 # Logs from ovn audit
 [sources.raw_ovn_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 

--- a/internal/generator/vector/source/audit_logs.go
+++ b/internal/generator/vector/source/audit_logs.go
@@ -9,7 +9,6 @@ const HostAuditLogTemplate = `
 # {{.Desc}}
 [sources.{{.ComponentID}}]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 {{end}}`
@@ -21,7 +20,6 @@ const OpenshiftAuditLogTemplate = `
 # {{.Desc}}
 [sources.{{.ComponentID}}]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 host_key = "hostname"
 {{end}}
@@ -34,7 +32,6 @@ const K8sAuditLogTemplate = `
 # {{.Desc}}
 [sources.{{.ComponentID}}]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 {{end}}
@@ -47,7 +44,6 @@ const OVNAuditLogTemplate = `
 # {{.Desc}}
 [sources.{{.ComponentID}}]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 {{end}}

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -86,28 +86,24 @@ journal_directory = "/var/log/journal"
 # Logs from host audit
 [sources.raw_host_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 
 # Logs from kubernetes audit
 [sources.raw_k8s_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 host_key = "hostname"
 
 # Logs from ovn audit
 [sources.raw_ovn_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 `,
@@ -145,28 +141,24 @@ journal_directory = "/var/log/journal"
 # Logs from host audit
 [sources.raw_host_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 
 # Logs from kubernetes audit
 [sources.raw_k8s_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 host_key = "hostname"
 
 # Logs from ovn audit
 [sources.raw_ovn_audit_logs]
 type = "file"
-ignore_older_secs = 600
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 `,


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

#### Summary:
- Removed `ignore_older_secs` from audit log [source] configuration for vector. 

#### Details

This PR addresses an issue with audit logs not being forwarded when using Vector. The problem stemmed from a configuration parameter for Vector called `ignore_older_secs` which "Ignores files with a data modification date older than the specified number of seconds." 

Originally this was set to 600 seconds. Removing the parameter from the audit log configurations should resolve this issue.

/cc @cahartma @jcantrill 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- [LOG-2662](https://issues.redhat.com/browse/LOG-2662)
