### PR TITLE
LOG-2648: glob_minimum_cooldown_ms of vector is too big (60000ms)

### DIFF
--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -175,8 +175,8 @@ spec:
                         type `cloudwatch` \n Note: the cloudwatch output recognizes
                         the following keys in the Secret: \n `aws_secret_access_key`:
                         AWS secret access key. `aws_access_key_id`: AWS secret access
-                        key ID. \n Or for sts-enabled clusters `role_arn` key specifying
-                        a properly formatted role arn"
+                        key ID. \n Or for sts-enabled clusters `credentials` or `role_arn`
+                        key specifying a properly formatted role arn"
                       properties:
                         groupBy:
                           description: GroupBy defines the strategy for grouping logstreams

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -171,8 +171,8 @@ spec:
                         type `cloudwatch` \n Note: the cloudwatch output recognizes
                         the following keys in the Secret: \n `aws_secret_access_key`:
                         AWS secret access key. `aws_access_key_id`: AWS secret access
-                        key ID. \n Or for sts-enabled clusters `role_arn` key specifying
-                        a properly formatted role arn"
+                        key ID. \n Or for sts-enabled clusters `credentials` or `role_arn`
+                        key specifying a properly formatted role arn"
                       properties:
                         groupBy:
                           description: GroupBy defines the strategy for grouping logstreams

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -91,6 +91,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
@@ -108,24 +109,28 @@ journal_directory = "/var/log/journal"
 type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from kubernetes audit
 [sources.raw_k8s_audit_logs]
 type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from ovn audit
 [sources.raw_ovn_audit_logs]
 type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 [sources.internal_metrics]
 type = "internal_metrics"
@@ -423,6 +428,7 @@ crt_file = "/etc/collector/metrics/tls.crt"
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
@@ -440,24 +446,28 @@ journal_directory = "/var/log/journal"
 type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from kubernetes audit
 [sources.raw_k8s_audit_logs]
 type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from ovn audit
 [sources.raw_ovn_audit_logs]
 type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 [sources.internal_metrics]
 type = "internal_metrics"

--- a/internal/generator/vector/source/audit_logs.go
+++ b/internal/generator/vector/source/audit_logs.go
@@ -11,6 +11,7 @@ const HostAuditLogTemplate = `
 type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 {{end}}`
 
 type HostAuditLog = generator.ConfLiteral
@@ -22,6 +23,7 @@ const OpenshiftAuditLogTemplate = `
 type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 {{end}}
 `
 
@@ -34,6 +36,7 @@ const K8sAuditLogTemplate = `
 type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 {{end}}
 `
 
@@ -46,6 +49,7 @@ const OVNAuditLogTemplate = `
 type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 {{end}}
 `
 

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -19,6 +19,7 @@ func (kl KubernetesLogs) Template() string {
 # {{.Desc}}
 [sources.{{.ComponentID}}]
 type = "kubernetes_logs"
+glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = {{.ExcludePaths}}
 pod_annotation_fields.pod_labels = "kubernetes.labels"

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Vector Config Generation", func() {
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
@@ -57,6 +58,7 @@ pod_annotation_fields.pod_node_name = "hostname"
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
@@ -88,24 +90,28 @@ journal_directory = "/var/log/journal"
 type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from kubernetes audit
 [sources.raw_k8s_audit_logs]
 type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from ovn audit
 [sources.raw_ovn_audit_logs]
 type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 `,
 		}),
 		Entry("All Log Sources", helpers.ConfGenerateTest{
@@ -126,6 +132,7 @@ host_key = "hostname"
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
@@ -143,24 +150,28 @@ journal_directory = "/var/log/journal"
 type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from kubernetes audit
 [sources.raw_k8s_audit_logs]
 type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 
 # Logs from ovn audit
 [sources.raw_ovn_audit_logs]
 type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
 `,
 		}),
 	)


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Summary:
- Changed `glob_minimum_cooldown_ms` from the default of 60s to 15s for audit and kubernetes logs when forwarding with Vector.

Details:

This PR addresses the issue where Vector sometimes reports "Failed to annotate event with pod metadata" errors. The proposed fix is to change `glob_minimum_cooldown_ms` to 15s instead of the default of 60s.

/cc @jcantrill @cahartma 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- https://issues.redhat.com/browse/LOG-2648
