### PR TITLE
Fix serialization of empty managementState value

### DIFF
--- a/apis/logging/v1/clusterlogging_types.go
+++ b/apis/logging/v1/clusterlogging_types.go
@@ -33,7 +33,7 @@ type ClusterLoggingSpec struct {
 	//
 	// +kubebuilder:validation:Enum:=Managed;Unmanaged
 	// +optional
-	ManagementState ManagementState `json:"managementState"`
+	ManagementState ManagementState `json:"managementState,omitempty"`
 
 	// Specification of the Visualization component for the cluster
 	//


### PR DESCRIPTION
### Description

The `managementState` attribute in the cluster-logging-operator has a `string` type so it converts an empty value received from the apiserver to `""` but an empty string is not a valid value for this field server-side, so if the operator tries to write the same resource it read back to the apiserver this generates an error.

This PR fixes this issue by omitting the value from the serialized output when it is empty.

/cherry-pick release-5.5

### Links

This was based on a discussion on Slack, so there's no JIRA issue for this. I can create one though.
