### PR TITLE
LOG-2290: ClusterLogging Instance status in not getting updated in UI

### DIFF
--- a/apis/logging/v1/clusterlogging_types.go
+++ b/apis/logging/v1/clusterlogging_types.go
@@ -85,7 +85,7 @@ type ClusterLoggingStatus struct {
 	Curation CurationStatus `json:"curation"`
 
 	// +optional
-	Conditions status.Conditions `json:"clusterConditions,omitempty"`
+	Conditions status.Conditions `json:"conditions,omitempty"`
 }
 
 // This is the struct that will contain information pertinent to Log visualization (Kibana)

--- a/bundle/manifests/logging.openshift.io_clusterloggings.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterloggings.yaml
@@ -968,46 +968,6 @@ spec:
           status:
             description: ClusterLoggingStatus defines the observed state of ClusterLogging
             properties:
-              clusterConditions:
-                description: Conditions is a set of Condition instances.
-                items:
-                  description: "Condition represents an observation of an object's
-                    state. Conditions are an extension mechanism intended to be used
-                    when the details of an observation are not a priori known or would
-                    not apply to all instances of a given Kind. \n Conditions should
-                    be added to explicitly convey properties that users and components
-                    care about rather than requiring those properties to be inferred
-                    from other observations. Once defined, the meaning of a Condition
-                    can not be changed arbitrarily - it becomes part of the API, and
-                    has the same backwards- and forwards-compatibility concerns of
-                    any other part of the API."
-                  properties:
-                    lastTransitionTime:
-                      format: date-time
-                      type: string
-                    message:
-                      type: string
-                    reason:
-                      description: ConditionReason is intended to be a one-word, CamelCase
-                        representation of the category of cause of the current status.
-                        It is intended to be used in concise output, such as one-line
-                        kubectl get output, and in summarizing occurrences of causes.
-                      type: string
-                    status:
-                      type: string
-                    type:
-                      description: "ConditionType is the type of the condition and
-                        is typically a CamelCased word or short phrase. \n Condition
-                        types should indicate state in the \"abnormal-true\" polarity.
-                        For example, if the condition indicates when a policy is invalid,
-                        the \"is valid\" case is probably the norm, so the condition
-                        should be called \"Invalid\"."
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
               collection:
                 properties:
                   logs:
@@ -1078,6 +1038,46 @@ spec:
                         type: object
                     type: object
                 type: object
+              conditions:
+                description: Conditions is a set of Condition instances.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
               curation:
                 properties:
                   curatorStatus:

--- a/config/crd/bases/logging.openshift.io_clusterloggings.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterloggings.yaml
@@ -964,46 +964,6 @@ spec:
           status:
             description: ClusterLoggingStatus defines the observed state of ClusterLogging
             properties:
-              clusterConditions:
-                description: Conditions is a set of Condition instances.
-                items:
-                  description: "Condition represents an observation of an object's
-                    state. Conditions are an extension mechanism intended to be used
-                    when the details of an observation are not a priori known or would
-                    not apply to all instances of a given Kind. \n Conditions should
-                    be added to explicitly convey properties that users and components
-                    care about rather than requiring those properties to be inferred
-                    from other observations. Once defined, the meaning of a Condition
-                    can not be changed arbitrarily - it becomes part of the API, and
-                    has the same backwards- and forwards-compatibility concerns of
-                    any other part of the API."
-                  properties:
-                    lastTransitionTime:
-                      format: date-time
-                      type: string
-                    message:
-                      type: string
-                    reason:
-                      description: ConditionReason is intended to be a one-word, CamelCase
-                        representation of the category of cause of the current status.
-                        It is intended to be used in concise output, such as one-line
-                        kubectl get output, and in summarizing occurrences of causes.
-                      type: string
-                    status:
-                      type: string
-                    type:
-                      description: "ConditionType is the type of the condition and
-                        is typically a CamelCased word or short phrase. \n Condition
-                        types should indicate state in the \"abnormal-true\" polarity.
-                        For example, if the condition indicates when a policy is invalid,
-                        the \"is valid\" case is probably the norm, so the condition
-                        should be called \"Invalid\"."
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
               collection:
                 properties:
                   logs:
@@ -1074,6 +1034,46 @@ spec:
                         type: object
                     type: object
                 type: object
+              conditions:
+                description: Conditions is a set of Condition instances.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
               curation:
                 properties:
                   curatorStatus:


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

This PR addresses an issue with displaying the status for a `Cluster Logging instance`. 

I found that the web UI is probably looking for the  `status.conditions` field in the cluster logging instance. In the `clusterlogging_types.go` the `json` name for `ClusterLoggingStatus.Conditions` was `clusterConditions`. Changing this to `conditions` fixes the issue and all conditions can be displayed. 

/cc @cahartma
/assign @jcantrill 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
https://issues.redhat.com/browse/LOG-2290
