### PR TITLE
LOG-2961: Fix 'Unknown Severity' error for audit logs in Google Cloud Logging

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -280,6 +280,8 @@ source = '''
   } else {
     log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
   }
+  
+  .level = "default"
 '''
 
 [transforms.k8s_audit_logs]
@@ -289,6 +291,8 @@ source = '''
   .tag = ".k8s-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
+  .k8s_audit_level = .level
+  .level = "default"
 '''
 
 [transforms.openshift_audit_logs]
@@ -298,6 +302,8 @@ source = '''
   .tag = ".openshift-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
+  .openshift_audit_level = .level
+  .level = "default"
 '''
 
 [transforms.ovn_audit_logs]
@@ -648,6 +654,8 @@ source = '''
   } else {
     log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
   }
+  
+  .level = "default"
 '''
 
 [transforms.k8s_audit_logs]
@@ -657,6 +665,8 @@ source = '''
   .tag = ".k8s-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
+  .k8s_audit_level = .level
+  .level = "default"
 '''
 
 [transforms.openshift_audit_logs]
@@ -666,6 +676,8 @@ source = '''
   .tag = ".openshift-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
+  .openshift_audit_level = .level
+  .level = "default"
 '''
 
 [transforms.ovn_audit_logs]

--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -130,6 +130,10 @@ if err == null {
 del(.message)
 `
 	FixHostname = `.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""`
+
+	FixK8sAuditLevel       = `.k8s_audit_level = .level`
+	FixOpenshiftAuditLevel = `.openshift_audit_level = .level`
+	AddDefaultLogLevel     = `.level = "default"`
 )
 
 var (
@@ -201,6 +205,7 @@ func NormalizeHostAuditLogs(inLabel, outLabel string) []generator.Element {
 			VRL: strings.Join(helpers.TrimSpaces([]string{
 				AddHostAuditTag,
 				ParseHostAuditLogs,
+				AddDefaultLogLevel,
 			}), "\n\n"),
 		},
 	}
@@ -214,6 +219,8 @@ func NormalizeK8sAuditLogs(inLabel, outLabel string) []generator.Element {
 			VRL: strings.Join(helpers.TrimSpaces([]string{
 				AddK8sAuditTag,
 				ParseAndFlatten,
+				FixK8sAuditLevel,
+				AddDefaultLogLevel,
 			}), "\n"),
 		},
 	}
@@ -227,6 +234,8 @@ func NormalizeOpenshiftAuditLogs(inLabel, outLabel string) []generator.Element {
 			VRL: strings.Join(helpers.TrimSpaces([]string{
 				AddOpenAuditTag,
 				ParseAndFlatten,
+				FixOpenshiftAuditLevel,
+				AddDefaultLogLevel,
 			}), "\n"),
 		},
 	}

--- a/internal/generator/vector/normalize_test.go
+++ b/internal/generator/vector/normalize_test.go
@@ -233,6 +233,8 @@ source = '''
   } else {
     log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
   }
+  
+  .level = "default"
 '''
     
 [transforms.k8s_audit_logs]
@@ -242,6 +244,8 @@ source = '''
   .tag = ".k8s-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
+  .k8s_audit_level = .level
+  .level = "default"
 '''
 
 [transforms.openshift_audit_logs]
@@ -251,6 +255,8 @@ source = '''
   .tag = ".openshift-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
+  .openshift_audit_level = .level
+  .level = "default"
 '''
 
 [transforms.ovn_audit_logs]

--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -167,7 +167,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				//K8SAuditLevel: "debug",
 				//}
 				// Template expected as output Log
-				k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
+				k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"Metadata"}`, functional.CRIOTime(nanoTime))
 				Expect(framework.WriteMessagesTok8sAuditLog(k8sAuditLogLine, 10)).To(BeNil())
 				// Read line from Log Forward output
 				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
@@ -179,7 +179,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				//outputTestLog := logs[0]
 				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 				results := strings.Join(raw, " ")
-				Expect(results).To(MatchRegexp("kind.*Event.*level.*debug"), "Message should contain the audit log: %v", raw)
+				Expect(results).To(MatchRegexp("kind.*Event.*level.*default.*k8s_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
 
 			})
 			//TODO: fix me when audit formatting is enabled
@@ -202,7 +202,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				//K8SAuditLevel: "debug",
 				//}
 				// Template expected as output Log
-				auditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
+				auditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"Metadata"}`, functional.CRIOTime(nanoTime))
 				Expect(framework.WriteMessagesToOpenshiftAuditLog(auditLogLine, 10)).To(BeNil())
 				// Read line from Log Forward output
 				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
@@ -214,7 +214,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				//outputTestLog := logs[0]
 				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 				results := strings.Join(raw, " ")
-				Expect(results).To(MatchRegexp("kind.*Event.*level.*debug"), "Message should contain the audit log: %v", raw)
+				Expect(results).To(MatchRegexp("kind.*Event.*level.*default.*openshift_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
 
 			})
 			It("should parse oauth audit log format correctly", func() {


### PR DESCRIPTION
### Description
Added a `"level: "default"` field in the audit logs to get rid of the `'Unknown Severity'` error in vector logs while sending audit logs to Google Cloud Logging.



/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->



### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2961

