### PR TITLE
LOG-2960: Enable functional audit log tests for vector

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -162,7 +162,7 @@ source = '''
   del(.source_type)
   del(.stream)
   del(.kubernetes.pod_ips)
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
 [transforms.journal_logs]
@@ -255,7 +255,7 @@ source = '''
   
   .time = format_timestamp!(.timestamp, format: "%FT%T%:z")
   
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
 [transforms.host_audit_logs]
@@ -362,7 +362,7 @@ inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_l
 source = '''
   .log_type = "audit"
   .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
 [transforms.route_application_logs]
@@ -536,7 +536,7 @@ source = '''
   del(.source_type)
   del(.stream)
   del(.kubernetes.pod_ips)
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
 [transforms.journal_logs]
@@ -629,7 +629,7 @@ source = '''
   
   .time = format_timestamp!(.timestamp, format: "%FT%T%:z")
   
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
 [transforms.host_audit_logs]
@@ -736,7 +736,7 @@ inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_l
 source = '''
   .log_type = "audit"
   .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
 [transforms.pipeline]

--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -36,7 +36,7 @@ if !exists(.level) {
 	RemoveSourceType  = `del(.source_type)`
 	RemoveStream      = `del(.stream)`
 	RemovePodIPs      = `del(.kubernetes.pod_ips)`
-	FixTimestampField = `."@timestamp" = del(.timestamp)`
+	FixTimestampField = `ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}`
 	AddJournalLogTag  = `.tag = ".journal.system"`
 	AddHostName       = `.hostname = del(.host)`
 	AddTime           = `.time = format_timestamp!(.timestamp, format: "%FT%T%:z")`

--- a/internal/generator/vector/normalize_test.go
+++ b/internal/generator/vector/normalize_test.go
@@ -56,7 +56,7 @@ source = '''
   del(.source_type)
   del(.stream)
   del(.kubernetes.pod_ips)
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 `,
 		}),
@@ -100,7 +100,7 @@ source = '''
   del(.source_type)
   del(.stream)
   del(.kubernetes.pod_ips)
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
 [transforms.journal_logs]
@@ -193,7 +193,7 @@ source = '''
   
   .time = format_timestamp!(.timestamp, format: "%FT%T%:z")
   
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
 `,

--- a/internal/generator/vector/sources_to_pipelines_test.go
+++ b/internal/generator/vector/sources_to_pipelines_test.go
@@ -63,7 +63,7 @@ inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_l
 source = '''
   .log_type = "audit"
   .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
 [transforms.pipeline]
@@ -125,7 +125,7 @@ inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_l
 source = '''
   .log_type = "audit"
   .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
-  ."@timestamp" = del(.timestamp)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
 [transforms.pipeline1]

--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -147,144 +147,105 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				Expect(framework.Deploy()).To(BeNil())
 			})
 
-			//TODO: fix me when audit formatting is enabled
 			It("should parse k8s audit log format correctly", func() {
 				// Log message data
 				timestamp := "2013-03-28T14:36:03.243000+00:00"
 				nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 
 				// Define a template for test format (used for input, and expected output)
-				//var outputLogTemplate = types.K8sAuditLog{
-				//AuditLogCommon: types.AuditLogCommon{
-				//	Kind:             "Event",
-				//	Hostname:         functional.FunctionalNodeName,
-				//	LogType:          "audit",
-				//	Level:            "debug",
-				//	Timestamp:        time.Time{},
-				//	ViaqMsgID:        "*",
-				//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-				//},
-				//K8SAuditLevel: "debug",
-				//}
+				var outputLogTemplate = types.K8sAuditLog{
+					AuditLogCommon: types.AuditLogCommon{
+						Kind:             "Event",
+						Hostname:         framework.Pod.Spec.NodeName,
+						LogType:          "audit",
+						Level:            "default",
+						Timestamp:        time.Time{},
+						PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+					},
+					K8SAuditLevel: "Metadata",
+				}
 				// Template expected as output Log
 				k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"Metadata"}`, functional.CRIOTime(nanoTime))
 				Expect(framework.WriteMessagesTok8sAuditLog(k8sAuditLogLine, 10)).To(BeNil())
 				// Read line from Log Forward output
 				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
 				Expect(err).To(BeNil(), "Expected no errors reading the logs")
-				//var logs []types.K8sAuditLog
-				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-				//Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
-				//// Compare to expected template
-				//outputTestLog := logs[0]
-				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+				var logs []types.K8sAuditLog
+				err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
+				// Compare to expected template
+				outputTestLog := logs[0]
+				Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 				results := strings.Join(raw, " ")
 				Expect(results).To(MatchRegexp("kind.*Event.*level.*default.*k8s_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
 
 			})
-			//TODO: fix me when audit formatting is enabled
 			It("should parse openshift audit log format correctly", func() {
 				// Log message data
 				timestamp := "2013-03-28T14:36:03.243000+00:00"
 				nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 
 				// Define a template for test format (used for input, and expected output)
-				//var outputLogTemplate = types.K8sAuditLog{
-				//AuditLogCommon: types.AuditLogCommon{
-				//	Kind:             "Event",
-				//	Hostname:         functional.FunctionalNodeName,
-				//	LogType:          "audit",
-				//	Level:            "debug",
-				//	Timestamp:        time.Time{},
-				//	ViaqMsgID:        "*",
-				//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-				//},
-				//K8SAuditLevel: "debug",
-				//}
+				var outputLogTemplate = types.OpenshiftAuditLog{
+					AuditLogCommon: types.AuditLogCommon{
+						Kind:             "Event",
+						Hostname:         framework.Pod.Spec.NodeName,
+						LogType:          "audit",
+						Level:            "default",
+						Timestamp:        time.Time{},
+						PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+					},
+					OpenshiftAuditLevel: "Metadata",
+				}
 				// Template expected as output Log
 				auditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"Metadata"}`, functional.CRIOTime(nanoTime))
 				Expect(framework.WriteMessagesToOpenshiftAuditLog(auditLogLine, 10)).To(BeNil())
-				// Read line from Log Forward output
-				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
-				Expect(err).To(BeNil(), "Expected no errors reading the logs")
-				//var logs []types.K8sAuditLog
-				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-				//Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
-				//// Compare to expected template
-				//outputTestLog := logs[0]
-				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-				results := strings.Join(raw, " ")
-				Expect(results).To(MatchRegexp("kind.*Event.*level.*default.*openshift_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
-
-			})
-			It("should parse oauth audit log format correctly", func() {
-				// Log message data
-				timestamp := "2013-03-28T14:36:03.243000+00:00"
-				nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
-
-				// Define a template for test format (used for input, and expected output)
-				//var outputLogTemplate = types.K8sAuditLog{
-				//AuditLogCommon: types.AuditLogCommon{
-				//	Kind:             "Event",
-				//	Hostname:         functional.FunctionalNodeName,
-				//	LogType:          "audit",
-				//	Level:            "debug",
-				//	Timestamp:        time.Time{},
-				//	ViaqMsgID:        "*",
-				//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-				//},
-				//K8SAuditLevel: "debug",
-				//}
-				// Template expected as output Log
-				auditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"debug"}`, functional.CRIOTime(nanoTime))
 				Expect(framework.WriteMessagesToOAuthAuditLog(auditLogLine, 10)).To(BeNil())
 				// Read line from Log Forward output
 				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
 				Expect(err).To(BeNil(), "Expected no errors reading the logs")
-				//var logs []types.K8sAuditLog
-				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-				//Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
-				//// Compare to expected template
-				//outputTestLog := logs[0]
-				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
-				results := strings.Join(raw, " ")
-				Expect(results).To(MatchRegexp("kind.*Event.*level.*debug"), "Message should contain the audit log: %v", raw)
-
+				var logs []types.OpenshiftAuditLog
+				err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				Expect(err).To(BeNil(), "Expected no errors parsing the logs: %v", raw)
+				// Compare to expected template
+				for _, outputTestLog := range logs {
+					Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+					results := strings.Join(raw, " ")
+					Expect(results).To(MatchRegexp("kind.*Event.*level.*default.*openshift_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
+				}
 			})
-			//TODO: fix me when audit formatting is enabled
 			It("should parse linux audit log format correctly", func() {
 				// Log message data
 				timestamp := "2013-03-28T14:36:03.243000+00:00"
 				testTime, _ := time.Parse(time.RFC3339Nano, timestamp)
 				auditLogLine := functional.NewAuditHostLog(testTime)
-				//// Template expected as output Log
-				//var outputLogTemplate = types.LinuxAuditLog{
-				//	Message:  auditLogLine,
-				//	LogType:  "audit",
-				//	Hostname: functional.FunctionalNodeName,
-				//	AuditLinux: types.AuditLinux{
-				//		Type:     "DAEMON_START",
-				//		RecordID: "*",
-				//	},
-				//	Timestamp:        testTime,
-				//	ViaqMsgID:        "*",
-				//	PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-				//}
+				// Template expected as output Log
+				var outputLogTemplate = types.LinuxAuditLog{
+					Message:  auditLogLine,
+					LogType:  "audit",
+					Level:    "default",
+					Hostname: framework.Pod.Spec.NodeName,
+					AuditLinux: types.AuditLinux{
+						Type:     "DAEMON_START",
+						RecordID: "*",
+					},
+					Timestamp:        testTime,
+					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+				}
 				// Write log line as input to fluentd
 				Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
 				// Read line from Log Forward output
 				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
 				Expect(err).To(BeNil(), "Expected no errors reading the logs")
-				//var logs []types.LinuxAuditLog
-				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-				//Expect(err).To(BeNil(), "Expected no errors parsing the logs")
-				//// Compare to expected template
-				//outputTestLog := logs[0]
-				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+				var logs []types.LinuxAuditLog
+				err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+				// Compare to expected template
+				outputTestLog := logs[0]
+				Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 				results := strings.Join(raw, " ")
 				Expect(results).To(MatchRegexp("format=enriched kernel="), "Message should contain the audit log: %v", raw)
 			})
-			//TODO: fix me when audit formatting is enabled
 			It("should parse ovn audit log correctly", func() {
 				// Log message data
 				level := "info"
@@ -294,13 +255,12 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				var outputLogTemplate = types.OVNAuditLog{
 					Message:   ovnLogLine,
 					Level:     level,
-					Hostname:  functional.FunctionalNodeName,
+					Hostname:  framework.Pod.Spec.NodeName,
 					Timestamp: time.Time{},
 					LogType:   "audit",
 					Openshift: types.OpenshiftMeta{
 						Sequence: types.NewOptionalInt(""),
 					},
-					ViaqMsgID:        "*",
 					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
 				}
 				outputLogTemplate.PipelineMetadata.Collector.ReceivedAt = time.Time{}
@@ -309,20 +269,14 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				// Read line from Log Forward output
 				raw, err := framework.ReadAuditLogsFrom(logging.OutputTypeElasticsearch)
 				Expect(err).To(BeNil(), "Expected no errors reading the logs")
-				//var logs []types.OVNAuditLog
-				//err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
-				//ExpectOK(err)
+				var logs []types.OVNAuditLog
+				err = types.StrictlyParseLogs(utils.ToJsonLogs(raw), &logs)
+				ExpectOK(err)
 				// Compare to expected template
-				//outputTestLog := logs[0]
-				//Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+				outputTestLog := logs[0]
+				Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 				results := strings.Join(raw, " ")
 				Expect(results).To(MatchRegexp("name=verify-audit-logging_deny-all"), "Message should contain the audit log: %v", raw)
-
-				// Parse logs and verify level and type
-				logs, err := types.ParseLogs(utils.ToJsonLogs(raw))
-				ExpectOK(err, "Expected no errors parsing the logs: %s", raw)
-				Expect(logs[0].Level).To(Equal(outputLogTemplate.Level))
-				Expect(logs[0].LogType).To(Equal(outputLogTemplate.LogType))
 			})
 
 			AfterEach(func() {


### PR DESCRIPTION
### Description
Enabled vector functional tests for audit logs.
Fixed a bug related to host audit log `@timestamp` field.

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick release-5.5

### Links
- JIRA: https://issues.redhat.com/browse/LOG-2960
