### PR TITLE
[release-5.4] LOG-2840: Create secret for logcollector serviceaccount manually

### DIFF
--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -457,29 +457,17 @@ func verifySecretKeysForCloudwatch(output *logging.OutputSpec, conds logging.Nam
 }
 
 func (clusterRequest *ClusterLoggingRequest) getLogCollectorServiceAccountTokenSecret() (*corev1.Secret, error) {
-	log.V(9).Info("Entered getServiceAccountToken")
-	sa := corev1.ServiceAccount{}
-	err := clusterRequest.Client.Get(context.Background(), client.ObjectKey{Name: constants.CollectorServiceAccountName, Namespace: constants.OpenshiftNS}, &sa)
-	if err != nil {
-		log.V(3).Error(err, "Could not find serviceAccount", "ServiceAccoutName", constants.CollectorServiceAccountName)
-		return nil, err
+	s := &corev1.Secret{}
+	log.V(9).Info("Fetching Secret", "Name", constants.LogCollectorToken)
+	if err := clusterRequest.Get(constants.LogCollectorToken, s); err != nil {
+		log.V(3).Error(err, "Could not find Secret", "Name", constants.LogCollectorToken)
+		return nil, errors.New("Could not retrieve ServiceAccount token")
 	}
-	log.V(9).Info("Found secrets", "Count", len(sa.Secrets))
-	for _, sref := range sa.Secrets {
-		s := corev1.Secret{}
-		log.V(9).Info("Fetching Secret", "Name", sref.Name)
-		err = clusterRequest.Client.Get(context.Background(), client.ObjectKey{Name: sref.Name, Namespace: constants.OpenshiftNS}, &s)
-		if err != nil {
-			log.V(3).Error(err, "Could not find Secret", "Name", sref.Name)
-		} else {
-			if t, ok := s.Data[constants.TokenKey]; ok {
-				log.V(9).Info("found token", constants.TokenKey, t)
-				return &s, nil
-			} else {
-				log.V(9).Info("did not find token in secret", "Name", s.Name)
-			}
-		}
+
+	if _, ok := s.Data[constants.TokenKey]; !ok {
+		log.V(9).Info("did not find token in secret", "Name", s.Name)
+		return nil, errors.New("logcollector secret is missing token")
 	}
-	log.V(9).Info("Exited getServiceAccountToken")
-	return nil, errors.New("Could not retrieve ServiceAccount token")
+
+	return s, nil
 }


### PR DESCRIPTION
### Description

Starting with Kubernetes 1.24 (OCP 4.11), ServiceAccounts will no longer automatically have an associated secret containing a token. The cluster-logging-operator currently looks for a secret containing a token associated with the logcollector ServiceAccount it creates for the collector DaemonSet. This secret is used for "default credentials" for the log forwarders. Failing to find the secret results in some forwarder configurations no longer having valid credentials.

This PR introduces a manually created secret to the cluster-logging-operator which then can be used like the automatically-created one before.

### Links

- Backport of #1561 
- JIRA: [LOG-2840](https://issues.redhat.com//browse/LOG-2840)
