### PR TITLE
LOG-3055: Fix Fluentd Alert query expr and labels

### DIFF
--- a/files/fluentd/fluentd_prometheus_alerts.yaml
+++ b/files/fluentd/fluentd_prometheus_alerts.yaml
@@ -3,13 +3,13 @@
   "rules":
   - "alert": "FluentdNodeDown"
     "annotations":
-      "message": "Prometheus could not scrape fluentd {{ $labels.instance }} for more than 10m."
+      "message": "Prometheus could not scrape fluentd {{ $labels.container }} for more than 10m."
       "summary": "Fluentd cannot be scraped"
     "expr": |
-      up{job="collector"} == 0 or absent(up{job="collector"}) == 1
+      up{job = "collector", container = "collector"} == 0 or absent(up{job="collector", container="collector"}) == 1
     "for": "10m"
     "labels":
-      "service": "fluentd"
+      "service": "collector"
       "severity": "critical"
       namespace: "openshift-logging"
   - "alert": "FluentdQueueLengthIncreasing"
@@ -20,7 +20,7 @@
       ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
     "for": "1h"
     "labels":
-      "service": "fluentd"
+      "service": "collector"
       "severity": "Warning"
       namespace: "openshift-logging"
   - alert: FluentDHighErrorRate


### PR DESCRIPTION
### Description
A `FluentdNodeDown` critical alert is raised as soon as fluentd is deployed.
The associated query `up{job="collector"}` results in metrics which also include `logfilemetricexporter` , this could be messing up the logic for alerting

This PR 
- adds `container="collector"` label filter
- fixes alert labels to use `service="collector"` instead of `service="fluentd"`

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick release-5.5
/cherry-pick release-5.4

### Links
- JIRA: https://issues.redhat.com/browse/LOG-3055
