### PR TITLE
LOG-2821: Allow metrics to bind to default interface

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "#{ENV['POD_IP']}"
+  bind "[::]"
   <ssl>
     enable true
     certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "#{ENV['POD_IP']}"
+  bind "[::]"
   <ssl>
     enable true
     certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
@@ -1047,7 +1047,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "#{ENV['POD_IP']}"
+  bind "[::]"
   <ssl>
     enable true
     certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
@@ -1878,7 +1878,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "#{ENV['POD_IP']}"
+  bind "[::]"
   <ssl>
     enable true
     certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
@@ -2654,7 +2654,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "#{ENV['POD_IP']}"
+  bind "[::]"
   <ssl>
     enable true
     certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
@@ -3132,7 +3132,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "#{ENV['POD_IP']}"
+  bind "[::]"
   <ssl>
     enable true
     certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
@@ -4342,7 +4342,7 @@ inputs:
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "#{ENV['POD_IP']}"
+  bind "[::]"
   <ssl>
     enable true
     certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"

--- a/internal/generator/fluentd/prometheus.go
+++ b/internal/generator/fluentd/prometheus.go
@@ -12,7 +12,7 @@ const PrometheusMonitorTemplate = `
 # {{.Desc}}
 <source>
   @type prometheus
-  bind "#{ENV['POD_IP']}"
+  bind "[::]"
   <ssl>
     enable true
     certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"

--- a/internal/generator/fluentd/sources_test.go
+++ b/internal/generator/fluentd/sources_test.go
@@ -492,7 +492,7 @@ var _ = Describe("Testing Config Generation", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "#{ENV['POD_IP']}"
+  bind "[::]"
   <ssl>
     enable true
     certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"


### PR DESCRIPTION
#### Description
This PR:

updates the metrics server to bind to the default interface

### Links
* https://issues.redhat.com/browse/LOG-2821
