### PR TITLE
NO-JIRA: Get rid of system:admin login from e2e cleanup

### DIFF
--- a/hack/lib/cleanup.sh
+++ b/hack/lib/cleanup.sh
@@ -258,7 +258,6 @@ function os::cleanup::dump_events() {
 	if [[ -n "${ADMIN_KUBECONFIG:-}" ]]; then
 		kubeconfig="--config=${ADMIN_KUBECONFIG}"
 	fi
-	oc login -u system:admin ${kubeconfig:-}
 	oc get events --all-namespaces ${kubeconfig:-} > "${ARTIFACT_DIR}/events.txt" 2>&1
 }
 readonly -f os::cleanup::dump_events


### PR DESCRIPTION
No longer needed and a nuisance, it logs you out of kube:admin on each test run.