### PR TITLE
Upgrate to vector v0.23-rh, align use of tls.enabled with that version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export LOGGING_VERSION?=5.6
 export NAMESPACE?=openshift-logging
 
 IMAGE_LOGGING_FLUENTD?=quay.io/openshift-logging/fluentd:1.14.6
-IMAGE_LOGGING_VECTOR?=quay.io/openshift-logging/vector:0.21-rh
+IMAGE_LOGGING_VECTOR?=quay.io/openshift-logging/vector:0.23-rh
 IMAGE_LOGFILEMETRICEXPORTER?=quay.io/openshift-logging/log-file-metric-exporter:1.1
 # Note: use logging-view-plugin:latest to pick up improvements in the console automatically.
 # Unlike the other components, console changes do not risk breaking the collector,

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -834,7 +834,6 @@ request.timeout_secs = 2147483648
 id_key = "_id"
 
 [sinks.es_1.tls]
-enabled = true
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
@@ -917,7 +916,6 @@ request.timeout_secs = 2147483648
 id_key = "_id"
 
 [sinks.es_2.tls]
-enabled = true
 key_file = "/var/run/ocp-collector/secrets/es-2/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-2/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/es-2/ca-bundle.crt"

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -232,7 +232,6 @@ request.timeout_secs = 2147483648
 id_key = "_id"
 
 [sinks.es_1.tls]
-enabled = true
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
@@ -462,7 +461,6 @@ request.timeout_secs = 2147483648
 id_key = "_id"
 
 [sinks.es_1.tls]
-enabled = true
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
@@ -545,7 +543,6 @@ request.timeout_secs = 2147483648
 id_key = "_id"
 
 [sinks.es_2.tls]
-enabled = true
 key_file = "/var/run/ocp-collector/secrets/es-2/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-2/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/es-2/ca-bundle.crt"

--- a/internal/generator/vector/output/kafka/kafka.go
+++ b/internal/generator/vector/output/kafka/kafka.go
@@ -146,6 +146,7 @@ func TLSConf(o logging.OutputSpec, secret *corev1.Secret) []Element {
 			ComponentID: componentID,
 			// Kafka does not use the verify_certificate or verify_hostname options, see insecureTLS
 			InsecureSkipVerify: false,
+			NeedsEnabled: true,
 		})
 
 		if security.HasPassphrase(secret) {

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -251,7 +251,7 @@ var _ = Describe("Generate vector config for in cluster loki", func() {
 					{
 						Type: logging.OutputTypeLoki,
 						Name: "loki-receiver",
-						URL:  "http://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application",
+						URL:  "https://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application",
 					},
 				},
 			},
@@ -266,7 +266,7 @@ var _ = Describe("Generate vector config for in cluster loki", func() {
 [sinks.loki_receiver]
 type = "loki"
 inputs = ["application"]
-endpoint = "http://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application"
+endpoint = "https://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application"
 out_of_order_action = "accept"
 healthcheck.enabled = false
 
@@ -281,7 +281,6 @@ kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
 
 [sinks.loki_receiver.tls]
-enabled = true
 ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 # Bearer Auth Config
 [sinks.loki_receiver.auth]

--- a/internal/generator/vector/output/security/security.go
+++ b/internal/generator/vector/output/security/security.go
@@ -39,6 +39,7 @@ type BearerToken struct {
 type TLSConf struct {
 	ComponentID        string
 	InsecureSkipVerify bool
+	NeedsEnabled       bool
 }
 
 func (t TLSConf) Name() string {
@@ -49,7 +50,9 @@ func (t TLSConf) Template() string {
 	return `
 {{define "vectorTLS" -}}
 [sinks.{{.ComponentID}}.tls]
+{{- if .NeedsEnabled }}
 enabled = true
+{{- end }}
 {{- if .InsecureSkipVerify }}
 verify_certificate = false
 verify_hostname = false


### PR DESCRIPTION
### Description

Upgrate to vector v0.23-rh, align use of tls.enabled with that version.
In Vector 0.23, the only two components we care about that require tls.enable are the kafka and prometheus_exporter sinks.

/cc @vimalk78 
/assign @jcantrill 
