### PR TITLE
Extend lint timeout to avoid occasional CI failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ image: .target/image
 # - don't run with --fix in CI, complain about everything. Do try to auto-fix outside of CI.
 export GOLANGCI_LINT_CACHE=$(CURDIR)/.cache
 lint:  $(GOLANGCI_LINT) lint-dockerfile
-	$(GOLANGCI_LINT) run --color=never $(if $(CI),,--fix)
+	$(GOLANGCI_LINT) run --color=never --timeout=3m $(if $(CI),,--fix)
 .PHONY: lint
 
 .PHONY: lint-dockerfile


### PR DESCRIPTION
### Description

Occasionally the `ci/prow/lint` check fails because `golangci-lint` does not complete inside its own timeout (which is one minute). This PR extends the timeout to three minutes to allow slow lint runs to succeed as well.
