### PR TITLE
LOG-2919: fix order of reconcilation for ServiceMonitor

### DIFF
--- a/controllers/forwarding/forwarding_controller.go
+++ b/controllers/forwarding/forwarding_controller.go
@@ -66,7 +66,7 @@ func (r *ReconcileForwarder) Reconcile(ctx context.Context, request ctrl.Request
 
 	log.V(3).Info("clusterlogforwarder-controller run reconciler...")
 
-	reconcileErr := k8shandler.ReconcileForClusterLogForwarder(instance, r.Client)
+	reconcileErr := k8shandler.ReconcileForClusterLogForwarder(instance, r.Client, r.Recorder)
 	if reconcileErr != nil {
 		// if cluster is set to fail to reconcile then set healthStatus as 0
 		telemetry.Data.CLFInfo.Set("healthStatus", constants.UnHealthyStatus)

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -19,10 +19,10 @@ import (
 
 const (
 	clusterLoggingPriorityClassName = "cluster-logging"
-	exporterPort                    = int32(2112)
-	exporterPortName                = "logfile-metrics"
-	metricsPort                     = int32(24231)
-	metricsPortName                 = "metrics"
+	ExporterPort                    = int32(2112)
+	ExporterPortName                = "logfile-metrics"
+	MetricsPort                     = int32(24231)
+	MetricsPortName                 = "metrics"
 	metricsVolumeName               = "collector-metrics"
 	logContainers                   = "varlogcontainers"
 	logContainersValue              = "/var/log/containers"
@@ -175,8 +175,8 @@ func (f *Factory) NewCollectorContainer(secretNames []string) *v1.Container {
 	collector := factory.NewContainer(constants.CollectorName, f.ImageName, v1.PullIfNotPresent, f.CollectorResourceRequirements())
 	collector.Ports = []v1.ContainerPort{
 		{
-			Name:          metricsPortName,
-			ContainerPort: metricsPort,
+			Name:          MetricsPortName,
+			ContainerPort: MetricsPort,
 			Protocol:      v1.ProtocolTCP,
 		},
 	}
@@ -218,8 +218,8 @@ func newLogMetricsExporterContainer() *v1.Container {
 	exporter := factory.NewContainer(constants.LogfilesmetricexporterName, constants.LogfilesmetricexporterName, v1.PullIfNotPresent, *exporterResources)
 	exporter.Ports = []v1.ContainerPort{
 		{
-			Name:          exporterPortName,
-			ContainerPort: exporterPort,
+			Name:          ExporterPortName,
+			ContainerPort: ExporterPort,
 			Protocol:      v1.ProtocolTCP,
 		},
 	}

--- a/internal/collector/service_monitor.go
+++ b/internal/collector/service_monitor.go
@@ -1,0 +1,72 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	log "github.com/ViaQ/logerr/v2/log/static"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/reconcile"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	prometheusCAFile = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
+)
+
+func NewServiceMonitor(namespace, name string, owner metav1.OwnerReference) *monitoringv1.ServiceMonitor {
+	endpoints := []monitoringv1.Endpoint{}
+	for _, portName := range []string{MetricsPortName, ExporterPortName} {
+		endpoints = append(endpoints,
+			monitoringv1.Endpoint{
+				Port:   portName,
+				Path:   "/metrics",
+				Scheme: "https",
+				TLSConfig: &monitoringv1.TLSConfig{
+					CAFile:     prometheusCAFile,
+					ServerName: fmt.Sprintf("%s.%s.svc", name, namespace),
+				},
+			},
+		)
+	}
+	desired := runtime.NewServiceMonitor(namespace, name)
+	desired.Spec = monitoringv1.ServiceMonitorSpec{
+		JobLabel:  "monitor-collector",
+		Endpoints: endpoints,
+		Selector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"logging-infra": "support",
+			},
+		},
+		NamespaceSelector: monitoringv1.NamespaceSelector{
+			MatchNames: []string{namespace},
+		},
+	}
+
+	utils.AddOwnerRefToObject(desired, owner)
+
+	return desired
+}
+
+func ReconcileServiceMonitor(er record.EventRecorder, k8sClient client.Client, namespace, name string, owner metav1.OwnerReference) {
+	desired := NewServiceMonitor(namespace, name, owner)
+	if err := reconcile.ServiceMonitor(er, k8sClient, desired); err != nil {
+		log.Error(err, "collector.ReconcileServiceMonitor")
+	}
+}
+
+func RemoveServiceMonitor(er record.EventRecorder, k8sClient client.Client, namespace, name string) {
+	serviceMonitor := runtime.NewServiceMonitor(namespace, name)
+	if err := k8sClient.Delete(context.TODO(), serviceMonitor); err != nil && !errors.IsNotFound(err) {
+		log.Error(err, "collector.RemoveServiceMonitor")
+		er.Eventf(serviceMonitor, v1.EventTypeWarning, constants.EventReasonRemoveObject, "Unable to remove ServiceMonitor %s/%s: %v", namespace, name, err)
+	} else {
+		er.Eventf(serviceMonitor, v1.EventTypeNormal, constants.EventReasonRemoveObject, "Removed ServiceMonitor %s/%s", namespace, name)
+	}
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -110,6 +110,11 @@ const (
 
 	// Commonly-used label names.
 	LabelApp = "app"
+
+	EventReasonCreateObject = "CreateObject"
+	EventReasonGetObject    = "GetObject"
+	EventReasonRemoveObject = "RemoveObject"
+	EventReasonUpdateObject = "UpdateObject"
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/factory"
-	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/servicemonitor"
 	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/services"
 
 	"github.com/openshift/cluster-logging-operator/internal/utils"
@@ -36,12 +35,6 @@ import (
 )
 
 const (
-	exporterPort     = int32(2112)
-	exporterPortName = "logfile-metrics"
-	metricsPort      = int32(24231)
-	metricsPortName  = "metrics"
-	prometheusCAFile = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
-
 	AnnotationDebugOutput = "logging.openshift.io/debug-output"
 )
 
@@ -101,10 +94,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 			return
 		}
 
-		if err = clusterRequest.reconcileCollectorServiceMonitor(); err != nil {
-			log.V(9).Error(err, "clusterRequest.reconcileCollectorServiceMonitor")
-			return
-		}
+		collector.ReconcileServiceMonitor(clusterRequest.EventRecorder, clusterRequest.Client, cluster.Namespace, constants.CollectorName, utils.AsOwner(cluster))
 
 		if err = clusterRequest.createOrUpdateCollectorPrometheusRule(); err != nil {
 			log.V(9).Error(err, "unable to create or update fluentd prometheus rule")
@@ -172,9 +162,7 @@ func (clusterRequest *ClusterLoggingRequest) removeCollector(name string) (err e
 			return
 		}
 
-		if err = clusterRequest.RemoveServiceMonitor(name); err != nil {
-			return
-		}
+		collector.RemoveServiceMonitor(clusterRequest.EventRecorder, clusterRequest.Client, clusterRequest.Cluster.Namespace, constants.CollectorName)
 
 		if err = clusterRequest.RemovePrometheusRule(name); err != nil {
 			return
@@ -207,14 +195,14 @@ func (clusterRequest *ClusterLoggingRequest) reconcileCollectorService() error {
 		constants.CollectorName,
 		[]v1.ServicePort{
 			{
-				Port:       metricsPort,
-				TargetPort: intstr.FromString(metricsPortName),
-				Name:       metricsPortName,
+				Port:       collector.MetricsPort,
+				TargetPort: intstr.FromString(collector.MetricsPortName),
+				Name:       collector.MetricsPortName,
 			},
 			{
-				Port:       exporterPort,
-				TargetPort: intstr.FromString(exporterPortName),
-				Name:       exporterPortName,
+				Port:       collector.ExporterPort,
+				TargetPort: intstr.FromString(collector.ExporterPortName),
+				Name:       collector.ExporterPortName,
 			},
 		},
 	)
@@ -251,81 +239,6 @@ func (clusterRequest *ClusterLoggingRequest) reconcileCollectorService() error {
 		})
 		if retryErr != nil {
 			log.V(3).Error(retryErr, "Reconcile Service retry error")
-		}
-		return retryErr
-	}
-	return err
-}
-
-func (clusterRequest *ClusterLoggingRequest) reconcileCollectorServiceMonitor() error {
-
-	cluster := clusterRequest.Cluster
-
-	desired := NewServiceMonitor(constants.CollectorName, cluster.Namespace)
-
-	endpoint := monitoringv1.Endpoint{
-		Port:   metricsPortName,
-		Path:   "/metrics",
-		Scheme: "https",
-		TLSConfig: &monitoringv1.TLSConfig{
-			CAFile:     prometheusCAFile,
-			ServerName: fmt.Sprintf("%s.%s.svc", constants.CollectorName, cluster.Namespace),
-		},
-	}
-	logMetricExporterEndpoint := monitoringv1.Endpoint{
-		Port:   exporterPortName,
-		Path:   "/metrics",
-		Scheme: "https",
-		TLSConfig: &monitoringv1.TLSConfig{
-			CAFile:     prometheusCAFile,
-			ServerName: fmt.Sprintf("%s.%s.svc", constants.CollectorName, cluster.Namespace),
-		},
-	}
-
-	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"logging-infra": "support",
-		},
-	}
-
-	desired.Spec = monitoringv1.ServiceMonitorSpec{
-		JobLabel:  "monitor-collector",
-		Endpoints: []monitoringv1.Endpoint{endpoint, logMetricExporterEndpoint},
-		Selector:  labelSelector,
-		NamespaceSelector: monitoringv1.NamespaceSelector{
-			MatchNames: []string{cluster.Namespace},
-		},
-	}
-
-	utils.AddOwnerRefToObject(desired, utils.AsOwner(cluster))
-
-	err := clusterRequest.Create(desired)
-	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("Failure creating the collector ServiceMonitor: %v", err)
-		}
-		current := &monitoringv1.ServiceMonitor{}
-		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err = clusterRequest.Get(desired.Name, current); err != nil {
-				if errors.IsNotFound(err) {
-					// the object doesn't exist -- it was likely culled
-					// recreate it on the next time through if necessary
-					return nil
-				}
-				return fmt.Errorf("Failed to get %q service for %q: %v", current.Name, clusterRequest.Cluster.Name, err)
-			}
-			if servicemonitor.AreSame(current, desired) {
-				log.V(3).Info("ServiceMonitor are the same skipping update")
-				return nil
-			}
-			current.Labels = desired.Labels
-			current.Spec = desired.Spec
-			current.Annotations = desired.Annotations
-
-			return clusterRequest.Update(current)
-		})
-		if retryErr != nil {
-			log.V(3).Error(retryErr, "Reconcile ServiceMonitor retry error")
 		}
 		return retryErr
 	}

--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -2,7 +2,6 @@ package k8shandler
 
 import (
 	"context"
-
 	"github.com/openshift/cluster-logging-operator/internal/collector/common"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 
@@ -17,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -110,8 +110,9 @@ var _ = Describe("Reconciling", func() {
 					fluentdCABundle,
 				)
 				clusterRequest = &ClusterLoggingRequest{
-					Client:  client,
-					Cluster: cluster,
+					Client:        client,
+					Cluster:       cluster,
+					EventRecorder: record.NewFakeRecorder(100),
 				}
 			})
 
@@ -169,8 +170,9 @@ var _ = Describe("Reconciling", func() {
 					fluentdCABundle,
 				)
 				clusterRequest = &ClusterLoggingRequest{
-					Client:  client,
-					Cluster: cluster,
+					Client:        client,
+					Cluster:       cluster,
+					EventRecorder: record.NewFakeRecorder(100),
 				}
 			})
 

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -141,9 +141,10 @@ func removeManagedStorage(clusterRequest ClusterLoggingRequest) {
 	}
 }
 
-func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, requestClient client.Client) (err error) {
+func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, requestClient client.Client, er record.EventRecorder) (err error) {
 	clusterLoggingRequest := ClusterLoggingRequest{
-		Client: requestClient,
+		Client:        requestClient,
+		EventRecorder: er,
 	}
 	if forwarder != nil {
 		clusterLoggingRequest.ForwarderRequest = forwarder

--- a/internal/reconcile/service_monitor.go
+++ b/internal/reconcile/service_monitor.go
@@ -1,0 +1,50 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	log "github.com/ViaQ/logerr/v2/log/static"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/servicemonitor"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ServiceMonitor reconciles a ServiceMonitor to the desired spec returning an error
+// if there is an issue creating or updating to the desired state
+func ServiceMonitor(er record.EventRecorder, k8Client client.Client, desired *monitoringv1.ServiceMonitor) error {
+	reason := constants.EventReasonGetObject
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &monitoringv1.ServiceMonitor{}
+		key := client.ObjectKeyFromObject(desired)
+		if err := k8Client.Get(context.TODO(), key, current); err != nil {
+			if errors.IsNotFound(err) {
+				reason = constants.EventReasonCreateObject
+				return k8Client.Create(context.TODO(), desired)
+			}
+			return fmt.Errorf("failed to get %v servicemonitor: %w", key, err)
+		}
+		if servicemonitor.AreSame(current, desired) {
+			log.V(3).Info("ServiceMonitor are the same skipping update")
+			return nil
+		}
+		reason = constants.EventReasonUpdateObject
+		current.Labels = desired.Labels
+		current.Spec = desired.Spec
+		current.Annotations = desired.Annotations
+
+		return k8Client.Update(context.TODO(), current)
+	})
+	eventType := v1.EventTypeNormal
+	msg := fmt.Sprintf("%s ServiceMonitor %s/%s", eventType, desired.Namespace, desired.Name)
+	if retryErr != nil {
+		eventType = v1.EventTypeWarning
+		msg = fmt.Sprintf("Unable to %s: %v", msg, retryErr)
+	}
+	er.Event(desired, eventType, reason, msg)
+	return retryErr
+}

--- a/internal/runtime/monitoring.go
+++ b/internal/runtime/monitoring.go
@@ -1,10 +1,6 @@
-package k8shandler
+package runtime
 
 import (
-	"fmt"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,17 +15,6 @@ func NewServiceMonitor(serviceMonitorName, namespace string) *monitoringv1.Servi
 			Name:      serviceMonitorName,
 			Namespace: namespace,
 		},
+		Spec: monitoringv1.ServiceMonitorSpec{},
 	}
-}
-
-func (clusterRequest *ClusterLoggingRequest) RemoveServiceMonitor(smName string) error {
-
-	serviceMonitor := NewServiceMonitor(smName, clusterRequest.Cluster.Namespace)
-
-	err := clusterRequest.Delete(serviceMonitor)
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("Failure deleting %v service monitor: %v", serviceMonitor, err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
### Description
This PR:
* fixes ServiceMonitor order of reconciliation to try to Get before Create
* Refactors  ServiceMonitor code out of k8shandler/collection.go to decouple from ClusterLoggingRequest

### Links
* https://issues.redhat.com/browse/LOG-2919
