### PR TITLE
LOG-3159: must-gather based upon whats deployed

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,43 +1,71 @@
 #!/bin/bash
-BASE_COLLECTION_PATH="${1:-/must-gather}"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASE_COLLECTION_PATH="${1:-./_artifacts}"
 mkdir -p "${BASE_COLLECTION_PATH}"
 
-# resource list
-resources=(ns/openshift-operator-lifecycle-manager)
-
-# cluster logging operator namespace
-resources+=(ns/openshift-logging)
-
-# elasticsearch operator namespace
-resources+=(ns/openshift-operators-redhat)
+LOGGING_NS="${2:-openshift-logging}"
 
 # cluster-scoped resources
-resources+=(nodes)
-resources+=(pods)
+cluster_resources=(ns/openshift-operator-lifecycle-manager)
+
+# cluster logging operator namespace
+cluster_resources+=(ns/$LOGGING_NS)
+
+# elasticsearch operator namespace
+cluster_resources+=(ns/openshift-operators-redhat)
+
+# cluster-scoped resources
+cluster_resources+=(nodes)
+cluster_resources+=(clusterroles)
+cluster_resources+=(clusterrolebindings)
+cluster_resources+=(persistentvolumes)
+
+for cr in "${cluster_resources[@]}" ; do
+  oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" "${cr}" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+done
+
+# namespace-scoped resources
+resources=(pods)
 resources+=(roles)
 resources+=(rolebindings)
-resources+=(clusterroles)
-resources+=(clusterrolebindings)
 resources+=(configmaps)
 resources+=(serviceaccounts)
 resources+=(events)
-resources+=(persistentvolumes)
 
 # run the collection of resources using must-gather
-for resource in ${resources[@]}; do
-  oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" --all-namespaces "${resource}" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+for ns in "${LOGGING_NS}" openshift-operator-lifecycle-manager openshift-operators-redhat ; do
+  for resource in "${resources[@]}" ; do
+    oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" -n "$ns" "${resource}" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  done
 done
 
-{
-    # Call operator and installation gather scripts
-    ./gather_cluster_logging_operator_resources "$BASE_COLLECTION_PATH"
-    ./gather_elasticsearch_operator_resources "$BASE_COLLECTION_PATH"
-    ./gather_install_resources "$BASE_COLLECTION_PATH"
+eo_found="$(oc -n openshift-operators-redhat get deployment elasticsearch-operator --ignore-not-found --no-headers)"
+clo_found="$(oc -n "$LOGGING_NS" get deployment cluster-logging-operator --ignore-not-found --no-headers)"
+if [ "$clo_found" != "" ] || [ "$eo_found" != "" ] ; then
+    ${SCRIPT_DIR}/gather_install_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+else
+  echo "Skipping install inspection.  No CLO or EO deployment found" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+fi
 
-    # Call per component gather scripts
-    ./gather_collection_resources "$BASE_COLLECTION_PATH"
-    ./gather_logstore_resources "$BASE_COLLECTION_PATH"
-    ./gather_visualization_resources "$BASE_COLLECTION_PATH"
-} >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+if [ "$clo_found" != "" ] ; then
+  ${SCRIPT_DIR}/gather_cluster_logging_operator_resources "$BASE_COLLECTION_PATH" "$LOGGING_NS" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  ${SCRIPT_DIR}/gather_collection_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+else
+  echo "Skipping collection inspection.  No CLO found" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+fi
+
+found="$(oc -n $LOGGING_NS get elasticsearch elasticsearch --ignore-not-found --no-headers)"
+if [ "$found" != "" ] ; then
+  # Call per component gather scripts
+  ${SCRIPT_DIR}/gather_elasticsearch_operator_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  ${SCRIPT_DIR}/gather_logstore_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+
+  found="$(oc -n $LOGGING_NS get kibana kibana --ignore-not-found --no-headers)"
+  if [ "$found" != "" ] ; then
+    ${SCRIPT_DIR}/gather_visualization_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  fi
+else
+  echo "Skipping logstorage inspection.  No Elasticsearch deployment found" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+fi
 
 exit 0

--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -1,16 +1,15 @@
 #!/bin/bash
-
-source ./common
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/common
 
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
+NAMESPACE=${2:-openshift-logging}
 
 # Use PWD as base path if no argument is passed
 if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
 fi
-
-NAMESPACE=openshift-logging
 
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 clo_folder="$CLO_COLLECTION_PATH/clo"
@@ -26,20 +25,31 @@ done
 
 oc -n $NAMESPACE get deployment cluster-logging-operator -o yaml > $clo_folder/deployment
 
-csv_name="$(oc -n $NAMESPACE get csv -o name | grep 'clusterlogging')"
-oc -n $NAMESPACE get "${csv_name}" -o yaml > "${clo_folder}/csv"
-oc -n $NAMESPACE get clusterlogging instance -o yaml > "${clo_folder}/cr"
-oc -n $NAMESPACE get clusterlogforwarder instance -o yaml > "${clo_folder}/clusterlogforwarder_cr"
+for csv in $(oc -n $NAMESPACE get csv -o name) ; do
+  oc -n $NAMESPACE get "${csv}" -o yaml > "${clo_folder}/${csv}.yaml"
+done
 
-oc -n $NAMESPACE get configmaps -o yaml > ${clo_folder}/configmaps.yaml 2>&1
+for r in "clusterlogging" "clusterlogforwarder" ; do
+  data="$(oc -n $NAMESPACE get $r --ignore-not-found -o yaml)"
+  if [ "$data" != "" ] ; then
+    echo "${data}" > "${clo_folder}/$r_instance.yaml"
+  fi
+done
+
 oc -n $NAMESPACE get secrets -o yaml > ${clo_folder}/secrets.yaml 2>&1
-oc -n $NAMESPACE get secret collector-config -o jsonpath='{.data.vector\.toml}' | base64 -d > ${clo_folder}/vector.toml 2>&1
-oc -n $NAMESPACE get cronjobs -o yaml > ${clo_folder}/cronjobs.yaml 2>&1
+
+data=$(oc -n $NAMESPACE get secret collector-config -o jsonpath='{.data.vector\.toml}' --ignore-not-found)
+if [ "$data" != "" ] ; then
+  echo $data | base64 -d > ${clo_folder}/vector.toml 2>&1
+fi
+
 oc -n $NAMESPACE get deployments -o wide > ${clo_folder}/deployments.txt 2>&1
 oc -n $NAMESPACE get ds -o wide > ${clo_folder}/daemonsets.txt 2>&1
-oc -n $NAMESPACE get pods -o wide > ${clo_folder}/pods.txt 2>&1
-oc -n $NAMESPACE extract secret/elasticsearch --to=${clo_folder}
-oc -n $NAMESPACE extract configmap/collector --to=${clo_folder}
-oc -n $NAMESPACE get events -o yaml > ${clo_folder}/$NAMESPACE-events.yaml 2>&1
 oc -n $NAMESPACE get "${csv_name}" -o jsonpath='{.spec.displayName}{"\n"}{.spec.version}' > "${clo_folder}/version"
 
+for r in "secret/elasticsearch" "configmap/collector" ; do
+  result="$(oc -n $NAMESPACE get $r --ignore-not-found)"
+  if [ "$result" != "" ] ; then
+    oc -n $NAMESPACE extract $r --to=${clo_folder}
+  fi
+done

--- a/must-gather/collection-scripts/gather_collection_resources
+++ b/must-gather/collection-scripts/gather_collection_resources
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-source ./common
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/common
 
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
@@ -10,7 +10,7 @@ if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
 fi
 
-NAMESPACE=openshift-logging
+NAMESPACE=${2:-openshift-logging}
 
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 collector_folder="$CLO_COLLECTION_PATH/collector"
@@ -19,61 +19,60 @@ check_collector_connectivity() {
   local pod=$1
   echo "--Connectivity between $pod and elasticsearch" >> $collector_folder/$pod
 
-  es_host=$(oc -n $NAMESPACE  get pod $pod  -o jsonpath='{.spec.containers[0].env[?(@.name=="ES_HOST")].value}')
-  es_port=$(oc -n $NAMESPACE  get pod $pod  -o jsonpath='{.spec.containers[0].env[?(@.name=="ES_PORT")].value}')
+  local es_host=$(oc -n $NAMESPACE  get pod $pod  -o jsonpath='{.spec.containers[0].env[?(@.name=="ES_HOST")].value}')
+  local es_port=$(oc -n $NAMESPACE  get pod $pod  -o jsonpath='{.spec.containers[0].env[?(@.name=="ES_PORT")].value}')
 
-  collector=fluent
-  for container in "fluentd" "collector"; do
-    echo "  with ca" >> $collector_folder/$pod
-    oc -n $NAMESPACE exec $pod -c $container -- curl -ILvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert --cacert /etc/$collector/keys/ca -XGET https://$es_host:$es_port &>> $collector_folder/$pod
+  local collector=fluent
+  local container=$2
+  echo "  with ca" >> $collector_folder/$pod
+  oc -n $NAMESPACE exec $pod -c $container -- curl -ILvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert --cacert /etc/$collector/keys/ca -XGET https://$es_host:$es_port &>> $collector_folder/$pod
 
-    echo "  without ca" >> $collector_folder/$pod
-    oc -n $NAMESPACE exec $pod -c $container -- curl -ILkvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert -XGET https://$es_host:$es_port &>> $collector_folder/$pod
-  done
+  echo "  without ca" >> $collector_folder/$pod
+  oc -n $NAMESPACE exec $pod -c $container -- curl -ILkvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert -XGET https://$es_host:$es_port &>> $collector_folder/$pod
 }
 
 check_collector_persistence() {
   local pod=$1
   echo "--Persistence stats for pod $pod" >> $collector_folder/$pod
 
-  collector=fluentd
-  fbstoragePath=$(oc -n $NAMESPACE get daemonset $collector -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[?(@.name=="filebufferstorage")].mountPath}')
+  local collector=$2
+  local fbstoragePath=$(oc -n $NAMESPACE get daemonset $collector -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[?(@.name=="filebufferstorage")].mountPath}')
 
   if [ -z "$fbstoragePath" ] ; then
     echo "No filebuffer storage defined" >>  $collector_folder/$pod
   else
-    for collector in "fluentd" "collector"; do
-      oc -n $NAMESPACE exec $pod -c $collector -- df -h $fbstoragePath >> $collector_folder/$pod
-      oc -n $NAMESPACE exec $pod -c $collector -- ls -lr $fbstoragePath >> $collector_folder/$pod
-    done
+    oc -n $NAMESPACE exec $pod -c $container -- df -h $fbstoragePath >> $collector_folder/$pod
+    oc -n $NAMESPACE exec $pod -c $container -- ls -lr $fbstoragePath >> $collector_folder/$pod
   fi
 }
 
 echo "if the collector 'fluentd' or 'collector' is missing thats OK"
 echo "this must gather is trying to cover all cases for name migration"
 for collector in "fluentd" "collector"; do
+  yaml="$(oc -n $NAMESPACE get ds/$collector --ignore-not-found -o yaml)"
+  if [ "$yaml" == "" ] ; then
+    continue
+  fi
+
+  is_fluent=$(echo $yaml|grep fluent)
+
   echo "Gathering data for collection component: $collector"
   mkdir -p $collector_folder
 
-  echo "-- Retrieving configmaps: $collector"
-  mkdir -p $collector_folder/cm/$collector
-  oc -n $NAMESPACE extract configmap/$collector --to=$collector_folder/cm/$collector
-  mkdir -p $collector_folder/cm/syslog
-  oc -n $NAMESPACE extract configmap/syslog --to=$collector_folder/cm/syslog
-
   echo "-- Checking Collector health: $collector"
-  pods="$(oc -n $NAMESPACE get pods -l logging-infra=$collector -o jsonpath='{.items[*].metadata.name}')"
+  pods="$(oc -n $NAMESPACE get pods -l component=collector -o jsonpath='{.items[*].metadata.name}')"
   for pod in $pods
   do
       echo "---- Collector pod: $pod"
       oc -n $NAMESPACE describe pod/$pod > $collector_folder/$pod.describe 2>&1
-      get_env $pod $collector_folder "$NAMESPACE"
-      check_collector_connectivity $pod
-      check_collector_persistence $pod
-      oc -n openshift-logging exec $pod -- ls -l /var/lib/$collector/clo_default_output_es > $collector_folder/$pod.es-buffers.txt
-      oc -n openshift-logging exec $pod -- ls -l /var/lib/$collector/retry_clo_default_output_es > $outdir/$pod.buffers.es-retry.txt
-      echo "$pod" >> $collector_folder/output-buffer-size.txt
-      echo "---------------" >> $collector_folder/output-buffer-size.txt
-      oc -n openshift-logging exec $pod -- bash -c ' du -sh /var/lib/fluentd/*' >> $collector_folder/output-buffer-size.txt
+      if [ "$is_fluent" != "" ] ; then
+        check_collector_connectivity $pod $collector
+        check_collector_persistence $pod $collector
+        oc -n $NAMESPACE exec $pod -c $collector -- ls -l /var/lib/fluentd/default > $collector_folder/$pod.es-buffers.txt
+        oc -n $NAMESPACE exec $pod -c $collector -- ls -l /var/lib/fluentd/retry_default > $collector_folder/$pod.buffers.es-retry.txt
+        echo "$pod" >> $collector_folder/output-buffer-size.txt
+        echo "---------------" >> $collector_folder/output-buffer-size.txt
+        oc -n $NAMESPACE exec $pod -c $collector -- bash -c ' du -sh /var/lib/fluentd/*' >> $collector_folder/output-buffer-size.txt
+      fi
   done
 done

--- a/must-gather/collection-scripts/gather_elasticsearch_operator_resources
+++ b/must-gather/collection-scripts/gather_elasticsearch_operator_resources
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-source ./common
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/common
 
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
@@ -11,6 +11,7 @@ if [ "${BASE_COLLECTION_PATH}" = "" ]; then
 fi
 
 NAMESPACE=openshift-operators-redhat
+LOGGING_NS=${2:-openshift-logging}
 
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 eo_folder="$CLO_COLLECTION_PATH/eo"
@@ -24,14 +25,8 @@ do
     get_env $pod $eo_folder $NAMESPACE "Dockerfile-*operator*"
 done
 
-oc -n $NAMESPACE get deployment elasticsearch-operator -o yaml > $eo_folder/deployment
-
-csv_name="$(oc -n $NAMESPACE get csv -o name | grep 'elasticsearch-operator')"
-oc -n $NAMESPACE get "${csv_name}" -o yaml > "${eo_folder}/csv"
 oc -n openshift-logging exec -c elasticsearch \
-    $(oc -n openshift-logging get pods -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}') \
+    $(oc -n $LOGGING_NS get pods -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}') \
     -- indices > ${eo_folder}/indices.txt
 
-oc -n $NAMESPACE get deployment elasticsearch-operator -o wide > ${eo_folder}/eo-deployment.txt 2>&1
 oc -n $NAMESPACE describe deployment elasticsearch-operator > ${eo_folder}/eo-deployment.describe 2>&1
-oc -n $NAMESPACE logs deployment/elasticsearch-operator -c elasticsearch-operator > ${eo_folder}/elasticsearch-operator.logs 2>&1

--- a/must-gather/collection-scripts/gather_install_resources
+++ b/must-gather/collection-scripts/gather_install_resources
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source ./common
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/common
 
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
@@ -10,7 +11,7 @@ if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
 fi
 
-NAMESPACE="openshift-logging"
+NAMESPACE=${2:-openshift-logging}
 
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 install_folder="$CLO_COLLECTION_PATH/install"
@@ -26,8 +27,3 @@ echo "-- Install Plan"
 oc get -n ${NAMESPACE} installplans.operators.coreos.com -o yaml > "$install_folder/install_plan-clo"
 oc get -n openshift-operators-redhat installplans.operators.coreos.com -o yaml > "$install_folder/install_plan-eo"
 
-echo "-- Catalog Operator logs"
-oc logs -n openshift-operator-lifecycle-manager -l app=catalog-operator > "$install_folder/co_logs"
-
-echo "-- OLM Operator logs"
-oc logs -n openshift-operator-lifecycle-manager -l app=olm-operator > "$install_folder/olmo_logs"

--- a/must-gather/collection-scripts/gather_logstore_resources
+++ b/must-gather/collection-scripts/gather_logstore_resources
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-source ./common
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/common
 
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
@@ -10,37 +10,10 @@ if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
 fi
 
-NAMESPACE=openshift-logging
+NAMESPACE=${2:-openshift-logging}
 
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 es_folder="$CLO_COLLECTION_PATH/es"
-
-get_es_logs() {
-  local pod=$1
-  local logs_folder=$2/logs
-  echo "-- POD $pod Elasticsearch Logs"
-
-  if [ ! -d "$logs_folder" ]
-  then
-    mkdir -p $logs_folder
-  fi
-
-  path=/elasticsearch/persistent/elasticsearch/logs
-  exists=$(oc -n $NAMESPACE exec $pod -c elasticsearch -- ls ${path} 2> /dev/null)
-
-  if [ -z "$exists" ]; then
-    path=/elasticsearch/elasticsearch/logs
-  fi
-
-  exists=$(oc -n $NAMESPACE exec $pod -c elasticsearch -- ls ${path} 2> /dev/null)
-  if [ -z "$exists" ]; then
-    echo "---- Unable to get ES logs from pod $pod"
-  else
-    oc -n $NAMESPACE rsync -c elasticsearch -q $pod:$path $logs_folder 2> /dev/null || echo "---- Unable to get ES logs from pod $pod"
-    mv -f $logs_folder/logs $logs_folder/$pod
-    nice xz $logs_folder/$pod/*
-  fi
-}
 
 list_es_storage() {
   local pod=$1
@@ -69,7 +42,7 @@ get_elasticsearch_status() {
 
   curl_es='curl -s --max-time 20 --key /etc/elasticsearch/secret/admin-key --cert /etc/elasticsearch/secret/admin-cert --cacert /etc/elasticsearch/secret/admin-ca https://localhost:9200'
   local cat_items=(health nodes aliases thread_pool)
-  for cat_item in ${cat_items[@]}
+  for cat_item in "${cat_items[@]}"
   do
     oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/${cat_item}.cat
   done
@@ -89,7 +62,7 @@ get_elasticsearch_status() {
     echo "Gathering additional cluster information Cluster status is $health"
 
     cat_items=(recovery shards pending_tasks)
-    for cat_item in ${cat_items[@]}
+    for cat_item in "${cat_items[@]}"
     do
       oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/${cat_item}.cat
     done
@@ -111,7 +84,6 @@ for pod in $es_pods
 do
     echo "---- Elasticsearch pod: $pod"
     get_env $pod $es_folder "$NAMESPACE"
-    get_es_logs $pod $es_folder
     list_es_storage $pod
 done
 

--- a/must-gather/collection-scripts/gather_visualization_resources
+++ b/must-gather/collection-scripts/gather_visualization_resources
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-source ./common
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source ${SCRIPT_DIR}/common
 
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
@@ -10,7 +10,7 @@ if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
 fi
 
-NAMESPACE="openshift-logging"
+NAMESPACE=${2:-openshift-logging}
 
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 kibana_folder="$CLO_COLLECTION_PATH/kibana"

--- a/test/e2e/collection/cleanup.sh
+++ b/test/e2e/collection/cleanup.sh
@@ -5,11 +5,3 @@ GENERATOR_NS=$2
 runtime=$(date +%s)
 mkdir -p "$artifact_dir/$runtime" ||:
 gather_logging_resources "openshift-logging" "$artifact_dir" "$runtime"
-
-oc -n "$GENERATOR_NS" describe deployment/log-generator  > "$artifact_dir/$runtime/log-generator.describe" ||:
-oc -n "$GENERATOR_NS" logs deployment/log-generator  > "$artifact_dir/$runtime/log-generator.logs" ||:
-oc -n "$GENERATOR_NS" get deployment/log-generator -o yaml > "$artifact_dir/$runtime/log-generator.deployment.yaml" ||:
-RECEIVER=$(oc -n openshift-logging get pods -l component=fluent-receiver -o name||:)
-if [ "$RECEIVER" != "" ] ; then
-  oc -n openshift-logging exec $(echo $RECEIVER| sed 's/pod\///') -- cat /tmp/app-logs > "$artifact_dir/$runtime/fluent-receiver-app-logs" ||:
-fi

--- a/test/e2e/logforwarding/cleanup.sh
+++ b/test/e2e/logforwarding/cleanup.sh
@@ -2,18 +2,25 @@
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../../../hack/testing-olm/utils"
 artifact_dir=$1
 GENERATOR_NS=$2
+LOGGING_NS=${3:-openshift-logging}
 runtime=$(date +%s)
 mkdir -p "$artifact_dir/$runtime" ||:
-gather_logging_resources "openshift-logging" "$artifact_dir" "$runtime"
+gather_logging_resources "$LOGGING_NS" "$artifact_dir" "$runtime"
 
-oc -n "$GENERATOR_NS" describe deployment/log-generator  > "$artifact_dir/$runtime/log-generator.describe" ||:
-oc -n "$GENERATOR_NS" logs deployment/log-generator  > "$artifact_dir/$runtime/log-generator.logs" ||:
-oc -n "$GENERATOR_NS" get deployment/log-generator -o yaml > "$artifact_dir/$runtime/log-generator.deployment.yaml" ||:
-oc -n "$GENERATOR_NS" get pods -o yaml > "$artifact_dir/$runtime/log-generator.pods.yaml" ||:
+if [ "$(oc -n "$GENERATOR_NS" describe deployment/log-generator --ignore-not-found --no-headers)" != "" ] ; then
+  oc -n "$GENERATOR_NS" describe deployment/log-generator  > "$artifact_dir/$runtime/log-generator.describe" ||:
+  oc -n "$GENERATOR_NS" logs deployment/log-generator  > "$artifact_dir/$runtime/log-generator.logs" ||:
+  oc -n "$GENERATOR_NS" get deployment/log-generator -o yaml > "$artifact_dir/$runtime/log-generator.deployment.yaml" ||:
+  oc -n "$GENERATOR_NS" get pods -o yaml > "$artifact_dir/$runtime/log-generator.pods.yaml" ||:
+fi
 
-oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- tail -n 20000 /var/log/infra.log > "$artifact_dir/$runtime/syslog-receiver.log" ||:
-oc -n openshift-logging exec $(oc -n openshift-logging get pods -l component=syslog-receiver -o name| sed 's/pod\///') -- cat /rsyslog/etc/rsyslog.conf > "$artifact_dir/$runtime/syslog-receiver.conf" ||:
-for pod in $(oc -n openshift-logging get pods -llogging-infra=kafka -oname| sed 's/pod\///')
+if [ "$(oc -n $LOGGING_NS get pods -l component=syslog-receiver -o name --ignore-not-found --no-headers)" != "" ] ; then
+  pod_name=$(oc -n $LOGGING_NS get pods -l component=syslog-receiver -o name| sed 's/pod\///')
+  oc -n $LOGGING_NS exec $pod_name -- tail -n 20000 /var/log/infra.log > "$artifact_dir/$runtime/syslog-receiver.log" ||:
+  oc -n $LOGGING_NS exec $pod_name -- cat /rsyslog/etc/rsyslog.conf > "$artifact_dir/$runtime/syslog-receiver.conf" ||:
+fi
+
+for pod in $(oc -n $LOGGING_NS pods -llogging-infra=kafka -oname| sed 's/pod\///')
 do
-    oc -n openshift-logging exec $pod -- tail -n 5000 /shared/consumed.logs > "$artifact_dir/$runtime/$pod.logs" ||:
+    oc -n $LOGGING_NS exec $pod -- tail -n 5000 /shared/consumed.logs > "$artifact_dir/$runtime/$pod.logs" ||:
 done


### PR DESCRIPTION
### Description
This PR:
* modifies must-gather scripts to conditional fetch resources based upon what is deployed
* Removes some fetches based upon resources already being gathered (e.g. pod logs)
* Removes obsolete constructs (e.g. DS/fluentd, containerName: fluentd)

### Links
* https://issues.redhat.com/browse/LOG-3159
