### PR TITLE
LOG-3049: Do not use global variable when updating CR status

### DIFF
--- a/internal/k8shandler/clusterloggingrequest.go
+++ b/internal/k8shandler/clusterloggingrequest.go
@@ -55,7 +55,7 @@ func (clusterRequest *ClusterLoggingRequest) Update(object client.Object) (err e
 	return err
 }
 
-//Update the runtime Object status or return error
+// UpdateStatus modifies the status sub-resource or returns an error.
 func (clusterRequest *ClusterLoggingRequest) UpdateStatus(object client.Object) (err error) {
 	if err = clusterRequest.Client.Status().Update(context.TODO(), object); err != nil {
 		// making this debug because we should be throwing the returned error if we are never
@@ -102,8 +102,13 @@ func (clusterRequest *ClusterLoggingRequest) Delete(object client.Object) error 
 }
 
 func (clusterRequest *ClusterLoggingRequest) UpdateCondition(t logging.ConditionType, message string, reason logging.ConditionReason, status v1.ConditionStatus) error {
-	if logging.SetCondition(&clusterRequest.Cluster.Status.Conditions, t, status, reason, message) {
-		return clusterRequest.UpdateStatus(clusterRequest.Cluster)
+	instance, err := clusterRequest.getClusterLogging(true)
+	if err != nil {
+		return err
+	}
+
+	if logging.SetCondition(&instance.Status.Conditions, t, status, reason, message) {
+		return clusterRequest.UpdateStatus(instance)
 	}
 	return nil
 }

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -497,18 +497,20 @@ func (clusterRequest *ClusterLoggingRequest) UpdateCollectorStatus(collectorType
 }
 
 func (clusterRequest *ClusterLoggingRequest) UpdateFluentdStatus() (err error) {
-
-	cluster := clusterRequest.Cluster
-
 	fluentdStatus, err := clusterRequest.getFluentdCollectorStatus()
 	if err != nil {
 		return fmt.Errorf("Failed to get status of the collector: %v", err)
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if !compareFluentdCollectorStatus(fluentdStatus, cluster.Status.Collection.Logs.FluentdStatus) {
-			cluster.Status.Collection.Logs.FluentdStatus = fluentdStatus
-			return clusterRequest.UpdateStatus(cluster)
+		instance, err := clusterRequest.getClusterLogging(true)
+		if err != nil {
+			return err
+		}
+
+		if !compareFluentdCollectorStatus(fluentdStatus, instance.Status.Collection.Logs.FluentdStatus) {
+			instance.Status.Collection.Logs.FluentdStatus = fluentdStatus
+			return clusterRequest.UpdateStatus(instance)
 		}
 		return nil
 	})

--- a/internal/k8shandler/logstore.go
+++ b/internal/k8shandler/logstore.go
@@ -58,9 +58,14 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateElasticSearchLogStore
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if !compareElasticsearchStatus(elasticsearchStatus, cluster.Status.LogStore.ElasticsearchStatus) {
-			cluster.Status.LogStore.ElasticsearchStatus = elasticsearchStatus
-			return clusterRequest.UpdateStatus(cluster)
+		instance, err := clusterRequest.getClusterLogging(true)
+		if err != nil {
+			return err
+		}
+
+		if !compareElasticsearchStatus(elasticsearchStatus, instance.Status.LogStore.ElasticsearchStatus) {
+			instance.Status.LogStore.ElasticsearchStatus = elasticsearchStatus
+			return clusterRequest.UpdateStatus(instance)
 		}
 		return nil
 	})

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -30,7 +30,7 @@ func Reconcile(requestClient client.Client, reader client.Reader, r record.Event
 		EventRecorder: r,
 	}
 
-	if instance, err = clusterLoggingRequest.getClusterLogging(); err != nil {
+	if instance, err = clusterLoggingRequest.getClusterLogging(false); err != nil {
 		return nil, err
 	}
 	clusterLoggingRequest.Cluster = instance
@@ -164,7 +164,7 @@ func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, req
 	}
 
 	var clusterLogging *logging.ClusterLogging
-	if clusterLogging, err = clusterLoggingRequest.getClusterLogging(); err != nil {
+	if clusterLogging, err = clusterLoggingRequest.getClusterLogging(false); err != nil {
 		return err
 	}
 	if clusterLogging == nil {
@@ -213,7 +213,7 @@ func ReconcileForTrustedCABundle(requestName string, requestClient client.Client
 	}
 
 	var clusterLogging *logging.ClusterLogging
-	if clusterLogging, err = clusterLoggingRequest.getClusterLogging(); err != nil {
+	if clusterLogging, err = clusterLoggingRequest.getClusterLogging(false); err != nil {
 		return err
 	}
 	clusterLoggingRequest.Cluster = clusterLogging
@@ -234,19 +234,22 @@ func ReconcileForTrustedCABundle(requestName string, requestClient client.Client
 	return clusterLoggingRequest.RestartCollector()
 }
 
-func (clusterRequest *ClusterLoggingRequest) getClusterLogging() (*logging.ClusterLogging, error) {
+func (clusterRequest *ClusterLoggingRequest) getClusterLogging(skipMigrations bool) (*logging.ClusterLogging, error) {
 	clusterLoggingNamespacedName := types.NamespacedName{Name: constants.SingletonName, Namespace: constants.OpenshiftNS}
 	clusterLogging := &logging.ClusterLogging{}
 
 	if err := clusterRequest.Client.Get(context.TODO(), clusterLoggingNamespacedName, clusterLogging); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Error(err, "Encountered unexpected error getting", "NamespacedName", clusterLoggingNamespacedName)
-			return nil, err
-		}
-		return nil, nil
+		return nil, err
 	}
 
-	//TODO Drop migration upon introduction of v2
+	// Do not modify cached copy
+	clusterLogging = clusterLogging.DeepCopy()
+
+	if skipMigrations {
+		return clusterLogging, nil
+	}
+
+	// TODO Drop migration upon introduction of v2
 	clusterLogging.Spec = migrations.MigrateCollectionSpec(clusterLogging.Spec)
 
 	return clusterLogging, nil

--- a/internal/k8shandler/visualization.go
+++ b/internal/k8shandler/visualization.go
@@ -118,9 +118,14 @@ func (clusterRequest *ClusterLoggingRequest) UpdateKibanaStatus() (err error) {
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if !compareKibanaStatus(kibanaStatus, clusterRequest.Cluster.Status.Visualization.KibanaStatus) {
-			clusterRequest.Cluster.Status.Visualization.KibanaStatus = kibanaStatus
-			return clusterRequest.UpdateStatus(clusterRequest.Cluster)
+		instance, err := clusterRequest.getClusterLogging(true)
+		if err != nil {
+			return err
+		}
+
+		if !compareKibanaStatus(kibanaStatus, instance.Status.Visualization.KibanaStatus) {
+			instance.Status.Visualization.KibanaStatus = kibanaStatus
+			return clusterRequest.UpdateStatus(instance)
 		}
 		return nil
 	})


### PR DESCRIPTION
### Description

The `ClusterLoggingRequest` struct contains a `cluster` variable that is used as a "cache" for the current ClusterLogging CR that is reconciled. The variable is meant to be written only once during the start of reconciliation and only with a result from the `getClusterLogging` function, so that migrations are correctly applied. These migrations are currently only applied in-memory inside the CLO and never written back to the apiserver.

The `Update` and `UpdateStatus` functions write the updated resource back into the variable passed to them, which causes a resource without applied migrations to be in the variable after the call happened.

This PR changes the code for updating status information on the ClusterLogging CR to use an modified copy of the CR and not write the result back into the "global variable".

### Links

- JIRA: [LOG-3049](https://issues.redhat.com//browse/LOG-3049)
