### PR TITLE
LOG-2911: Add host metrics

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -134,6 +134,12 @@ glob_minimum_cooldown_ms = 15000
 
 [sources.internal_metrics]
 type = "internal_metrics"
+scrape_interval_secs = 20
+
+[sources.host_metrics]
+type = "host_metrics"
+collectors = ["cpu", "disk", "filesystem", "load", "host", "memory", "network"]
+scrape_interval_secs = 20
 
 [transforms.container_logs]
 type = "remap"
@@ -502,6 +508,12 @@ glob_minimum_cooldown_ms = 15000
 
 [sources.internal_metrics]
 type = "internal_metrics"
+scrape_interval_secs = 20
+
+[sources.host_metrics]
+type = "host_metrics"
+collectors = ["cpu", "disk", "filesystem", "load", "host", "memory", "network"]
+scrape_interval_secs = 20
 
 [transforms.container_logs]
 type = "remap"

--- a/internal/generator/vector/metrics.go
+++ b/internal/generator/vector/metrics.go
@@ -2,10 +2,12 @@ package vector
 
 const (
 	InternalMetricsSourceName = "internal_metrics"
+	HostMetricsSourceName     = "host_metrics"
 	PrometheusOutputSinkName  = "prometheus_output"
 	PrometheusExporterAddress = "0.0.0.0:24231"
 
 	AddNodenameToMetricTransformName = "add_nodename_to_metric"
+	MetricsScrapeIntervalSeconds     = 20
 )
 
 type InternalMetrics struct {
@@ -18,12 +20,32 @@ func (InternalMetrics) Name() string {
 }
 
 //#namespace = "collector"
-//#scrape_interval_secs = {{.ScrapeIntervalSec}}
 func (i InternalMetrics) Template() string {
 	return `
 {{define "` + i.Name() + `" -}}
 [sources.{{.ID}}]
 type = "internal_metrics"
+scrape_interval_secs = {{.ScrapeIntervalSec}}
+{{end}}
+`
+}
+
+type HostMetrics struct {
+	ID                string
+	ScrapeIntervalSec int
+}
+
+func (h HostMetrics) Name() string {
+	return "hostMetricsTemplate"
+}
+
+func (h HostMetrics) Template() string {
+	return `
+{{define "` + h.Name() + `" -}}
+[sources.{{.ID}}]
+type = "host_metrics"
+collectors = ["cpu", "disk", "filesystem", "load", "host", "memory", "network"]
+scrape_interval_secs = {{.ScrapeIntervalSec}}
 {{end}}
 `
 }

--- a/internal/generator/vector/sources.go
+++ b/internal/generator/vector/sources.go
@@ -28,7 +28,7 @@ const (
 func Sources(spec *logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 	return generator.MergeElements(
 		LogSources(spec, op),
-		MetricsSources(InternalMetricsSourceName),
+		MetricsSources(),
 	)
 }
 
@@ -109,11 +109,15 @@ func ExcludeContainerPaths() string {
 	))
 }
 
-func MetricsSources(id string) []generator.Element {
+func MetricsSources() []generator.Element {
 	return []generator.Element{
 		InternalMetrics{
-			ID:                id,
-			ScrapeIntervalSec: 2,
+			ID:                InternalMetricsSourceName,
+			ScrapeIntervalSec: MetricsScrapeIntervalSeconds,
+		},
+		HostMetrics{
+			ID:                HostMetricsSourceName,
+			ScrapeIntervalSec: MetricsScrapeIntervalSeconds,
 		},
 	}
 }


### PR DESCRIPTION
### Description
Adds host metrics source in the pipeline. This adds metrics for  `"cpu", "disk", "filesystem", "load", "host", "memory", "network"`

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
