### PR TITLE
LOG-3141: Only call cleanup and must-gather upon test failure

### DIFF
--- a/test/e2e/logforwarding/fluent/fluent_secure_test.go
+++ b/test/e2e/logforwarding/fluent/fluent_secure_test.go
@@ -12,7 +12,7 @@ import (
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test"
 	"github.com/openshift/cluster-logging-operator/test/client"
-	"github.com/openshift/cluster-logging-operator/test/framework/e2e"
+	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
 	"github.com/openshift/cluster-logging-operator/test/helpers/certificate"
 	"github.com/openshift/cluster-logging-operator/test/helpers/fluentd"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
@@ -29,9 +29,11 @@ var _ = Describe("[ClusterLogForwarder]", func() {
 		privateCA, serverCert, clientCert *certificate.CertKey
 		sharedKey                         string
 		portOffset                        int
+		e2e                               *framework.E2ETestFramework
 	)
 
 	BeforeEach(func() {
+		e2e = framework.NewE2ETestFramework()
 		c = client.NewTest()
 		f = NewFixture(c.NS.Name, secureMessage)
 
@@ -89,7 +91,7 @@ var _ = Describe("[ClusterLogForwarder]", func() {
 
 	AfterEach(func() {
 		c.Close()
-		e2e.RunCleanupScript()
+		e2e.Cleanup()
 	})
 
 	It("connects to secure destinations", func() {

--- a/test/e2e/logforwarding/fluent/fluent_test.go
+++ b/test/e2e/logforwarding/fluent/fluent_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test/client"
-	"github.com/openshift/cluster-logging-operator/test/framework/e2e"
+	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
 	"github.com/openshift/cluster-logging-operator/test/helpers/fluentd"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
@@ -23,11 +23,16 @@ var _ = Describe("[ClusterLogForwarder]", func() {
 		f          *Fixture
 		portOffset int
 		logTypes   = loggingv1.ReservedInputNames.UnsortedList()
+		e2e        *framework.E2ETestFramework
 	)
-	BeforeEach(func() { c = client.NewTest(); f = NewFixture(c.NS.Name, message) })
+	BeforeEach(func() {
+		c = client.NewTest()
+		f = NewFixture(c.NS.Name, message)
+		e2e = framework.NewE2ETestFramework()
+	})
 	AfterEach(func() {
 		c.Close()
-		e2e.RunCleanupScript()
+		e2e.Cleanup()
 	})
 
 	Context("with app/infra/audit receiver", func() {

--- a/test/e2e/logforwarding/loki/forward_to_loki_test.go
+++ b/test/e2e/logforwarding/loki/forward_to_loki_test.go
@@ -95,7 +95,7 @@ func TestLogForwardingToLokiWithVector(t *testing.T) {
 
 func testLogForwardingToLoki(t *testing.T, cl *loggingv1.ClusterLogging, clf *loggingv1.ClusterLogForwarder) {
 	c := client.ForTest(t)
-	defer e2e.RunCleanupScript()
+	defer e2e.NewE2ETestFramework().Cleanup()
 	rcv := loki.NewReceiver(c.NS.Name, "loki-receiver")
 	gen := runtime.NewLogGenerator(c.NS.Name, rcv.Name, 100, 0, "I am Loki, of Asgard, and I am burdened with glorious purpose.")
 	clf.Spec.Outputs[0].URL = rcv.InternalURL("").String()


### PR DESCRIPTION
### Description
 This PR:
* modifies several e2e scripts to only call cleanup/must-gather upon test failure

### Links
* https://issues.redhat.com/browse/LOG-3141

cc @vparfonov  you have an open PR for splunk which needs to ensure the same. 