### PR TITLE
LOG-1806: ParserError warning message suppressed, but logs will still be forwarded to the non-JSON index

### DIFF
--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -3671,6 +3671,7 @@ var _ = Describe("Generating fluentd config", func() {
     key_name message
     reserve_data yes
     hash_value_field structured
+    emit_invalid_record_to_error false
     <parse>
       @type json
       json_parser oj

--- a/internal/generator/fluentd/pipeline_to_output.go
+++ b/internal/generator/fluentd/pipeline_to_output.go
@@ -33,6 +33,10 @@ const (
   key_name message
   reserve_data yes
   hash_value_field structured
+  {{/* https://issues.redhat.com/browse/LOG-1806 
+    A non-JSON log message is forwarded as it would be if JSON parsing was not enabled (e.g. to the app index).
+    This warning is just fluentd detecting a non-JSON message, but it will still be forwarded to the non-JSON index. */}}
+  emit_invalid_record_to_error false 
   <parse>
     @type json
     json_parser oj

--- a/internal/generator/fluentd/pipeline_to_output_test.go
+++ b/internal/generator/fluentd/pipeline_to_output_test.go
@@ -155,6 +155,7 @@ var _ = Describe("Testing Config Generation", func() {
     key_name message
     reserve_data yes
     hash_value_field structured
+    emit_invalid_record_to_error false
     <parse>
       @type json
       json_parser oj

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -349,3 +349,11 @@ func (f *CollectorFunctionalFramework) addOutputContainers(b *runtime.PodBuilder
 func (f *CollectorFunctionalFramework) WaitForPodToBeReady() error {
 	return oc.Literal().From("oc wait -n %s pod/%s --timeout=60s --for=condition=Ready", f.Test.NS.Name, f.Name).Output()
 }
+
+func (f *CollectorFunctionalFramework) GetLogsFromCollector() (string, error) {
+	output, err := oc.Literal().From("oc logs -n %s pod/%s -c %s", f.Test.NS.Name, f.Name, constants.CollectorName).Run()
+	if err != nil {
+		return output, err
+	}
+	return output, nil
+}


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Add to the fluentd configuration:
` emit_invalid_record_to_error false`
 This will suspend the warning in case fluentd detecting a non-JSON message, but logs will still be forwarded to the non-JSON index.
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @jcantrill <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @alanconway <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-1806
- Enhancement proposal:
