### PR TITLE
LOG-2285: Fix disabling certificate validation for Kafka output

### DIFF
--- a/internal/generator/vector/output/kafka/kafka_test.go
+++ b/internal/generator/vector/output/kafka/kafka_test.go
@@ -255,10 +255,10 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
+[sinks.kafka_receiver.librdkafka_options]
+"enable.ssl.certificate.verification" = "false"
 [sinks.kafka_receiver.tls]
 enabled = true
-verify_certificate = false
-verify_hostname = false
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"

--- a/internal/generator/vector/output/kafka/security.go
+++ b/internal/generator/vector/output/kafka/security.go
@@ -16,3 +16,18 @@ key_pass = "{{p.PassphrasePath}}"
 {{- end}}
 `
 }
+
+type insecureTLS struct {
+	ComponentID string
+}
+
+func (i insecureTLS) Name() string {
+	return "kafkaInsecureTLSTemplate"
+}
+
+func (i insecureTLS) Template() string {
+	return `{{define "` + i.Name() + `" -}}
+[sinks.{{.ComponentID}}.librdkafka_options]
+"enable.ssl.certificate.verification" = "false"
+{{- end}}`
+}


### PR DESCRIPTION
### Description

During #1548 I failed to realize that the Kafka output for vector does not use the common `tls.*` options for disabling validation of the certificate.

This PR fixes two issues with the Kafka output:

- TLS was not enabled if the URL contained a `tls://` scheme but the secret did not contain any other TLS options
- Use Kafka's custom option to disable verification of the certificate

/cc @cahartma 
/assign @alanconway 

### Links

- JIRA: [LOG-2285](https://issues.redhat.com//browse/LOG-2285)
