### PR TITLE
LOG-2720: Add clusterID to data model for vector

### DIFF
--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -359,6 +359,7 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - clusterversions
           - proxies
           - infrastructures
           verbs:

--- a/config/rbac/cluster-logging-operator_clusterrole.yaml
+++ b/config/rbac/cluster-logging-operator_clusterrole.yaml
@@ -39,6 +39,7 @@ rules:
 - apiGroups:
     - config.openshift.io
   resources:
+    - clusterversions
     - proxies
     - infrastructures
   verbs:

--- a/controllers/clusterlogging/clusterlogging_controller.go
+++ b/controllers/clusterlogging/clusterlogging_controller.go
@@ -43,6 +43,9 @@ type ReconcileClusterLogging struct {
 	Reader   client.Reader
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+
+	//ClusterID is the unique identifier of the cluster in which the operator is deployed
+	ClusterID string
 }
 
 // Reconcile reads that state of the cluster for a ClusterLogging object and makes changes based on the state read
@@ -77,7 +80,7 @@ func (r *ReconcileClusterLogging) Reconcile(ctx context.Context, request ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	if _, err = k8shandler.Reconcile(r.Client, r.Reader, r.Recorder); err != nil {
+	if _, err = k8shandler.Reconcile(r.Client, r.Reader, r.Recorder, r.ClusterID); err != nil {
 		telemetry.ResetCLMetricsNoErr()
 		telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 		telemetry.UpdateCLMetricsNoErr()

--- a/controllers/forwarding/forwarding_controller.go
+++ b/controllers/forwarding/forwarding_controller.go
@@ -29,6 +29,9 @@ type ReconcileForwarder struct {
 	Client   client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+
+	//ClusterID is the unique identifier of the cluster in which the operator is deployed
+	ClusterID string
 }
 
 var condReady = status.Condition{Type: logging.ConditionReady, Status: corev1.ConditionTrue}
@@ -66,7 +69,7 @@ func (r *ReconcileForwarder) Reconcile(ctx context.Context, request ctrl.Request
 
 	log.V(3).Info("clusterlogforwarder-controller run reconciler...")
 
-	reconcileErr := k8shandler.ReconcileForClusterLogForwarder(instance, r.Client, r.Recorder)
+	reconcileErr := k8shandler.ReconcileForClusterLogForwarder(instance, r.Client, r.Recorder, r.ClusterID)
 	if reconcileErr != nil {
 		// if cluster is set to fail to reconcile then set healthStatus as 0
 		telemetry.ResetCLFMetricsNoErr()

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 			ImageName:     constants.FluentdName,
 			Visit:         fluentd.CollectorVisitor,
 		}
-		podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{})
+		podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234")
 		collector = podSpec.Containers[0]
 	})
 	Describe("when creating of the collector container", func() {
@@ -74,7 +74,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 						},
 					},
 				}
-				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{})
+				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234")
 				expTolerations := append(defaultTolerations, providedToleration)
 				Expect(podSpec.Tolerations).To(Equal(expTolerations))
 			})
@@ -98,7 +98,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 						},
 					},
 				}
-				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{})
+				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234")
 				Expect(podSpec.NodeSelector).To(Equal(expSelector))
 			})
 
@@ -164,7 +164,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 					Data: map[string]string{
 						constants.TrustedCABundleKey: caBundle,
 					},
-				}, logging.ClusterLogForwarderSpec{})
+				}, logging.ClusterLogForwarderSpec{}, "1234")
 				collector = podSpec.Containers[0]
 
 				verifyEnvVar(collector, "HTTP_PROXY", httpproxy)
@@ -307,7 +307,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				})
+				}, "1234")
 				collector := podSpec.Containers[0]
 
 				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
@@ -330,7 +330,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				})
+				}, "1234")
 				collector := podSpec.Containers[0]
 
 				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
@@ -356,7 +356,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				})
+				}, "1234")
 				collector := podSpec.Containers[0]
 
 				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
@@ -379,7 +379,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				})
+				}, "1234")
 				collector := podSpec.Containers[0]
 
 				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)

--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	ClusterID   = `.openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"`
 	FixLogLevel = `
 if !exists(.level) {
   .level = "default"
@@ -167,6 +168,7 @@ func NormalizeContainerLogs(inLabel, outLabel string) []generator.Element {
 			ComponentID: outLabel,
 			Inputs:      helpers.MakeInputs(inLabel),
 			VRL: strings.Join(helpers.TrimSpaces([]string{
+				ClusterID,
 				FixLogLevel,
 				RemoveSourceType,
 				RemoveStream,
@@ -183,6 +185,7 @@ func NormalizeJournalLogs(inLabel, outLabel string) []generator.Element {
 			ComponentID: outLabel,
 			Inputs:      helpers.MakeInputs(inLabel),
 			VRL: strings.Join(helpers.TrimSpaces([]string{
+				ClusterID,
 				AddJournalLogTag,
 				DeleteJournalLogFields,
 				FixLogLevel,
@@ -203,6 +206,7 @@ func NormalizeHostAuditLogs(inLabel, outLabel string) []generator.Element {
 			ComponentID: outLabel,
 			Inputs:      helpers.MakeInputs(inLabel),
 			VRL: strings.Join(helpers.TrimSpaces([]string{
+				ClusterID,
 				AddHostAuditTag,
 				ParseHostAuditLogs,
 				AddDefaultLogLevel,
@@ -217,6 +221,7 @@ func NormalizeK8sAuditLogs(inLabel, outLabel string) []generator.Element {
 			ComponentID: outLabel,
 			Inputs:      helpers.MakeInputs(inLabel),
 			VRL: strings.Join(helpers.TrimSpaces([]string{
+				ClusterID,
 				AddK8sAuditTag,
 				ParseAndFlatten,
 				FixK8sAuditLevel,
@@ -232,6 +237,7 @@ func NormalizeOpenshiftAuditLogs(inLabel, outLabel string) []generator.Element {
 			ComponentID: outLabel,
 			Inputs:      helpers.MakeInputs(inLabel),
 			VRL: strings.Join(helpers.TrimSpaces([]string{
+				ClusterID,
 				AddOpenAuditTag,
 				ParseAndFlatten,
 				FixOpenshiftAuditLevel,
@@ -247,6 +253,7 @@ func NormalizeOVNAuditLogs(inLabel, outLabel string) []generator.Element {
 			ComponentID: outLabel,
 			Inputs:      helpers.MakeInputs(inLabel),
 			VRL: strings.Join(helpers.TrimSpaces([]string{
+				ClusterID,
 				AddOvnAuditTag,
 				FixLogLevel,
 			}), "\n"),

--- a/internal/generator/vector/normalize_test.go
+++ b/internal/generator/vector/normalize_test.go
@@ -10,11 +10,14 @@ import (
 )
 
 var _ = Describe("Vector Config Generation", func() {
-	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
-		return generator.MergeElements(
-			NormalizeLogs(&clfspec, op),
-		)
-	}
+	var (
+		f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
+			return generator.MergeElements(
+				NormalizeLogs(&clfspec, op),
+			)
+		}
+	)
+
 	DescribeTable("NormalizeLogs(s)", helpers.TestGenerateConfWith(f),
 		Entry("Application logs only", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
@@ -33,6 +36,7 @@ var _ = Describe("Vector Config Generation", func() {
 type = "remap"
 inputs = ["raw_container_logs"]
 source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   if !exists(.level) {
     .level = "default"
     if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
@@ -77,6 +81,7 @@ source = '''
 type = "remap"
 inputs = ["raw_container_logs"]
 source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   if !exists(.level) {
     .level = "default"
     if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
@@ -107,6 +112,7 @@ source = '''
 type = "remap"
 inputs = ["raw_journal_logs"]
 source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   .tag = ".journal.system"
   
   del(.source_type)
@@ -215,6 +221,7 @@ source = '''
 type = "remap"
 inputs = ["raw_host_audit_logs"]
 source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   .tag = ".linux-audit.log"
   
   match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
@@ -241,6 +248,7 @@ source = '''
 type = "remap"
 inputs = ["raw_k8s_audit_logs"]
 source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   .tag = ".k8s-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
@@ -252,6 +260,7 @@ source = '''
 type = "remap"
 inputs = ["raw_openshift_audit_logs"]
 source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   .tag = ".openshift-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
@@ -263,6 +272,7 @@ source = '''
 type = "remap"
 inputs = ["raw_ovn_audit_logs"]
 source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   .tag = ".ovn-audit.log"
   if !exists(.level) {
     .level = "default"

--- a/internal/k8shandler/clusterloggingrequest.go
+++ b/internal/k8shandler/clusterloggingrequest.go
@@ -14,8 +14,12 @@ import (
 )
 
 type ClusterLoggingRequest struct {
-	Client        client.Client
-	Reader        client.Reader
+	Client client.Client
+	Reader client.Reader
+
+	//ClusterID is the unique identifier of the cluster in which the operator is deployed
+	ClusterID string
+
 	Cluster       *logging.ClusterLogging
 	EventRecorder record.EventRecorder
 	// ForwarderRequest is a logforwarder instance

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -370,7 +370,7 @@ func (clusterRequest *ClusterLoggingRequest) reconcileCollectorDaemonset(collect
 	}
 
 	instance := clusterRequest.Cluster
-	desired := collector.NewDaemonSet(instance.Namespace, configHash, caTrustHash, collectorType, caTrustBundle, *instance.Spec.Collection, clusterRequest.ForwarderSpec, clusterRequest.OutputSecrets)
+	desired := collector.NewDaemonSet(instance.Namespace, configHash, caTrustHash, clusterRequest.ClusterID, collectorType, caTrustBundle, *instance.Spec.Collection, clusterRequest.ForwarderSpec, clusterRequest.OutputSecrets)
 	utils.AddOwnerRefToObject(desired, utils.AsOwner(instance))
 
 	current := &apps.DaemonSet{}

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -23,11 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func Reconcile(requestClient client.Client, reader client.Reader, r record.EventRecorder) (instance *logging.ClusterLogging, err error) {
+func Reconcile(requestClient client.Client, reader client.Reader, r record.EventRecorder, clusterID string) (instance *logging.ClusterLogging, err error) {
 	clusterLoggingRequest := ClusterLoggingRequest{
 		Client:        requestClient,
 		Reader:        reader,
 		EventRecorder: r,
+		ClusterID:     clusterID,
 	}
 
 	if instance, err = clusterLoggingRequest.getClusterLogging(); err != nil {
@@ -154,10 +155,11 @@ func removeManagedStorage(clusterRequest ClusterLoggingRequest) {
 	}
 }
 
-func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, requestClient client.Client, er record.EventRecorder) (err error) {
+func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, requestClient client.Client, er record.EventRecorder, clusterID string) (err error) {
 	clusterLoggingRequest := ClusterLoggingRequest{
 		Client:        requestClient,
 		EventRecorder: er,
+		ClusterID:     clusterID,
 	}
 	if forwarder != nil {
 		clusterLoggingRequest.ForwarderRequest = forwarder

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -261,6 +261,7 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 		AddConfigMapVolume("certs", certsName)
 	b = f.collector.BuildCollectorContainer(
 		b.AddContainer(constants.CollectorName, f.image).
+			AddEnvVar("OPENSHIFT_CLUSTER_ID", f.Name).
 			WithImagePullPolicy(corev1.PullAlways).ResourceRequirements(resources), FunctionalNodeName).End()
 
 	for _, visit := range visitors {

--- a/test/framework/functional/message_templates.go
+++ b/test/framework/functional/message_templates.go
@@ -53,16 +53,16 @@ var (
 
 func NewApplicationLogTemplate() types.ApplicationLog {
 	return types.ApplicationLog{
-		Timestamp:  time.Time{},
-		Message:    "*",
-		LogType:    "application",
-		Level:      "*",
-		Hostname:   "*",
-		ViaqMsgID:  "**optional**",
-		WriteIndex: "**optional**",
+		Timestamp: time.Time{},
+		Message:   "*",
+		LogType:   "application",
+		Level:     "*",
+		Hostname:  "*",
+		ViaqMsgID: "**optional**",
 		Openshift: types.OpenshiftMeta{
-			Labels:   map[string]string{"*": "*"},
-			Sequence: types.NewOptionalInt(""),
+			Labels:    map[string]string{"*": "*"},
+			Sequence:  types.NewOptionalInt(""),
+			ClusterID: "**optional**",
 		},
 		PipelineMetadata: TemplateForAnyPipelineMetadata,
 		Docker: types.Docker{
@@ -75,16 +75,16 @@ func NewApplicationLogTemplate() types.ApplicationLog {
 // NewContainerInfrastructureLogTemplate creates a generally expected template for infrastructure container logs
 func NewContainerInfrastructureLogTemplate() types.ApplicationLog {
 	return types.ApplicationLog{
-		Timestamp:  time.Time{},
-		Message:    "*",
-		LogType:    "infrastructure",
-		Level:      "*",
-		Hostname:   "*",
-		ViaqMsgID:  "**optional**",
-		WriteIndex: "**optional**",
+		Timestamp: time.Time{},
+		Message:   "*",
+		LogType:   "infrastructure",
+		Level:     "*",
+		Hostname:  "*",
+		ViaqMsgID: "**optional**",
 		Openshift: types.OpenshiftMeta{
-			Labels:   map[string]string{"*": "*"},
-			Sequence: types.NewOptionalInt(""),
+			Labels:    map[string]string{"*": "*"},
+			Sequence:  types.NewOptionalInt(""),
+			ClusterID: "**optional**",
 		},
 		PipelineMetadata: TemplateForAnyPipelineMetadata,
 		Docker: types.Docker{

--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -161,6 +161,9 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 						Level:            "default",
 						Timestamp:        time.Time{},
 						PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+						OpenshiftLabels: types.OpenshiftMeta{
+							ClusterID: "*",
+						},
 					},
 					K8SAuditLevel: "Metadata",
 				}
@@ -194,6 +197,9 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 						Level:            "default",
 						Timestamp:        time.Time{},
 						PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+						OpenshiftLabels: types.OpenshiftMeta{
+							ClusterID: "*",
+						},
 					},
 					OpenshiftAuditLevel: "Metadata",
 				}
@@ -231,6 +237,9 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 					},
 					Timestamp:        testTime,
 					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+					OpenshiftLabels: types.OpenshiftMeta{
+						ClusterID: "*",
+					},
 				}
 				// Write log line as input to fluentd
 				Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
@@ -259,7 +268,8 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 					Timestamp: time.Time{},
 					LogType:   "audit",
 					Openshift: types.OpenshiftMeta{
-						Sequence: types.NewOptionalInt(""),
+						Sequence:  types.NewOptionalInt(""),
+						ClusterID: "*",
 					},
 					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
 				}

--- a/test/helpers/types/types.go
+++ b/test/helpers/types/types.go
@@ -31,7 +31,6 @@ type ContainerLog struct {
 	LogType          string                 `json:"log_type,omitempty"`
 	ViaqIndexName    string                 `json:"viaq_index_name"`
 	ViaqMsgID        string                 `json:"viaq_msg_id"`
-	WriteIndex       string                 `json:"write_index"`
 	Openshift        OpenshiftMeta          `json:"openshift"`
 	Structured       map[string]interface{} `json:"structured"`
 }
@@ -80,8 +79,9 @@ type PipelineMetadata struct {
 }
 
 type OpenshiftMeta struct {
-	Labels   map[string]string `json:"labels,omitempty"`
-	Sequence OptionalInt       `json:"sequence,omitempty"`
+	ClusterID string            `json:"cluster_id,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+	Sequence  OptionalInt       `json:"sequence,omitempty"`
 }
 
 // Application Logs are container logs from all namespaces except "openshift" and "openshift-*" namespaces

--- a/test/matchers/log_format.go
+++ b/test/matchers/log_format.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/onsi/gomega/types"
@@ -136,11 +137,19 @@ func compareLogLogic(name string, templateValue interface{}, value interface{}) 
 		log.V(3).Info("CompareLogLogic: Any value for * ", "name", name, "value", valueString)
 		return true
 	}
+	if reflect.TypeOf(templateValue).Name() == "Time" {
 
-	// Any time value not Nil is ok if template value is empty time and also does not equal the value for time.Time{}
-	if templateValueString == "0001-01-01 00:00:00 +0000 UTC" && valueString != "" && valueString != "0001-01-01 00:00:00 +0000 UTC" {
-		log.V(3).Info("CompareLogLogic: Any value for 'empty time' ", "name", name, "value", valueString)
-		return true
+		templateTime := templateValue.(time.Time)
+		valueTime := value.(time.Time)
+		if templateTime.UTC() == valueTime.UTC() {
+			return true
+		}
+
+		// Any time value not Nil is ok if template value is empty time and also does not equal the value for time.Time{}
+		if templateValueString == "0001-01-01 00:00:00 +0000 UTC" && valueString != "" && valueString != "0001-01-01 00:00:00 +0000 UTC" {
+			log.V(3).Info("CompareLogLogic: Any value for 'empty time' ", "name", name, "value", valueString)
+			return true
+		}
 	}
 
 	if strings.HasPrefix(templateValueString, "regex:") { // Using regex if starts with "/"


### PR DESCRIPTION
### Description
This PR:
* add support to vector to include openshift.cluster_id in the log payload
* Enables some audit functional testing for vector

### Links
* https://issues.redhat.com/browse/LOG-2720
