### PR TITLE
[release-5.4] LOG-3063: Detect correct prometheus bind address

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
@@ -920,7 +920,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
@@ -1624,7 +1624,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
@@ -2273,7 +2273,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
@@ -2620,7 +2620,7 @@ var _ = Describe("Generating fluentd config", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"
@@ -3711,7 +3711,7 @@ inputs:
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"

--- a/internal/generator/fluentd/prometheus.go
+++ b/internal/generator/fluentd/prometheus.go
@@ -9,7 +9,7 @@ const PrometheusMonitorTemplate = `
 # {{.Desc}}
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"

--- a/internal/generator/fluentd/sources_test.go
+++ b/internal/generator/fluentd/sources_test.go
@@ -476,7 +476,7 @@ var _ = Describe("Testing Config Generation", func() {
 # Prometheus Monitoring
 <source>
   @type prometheus
-  bind "[::]"
+  bind "#{ENV['PROM_BIND_IP']}"
   <transport tls>
     cert_path "#{ENV['METRICS_CERT'] || '/etc/fluent/metrics/tls.crt'}"
     private_key_path "#{ENV['METRICS_KEY'] || '/etc/fluent/metrics/tls.key'}"

--- a/internal/k8shandler/fluentd.go
+++ b/internal/k8shandler/fluentd.go
@@ -119,6 +119,7 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *v1.Co
 		{Name: "K8S_NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "spec.nodeName"}}},
 		{Name: "NODE_IPV4", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.hostIP"}}},
 		{Name: "POD_IP", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"}}},
+		{Name: "POD_IPS", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIPs"}}},
 		{Name: "RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR", Value: "0.9"},
 	}
 

--- a/internal/k8shandler/vector.go
+++ b/internal/k8shandler/vector.go
@@ -95,6 +95,7 @@ func newVectorPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *corev1
 		{Name: "METRICS_KEY", Value: "/etc/vector/metrics/tls.key"},
 		{Name: "NODE_IPV4", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.hostIP"}}},
 		{Name: "POD_IP", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"}}},
+		{Name: "POD_IPS", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIPs"}}},
 	}
 	proxyEnv := utils.GetProxyEnvVars()
 	vectorContainer.Env = append(vectorContainer.Env, proxyEnv...)

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -2,15 +2,21 @@ package functional
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/certificates"
-	"github.com/openshift/cluster-logging-operator/internal/runtime"
-	testruntime "github.com/openshift/cluster-logging-operator/test/runtime"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/internal/certificates"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	testruntime "github.com/openshift/cluster-logging-operator/test/runtime"
+
+	"github.com/openshift/cluster-logging-operator/internal/certificates"
+	"github.com/openshift/cluster-logging-operator/internal/pkg/generator/forwarder"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	testruntime "github.com/openshift/cluster-logging-operator/test/runtime"
 
 	yaml "sigs.k8s.io/yaml"
 
@@ -223,7 +229,9 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 		AddConfigMapVolume("config", f.Name).
 		AddConfigMapVolume("entrypoint", f.Name).
 		AddConfigMapVolume("certs", certsName)
-	b = f.collector.BuildCollectorContainer(b.AddContainer(constants.CollectorName, f.image), FunctionalNodeName).End()
+	b = f.collector.BuildCollectorContainer(
+		b.AddContainer(constants.CollectorName, f.image).
+			AddEnvVarFromFieldRef("POD_IPS", "status.podIPs"), FunctionalNodeName).End()
 
 	for _, visit := range visitors {
 		if err = visit(b); err != nil {


### PR DESCRIPTION
### Description
the issue [LOG-3163](https://issues.redhat.com//browse/LOG-3163) is a clone of [LOG-3055](https://issues.redhat.com//browse/LOG-3055) for release-5.4
this is a manual cherry pick of https://github.com/openshift/cluster-logging-operator/commit/2d4c12fa2e4c8bd6600403940fc2e25558e76531

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: [LOG-3163](https://issues.redhat.com/browse/LOG-3163)
- Enhancement proposal:
