### PR TITLE
LOG-3123: fix OCP max version

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.11
+    value: 4.12


### PR DESCRIPTION
This PR:
Updates the max supported OCP version to 4.12

https://issues.redhat.com/browse/LOG-3123