### PR TITLE
[release-5.4]LOG-2464: replace deprecated configuration parameter

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -78,11 +78,10 @@ var _ = Describe("Testing Complete Config Generation", func() {
 <source>
   @type prometheus
   bind "[::]"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>

--- a/internal/generator/fluentd/elements/copy.go
+++ b/internal/generator/fluentd/elements/copy.go
@@ -17,7 +17,7 @@ func (c Copy) Template() string {
 	return `{{define "` + c.Name() + `"  -}}
 @type copy
 {{if .DeepCopy -}}
-deep_copy true
+copy_mode deep
 {{end -}}
 {{compose .Stores}}
 {{end}}`

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -202,11 +202,10 @@ var _ = Describe("Generating fluentd config", func() {
 <source>
   @type prometheus
   bind "[::]"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>
@@ -660,7 +659,7 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_PIPELINE>
   <match **>
     @type copy
-    deep_copy true
+    copy_mode deep
     <store>
       @type relabel
       @label @APPS_ES_1
@@ -1048,11 +1047,10 @@ var _ = Describe("Generating fluentd config", func() {
 <source>
   @type prometheus
   bind "[::]"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>
@@ -1879,11 +1877,10 @@ var _ = Describe("Generating fluentd config", func() {
 <source>
   @type prometheus
   bind "[::]"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>
@@ -2655,11 +2652,10 @@ var _ = Describe("Generating fluentd config", func() {
 <source>
   @type prometheus
   bind "[::]"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>
@@ -3133,11 +3129,10 @@ var _ = Describe("Generating fluentd config", func() {
 <source>
   @type prometheus
   bind "[::]"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>
@@ -3669,7 +3664,7 @@ var _ = Describe("Generating fluentd config", func() {
 <label @APPS_PIPELINE>
   <match **>
     @type copy
-	deep_copy true
+	copy_mode deep
     <store>
       @type relabel
       @label @APPS_ES_1
@@ -4343,11 +4338,10 @@ inputs:
 <source>
   @type prometheus
   bind "[::]"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>

--- a/internal/generator/fluentd/output/elasticsearch/output_conf_es_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/output_conf_es_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Generating fluentd config blocks", func() {
 <label @MY_SECURE_PIPELINE>
   <match **>
     @type copy
-	deep_copy true
+	copy_mode deep
     <store>
       @type relabel
       @label @ONCLUSTER_ELASTICSEARCH

--- a/internal/generator/fluentd/pipeline_to_output_test.go
+++ b/internal/generator/fluentd/pipeline_to_output_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Testing Config Generation", func() {
 <label @APP_TO_ES>
   <match **>
     @type copy
-    deep_copy true
+    copy_mode deep
     <store>
       @type relabel
       @label @DEFAULT
@@ -70,7 +70,7 @@ var _ = Describe("Testing Config Generation", func() {
 <label @AUDIT_TO_ES>
   <match **>
     @type copy
-    deep_copy true
+    copy_mode deep
     <store>
       @type relabel
       @label @DEFAULT
@@ -110,7 +110,7 @@ var _ = Describe("Testing Config Generation", func() {
   
   <match **>
     @type copy
-    deep_copy true
+    copy_mode deep
     <store>
       @type relabel
       @label @DEFAULT
@@ -163,7 +163,7 @@ var _ = Describe("Testing Config Generation", func() {
   
   <match **>
     @type copy
-    deep_copy true
+    copy_mode deep
     <store>
       @type relabel
       @label @DEFAULT

--- a/internal/generator/fluentd/prometheus.go
+++ b/internal/generator/fluentd/prometheus.go
@@ -13,11 +13,10 @@ const PrometheusMonitorTemplate = `
 <source>
   @type prometheus
   bind "[::]"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>

--- a/internal/generator/fluentd/sources_test.go
+++ b/internal/generator/fluentd/sources_test.go
@@ -493,11 +493,10 @@ var _ = Describe("Testing Config Generation", func() {
 <source>
   @type prometheus
   bind "[::]"
-  <ssl>
-    enable true
-    certificate_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
+  <transport tls>
+    cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
-  </ssl>
+  </transport>
 </source>
 
 <source>


### PR DESCRIPTION
### Description

1. Prometheus listener needs <transport tls> configuration to enable async HTTP server instead of Webrick.
2. Should fix: `2022-04-14 05:43:19 +0000 [warn]: 'deep_copy' parameter is deprecated: use 'copy_mode' parameter instead`

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign  @jcantrill  <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2464
- Enhancement proposal:
