### PR TITLE
LOG-3090: Do not overwrite custom outputs when using LokiStack as log output

### DIFF
--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -143,7 +143,7 @@ func (clusterRequest *ClusterLoggingRequest) NormalizeForwarder() (*logging.Clus
 	if logStore != nil && logStore.Type == logging.LogStoreTypeLokiStack {
 		outputs, pipelines := clusterRequest.processPipelinesForLokiStack(clusterRequest.ForwarderSpec.Pipelines)
 
-		clusterRequest.ForwarderSpec.Outputs = outputs
+		clusterRequest.ForwarderSpec.Outputs = append(clusterRequest.ForwarderSpec.Outputs, outputs...)
 		clusterRequest.ForwarderSpec.Pipelines = pipelines
 	}
 


### PR DESCRIPTION
### Description

The processing of the forwarder pipelines introduced in #1587 contains a bug where custom output pipelines are overwritten by the newly-created outputs for LokiStack. This PR fixes this issue by adding the LokiStack outputs to the set of already existing outputs.

/cherry-pick release-5.5

### Links

- JIRA: [LOG-3090](https://issues.redhat.com//browse/LOG-3090)
