### PR TITLE
LOG-2869: Simplify sending audit-logs to LokiStack

### DIFF
--- a/apis/logging/v1/clusterlogging_types.go
+++ b/apis/logging/v1/clusterlogging_types.go
@@ -221,6 +221,12 @@ type LokiStackStoreSpec struct {
 	//
 	// +required
 	Name string `json:"name"`
+
+	// SendAuditLogs controls whether audit-logs will be sent to the LokiStack log store.
+	// By default, only application and infrastructure logs will be sent to the store.
+	//
+	// +optional
+	SendAuditLogs bool `json:"sendAuditLogs,omitempty"`
 }
 
 // This is the struct that will contain information pertinent to Log and event collection

--- a/bundle/manifests/logging.openshift.io_clusterloggings.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterloggings.yaml
@@ -686,6 +686,11 @@ spec:
                       name:
                         description: Name of the LokiStack resource.
                         type: string
+                      sendAuditLogs:
+                        description: SendAuditLogs controls whether audit-logs will
+                          be sent to the LokiStack log store. By default, only application
+                          and infrastructure logs will be sent to the store.
+                        type: boolean
                     required:
                     - name
                     type: object

--- a/config/crd/bases/logging.openshift.io_clusterloggings.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterloggings.yaml
@@ -682,6 +682,11 @@ spec:
                       name:
                         description: Name of the LokiStack resource.
                         type: string
+                      sendAuditLogs:
+                        description: SendAuditLogs controls whether audit-logs will
+                          be sent to the LokiStack log store. By default, only application
+                          and infrastructure logs will be sent to the store.
+                        type: boolean
                     required:
                     - name
                     type: object

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -148,6 +148,13 @@ func (clusterRequest *ClusterLoggingRequest) NormalizeForwarder() (*logging.Clus
 						OutputRefs: []string{logging.OutputNameDefault + "-infra"},
 					},
 				}
+
+				if logStore.LokiStack.SendAuditLogs {
+					clusterRequest.ForwarderSpec.Pipelines = append(clusterRequest.ForwarderSpec.Pipelines, logging.PipelineSpec{
+						InputRefs:  []string{logging.InputNameAudit},
+						OutputRefs: []string{logging.OutputNameDefault + "-audit"},
+					})
+				}
 			}
 			// Continue with normalization to fill out spec and status.
 		} else if clusterRequest.ForwarderRequest == nil {
@@ -411,6 +418,14 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.Cluster
 						Type: logging.OutputTypeLoki,
 						URL:  clusterRequest.LokiStackURL("infrastructure"),
 					})
+
+				if logStore.LokiStack.SendAuditLogs {
+					spec.Outputs = append(spec.Outputs, logging.OutputSpec{
+						Name: logging.OutputNameDefault + "-audit",
+						Type: logging.OutputTypeLoki,
+						URL:  clusterRequest.LokiStackURL("audit"),
+					})
+				}
 			default:
 				status.Outputs.Set(name, condInvalid(fmt.Sprintf("unknown log store type: %s", clusterRequest.Cluster.Spec.LogStore.Type)))
 			}

--- a/internal/k8shandler/forwarding_test.go
+++ b/internal/k8shandler/forwarding_test.go
@@ -661,6 +661,46 @@ pipelines:
 `))
 		})
 
+		It("generates default configuration for empty spec with LokiStack log store and audit logs enabled", func() {
+			cluster.Spec.LogStore = &logging.LogStoreSpec{
+				Type: logging.LogStoreTypeLokiStack,
+				LokiStack: logging.LokiStackStoreSpec{
+					Name:          "lokistack-testing",
+					SendAuditLogs: true,
+				},
+			}
+
+			spec, _ := request.NormalizeForwarder()
+			Expect(YAMLString(spec)).To(EqualLines(`
+outputs:
+- name: default
+	type: loki
+	url: https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/application
+- name: default-infra
+	type: loki
+	url: https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/infrastructure
+- name: default-audit
+	type: loki
+	url: https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/audit
+pipelines:
+- inputRefs:
+  - application
+  name: pipeline_0_
+  outputRefs:
+  - default
+- inputRefs:
+  - infrastructure
+  name: pipeline_1_
+  outputRefs:
+  - default-infra
+- inputRefs:
+  - audit
+  name: pipeline_2_
+  outputRefs:
+  - default-audit
+`))
+		})
+
 		It("forwards logs to an explicit default logstore", func() {
 			cluster.Spec.LogStore = &logging.LogStoreSpec{
 				Type: logging.LogStoreTypeElasticsearch,


### PR DESCRIPTION
### Description

This PR simplifies the configuration needed for forwarding audit-logs into LokiStack log store.

### Links

- JIRA: [LOG-2869](https://issues.redhat.com//browse/LOG-2869)
