### PR TITLE
LOG-3094: Add list 'nodes' permission to logcollector serviceaccount

### DIFF
--- a/bundle/manifests/metadata-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/metadata-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - pods
   - namespaces
+  - nodes
   verbs:
   - get
   - list

--- a/config/rbac/metadata_reader_clusterrole.yaml
+++ b/config/rbac/metadata_reader_clusterrole.yaml
@@ -12,3 +12,4 @@ rules:
     resources:
       - pods
       - namespaces
+      - nodes


### PR DESCRIPTION
### Description
Since vector version 0.23, the serviceaccount associated with vector needs permission to list kubernetes nodes.

This change is listed as a breaking change in the upgrade guide.

This PR adds appropriate permissions to `logcollector` service account.

Reference: https://vector.dev/highlights/2022-07-07-0-23-0-upgrade-guide/#kubernetes-logs-list-watch-nodes


/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:  https://issues.redhat.com/browse/LOG-3094
- Enhancement proposal:
