### PR TITLE
LOG-2778: Create secret for logcollector serviceaccount manually

### DIFF
--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -76,6 +76,11 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 		if collectorServiceAccount, err = clusterRequest.createOrUpdateCollectorServiceAccount(); err != nil {
 			log.V(9).Error(err, "clusterRequest.createOrUpdateCollectorServiceAccount")
 			return
+		} else {
+			if err = clusterRequest.createOrUpdateCollectorTokenSecret(); err != nil {
+				log.V(9).Error(err, "clusterRequest.createOrUpdateCollectorTokenSecret")
+				return
+			}
 		}
 
 		if collectorConfig, err = clusterRequest.generateCollectorConfig(); err != nil {
@@ -585,4 +590,48 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateCollectorServiceAccou
 	} else {
 		return nil, nil
 	}
+}
+
+func (clusterRequest *ClusterLoggingRequest) createOrUpdateCollectorTokenSecret() error {
+	serviceAccount := &corev1.ServiceAccount{}
+	if err := clusterRequest.Get(constants.CollectorServiceAccountName, serviceAccount); err != nil {
+		return fmt.Errorf("failed to get ServiceAccount: %w", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterRequest.Cluster.Namespace,
+			Name:      constants.LogCollectorToken,
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: serviceAccount.Name,
+				corev1.ServiceAccountUIDKey:  string(serviceAccount.UID),
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+	utils.AddOwnerRefToObject(secret, utils.AsOwner(clusterRequest.Cluster))
+
+	if err := clusterRequest.Get(constants.LogCollectorToken, secret); err == nil {
+		accountName := secret.Annotations[corev1.ServiceAccountNameKey]
+		accountUID := secret.Annotations[corev1.ServiceAccountUIDKey]
+		if accountName != serviceAccount.Name || accountUID != string(serviceAccount.UID) {
+			// Delete secret, so that we can create a new one next loop
+			if err := clusterRequest.Delete(secret); err != nil {
+				return err
+			}
+
+			return fmt.Errorf("deleted stale secret: %s", constants.LogCollectorToken)
+		}
+
+		// Existing secret is up-to-date
+		return nil
+	} else if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to get logcollector token secret: %w", err)
+	}
+
+	if err := clusterRequest.Create(secret); err != nil {
+		return fmt.Errorf("failed to create logcollector token secret: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Description

Starting with Kubernetes 1.24 (OCP 4.11), ServiceAccounts will no longer automatically have an associated secret containing a token. The cluster-logging-operator currently looks for a secret containing a token associated with the `logcollector` ServiceAccount it creates for the collector DaemonSet. This secret is used for "default credentials" for the log forwarders. Failing to find the secret results in some forwarder configurations no longer having valid credentials.

This PR introduces a manually created secret to the cluster-logging-operator which then can be used like the automatically-created one before.

### Links

- JIRA: https://issues.redhat.com/browse/LOG-2778
