### PR TITLE
LOG-1300: The invalid event can't be collected.

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder.go
+++ b/apis/logging/v1/cluster_log_forwarder.go
@@ -30,6 +30,20 @@ func IsOutputTypeName(s string) bool {
 	return ok
 }
 
+// Get all subordinate condition messages for condition of type "Ready" and False
+func (status ClusterLogForwarderStatus) GetReadyConditionMessages() []string {
+	var messages = []string{}
+	for _, nc := range []NamedConditions{status.Pipelines, status.Inputs, status.Outputs} {
+		for _, conds := range nc {
+			if !conds.IsTrueFor(ConditionReady) {
+				currCond := conds.GetCondition(ConditionReady)
+				messages = append(messages, currCond.Message)
+			}
+		}
+	}
+	return messages
+}
+
 // IsReady returns true if all of the subordinate conditions are ready.
 func (status ClusterLogForwarderStatus) IsReady() bool {
 	for _, nc := range []NamedConditions{status.Pipelines, status.Inputs, status.Outputs} {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR addresses `LOG-1300: The invalid event can't be collected` in the `ClusterLogForwarder` instance. Any invalid events in the `ClusterLogForwarder` instance will now display when `oc get events` is performed on the CLF instance. These events can also be seen on the openshift console.

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file --> @cahartma 
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file --> @jcantrill 

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- https://issues.redhat.com/browse/LOG-1300
