### PR TITLE
LOG-2801: fix pattern for infrastructure indexing

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -629,7 +629,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -681,7 +681,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -810,7 +810,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -1484,7 +1484,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -1613,7 +1613,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -2291,9 +2291,9 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
-      static_index_name infra-write
+	  static_index_name infra-write
 	</elasticsearch_index_name>
 	<elasticsearch_index_name>
 	  enabled 'true'
@@ -2420,7 +2420,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -3596,7 +3596,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -3725,7 +3725,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -3854,7 +3854,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>
@@ -3983,7 +3983,7 @@ var _ = Describe("Generating fluentd config", func() {
 	elasticsearch_index_prefix_field 'viaq_index_name'
 	<elasticsearch_index_name>
 	  enabled 'true'
-	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 	  name_type static
 	  static_index_name infra-write
 	</elasticsearch_index_name>

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
@@ -201,7 +201,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
@@ -345,7 +345,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
@@ -478,7 +478,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
@@ -623,7 +623,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>
@@ -765,7 +765,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
       structured_type_annotation_prefix containerType.logging.openshift.io
@@ -902,7 +902,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
       structured_type_key kubernetes.labels.foo-bar
@@ -1039,7 +1039,7 @@ var _ = Describe("Generate fluentd config", func() {
     elasticsearch_index_prefix_field 'viaq_index_name'
     <elasticsearch_index_name>
       enabled 'true'
-      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
       name_type static
       static_index_name infra-write
     </elasticsearch_index_name>

--- a/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
+++ b/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
@@ -69,7 +69,7 @@ func (im Viaq) Template() string {
   elasticsearch_index_prefix_field 'viaq_index_name'
   <elasticsearch_index_name>
     enabled 'true'
-    tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+    tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
     name_type static
     static_index_name infra-write
 {{if (ne .StructuredTypeKey "") -}}

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Generating fluentd config", func() {
 			elasticsearch_index_prefix_field 'viaq_index_name'
 			<elasticsearch_index_name>
 			  enabled 'true'
-			  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+			  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 			  name_type static
 			  static_index_name infra-write
 			</elasticsearch_index_name>
@@ -234,7 +234,7 @@ var _ = Describe("Generating fluentd config", func() {
 			elasticsearch_index_prefix_field 'viaq_index_name'
 			<elasticsearch_index_name>
 			  enabled 'true'
-			  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+			  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 			  name_type static
 			  static_index_name infra-write
 			</elasticsearch_index_name>
@@ -363,7 +363,7 @@ var _ = Describe("Generating fluentd config", func() {
 			elasticsearch_index_prefix_field 'viaq_index_name'
 			<elasticsearch_index_name>
 			  enabled 'true'
-			  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.system** system.var.log**"
+			  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
 			  name_type static
 			  static_index_name infra-write
 			</elasticsearch_index_name>


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
After adding multiline error detection in #1192, `kubernetes` prefix tag removed, so pattern for infrastructure index not match all logs going to the application index 
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @vimalk78 <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2801
- Enhancement proposal:
