### PR TITLE
LOG-2793: Vector ovn audit logs missing level field

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -134,19 +134,20 @@ type = "internal_metrics"
 type = "remap"
 inputs = ["raw_container_logs"]
 source = '''
-  level = "unknown"
-  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
-    level = "warn"
-  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
-    level = "info"
-  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
-    level = "error"
-  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
-    level = "critical"
-  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
-    level = "debug"
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+      .level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    }
   }
-  .level = level
   del(.source_type)
   del(.stream)
   del(.kubernetes.pod_ips)
@@ -170,19 +171,20 @@ source = '''
   del(.TIMESTAMP_BOOTTIME)
   del(.TIMESTAMP_MONOTONIC)
   
-  level = "unknown"
-  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
-    level = "warn"
-  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
-    level = "info"
-  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
-    level = "error"
-  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
-    level = "critical"
-  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
-    level = "debug"
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+      .level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    }
   }
-  .level = level
   
   .hostname = del(.host)
   
@@ -261,8 +263,6 @@ source = '''
   } else {
     log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
   }
-  
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
 '''
 
 [transforms.k8s_audit_logs]
@@ -270,11 +270,8 @@ type = "remap"
 inputs = ["raw_k8s_audit_logs"]
 source = '''
   .tag = ".k8s-audit.log"
-  
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
-  
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
 '''
 
 [transforms.openshift_audit_logs]
@@ -282,11 +279,8 @@ type = "remap"
 inputs = ["raw_openshift_audit_logs"]
 source = '''
   .tag = ".openshift-audit.log"
-  
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
-  
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
 '''
 
 [transforms.ovn_audit_logs]
@@ -294,8 +288,20 @@ type = "remap"
 inputs = ["raw_ovn_audit_logs"]
 source = '''
   .tag = ".ovn-audit.log"
-  
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+      .level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    }
+  }
 '''
 
 [transforms.route_container_logs]
@@ -326,6 +332,7 @@ type = "remap"
 inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
 source = '''
   .log_type = "audit"
+  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ."@timestamp" = del(.timestamp)
 '''
 
@@ -466,19 +473,20 @@ type = "internal_metrics"
 type = "remap"
 inputs = ["raw_container_logs"]
 source = '''
-  level = "unknown"
-  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
-    level = "warn"
-  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
-    level = "info"
-  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
-    level = "error"
-  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
-    level = "critical"
-  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
-    level = "debug"
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+      .level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    }
   }
-  .level = level
   del(.source_type)
   del(.stream)
   del(.kubernetes.pod_ips)
@@ -502,19 +510,20 @@ source = '''
   del(.TIMESTAMP_BOOTTIME)
   del(.TIMESTAMP_MONOTONIC)
   
-  level = "unknown"
-  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
-    level = "warn"
-  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
-    level = "info"
-  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
-    level = "error"
-  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
-    level = "critical"
-  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
-    level = "debug"
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+      .level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    }
   }
-  .level = level
   
   .hostname = del(.host)
   
@@ -593,8 +602,6 @@ source = '''
   } else {
     log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
   }
-  
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
 '''
 
 [transforms.k8s_audit_logs]
@@ -602,11 +609,8 @@ type = "remap"
 inputs = ["raw_k8s_audit_logs"]
 source = '''
   .tag = ".k8s-audit.log"
-  
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
-  
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
 '''
 
 [transforms.openshift_audit_logs]
@@ -614,11 +618,8 @@ type = "remap"
 inputs = ["raw_openshift_audit_logs"]
 source = '''
   .tag = ".openshift-audit.log"
-  
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
-  
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
 '''
 
 [transforms.ovn_audit_logs]
@@ -626,8 +627,20 @@ type = "remap"
 inputs = ["raw_ovn_audit_logs"]
 source = '''
   .tag = ".ovn-audit.log"
-  
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+      .level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    }
+  }
 '''
 
 [transforms.route_container_logs]
@@ -658,6 +671,7 @@ type = "remap"
 inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
 source = '''
   .log_type = "audit"
+  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ."@timestamp" = del(.timestamp)
 '''
 

--- a/internal/generator/vector/inputs.go
+++ b/internal/generator/vector/inputs.go
@@ -95,6 +95,7 @@ func Inputs(spec *logging.ClusterLogForwarderSpec, o Options) []Element {
 				Inputs:      helpers.MakeInputs(HostAuditLogs, K8sAuditLogs, OpenshiftAuditLogs, OvnAuditLogs),
 				VRL: strings.Join(helpers.TrimSpaces([]string{
 					AddLogTypeAudit,
+					FixHostname,
 					FixTimestampField,
 				}), "\n"),
 			})

--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -12,19 +12,20 @@ import (
 
 const (
 	FixLogLevel = `
-level = "unknown"
-if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
-  level = "warn"
-} else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
-  level = "info"
-} else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
-  level = "error"
-} else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
-  level = "critical"
-} else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
-  level = "debug"
+if !exists(.level) {
+  .level = "unknown"
+  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+    .level = "warn"
+  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+    .level = "info"
+  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+    .level = "error"
+  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+    .level = "critical"
+  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+    .level = "debug"
+  }
 }
-.level = level
 `
 	RemoveSourceType  = `del(.source_type)`
 	RemoveStream      = `del(.stream)`
@@ -194,7 +195,6 @@ func NormalizeHostAuditLogs(inLabel, outLabel string) []generator.Element {
 			VRL: strings.Join(helpers.TrimSpaces([]string{
 				AddHostAuditTag,
 				ParseHostAuditLogs,
-				FixHostname,
 			}), "\n\n"),
 		},
 	}
@@ -208,8 +208,7 @@ func NormalizeK8sAuditLogs(inLabel, outLabel string) []generator.Element {
 			VRL: strings.Join(helpers.TrimSpaces([]string{
 				AddK8sAuditTag,
 				ParseAndFlatten,
-				FixHostname,
-			}), "\n\n"),
+			}), "\n"),
 		},
 	}
 }
@@ -222,8 +221,7 @@ func NormalizeOpenshiftAuditLogs(inLabel, outLabel string) []generator.Element {
 			VRL: strings.Join(helpers.TrimSpaces([]string{
 				AddOpenAuditTag,
 				ParseAndFlatten,
-				FixHostname,
-			}), "\n\n"),
+			}), "\n"),
 		},
 	}
 }
@@ -235,8 +233,8 @@ func NormalizeOVNAuditLogs(inLabel, outLabel string) []generator.Element {
 			Inputs:      helpers.MakeInputs(inLabel),
 			VRL: strings.Join(helpers.TrimSpaces([]string{
 				AddOvnAuditTag,
-				FixHostname,
-			}), "\n\n"),
+				FixLogLevel,
+			}), "\n"),
 		},
 	}
 }

--- a/internal/generator/vector/normalize_test.go
+++ b/internal/generator/vector/normalize_test.go
@@ -33,19 +33,20 @@ var _ = Describe("Vector Config Generation", func() {
 type = "remap"
 inputs = ["raw_container_logs"]
 source = '''
-  level = "unknown"
-  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
-    level = "warn"
-  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
-    level = "info"
-  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
-    level = "error"
-  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
-    level = "critical"
-  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
-    level = "debug"
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+  	.level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+  	.level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+  	.level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+  	.level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+  	.level = "debug"
+    }
   }
-  .level = level
   del(.source_type)
   del(.stream)
   del(.kubernetes.pod_ips)
@@ -70,19 +71,20 @@ source = '''
 type = "remap"
 inputs = ["raw_container_logs"]
 source = '''
-  level = "unknown"
-  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
-    level = "warn"
-  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
-    level = "info"
-  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
-    level = "error"
-  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
-    level = "critical"
-  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
-    level = "debug"
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+  	.level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+  	.level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+  	.level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+  	.level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+  	.level = "debug"
+    }
   }
-  .level = level
   del(.source_type)
   del(.stream)
   del(.kubernetes.pod_ips)
@@ -106,19 +108,20 @@ source = '''
   del(.TIMESTAMP_BOOTTIME)
   del(.TIMESTAMP_MONOTONIC)
   
-  level = "unknown"
-  if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)'){
-    level = "warn"
-  } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>'){
-    level = "info"
-  } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>'){
-    level = "error"
-  } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>'){
-    level = "critical"
-  } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>'){
-    level = "debug"
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+  	.level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+  	.level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+  	.level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+  	.level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+  	.level = "debug"
+    }
   }
-  .level = level
   
   .hostname = del(.host)
   
@@ -212,7 +215,6 @@ source = '''
   } else {
     log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
   }
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
 '''
     
 [transforms.k8s_audit_logs]
@@ -220,10 +222,8 @@ type = "remap"
 inputs = ["raw_k8s_audit_logs"]
 source = '''
   .tag = ".k8s-audit.log"
-  
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
 '''
 
 [transforms.openshift_audit_logs]
@@ -231,10 +231,8 @@ type = "remap"
 inputs = ["raw_openshift_audit_logs"]
 source = '''
   .tag = ".openshift-audit.log"
-  
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
 '''
 
 [transforms.ovn_audit_logs]
@@ -242,7 +240,20 @@ type = "remap"
 inputs = ["raw_ovn_audit_logs"]
 source = '''
   .tag = ".ovn-audit.log"
-  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+  if !exists(.level) {
+    .level = "unknown"
+    if match!(.message,r'(Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>)') {
+  	.level = "warn"
+    } else if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+  	.level = "info"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+  	.level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+  	.level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+  	.level = "debug"
+    }
+  }
 '''
 `,
 		}),

--- a/internal/generator/vector/sources_to_pipelines_test.go
+++ b/internal/generator/vector/sources_to_pipelines_test.go
@@ -62,6 +62,7 @@ type = "remap"
 inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
 source = '''
   .log_type = "audit"
+  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ."@timestamp" = del(.timestamp)
 '''
 
@@ -123,6 +124,7 @@ type = "remap"
 inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
 source = '''
   .log_type = "audit"
+  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ."@timestamp" = del(.timestamp)
 '''
 

--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -316,6 +316,12 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 				results := strings.Join(raw, " ")
 				Expect(results).To(MatchRegexp("name=verify-audit-logging_deny-all"), "Message should contain the audit log: %v", raw)
+
+				// Parse logs and verify level and type
+				logs, err := types.ParseLogs(utils.ToJsonLogs(raw))
+				ExpectOK(err, "Expected no errors parsing the logs: %s", raw)
+				Expect(logs[0].Level).To(Equal(outputLogTemplate.Level))
+				Expect(logs[0].LogType).To(Equal(outputLogTemplate.LogType))
 			})
 
 			AfterEach(func() {


### PR DESCRIPTION
### Description
Fixes issue where the OVN audit logs are missing the level field when using Vector as collector,   I've updated the if/else logic to leave the field if it exists, in order to match current fluentd functionality.
Additionally, the hostname field was consolidated and moved to the audit remap.

/cc @jcantrill 
/assign @vimalk78 @syedriko  @vparfonov 

### Links
- https://issues.redhat.com/browse/LOG-2793
