### PR TITLE
LOG-3501: revert api validation for structuredTypeKey

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -184,7 +184,6 @@ type Elasticsearch struct {
 	// StructuredTypeKey specifies the metadata key to be used as name of elasticsearch index
 	// It takes precedence over StructuredTypeName
 	//
-	// +kubebuilder:validation:Pattern:=(kubernetes\.container_name|kubernetes\.labels\..+|openshift\.labels\..+)
 	// +optional
 	StructuredTypeKey string `json:"structuredTypeKey,omitempty"`
 

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -155,7 +155,6 @@ spec:
                         description: StructuredTypeKey specifies the metadata key
                           to be used as name of elasticsearch index It takes precedence
                           over StructuredTypeName
-                        pattern: (kubernetes\.container_name|kubernetes\.labels\..+|openshift\.labels\..+)
                         type: string
                       structuredTypeName:
                         description: StructuredTypeName specifies the name of elasticsearch
@@ -210,7 +209,6 @@ spec:
                           description: StructuredTypeKey specifies the metadata key
                             to be used as name of elasticsearch index It takes precedence
                             over StructuredTypeName
-                          pattern: (kubernetes\.container_name|kubernetes\.labels\..+|openshift\.labels\..+)
                           type: string
                         structuredTypeName:
                           description: StructuredTypeName specifies the name of elasticsearch

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -151,7 +151,6 @@ spec:
                         description: StructuredTypeKey specifies the metadata key
                           to be used as name of elasticsearch index It takes precedence
                           over StructuredTypeName
-                        pattern: (kubernetes\.container_name|kubernetes\.labels\..+|openshift\.labels\..+)
                         type: string
                       structuredTypeName:
                         description: StructuredTypeName specifies the name of elasticsearch
@@ -206,7 +205,6 @@ spec:
                           description: StructuredTypeKey specifies the metadata key
                             to be used as name of elasticsearch index It takes precedence
                             over StructuredTypeName
-                          pattern: (kubernetes\.container_name|kubernetes\.labels\..+|openshift\.labels\..+)
                           type: string
                         structuredTypeName:
                           description: StructuredTypeName specifies the name of elasticsearch

--- a/test/e2e/logforwarding/elasticsearchunmanaged/forward_to_unmanaged_elasticsearch_test.go
+++ b/test/e2e/logforwarding/elasticsearchunmanaged/forward_to_unmanaged_elasticsearch_test.go
@@ -3,15 +3,12 @@ package elasticsearchunmanaged
 import (
 	"fmt"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
-	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"path/filepath"
 	"runtime"
 
-	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
-	testruntime "github.com/openshift/cluster-logging-operator/test/runtime"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -48,31 +45,6 @@ var _ = Describe("[ClusterLogForwarder] Forwards logs", func() {
 		if err := e2e.CreateClusterLogging(cr); err != nil {
 			Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
 		}
-	})
-
-	Describe("when the output is Elasticsearch", func() {
-
-		Context("and JSON parsing is enabled", func() {
-
-			It("should fail validation when structuredTypeKey references an invalid value", func() {
-				forwarder := testruntime.NewClusterLogForwarder()
-				clfb := functional.NewClusterLogForwarderBuilder(forwarder).
-					FromInput(logging.InputNameApplication).
-					ToOutputWithVisitor(func(spec *logging.OutputSpec) {
-						spec.Elasticsearch = &logging.Elasticsearch{
-							StructuredTypeKey: "junk",
-						}
-					}, logging.OutputTypeElasticsearch)
-				clfb.Forwarder.Spec.Pipelines[0].Parse = "json"
-				var err error
-				if err = e2e.CreateClusterLogForwarder(forwarder); err == nil {
-					Fail(fmt.Sprintf("Expected kubevalidation to fail creation of: %#v", forwarder))
-				}
-				Expect(err.Error()).To(MatchRegexp(`invalid.*spec\.outputs\[[0-9]*\]\.elasticsearch\.structuredTypeKey`))
-			})
-
-		})
-
 	})
 
 	Describe("when the output is a third-party managed elasticsearch", func() {


### PR DESCRIPTION
### Description
This PR:
* reverts the api validation and restriction that was introduced as part of https://github.com/openshift/cluster-logging-operator/pull/1622

### Links
* https://issues.redhat.com/browse/LOG-3051
