### PR TITLE
LOG-3055: Detect correct prometheus bind address

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -187,6 +187,7 @@ func (f *Factory) NewCollectorContainer(secretNames []string, clusterID string) 
 		{Name: "NODE_IPV4", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.hostIP"}}},
 		{Name: "OPENSHIFT_CLUSTER_ID", Value: clusterID},
 		{Name: "POD_IP", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"}}},
+		{Name: "POD_IPS", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIPs"}}},
 	}
 	collector.Env = append(collector.Env, utils.GetProxyEnvVars()...)
 

--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
@@ -929,7 +929,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
@@ -1643,7 +1643,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
@@ -2302,7 +2302,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
@@ -2659,7 +2659,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
@@ -3761,7 +3761,7 @@ inputs:
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key

--- a/internal/generator/fluentd/prometheus.go
+++ b/internal/generator/fluentd/prometheus.go
@@ -9,7 +9,7 @@ const PrometheusMonitorTemplate = `
 # {{.Desc}}
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key

--- a/internal/generator/fluentd/sources_test.go
+++ b/internal/generator/fluentd/sources_test.go
@@ -472,7 +472,7 @@ var _ = Describe("Testing Config Generation", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -2,13 +2,14 @@ package functional
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/openshift/cluster-logging-operator/internal/certificates"
 	"github.com/openshift/cluster-logging-operator/internal/pkg/generator/forwarder"
@@ -262,6 +263,7 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 	b = f.collector.BuildCollectorContainer(
 		b.AddContainer(constants.CollectorName, f.image).
 			AddEnvVar("OPENSHIFT_CLUSTER_ID", f.Name).
+			AddEnvVarFromFieldRef("POD_IPS", "status.podIPs").
 			WithImagePullPolicy(corev1.PullAlways).ResourceRequirements(resources), FunctionalNodeName).End()
 
 	for _, visit := range visitors {


### PR DESCRIPTION
### Description
Updated fluentd `run.sh` to add logic to detect correct prometheus bind address

When the cluster is dual stack, the collector pod will have an ipv4 address and an ipv6 address. Downward API will add a `status.podIPs` field in the pod, use these array of values. If one of the IPs is an ipv6 address, use `[::]` as the bind address, if no IP is an ipv6 address and all ips are ipv4, use `0.0.0.0` as the bind address.

sample logs from dual stack cluster
```
POD_IPS: 10.131.0.34,fd01:0:0:4::22, PROM_BIND_IP: [::]
```
sample logs from ipv4 only cluster
```
POD_IPS: 10.217.0.220, PROM_BIND_IP: 0.0.0.0
```

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-3055

