### PR TITLE
LOG-2703: Remove collector when no forwarder or logStore

### DIFF
--- a/controllers/clusterlogging/clusterlogging_controller.go
+++ b/controllers/clusterlogging/clusterlogging_controller.go
@@ -148,6 +148,7 @@ func (r *ReconcileClusterLogging) SetupWithManager(mgr ctrl.Manager) error {
 
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		Watches(&source.Kind{Type: &loggingv1.ClusterLogging{}}, &handler.EnqueueRequestForObject{}).
+		Watches(&source.Kind{Type: &loggingv1.ClusterLogForwarder{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
 			IsController: true,
 			OwnerType:    &loggingv1.ClusterLogging{},

--- a/internal/k8shandler/logstore_lokistack.go
+++ b/internal/k8shandler/logstore_lokistack.go
@@ -96,7 +96,9 @@ func (clusterRequest *ClusterLoggingRequest) removeLokiStackRbac() error {
 		},
 	}
 	if err := clusterRequest.Delete(clusterRoleBinding); err != nil {
-		return kverrors.Wrap(err, "Failed to delete LokiStack ClusterRoleBinding", "name", lokiStackClusterRoleBindingName)
+		if !apierrors.IsNotFound(err) {
+			return kverrors.Wrap(err, "Failed to delete LokiStack ClusterRoleBinding", "name", lokiStackClusterRoleBindingName)
+		}
 	}
 
 	clusterRole := &rbacv1.ClusterRole{
@@ -105,7 +107,9 @@ func (clusterRequest *ClusterLoggingRequest) removeLokiStackRbac() error {
 		},
 	}
 	if err := clusterRequest.Delete(clusterRole); err != nil {
-		return kverrors.Wrap(err, "Failed to delete LokiStack ClusterRole", "name", lokiStackClusterRoleName)
+		if !apierrors.IsNotFound(err) {
+			return kverrors.Wrap(err, "Failed to delete LokiStack ClusterRole", "name", lokiStackClusterRoleName)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
### Description
As per fix for LOG-2063, fluentd/vector only CL instance deployments should be stopped when CLF is missing. In the scenario where CLF is deleted, Collector DaemonSets are not removed/terminated.

/assign @jcantrill 

### Links
- https://issues.redhat.com/browse/LOG-2703
