### PR TITLE
LOG-2862: Enable function JSON parsing tests for vector

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -181,6 +181,7 @@ type Elasticsearch struct {
 	// StructuredTypeKey specifies the metadata key to be used as name of elasticsearch index
 	// It takes precedence over StructuredTypeName
 	//
+	// +kubebuilder:validation:Pattern:=(kubernetes\.container_name|kubernetes\.labels\..+|openshift\.labels\..+)
 	// +optional
 	StructuredTypeKey string `json:"structuredTypeKey,omitempty"`
 

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -155,6 +155,7 @@ spec:
                         description: StructuredTypeKey specifies the metadata key
                           to be used as name of elasticsearch index It takes precedence
                           over StructuredTypeName
+                        pattern: (kubernetes\.container_name|kubernetes\.labels\..+|openshift\.labels\..+)
                         type: string
                       structuredTypeName:
                         description: StructuredTypeName specifies the name of elasticsearch
@@ -209,6 +210,7 @@ spec:
                           description: StructuredTypeKey specifies the metadata key
                             to be used as name of elasticsearch index It takes precedence
                             over StructuredTypeName
+                          pattern: (kubernetes\.container_name|kubernetes\.labels\..+|openshift\.labels\..+)
                           type: string
                         structuredTypeName:
                           description: StructuredTypeName specifies the name of elasticsearch

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -151,6 +151,7 @@ spec:
                         description: StructuredTypeKey specifies the metadata key
                           to be used as name of elasticsearch index It takes precedence
                           over StructuredTypeName
+                        pattern: (kubernetes\.container_name|kubernetes\.labels\..+|openshift\.labels\..+)
                         type: string
                       structuredTypeName:
                         description: StructuredTypeName specifies the name of elasticsearch
@@ -205,6 +206,7 @@ spec:
                           description: StructuredTypeKey specifies the metadata key
                             to be used as name of elasticsearch index It takes precedence
                             over StructuredTypeName
+                          pattern: (kubernetes\.container_name|kubernetes\.labels\..+|openshift\.labels\..+)
                           type: string
                         structuredTypeName:
                           description: StructuredTypeName specifies the name of elasticsearch

--- a/test/client/test_test.go
+++ b/test/client/test_test.go
@@ -1,0 +1,30 @@
+package client_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/openshift/cluster-logging-operator/test/client"
+)
+
+var _ = Describe("TestOptions", func() {
+
+	var (
+		options TestOptions
+	)
+
+	BeforeEach(func() {
+		options = TestOptions{}
+	})
+
+	Context("#Includes", func() {
+		It("should return false when the option is missing from the list", func() {
+			Expect(options.Include(UseInfraNamespaceTestOption)).To(BeFalse())
+		})
+
+		It("should return true when the list contains the option", func() {
+			options = append(options, UseInfraNamespaceTestOption)
+			Expect(options.Include(UseInfraNamespaceTestOption)).To(BeTrue())
+		})
+	})
+})

--- a/test/framework/functional/common/loglevel.go
+++ b/test/framework/functional/common/loglevel.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	log "github.com/ViaQ/logerr/v2/log/static"
+	"os"
+	"strconv"
+)
+
+func AdaptLogLevel() string {
+	logLevel := "debug"
+	if level, found := os.LookupEnv("LOG_LEVEL"); found {
+		if i, err := strconv.Atoi(level); err == nil {
+			switch i {
+			case 0:
+				logLevel = "error"
+			case 1:
+				logLevel = "info"
+			case 2:
+				logLevel = "debug"
+			case 3 - 8:
+				logLevel = "trace"
+			default:
+			}
+		} else {
+			log.V(1).Error(err, "Unable to set LOG_LEVEL from environment")
+		}
+	}
+	return logLevel
+}

--- a/test/framework/functional/fluentd/deploy.go
+++ b/test/framework/functional/fluentd/deploy.go
@@ -1,9 +1,8 @@
 package fluentd
 
 import (
+	. "github.com/openshift/cluster-logging-operator/test/framework/functional/common"
 	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
-	"os"
-	"strconv"
 	"strings"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -45,7 +44,7 @@ done
 }
 
 func (c *FluentdCollector) BuildCollectorContainer(b *runtime.ContainerBuilder, nodeName string) *runtime.ContainerBuilder {
-	return b.AddEnvVar("LOG_LEVEL", adaptLogLevel()).
+	return b.AddEnvVar("LOG_LEVEL", AdaptLogLevel()).
 		AddEnvVarFromFieldRef("POD_IP", "status.podIP").
 		AddEnvVarFromFieldRef("K8S_NODE_NAME", "spec.nodeName").
 		AddEnvVar("NODE_NAME", nodeName).
@@ -61,28 +60,6 @@ func (c *FluentdCollector) IsStarted(logs string) bool {
 		return false
 	}
 	return "Running" == strings.TrimSpace(phase)
-}
-
-func adaptLogLevel() string {
-	logLevel := "debug"
-	if level, found := os.LookupEnv("LOG_LEVEL"); found {
-		if i, err := strconv.Atoi(level); err == nil {
-			switch i {
-			case 0:
-				logLevel = "error"
-			case 1:
-				logLevel = "info"
-			case 2:
-				logLevel = "debug"
-			case 3 - 8:
-				logLevel = "trace"
-			default:
-			}
-		} else {
-			log.V(1).Error(err, "Unable to set LOG_LEVEL from environment")
-		}
-	}
-	return logLevel
 }
 
 func (c *FluentdCollector) Image() string {

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -73,8 +73,8 @@ func NewCollectorFunctionalFramework() *CollectorFunctionalFramework {
 	return NewCollectorFunctionalFrameworkUsing(test, test.Close, 0, logging.LogCollectionTypeFluentd)
 }
 
-func NewCollectorFunctionalFrameworkUsingCollector(logCollectorType logging.LogCollectionType) *CollectorFunctionalFramework {
-	test := client.NewTest()
+func NewCollectorFunctionalFrameworkUsingCollector(logCollectorType logging.LogCollectionType, testOptions ...client.TestOption) *CollectorFunctionalFramework {
+	test := client.NewTest(testOptions...)
 	return NewCollectorFunctionalFrameworkUsing(test, test.Close, 0, logCollectorType)
 }
 

--- a/test/framework/functional/message_templates.go
+++ b/test/framework/functional/message_templates.go
@@ -33,6 +33,7 @@ var (
 		Annotations:      map[string]string{"*": "*"},
 	}
 	templateForInfraKubernetes = types.Kubernetes{
+		ContainerID:       "**optional**",
 		ContainerName:     "*",
 		PodName:           "*",
 		NamespaceName:     "*",
@@ -74,18 +75,21 @@ func NewApplicationLogTemplate() types.ApplicationLog {
 // NewContainerInfrastructureLogTemplate creates a generally expected template for infrastructure container logs
 func NewContainerInfrastructureLogTemplate() types.ApplicationLog {
 	return types.ApplicationLog{
-		Timestamp: time.Time{},
-		Message:   "*",
-		LogType:   "infrastructure",
-		Level:     "*",
-		Hostname:  "*",
-		ViaqMsgID: "*",
+		Timestamp:  time.Time{},
+		Message:    "*",
+		LogType:    "infrastructure",
+		Level:      "*",
+		Hostname:   "*",
+		ViaqMsgID:  "**optional**",
+		WriteIndex: "**optional**",
 		Openshift: types.OpenshiftMeta{
 			Labels:   map[string]string{"*": "*"},
 			Sequence: types.NewOptionalInt(""),
 		},
 		PipelineMetadata: TemplateForAnyPipelineMetadata,
-		Docker:           types.Docker{},
-		Kubernetes:       templateForInfraKubernetes,
+		Docker: types.Docker{
+			ContainerID: "**optional**",
+		},
+		Kubernetes: templateForInfraKubernetes,
 	}
 }

--- a/test/framework/functional/vector/deploy.go
+++ b/test/framework/functional/vector/deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/test/client"
+	. "github.com/openshift/cluster-logging-operator/test/framework/functional/common"
 )
 
 const entrypointScript = `#!/bin/bash
@@ -38,7 +39,7 @@ func (c *VectorCollector) DeployConfigMapForConfig(name, config, clfYaml string)
 }
 
 func (c *VectorCollector) BuildCollectorContainer(b *runtime.ContainerBuilder, nodeName string) *runtime.ContainerBuilder {
-	return b.AddEnvVar("LOG", "debug").
+	return b.AddEnvVar("LOG", AdaptLogLevel()).
 		AddEnvVarFromFieldRef("POD_IP", "status.podIP").
 		AddEnvVar("NODE_NAME", nodeName).
 		AddEnvVarFromFieldRef("VECTOR_SELF_NODE_NAME", "spec.nodeName").

--- a/test/framework/functional/write.go
+++ b/test/framework/functional/write.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -26,7 +27,11 @@ func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLogForContainer
 // enabling the mock api adapter to get metadata for infrastructure logs since the path does not match a pod
 // running on the cluster (e.g framework.VisitConfig = functional.TestAPIAdapterConfigVisitor)
 func (f *CollectorFunctionalFramework) WriteMessagesToInfraContainerLog(msg string, numOfLogs int) error {
-	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], "openshift-fake-infra", f.Pod.Name, f.Pod.UID, constants.CollectorName)
+	ns := "openshift-fake-infra"
+	if strings.HasPrefix(f.Namespace, "openshift-test") {
+		ns = f.Namespace
+	}
+	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fluentdLogPath[applicationLog], ns, f.Pod.Name, f.Pod.UID, constants.CollectorName)
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
 


### PR DESCRIPTION
### Description
This PR:
* Enables functional testing of infrastructure logs for vector, specifically those related to JSON parsing
* Add API validation to reject invalid structured type configuration
* Moves test of invalid structure type from functional to e2e in order to test API validation 

### Links
* https://issues.redhat.com/browse/LOG-2862
