### PR TITLE
LOG-3119: Update max OCP to 4.12

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.11
+    value: 4.12


### PR DESCRIPTION
### Description
* updates maxOpenShiftVersion to 4.12

### Links
https://issues.redhat.com/browse/LOG-3119
