### PR TITLE
LOG-2763: Vector's healthcheck fails when forwarding logs to Lokistack

### DIFF
--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -57,6 +57,7 @@ func (l Loki) Template() string {
 type = "loki"
 inputs = {{.Inputs}}
 endpoint = "{{.Endpoint}}"
+healthcheck.enabled = false
 {{kv .TenantID -}}
 {{end}}`
 }

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -1,9 +1,10 @@
 package loki
 
 import (
-	"github.com/openshift/cluster-logging-operator/test/helpers"
 	"sort"
 	"testing"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -73,6 +74,7 @@ var _ = Describe("Generate vector config", func() {
 type = "loki"
 inputs = ["application"]
 endpoint = "https://logs-us-west1.grafana.net"
+healthcheck.enabled = false
 
 [sinks.loki_receiver.encoding]
 codec = "json"
@@ -120,6 +122,7 @@ password = "password"
 type = "loki"
 inputs = ["application"]
 endpoint = "https://logs-us-west1.grafana.net"
+healthcheck.enabled = false
 
 [sinks.loki_receiver.encoding]
 codec = "json"
@@ -165,6 +168,7 @@ password = "password"
 type = "loki"
 inputs = ["application"]
 endpoint = "https://logs-us-west1.grafana.net"
+healthcheck.enabled = false
 tenant_id = "{{foo.bar.baz}}"
 
 [sinks.loki_receiver.encoding]
@@ -210,6 +214,7 @@ password = "password"
 type = "loki"
 inputs = ["application"]
 endpoint = "http://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application"
+healthcheck.enabled = false
 
 [sinks.loki_receiver.encoding]
 codec = "json"
@@ -258,6 +263,7 @@ var _ = Describe("Generate vector config for in cluster loki", func() {
 type = "loki"
 inputs = ["application"]
 endpoint = "http://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application"
+healthcheck.enabled = false
 
 [sinks.loki_receiver.encoding]
 codec = "json"


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

This PR addresses a problem with `Vector` forwarding logs to the `Loki` with the error

``` 
ERROR vector::topology::builder: msg="Healthcheck: Failed Reason." error=A non-successful status returned: 404 Not Found component_kind="sink" component_type="loki" component_id=loki_infra component_name=loki_infra

x Health check for "loki_infra" failed
```

Since logs are still forwarded to `Loki` even with this healthcheck error, it was decided to disable the healthcheck in the `[sink] ` portion of vector's config file, `vector.toml` with the configuration `healthcheck.enabled = false`.


/cc @cahartma @jcantrill 
/assign @jcantrill @vimalk78 

### Links

https://issues.redhat.com/browse/LOG-2763
