### PR TITLE
LOG-3093: Healthcheck fails for vector cloudwatch forwarding

### DIFF
--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -61,6 +61,7 @@ stream_name = "{{"{{ stream_name }}"}}"
 {{compose_one .SecurityConfig}}
 encoding.codec = "json"
 request.concurrency = 2
+healthcheck.enabled = false
 {{compose_one .EndpointConfig}}
 {{- end}}
 `

--- a/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
@@ -50,6 +50,7 @@ auth.access_key_id = "` + keyId + `"
 auth.secret_access_key = "` + keySecret + `"
 encoding.codec = "json"
 request.concurrency = 2
+healthcheck.enabled = false
 `
 	cwSinkRole = `
 # Cloudwatch Logs
@@ -63,6 +64,7 @@ stream_name = "{{ stream_name }}"
 # role_arn and identity token set via env vars
 encoding.codec = "json"
 request.concurrency = 2
+healthcheck.enabled = false
 `
 )
 


### PR DESCRIPTION
### Description
When the vector collector pods start, there are healthchecks that run for every sink, including Cloudwatch.  The healthcheck for cw fails due to a validation error: Value '{{ group_name }}' at 'logGroupNamePrefix'  must satisfy regular expression pattern: [\.\-_/#A-Za-z0-9]

Since we use template syntax for this field, the healthcheck will always fail because it is run before any events actually flow through Vector.   We are disabling healthcheck for this sink

/cc @vimalk78 @jcantrill 

### Links
- https://issues.redhat.com/browse/LOG-3093
