### PR TITLE
LOG-2464: replace deprecated configuration parameter

### DIFF
--- a/internal/generator/fluentd/elements/copy.go
+++ b/internal/generator/fluentd/elements/copy.go
@@ -17,7 +17,7 @@ func (c Copy) Template() string {
 	return `{{define "` + c.Name() + `"  -}}
 @type copy
 {{if .DeepCopy -}}
-deep_copy true
+copy_mode deep
 {{end -}}
 {{compose .Stores}}
 {{end}}`

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -644,7 +644,7 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_PIPELINE>
   <match **>
     @type copy
-    deep_copy true
+    copy_mode deep
     <store>
       @type relabel
       @label @APPS_ES_1
@@ -3559,7 +3559,7 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_PIPELINE>
   <match **>
     @type copy
-	deep_copy true
+	copy_mode deep
     <store>
       @type relabel
       @label @APPS_ES_1

--- a/internal/generator/fluentd/pipeline_to_output_test.go
+++ b/internal/generator/fluentd/pipeline_to_output_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Testing Config Generation", func() {
 <label @APP_TO_ES>
   <match **>
     @type copy
-    deep_copy true
+    copy_mode deep
     <store>
       @type relabel
       @label @DEFAULT
@@ -70,7 +70,7 @@ var _ = Describe("Testing Config Generation", func() {
 <label @AUDIT_TO_ES>
   <match **>
     @type copy
-    deep_copy true
+    copy_mode deep
     <store>
       @type relabel
       @label @DEFAULT
@@ -110,7 +110,7 @@ var _ = Describe("Testing Config Generation", func() {
   
   <match **>
     @type copy
-    deep_copy true
+    copy_mode deep
     <store>
       @type relabel
       @label @DEFAULT
@@ -163,7 +163,7 @@ var _ = Describe("Testing Config Generation", func() {
   
   <match **>
     @type copy
-    deep_copy true
+    copy_mode deep
     <store>
       @type relabel
       @label @DEFAULT


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Should fix 
`2022-04-14 05:43:19 +0000 [warn]: 'deep_copy' parameter is deprecated: use 'copy_mode' parameter instead`

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2464
- Enhancement proposal:
