### PR TITLE
LOG-2667: Fix test flake caused by console test.

### DIFF
--- a/test/e2e/consoleplugin/smoke_test/consoleplugin_test.go
+++ b/test/e2e/consoleplugin/smoke_test/consoleplugin_test.go
@@ -43,18 +43,24 @@ var _ = Describe("[ConsolePlugin]", func() {
 		r *consoleplugin.Reconciler
 	)
 
+	cleanup := func() {
+		_ = r.Delete(ctx)
+		_ = c.Remove(testruntime.NewClusterLogForwarder())
+		_ = c.Remove(testruntime.NewClusterLogging())
+	}
+
 	BeforeEach(func() {
 		c = client.NewTest()
 		r = consoleplugin.NewReconciler(
 			c.ControllerRuntimeClient(),
 			consoleplugin.NewConfig(testruntime.NewClusterLogging(), "lokiService"))
-		// Clear out any previosly-existing objects
-		_ = c.Remove(testruntime.NewClusterLogging())
-		_ = c.Remove(testruntime.NewClusterLogForwarder())
-		_ = r.Delete(ctx)
+		cleanup() // Clear out objects left behind by previous tests.
 	})
 
-	AfterEach(func() { c.Close() })
+	AfterEach(func() {
+		cleanup()
+		c.Close()
+	})
 
 	It("activates logging view if log type is lokistack", func() {
 		cl := testruntime.NewClusterLogging()


### PR DESCRIPTION
Add missing cleanup actions to the console e2e test, suspected to be the cause of logforwarding e2e test flakes.

/cc @xperimental
/cc @periklis