### PR TITLE
LOG-2911: Add nodename label to vector metrics

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -388,9 +388,16 @@ key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"
 
+[transforms.add_nodename_to_metric]
+type = "remap"
+inputs = ["internal_metrics"]
+source = '''
+.tags.hostname = get_env_var!("VECTOR_SELF_NODE_NAME")
+'''
+
 [sinks.prometheus_output]
 type = "prometheus_exporter"
-inputs = ["internal_metrics"]
+inputs = ["add_nodename_to_metric"]
 address = "0.0.0.0:24231"
 default_namespace = "collector"
 
@@ -891,9 +898,16 @@ key_file = "/var/run/ocp-collector/secrets/es-2/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-2/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/es-2/ca-bundle.crt"
 
+[transforms.add_nodename_to_metric]
+type = "remap"
+inputs = ["internal_metrics"]
+source = '''
+.tags.hostname = get_env_var!("VECTOR_SELF_NODE_NAME")
+'''
+
 [sinks.prometheus_output]
 type = "prometheus_exporter"
-inputs = ["internal_metrics"]
+inputs = ["add_nodename_to_metric"]
 address = "0.0.0.0:24231"
 default_namespace = "collector"
 

--- a/internal/generator/vector/metrics.go
+++ b/internal/generator/vector/metrics.go
@@ -4,6 +4,8 @@ const (
 	InternalMetricsSourceName = "internal_metrics"
 	PrometheusOutputSinkName  = "prometheus_output"
 	PrometheusExporterAddress = "0.0.0.0:24231"
+
+	AddNodenameToMetricTransformName = "add_nodename_to_metric"
 )
 
 type InternalMetrics struct {
@@ -48,5 +50,25 @@ default_namespace = "collector"
 enabled = true
 key_file = "/etc/collector/metrics/tls.key"
 crt_file = "/etc/collector/metrics/tls.crt"
+{{end}}`
+}
+
+type AddNodenameToMetric struct {
+	ID     string
+	Inputs string
+}
+
+func (a AddNodenameToMetric) Name() string {
+	return AddNodenameToMetricTransformName
+}
+
+func (a AddNodenameToMetric) Template() string {
+	return `{{define "` + a.Name() + `" -}}
+[transforms.{{.ID}}]
+type = "remap"
+inputs = {{.Inputs}}
+source = '''
+.tags.hostname = get_env_var!("VECTOR_SELF_NODE_NAME")
+'''
 {{end}}`
 }

--- a/internal/generator/vector/outputs.go
+++ b/internal/generator/vector/outputs.go
@@ -55,7 +55,9 @@ func Outputs(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, 
 			outputs = generator.MergeElements(outputs, gcl.Conf(o, inputs, secret, op))
 		}
 	}
-	outputs = append(outputs, PrometheusOutput(PrometheusOutputSinkName, []string{InternalMetricsSourceName}))
+	outputs = append(outputs,
+		AddNodeNameToMetric(AddNodenameToMetricTransformName, []string{InternalMetricsSourceName}),
+		PrometheusOutput(PrometheusOutputSinkName, []string{AddNodenameToMetricTransformName}))
 	return outputs
 }
 
@@ -64,5 +66,12 @@ func PrometheusOutput(id string, inputs []string) generator.Element {
 		ID:      id,
 		Inputs:  helpers.MakeInputs(inputs...),
 		Address: PrometheusExporterAddress,
+	}
+}
+
+func AddNodeNameToMetric(id string, inputs []string) generator.Element {
+	return AddNodenameToMetric{
+		ID:     id,
+		Inputs: helpers.MakeInputs(inputs...),
 	}
 }


### PR DESCRIPTION
### Description
Metrics generated by Vector lack a label whose value is the name opf the kubernetes node on which the collector runs. best available now is hostname which is same as pod name. But podname is not suitable because it is transient. this name changes every time collector is re-deloyed.


This PR adds a new label to the emitted metrics whose value is same as the value of environment variable `${VECTOR_SELF_NODE_NAME}`

The new label will also help in determining correct values to raise an alert, and clear an alert.

metric after this change

```
{
  "name": "internal_metrics_cardinality_total",
  "namespace": "vector",
  "tags": {
    "host": "collector-7vkk5",
    "hostname": "ip-10-0-140-184.ec2.internal"
  },
  "timestamp": "2022-09-12T11:59:20.964479613Z",
  "kind": "absolute",
  "counter": {
    "value": 305.0
  }
}
```


/cc @cahartma @jcantrill 
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->



### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2911

