### PR TITLE
LOG-2886: fix CVE-2022-30631

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### This is a generated file from Dockerfile.in ###
 #@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.17)
-FROM registry.redhat.io/ubi8/go-toolset:1.17.7 AS builder
+FROM registry.redhat.io/ubi8/go-toolset:1.17.12 AS builder
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
@@ -8,36 +8,22 @@ ENV OS_GIT_MINOR=${CI_Y_VERSION}
 ENV OS_GIT_PATCH=${CI_Z_VERSION}
 ENV SOURCE_GIT_COMMIT=${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_COMMIT}
 ENV SOURCE_GIT_URL=${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_URL}
-ENV REMOTE_SOURCE=${REMOTE_SOURCE:-.}
-
-
-WORKDIR /go/src/github.com/openshift/cluster-logging-operator
-
-# Copy and download Go dependencies first so they are cached before source changes.
-COPY ${REMOTE_SOURCE}/go.mod ${REMOTE_SOURCE}/go.sum .
-RUN go mod download
-
-COPY ${REMOTE_SOURCE}/.bingo .bingo
-COPY ${REMOTE_SOURCE}/Makefile ./Makefile
-COPY ${REMOTE_SOURCE}/must-gather ./must-gather
-COPY ${REMOTE_SOURCE}/version ./version
-COPY ${REMOTE_SOURCE}/scripts ./scripts
-COPY ${REMOTE_SOURCE}/files ./files
-COPY ${REMOTE_SOURCE}/bundle/manifests ./manifests
-COPY ${REMOTE_SOURCE}/main.go .
-COPY ${REMOTE_SOURCE}/apis ./apis
-COPY ${REMOTE_SOURCE}/controllers ./controllers
-COPY ${REMOTE_SOURCE}/internal ./internal
+ENV REMOTE_SOURCES=${REMOTE_SOURCES:-.}
+ENV REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-.}
+ENV APP_DIR=.
+COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 
 USER 0
 RUN make build
 
-
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.8)
-FROM quay.io/openshift/origin-cli:4.8 AS origincli
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.9)
+FROM quay.io/openshift/origin-cli:4.11 AS origincli
 
 #@follow_tag(registry.redhat.io/ubi8:latest)
-FROM registry.redhat.io/ubi8:8.5
+FROM registry.redhat.io/ubi8:8.6
+
+ENV APP_DIR=/opt/app-root/src
+
 RUN INSTALL_PKGS=" \
       openssl \
       rsync \
@@ -49,15 +35,18 @@ RUN INSTALL_PKGS=" \
     yum clean all && \
     mkdir /tmp/ocp-clo && \
     chmod og+w /tmp/ocp-clo
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/bin/cluster-logging-operator /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/scripts/* /usr/bin/scripts/
-RUN mkdir -p /usr/share/logging/
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/files/ /usr/share/logging/
 
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/manifests /manifests
+COPY --from=builder $APP_DIR/bin/cluster-logging-operator /usr/bin/
+COPY --from=builder $APP_DIR/scripts/* /usr/bin/scripts/
+
+RUN mkdir -p /usr/share/logging/
+
+COPY --from=builder $APP_DIR/files/ /usr/share/logging/
+
+COPY --from=builder $APP_DIR/bundle/manifests /manifests
 
 COPY --from=origincli /usr/bin/oc /usr/bin
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/must-gather/collection-scripts/* /usr/bin/
+COPY --from=builder $APP_DIR/must-gather/collection-scripts/* /usr/bin/
 
 # this is required because the operator invokes a script as `bash scripts/cert_generation.sh`
 WORKDIR /usr/bin
@@ -68,14 +57,13 @@ LABEL \
         io.k8s.description="This is a component of OpenShift Container Platform that manages the lifecycle of the Aggregated logging stack." \
         io.openshift.tags="openshift,logging" \
         com.redhat.delivery.appregistry="false" \
-        maintainer="AOS Logging <aos-logging@redhat.com>" \
+        maintainer="AOS Logging <team-logging@redhat.com>" \
         License="Apache-2.0" \
-        name="openshift-logging/cluster-logging-rhel8-operator" \
+        name="openshift/ose-cluster-logging-operator" \
         com.redhat.component="cluster-logging-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.build.commit.id=${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_COMMIT} \
         io.openshift.build.source-location=${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_URL} \
         io.openshift.build.commit.url=${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_URL}/commit/${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_COMMIT} \
         version=${CI_CONTAINER_VERSION}
-
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,5 +1,5 @@
 #@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.17)
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.17
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.17.12-202207291741.el8.g01211db AS builder
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
@@ -7,39 +7,31 @@ ENV OS_GIT_MINOR=${CI_Y_VERSION}
 ENV OS_GIT_PATCH=${CI_Z_VERSION}
 ENV SOURCE_GIT_COMMIT=${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_COMMIT}
 ENV SOURCE_GIT_URL=${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_URL}
-ENV REMOTE_SOURCE=${REMOTE_SOURCE:-.}
+ENV REMOTE_SOURCES=${REMOTE_SOURCES:-.}
+ENV REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-.}
+ENV APP_DIR=.
+COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 
 ## EXCLUDE BEGIN ##
-ENV REMOTE_SOURCE=${REMOTE_SOURCE}/app
+ENV APP_DIR=$REMOTE_SOURCES_DIR/cluster-logging-operator/app
+WORKDIR $APP_DIR
+RUN source $REMOTE_SOURCES_DIR/cluster-logging-operator/cachito.env
 ## EXCLUDE END ##
-
-WORKDIR /go/src/github.com/openshift/cluster-logging-operator
-
-# Copy and download Go dependencies first so they are cached before source changes.
-COPY ${REMOTE_SOURCE}/go.mod ${REMOTE_SOURCE}/go.sum .
-RUN go mod download
-
-COPY ${REMOTE_SOURCE}/.bingo .bingo
-COPY ${REMOTE_SOURCE}/Makefile ./Makefile
-COPY ${REMOTE_SOURCE}/must-gather ./must-gather
-COPY ${REMOTE_SOURCE}/version ./version
-COPY ${REMOTE_SOURCE}/scripts ./scripts
-COPY ${REMOTE_SOURCE}/files ./files
-COPY ${REMOTE_SOURCE}/bundle/manifests ./manifests
-COPY ${REMOTE_SOURCE}/main.go .
-COPY ${REMOTE_SOURCE}/apis ./apis
-COPY ${REMOTE_SOURCE}/controllers ./controllers
-COPY ${REMOTE_SOURCE}/internal ./internal
-
 USER 0
 RUN make build
 
-
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.8)
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.8.0-202104250659.p0 AS origincli
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.9)
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.9.0-202208150436.p0.gb49c285.assembly.stream AS origincli
 
 #@follow_tag(registry.redhat.io/ubi8:latest)
-FROM registry.redhat.io/ubi8:8.4-209
+FROM registry.redhat.io/ubi8:8.6-903
+
+ENV APP_DIR=/opt/app-root/src
+## EXCLUDE BEGIN ##
+ENV APP_DIR=$REMOTE_SOURCES_DIR/cluster-logging-operator/app
+WORKDIR $APP_DIR
+## EXCLUDE END ##
+
 RUN INSTALL_PKGS=" \
       openssl \
       rsync \
@@ -51,15 +43,18 @@ RUN INSTALL_PKGS=" \
     yum clean all && \
     mkdir /tmp/ocp-clo && \
     chmod og+w /tmp/ocp-clo
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/bin/cluster-logging-operator /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/scripts/* /usr/bin/scripts/
-RUN mkdir -p /usr/share/logging/
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/files/ /usr/share/logging/
 
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/manifests /manifests
+COPY --from=builder $APP_DIR/bin/cluster-logging-operator /usr/bin/
+COPY --from=builder $APP_DIR/scripts/* /usr/bin/scripts/
+
+RUN mkdir -p /usr/share/logging/
+
+COPY --from=builder $APP_DIR/files/ /usr/share/logging/
+
+COPY --from=builder $APP_DIR/bundle/manifests /manifests
 
 COPY --from=origincli /usr/bin/oc /usr/bin
-COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/must-gather/collection-scripts/* /usr/bin/
+COPY --from=builder $APP_DIR/must-gather/collection-scripts/* /usr/bin/
 
 # this is required because the operator invokes a script as `bash scripts/cert_generation.sh`
 WORKDIR /usr/bin
@@ -70,9 +65,9 @@ LABEL \
         io.k8s.description="This is a component of OpenShift Container Platform that manages the lifecycle of the Aggregated logging stack." \
         io.openshift.tags="openshift,logging" \
         com.redhat.delivery.appregistry="false" \
-        maintainer="AOS Logging <aos-logging@redhat.com>" \
+        maintainer="AOS Logging <team-logging@redhat.com>" \
         License="Apache-2.0" \
-        name="openshift-logging/cluster-logging-rhel8-operator" \
+        name="openshift/ose-cluster-logging-operator" \
         com.redhat.component="cluster-logging-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.build.commit.id=${CI_CLUSTER_LOGGING_OPERATOR_UPSTREAM_COMMIT} \

--- a/origin-meta.yaml
+++ b/origin-meta.yaml
@@ -1,7 +1,7 @@
 from:
   - source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder\:v(?:[\.0-9\-]*).*
-    target: registry.redhat.io/ubi8/go-toolset:1.17.7 AS builder
-  - source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.8.0-([0-9]*).*
-    target: quay.io/openshift/origin-cli:4.8 AS origincli
+    target: registry.redhat.io/ubi8/go-toolset:1.17.12 AS builder
+  - source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.9.0-([0-9]*).*
+    target: quay.io/openshift/origin-cli:4.11 AS origincli
   - source: registry.redhat.io/ubi8:8.(\d)-([\.0-9])*
-    target: registry.redhat.io/ubi8:8.5
+    target: registry.redhat.io/ubi8:8.6


### PR DESCRIPTION
### Description
This PR:
* fixes CVE-2022-30631 cluster-logging-operator-container: golang: compress/gzip: stack exhaustion in Reader.Read

### Links
* https://issues.redhat.com/browse/LOG-2886
