### PR TITLE
LOG-3071: Elasticsearch output: Remove 'write_index' field from log record

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -807,6 +807,7 @@ inputs = ["es_1_dedot_and_flatten"]
 endpoint = "https://es-1.svc.messaging.cluster.local:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 
@@ -889,6 +890,7 @@ inputs = ["es_2_dedot_and_flatten"]
 endpoint = "https://es-2.svc.messaging.cluster.local:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -35,6 +35,7 @@ inputs = {{.Inputs}}
 endpoint = "{{.Endpoint}}"
 bulk.index = "{{ "{{ write_index }}" }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 {{end}}`

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -120,6 +120,7 @@ inputs = ["es_1_dedot_and_flatten"]
 endpoint = "https://es.svc.infra.cluster:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 
@@ -226,6 +227,7 @@ inputs = ["es_1_dedot_and_flatten"]
 endpoint = "https://es.svc.infra.cluster:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 
@@ -322,6 +324,7 @@ inputs = ["es_1_dedot_and_flatten"]
 endpoint = "http://es.svc.infra.cluster:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 `,
@@ -454,6 +457,7 @@ inputs = ["es_1_dedot_and_flatten"]
 endpoint = "https://es-1.svc.messaging.cluster.local:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 
@@ -536,6 +540,7 @@ inputs = ["es_2_dedot_and_flatten"]
 endpoint = "https://es-2.svc.messaging.cluster.local:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 
@@ -643,6 +648,7 @@ inputs = ["es_1_dedot_and_flatten"]
 endpoint = "http://es.svc.infra.cluster:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 `,
@@ -741,6 +747,7 @@ inputs = ["es_1_dedot_and_flatten"]
 endpoint = "http://es.svc.infra.cluster:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 `,
@@ -845,6 +852,7 @@ inputs = ["es_1_dedot_and_flatten"]
 endpoint = "http://es.svc.infra.cluster:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 `,
@@ -961,6 +969,7 @@ inputs = ["es_1_dedot_and_flatten"]
 endpoint = "http://es.svc.infra.cluster:9200"
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
+encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
 `,


### PR DESCRIPTION
### Description
Vector elasticsearch sink can use a record field value to be used as the elasticsearch index. Config generator generates a transform block which determines the index name, and sets it as the value of `write_index` field. As a side effect, this field is  getting sent to elastiocsearch as part of the log record.

This PR attempts to disable sending this field to elasticsearch by using `encoding.except_fields = ["write_index"]` config.


/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3071
- Enhancement proposal:
