### PR TITLE
LOG-2873: fix resources for vector when spec'd

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -74,11 +74,13 @@ type Factory struct {
 	Secrets       map[string]*v1.Secret
 }
 
+// CollectorResourceRequirements returns the resource requirements for a given collector implementation
+// or it's default if none are specified
 func (f *Factory) CollectorResourceRequirements() v1.ResourceRequirements {
-	if f.CollectorType == logging.LogCollectionTypeVector {
-		return v1.ResourceRequirements{}
-	}
 	if f.CollectorSpec.Resources == nil {
+		if f.CollectorType == logging.LogCollectionTypeVector {
+			return v1.ResourceRequirements{}
+		}
 		return v1.ResourceRequirements{
 			Limits: v1.ResourceList{v1.ResourceMemory: fluentd.DefaultMemory},
 			Requests: v1.ResourceList{

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -177,7 +177,29 @@ var _ = Describe("Factory#NewPodSpec", func() {
 
 var _ = Describe("Factory#CollectorResourceRequirements", func() {
 	var (
-		factory *Factory
+		factory        *Factory
+		collectionSpec = logging.CollectionSpec{
+			CollectorSpec: logging.CollectorSpec{
+				Resources: &v1.ResourceRequirements{
+					Limits: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("120Gi"),
+					},
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("100Gi"),
+						v1.ResourceCPU:    resource.MustParse("500m"),
+					},
+				},
+			},
+		}
+		expResources = v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("120Gi"),
+			},
+			Requests: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("100Gi"),
+				v1.ResourceCPU:    resource.MustParse("500m"),
+			},
+		}
 	)
 
 	Context("when collectorType is vector", func() {
@@ -187,8 +209,13 @@ var _ = Describe("Factory#CollectorResourceRequirements", func() {
 				Visit:         vector.CollectorVisitor,
 			}
 		})
-		It("should not define any resources", func() {
+		It("should not define any resources when none are specified", func() {
 			Expect(factory.CollectorResourceRequirements()).To(Equal(v1.ResourceRequirements{}))
+		})
+
+		It("should apply the spec'd resources when defined", func() {
+			factory.CollectorSpec = collectionSpec
+			Expect(factory.CollectorResourceRequirements()).To(Equal(expResources))
 		})
 
 	})
@@ -209,28 +236,8 @@ var _ = Describe("Factory#CollectorResourceRequirements", func() {
 			}))
 		})
 		It("should apply the spec'd resources when defined", func() {
-			factory.CollectorSpec = logging.CollectionSpec{
-				CollectorSpec: logging.CollectorSpec{
-					Resources: &v1.ResourceRequirements{
-						Limits: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("120Gi"),
-						},
-						Requests: v1.ResourceList{
-							v1.ResourceMemory: resource.MustParse("100Gi"),
-							v1.ResourceCPU:    resource.MustParse("500m"),
-						},
-					},
-				},
-			}
-			Expect(factory.CollectorResourceRequirements()).To(Equal(v1.ResourceRequirements{
-				Limits: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("120Gi"),
-				},
-				Requests: v1.ResourceList{
-					v1.ResourceMemory: resource.MustParse("100Gi"),
-					v1.ResourceCPU:    resource.MustParse("500m"),
-				},
-			}))
+			factory.CollectorSpec = collectionSpec
+			Expect(factory.CollectorResourceRequirements()).To(Equal(expResources))
 		})
 
 	})


### PR DESCRIPTION
### Description
This PR:
* fixes vector deployments to honor the spec'd memory

### Links
* https://issues.redhat.com/browse/LOG-2873
