### PR TITLE
LOG-2843: tls.key and tls.cert not in fluentd real configuration when forwarding logs using syslog tls

### DIFF
--- a/internal/generator/fluentd/output/syslog/cert-key.go
+++ b/internal/generator/fluentd/output/syslog/cert-key.go
@@ -1,0 +1,18 @@
+package syslog
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+)
+
+type TLSKeyCert security.TLSCertKey
+
+func (kc TLSKeyCert) Name() string {
+	return "syslogCertKeyTemplate"
+}
+
+func (kc TLSKeyCert) Template() string {
+	return `{{define "` + kc.Name() + `" -}}
+client_cert_key {{.KeyPath}}
+client_cert {{.CertPath}}
+{{- end}}`
+}

--- a/test/framework/e2e/syslog_conf.go
+++ b/test/framework/e2e/syslog_conf.go
@@ -15,7 +15,7 @@ input(type="imtcp" port="24224" ruleset="test")
 module(load="imtcp"
     StreamDriver.Name="gtls"
     StreamDriver.Mode="1" # run driver in TLS-only mode
-    StreamDriver.Authmode="anon"
+    StreamDriver.Authmode="x509/certvalid"
 )
 # make gtls driver the default and set certificate files
 global(
@@ -40,7 +40,7 @@ input(type="imudp" port="24224" ruleset="test")
 module(load="imudp"
     StreamDriver.Name="gtls"
     StreamDriver.Mode="1" # run driver in TLS-only mode
-    StreamDriver.Authmode="anon"
+    StreamDriver.Authmode="x509/certvalid"
 ) # needs to be done just once
 # make gtls driver the default and set certificate files
 global(


### PR DESCRIPTION
### Description
Implement support for client-side certificate and key for the remote_syslog fluentd plugin

/cc @vimalk78 
/assign @jcantrill 

### Links
- Depending on PR(s): https://github.com/ViaQ/logging-fluentd/pull/42
- JIRA: https://issues.redhat.com/browse/LOG-2843

