### PR TITLE
LOG-3122: Use correct env variable for vector logging

### DIFF
--- a/internal/collector/vector/visitors.go
+++ b/internal/collector/vector/visitors.go
@@ -16,7 +16,7 @@ const (
 
 func CollectorVisitor(collectorContainer *corev1.Container, podSpec *corev1.PodSpec) {
 	collectorContainer.Env = append(collectorContainer.Env,
-		corev1.EnvVar{Name: "LOG", Value: "info"},
+		corev1.EnvVar{Name: "VECTOR_LOG", Value: "info"},
 		corev1.EnvVar{
 			Name: "VECTOR_SELF_NODE_NAME",
 			ValueFrom: &corev1.EnvVarSource{

--- a/test/framework/functional/vector/deploy.go
+++ b/test/framework/functional/vector/deploy.go
@@ -1,13 +1,14 @@
 package vector
 
 import (
+	"strings"
+
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/test/client"
 	. "github.com/openshift/cluster-logging-operator/test/framework/functional/common"
-	"strings"
 )
 
 const entrypointScript = `#!/bin/bash
@@ -38,7 +39,7 @@ func (c *VectorCollector) DeployConfigMapForConfig(name, config, clfYaml string)
 }
 
 func (c *VectorCollector) BuildCollectorContainer(b *runtime.ContainerBuilder, nodeName string) *runtime.ContainerBuilder {
-	return b.AddEnvVar("LOG", AdaptLogLevel()).
+	return b.AddEnvVar("VECTOR_LOG", AdaptLogLevel()).
 		AddEnvVarFromFieldRef("POD_IP", "status.podIP").
 		AddEnvVar("NODE_NAME", nodeName).
 		AddEnvVarFromFieldRef("VECTOR_SELF_NODE_NAME", "spec.nodeName").


### PR DESCRIPTION
### Description
vector uses `VECTOR_LOG` as the env variable to control logging. The env variable used in CLO now, `LOG` is deprecated.


/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA:  https://issues.redhat.com/browse/LOG-3122

