### PR TITLE
LOG-3002: Configure cluster-logging-operator to honor the global tlsSecurityProfile

### DIFF
--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -359,6 +359,7 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - apiservers
           - clusterversions
           - proxies
           - infrastructures

--- a/config/rbac/cluster-logging-operator_clusterrole.yaml
+++ b/config/rbac/cluster-logging-operator_clusterrole.yaml
@@ -39,6 +39,7 @@ rules:
 - apiGroups:
     - config.openshift.io
   resources:
+    - apiservers
     - clusterversions
     - proxies
     - infrastructures

--- a/internal/collector/fluentd/visitors.go
+++ b/internal/collector/fluentd/visitors.go
@@ -1,10 +1,12 @@
 package fluentd
 
 import (
+	"fmt"
+
 	"github.com/openshift/cluster-logging-operator/internal/collector/common"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -33,6 +35,7 @@ func CollectorVisitor(collectorContainer *v1.Container, podSpec *v1.PodSpec) {
 			},
 		},
 		v1.EnvVar{Name: "RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR", Value: "0.9"},
+		v1.EnvVar{Name: "OPENSSL_CONF", Value: fmt.Sprintf("%s/openssl.cnf", configVolumePath)},
 	)
 	collectorContainer.VolumeMounts = append(collectorContainer.VolumeMounts,
 		v1.VolumeMount{Name: certsVolumeName, ReadOnly: true, MountPath: certsVolumePath},

--- a/internal/collector/vector/visitors.go
+++ b/internal/collector/vector/visitors.go
@@ -1,10 +1,12 @@
 package fluentd
 
 import (
+	"fmt"
+
 	"github.com/openshift/cluster-logging-operator/internal/collector/common"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -12,24 +14,25 @@ const (
 	vectorDataPath   = "/var/lib/vector"
 )
 
-func CollectorVisitor(collectorContainer *v1.Container, podSpec *v1.PodSpec) {
+func CollectorVisitor(collectorContainer *corev1.Container, podSpec *corev1.PodSpec) {
 	collectorContainer.Env = append(collectorContainer.Env,
-		v1.EnvVar{Name: "LOG", Value: "info"},
-		v1.EnvVar{
+		corev1.EnvVar{Name: "LOG", Value: "info"},
+		corev1.EnvVar{
 			Name: "VECTOR_SELF_NODE_NAME",
-			ValueFrom: &v1.EnvVarSource{
-				FieldRef: &v1.ObjectFieldSelector{
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
 					APIVersion: "v1", FieldPath: "spec.nodeName",
 				},
 			},
 		},
+		corev1.EnvVar{Name: "OPENSSL_CONF", Value: fmt.Sprintf("%s/openssl.cnf", vectorConfigPath)},
 	)
 	collectorContainer.VolumeMounts = append(collectorContainer.VolumeMounts,
-		v1.VolumeMount{Name: common.ConfigVolumeName, ReadOnly: true, MountPath: vectorConfigPath},
-		v1.VolumeMount{Name: common.DataDir, ReadOnly: false, MountPath: vectorDataPath},
+		corev1.VolumeMount{Name: common.ConfigVolumeName, ReadOnly: true, MountPath: vectorConfigPath},
+		corev1.VolumeMount{Name: common.DataDir, ReadOnly: false, MountPath: vectorDataPath},
 	)
 	podSpec.Volumes = append(podSpec.Volumes,
-		v1.Volume{Name: common.ConfigVolumeName, VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: constants.CollectorConfigSecretName, Optional: utils.GetBool(true)}}},
-		v1.Volume{Name: common.DataDir, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: vectorDataPath}}},
+		corev1.Volume{Name: common.ConfigVolumeName, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: constants.CollectorConfigSecretName, Optional: utils.GetBool(true)}}},
+		corev1.Volume{Name: common.DataDir, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: vectorDataPath}}},
 	)
 }

--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -3,9 +3,10 @@ package fluentd
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 	testhelpers "github.com/openshift/cluster-logging-operator/test/helpers"
-	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo"

--- a/internal/tls/profile.go
+++ b/internal/tls/profile.go
@@ -1,0 +1,67 @@
+package tls
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	OpenSSLConfTemplate = `
+{{define "openssl_conf_template" -}}
+
+config_diagnostics = 1
+
+openssl_conf = default_conf_section
+
+[default_conf_section]
+ssl_conf = ssl_section
+
+[ssl_section]
+system_default = system_default_section
+
+[system_default_section]
+MinProtocol = {{MinProtocol}}
+CipherSuites = {{CipherSuites}}
+{{end}}
+`
+)
+
+func OpenSSLConf(k8client client.Client) string {
+	pr, _ := FetchAPIServerTlsProfile(k8client)
+	tls := getTLSProfileSpec(pr)
+	conf, _ := opensslConf(tls)
+	return conf
+}
+
+func opensslConf(tlsConf configv1.TLSProfileSpec) (string, error) {
+	t := template.New("openssl_conf_template")
+	t.Funcs(template.FuncMap{
+		"MinProtocol": func() string {
+			switch MinTLSVersion(tlsConf) {
+			case string(configv1.VersionTLS10):
+				return "TLSv1.0"
+			case string(configv1.VersionTLS11):
+				return "TLSv1.1"
+			case string(configv1.VersionTLS12):
+				return "TLSv1.2"
+			case string(configv1.VersionTLS13):
+				return "TLSv1.3"
+			}
+			return "invalid"
+		},
+		"CipherSuites": func() string {
+			return strings.TrimSpace(strings.Join(TLSCiphers(tlsConf), ", "))
+		},
+	})
+	t, err := t.Parse(OpenSSLConfTemplate)
+	if err != nil {
+		return "", err
+	}
+	buf := new(bytes.Buffer)
+	err = t.ExecuteTemplate(buf, "openssl_conf_template", nil)
+	return buf.String(), err
+}

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -1,0 +1,71 @@
+package tls
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	APIServerName = "cluster"
+)
+
+var (
+	// DefaultTLSProfileType is the intermediate profile type
+	DefaultTLSProfileType = configv1.TLSProfileIntermediateType
+	// DefaultTLSCiphers are the default TLS ciphers for API servers
+	DefaultTLSCiphers = configv1.TLSProfiles[DefaultTLSProfileType].Ciphers
+	// DefaultMinTLSVersion is the default minimum TLS version for API servers
+	DefaultMinTLSVersion = configv1.TLSProfiles[DefaultTLSProfileType].MinTLSVersion
+)
+
+//FetchAPIServerTlsProfile fetches tlsSecurityProfile configured in APIServer
+func FetchAPIServerTlsProfile(k8client client.Client) (*configv1.TLSSecurityProfile, error) {
+	apiServer := &configv1.APIServer{}
+	key := client.ObjectKey{Name: APIServerName}
+	if err := k8client.Get(context.TODO(), key, apiServer); err != nil {
+		return nil, err
+	}
+	return apiServer.Spec.TLSSecurityProfile, nil
+}
+
+// TLSCiphers returns the TLS ciphers for the
+// TLS security profile defined in the APIServerConfig.
+func TLSCiphers(profile configv1.TLSProfileSpec) []string {
+	if len(profile.Ciphers) == 0 {
+		return DefaultTLSCiphers
+	}
+	return profile.Ciphers
+}
+
+// MinTLSVersion returns the minimum TLS version for the
+// TLS security profile defined in the APIServerConfig.
+func MinTLSVersion(profile configv1.TLSProfileSpec) string {
+	if profile.MinTLSVersion == "" {
+		return string(DefaultMinTLSVersion)
+	}
+	return string(profile.MinTLSVersion)
+}
+
+// getTLSProfileSpec returns TLSProfileSpec to be used for generating OPENSSL_CONF
+func getTLSProfileSpec(apiServerTLSProfile *configv1.TLSSecurityProfile) configv1.TLSProfileSpec {
+	defaultProfile := *configv1.TLSProfiles[DefaultTLSProfileType]
+	if apiServerTLSProfile == nil || apiServerTLSProfile.Type == "" {
+		return defaultProfile
+	}
+	profileType := apiServerTLSProfile.Type
+
+	if profileType != configv1.TLSProfileCustomType {
+		if tlsConfig, ok := configv1.TLSProfiles[profileType]; ok {
+			return *tlsConfig
+		}
+		return defaultProfile
+	}
+
+	if apiServerTLSProfile.Custom != nil {
+		return apiServerTLSProfile.Custom.TLSProfileSpec
+	}
+
+	return defaultProfile
+}

--- a/internal/tls/tls_test.go
+++ b/internal/tls/tls_test.go
@@ -1,0 +1,108 @@
+package tls
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-logging-operator/test/matchers"
+)
+
+const (
+	TLSProfileModern = `
+config_diagnostics = 1
+
+openssl_conf = default_conf_section
+
+[default_conf_section]
+ssl_conf = ssl_section
+
+[ssl_section]
+system_default = system_default_section
+
+[system_default_section]
+MinProtocol = TLSv1.3
+CipherSuites = TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256
+`
+	TLSProfileIntermediate = `
+config_diagnostics = 1
+
+openssl_conf = default_conf_section
+
+[default_conf_section]
+ssl_conf = ssl_section
+
+[ssl_section]
+system_default = system_default_section
+
+[system_default_section]
+MinProtocol = TLSv1.2
+CipherSuites = TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256, ECDHE-ECDSA-AES128-GCM-SHA256, ECDHE-RSA-AES128-GCM-SHA256, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES256-GCM-SHA384, ECDHE-ECDSA-CHACHA20-POLY1305, ECDHE-RSA-CHACHA20-POLY1305, DHE-RSA-AES128-GCM-SHA256, DHE-RSA-AES256-GCM-SHA384
+`
+	TLSProfileOldCompatibility = `
+config_diagnostics = 1
+
+openssl_conf = default_conf_section
+
+[default_conf_section]
+ssl_conf = ssl_section
+
+[ssl_section]
+system_default = system_default_section
+
+[system_default_section]
+MinProtocol = TLSv1.0
+CipherSuites = TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256, ECDHE-ECDSA-AES128-GCM-SHA256, ECDHE-RSA-AES128-GCM-SHA256, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES256-GCM-SHA384, ECDHE-ECDSA-CHACHA20-POLY1305, ECDHE-RSA-CHACHA20-POLY1305, DHE-RSA-AES128-GCM-SHA256, DHE-RSA-AES256-GCM-SHA384, DHE-RSA-CHACHA20-POLY1305, ECDHE-ECDSA-AES128-SHA256, ECDHE-RSA-AES128-SHA256, ECDHE-ECDSA-AES128-SHA, ECDHE-RSA-AES128-SHA, ECDHE-ECDSA-AES256-SHA384, ECDHE-RSA-AES256-SHA384, ECDHE-ECDSA-AES256-SHA, ECDHE-RSA-AES256-SHA, DHE-RSA-AES128-SHA256, DHE-RSA-AES256-SHA256, AES128-GCM-SHA256, AES256-GCM-SHA384, AES128-SHA256, AES256-SHA256, AES128-SHA, AES256-SHA, DES-CBC3-SHA
+`
+)
+
+var _ = Describe("Based on tlsSecurityProfile", func() {
+	Context("should generate OPENSSL_CONF for", func() {
+		It("Modern profile", func() {
+			c, err := opensslConf(*configv1.TLSProfiles[configv1.TLSProfileModernType])
+			Expect(err).To(BeNil())
+			Expect(strings.TrimSpace(c)).To(matchers.EqualTrimLines(TLSProfileModern))
+		})
+		It("Intermediate profile", func() {
+			c, err := opensslConf(*configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
+			Expect(err).To(BeNil())
+			Expect(strings.TrimSpace(c)).To(matchers.EqualTrimLines(TLSProfileIntermediate))
+		})
+		It("Old profile", func() {
+			c, err := opensslConf(*configv1.TLSProfiles[configv1.TLSProfileOldType])
+			Expect(err).To(BeNil())
+			Expect(strings.TrimSpace(c)).To(matchers.EqualTrimLines(TLSProfileOldCompatibility))
+		})
+		It("Custom profile", func() {
+			customProfile := `
+config_diagnostics = 1
+
+openssl_conf = default_conf_section
+
+[default_conf_section]
+ssl_conf = ssl_section
+
+[ssl_section]
+system_default = system_default_section
+
+[system_default_section]
+MinProtocol = TLSv1.2
+CipherSuites = TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384
+`
+			customTLSSpec := configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers:       []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+			}
+			c, err := opensslConf(customTLSSpec)
+			Expect(err).To(BeNil())
+			Expect(strings.TrimSpace(c)).To(matchers.EqualTrimLines(customProfile))
+		})
+	})
+})
+
+func TestTLSSecurityProfile(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TLS Security Profile")
+}


### PR DESCRIPTION
### Description
This PR enables cluster-logging-operator to pull `.spec.tlsSecurityProfile` of `APIServer` resource in `config.openshift.io/v1`, and generate TLSProfile for the collector. 
The TLSProfile is added to  a file `openssl.cnf`,a nd the path is added to environment variable `OPENSSL_CONF`.

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- Github issue: https://issues.redhat.com/browse/LOG-3002
