### PR TITLE
all info metrics of Gauge type now got two values : 0 and 1, on chang…

### DIFF
--- a/controllers/clusterlogging/clusterlogging_controller.go
+++ b/controllers/clusterlogging/clusterlogging_controller.go
@@ -71,12 +71,14 @@ func (r *ReconcileClusterLogging) Reconcile(ctx context.Context, request ctrl.Re
 
 	if instance.Spec.ManagementState == loggingv1.ManagementStateUnmanaged {
 		// if cluster is set to unmanaged then set managedStatus as 0
+		telemetry.ResetCLMetricsNoErr()
 		telemetry.Data.CLInfo.Set("managedStatus", constants.UnManagedStatus)
 		telemetry.UpdateCLMetricsNoErr()
 		return ctrl.Result{}, nil
 	}
 
 	if _, err = k8shandler.Reconcile(r.Client, r.Reader, r.Recorder); err != nil {
+		telemetry.ResetCLMetricsNoErr()
 		telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 		telemetry.UpdateCLMetricsNoErr()
 		log.Error(err, "Error reconciling clusterlogging instance")
@@ -91,6 +93,7 @@ func (r *ReconcileClusterLogging) Reconcile(ctx context.Context, request ctrl.Re
 
 func (r *ReconcileClusterLogging) updateStatus(instance *loggingv1.ClusterLogging) (ctrl.Result, error) {
 	if err := r.Client.Status().Update(context.TODO(), instance); err != nil {
+		telemetry.ResetCLMetricsNoErr()
 		telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 		telemetry.UpdateCLMetricsNoErr()
 		log.Error(err, "clusterlogging-controller error updating status")

--- a/controllers/forwarding/forwarding_controller.go
+++ b/controllers/forwarding/forwarding_controller.go
@@ -69,6 +69,7 @@ func (r *ReconcileForwarder) Reconcile(ctx context.Context, request ctrl.Request
 	reconcileErr := k8shandler.ReconcileForClusterLogForwarder(instance, r.Client)
 	if reconcileErr != nil {
 		// if cluster is set to fail to reconcile then set healthStatus as 0
+		telemetry.ResetCLFMetricsNoErr()
 		telemetry.Data.CLFInfo.Set("healthStatus", constants.UnHealthyStatus)
 		telemetry.UpdateCLFMetricsNoErr()
 		log.V(2).Error(reconcileErr, "clusterlogforwarder-controller returning, error")
@@ -84,6 +85,7 @@ func (r *ReconcileForwarder) Reconcile(ctx context.Context, request ctrl.Request
 		// This returns False if SetCondition updates the condition instead of setting it.
 		// For condReady, it will always be updating the status.
 		if !instance.Status.Conditions.SetCondition(condReady) {
+			telemetry.ResetCLFMetricsNoErr()
 			telemetry.Data.CLFInfo.Set("healthStatus", constants.HealthyStatus)
 			telemetry.UpdateCLFMetricsNoErr()
 			r.Recorder.Event(instance, "Normal", string(condReady.Type), "All pipelines are valid")
@@ -106,6 +108,7 @@ func (r *ReconcileForwarder) Reconcile(ctx context.Context, request ctrl.Request
 	if instance.Status.IsDegraded() {
 		msg := "Some pipelines are degraded or invalid"
 		if instance.Status.Conditions.SetCondition(condDegraded(logging.ReasonInvalid, msg)) {
+			telemetry.ResetCLFMetricsNoErr()
 			telemetry.Data.CLFInfo.Set("healthStatus", constants.UnHealthyStatus)
 			telemetry.UpdateCLFMetricsNoErr()
 			r.Recorder.Event(instance, "Warning", string(logging.ReasonInvalid), msg)

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -37,6 +37,7 @@ func Reconcile(requestClient client.Client, reader client.Reader, r record.Event
 
 	if !clusterLoggingRequest.isManaged() {
 		// if cluster is set to unmanaged then set managedStatus as 0
+		telemetry.ResetCLMetricsNoErr()
 		telemetry.Data.CLInfo.Set("managedStatus", constants.UnManagedStatus)
 		telemetry.UpdateCLMetricsNoErr()
 		return clusterLoggingRequest.Cluster, nil
@@ -61,6 +62,7 @@ func Reconcile(requestClient client.Client, reader client.Reader, r record.Event
 	if clusterLoggingRequest.IncludesManagedStorage() {
 		// Reconcile Log Store
 		if err = clusterLoggingRequest.CreateOrUpdateLogStore(); err != nil {
+			telemetry.ResetCLMetricsNoErr()
 			telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 			telemetry.UpdateCLMetricsNoErr()
 			return clusterLoggingRequest.Cluster, fmt.Errorf("unable to create or update logstore for %q: %v", clusterLoggingRequest.Cluster.Name, err)
@@ -68,6 +70,7 @@ func Reconcile(requestClient client.Client, reader client.Reader, r record.Event
 
 		// Reconcile Visualization
 		if err = clusterLoggingRequest.CreateOrUpdateVisualization(); err != nil {
+			telemetry.ResetCLMetricsNoErr()
 			telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 			telemetry.UpdateCLMetricsNoErr()
 			return clusterLoggingRequest.Cluster, fmt.Errorf("unable to create or update visualization for %q: %v", clusterLoggingRequest.Cluster.Name, err)
@@ -90,6 +93,7 @@ func Reconcile(requestClient client.Client, reader client.Reader, r record.Event
 
 	// Reconcile Collection
 	if err = clusterLoggingRequest.CreateOrUpdateCollection(); err != nil {
+		telemetry.ResetCLMetricsNoErr()
 		telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 		telemetry.Data.CollectorErrorCount.Inc("CollectorErrorCount")
 		telemetry.UpdateCLMetricsNoErr()
@@ -98,6 +102,7 @@ func Reconcile(requestClient client.Client, reader client.Reader, r record.Event
 
 	// Reconcile metrics Dashboards
 	if err = metrics.ReconcileDashboards(clusterLoggingRequest.Client, reader, clusterLoggingRequest.Cluster.Spec.Collection); err != nil {
+		telemetry.ResetCLMetricsNoErr()
 		telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 		telemetry.UpdateCLMetricsNoErr()
 		log.Error(err, "Unable to create or update metrics dashboards", "clusterName", clusterLoggingRequest.Cluster.Name)
@@ -133,6 +138,7 @@ func removeCollectorAndUpdate(clusterRequest ClusterLoggingRequest) {
 func removeManagedStorage(clusterRequest ClusterLoggingRequest) {
 	log.V(1).Info("Removing managed store components...")
 	for _, remove := range []func() error{clusterRequest.removeElasticsearch, clusterRequest.removeKibana, clusterRequest.removeLokiStackRbac} {
+		telemetry.ResetCLMetricsNoErr()
 		telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 		telemetry.UpdateCLMetricsNoErr()
 		if err := remove(); err != nil {
@@ -160,6 +166,7 @@ func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, req
 	clusterLoggingRequest.Cluster = clusterLogging
 
 	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {
+		telemetry.ResetCLMetricsNoErr()
 		telemetry.Data.CLInfo.Set("managedStatus", constants.UnManagedStatus)
 		telemetry.UpdateCLMetricsNoErr()
 		return nil
@@ -171,6 +178,7 @@ func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, req
 
 	if err != nil {
 		msg := fmt.Sprintf("Unable to reconcile collection for %q: %v", clusterLoggingRequest.Cluster.Name, err)
+		telemetry.ResetCLFMetricsNoErr()
 		telemetry.Data.CLFInfo.Set("healthStatus", constants.UnHealthyStatus)
 		telemetry.UpdateCLFMetricsNoErr()
 		log.Error(err, msg)
@@ -179,6 +187,7 @@ func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, req
 
 	///////
 	// if it reaches to this point without throwing any errors than mark CLF in healthy state as with '1' value and also CL in healthy state with '1' value
+	telemetry.ResetCLFMetricsNoErr()
 	telemetry.Data.CLFInfo.Set("healthStatus", constants.HealthyStatus)
 	updateCLFInfo := UpdateInfofromCLF(&clusterLoggingRequest)
 	if updateCLFInfo != nil {
@@ -203,6 +212,7 @@ func ReconcileForTrustedCABundle(requestName string, requestClient client.Client
 	clusterLoggingRequest.Cluster = clusterLogging
 
 	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {
+		telemetry.ResetCLMetricsNoErr()
 		telemetry.Data.CLInfo.Set("managedStatus", constants.UnManagedStatus)
 		telemetry.UpdateCLMetricsNoErr()
 		return nil


### PR DESCRIPTION

### Description
[LOG-2315]
All info metrics in CLO are implemented as Gauge type where values of those metrics were fixed to have a constant value '1'.
This was causing issue as when the labels attain a different value.  For each unique value of labels - prometheus creates a new time-series with update label-value pair.  It still keeps the older label-value pair alive with the older state of metric time-series.  To address this now all info type of clo metrics accommodate two values - 0 and 1.  When metric labels attain a different value then the previous state of metric with old label-value pair is reset to 0.

/cc @alanconway 
/assign @jcantrill 

### Links

- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2315
- Enhancement proposal:
