### PR TITLE
extend functional timeout to account for slow pod startup

### DIFF
--- a/test/e2e/logforwarding/loki/forward_to_loki_test.go
+++ b/test/e2e/logforwarding/loki/forward_to_loki_test.go
@@ -2,6 +2,7 @@ package loki
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,6 +110,8 @@ func testLogForwardingToLoki(t *testing.T, cl *loggingv1.ClusterLogging, clf *lo
 	g.Go(func() error { return c.Create(gen) })
 	require.NoError(t, g.Wait())
 	require.NoError(t, c.WaitFor(clf, client.ClusterLogForwarderReady))
+	framework := e2e.NewE2ETestFramework()
+	require.NoError(t, framework.WaitFor(helpers.ComponentTypeCollector))
 
 	// Now the actual test.
 	for _, logType := range []string{"application", "infrastructure", "audit"} {

--- a/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
+++ b/test/e2e/logforwarding/syslog/forward_to_syslog_test.go
@@ -50,7 +50,7 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 		}
 	})
 	JustBeforeEach(func() {
-		if logGenNS, logGenPod, err = e2e.DeployJsonLogGenerator(generatorPayload); err != nil {
+		if logGenNS, logGenPod, err = e2e.DeployJsonLogGenerator(generatorPayload, map[string]string{}); err != nil {
 			log.Error(err, "unable to deploy log generator.")
 		}
 		log.Info("log generator pod: ", "podname", logGenPod)

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -297,7 +297,7 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 		return fmt.Errorf("service could not be started")
 	}
 	log.V(2).Info("waiting for the collector to be ready")
-	err = wait.PollImmediate(time.Second*2, time.Second*30, func() (bool, error) {
+	err = wait.PollImmediate(time.Second*2, time.Second*90, func() (bool, error) {
 		output, err := oc.Literal().From("oc logs -n %s pod/%s -c %s", f.Test.NS.Name, f.Name, constants.CollectorName).Run()
 		if err != nil {
 			return false, nil

--- a/test/helpers/oc/runner.go
+++ b/test/helpers/oc/runner.go
@@ -76,11 +76,11 @@ func (r *runner) runCmd(timeoutCh <-chan time.Time) (string, error) {
 	select {
 	case <-timeoutCh:
 		if err = r.Cmd.Process.Kill(); err != nil {
-			log.V(1).Error(err, "failed to kill process: ")
+			log.V(1).Error(err, "failed to kill oc process")
 		}
 	case err = <-done:
 		if err != nil {
-			log.V(1).Error(err, "oc finished with error = %v")
+			log.V(1).Error(err, "oc finished with error", "args", cmdargs)
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
### Description
This PR:
* extends the timeout to determine if fluent is started to account for slow pod boot
* refactors e2e test in effort to make it consistent
