### PR TITLE
LOG-3112: Temp make clusterid optional until fluentd changes merge

### DIFF
--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -162,7 +162,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 						Timestamp:        time.Time{},
 						PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
 						OpenshiftLabels: types.OpenshiftMeta{
-							ClusterID: "*",
+							ClusterID: "**optional**",
 						},
 					},
 					K8SAuditLevel: "Metadata",
@@ -198,7 +198,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 						Timestamp:        time.Time{},
 						PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
 						OpenshiftLabels: types.OpenshiftMeta{
-							ClusterID: "*",
+							ClusterID: "**optional**",
 						},
 					},
 					OpenshiftAuditLevel: "Metadata",
@@ -238,7 +238,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 					Timestamp:        testTime,
 					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
 					OpenshiftLabels: types.OpenshiftMeta{
-						ClusterID: "*",
+						ClusterID: "**optional**",
 					},
 				}
 				// Write log line as input to fluentd
@@ -269,7 +269,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 					LogType:   "audit",
 					Openshift: types.OpenshiftMeta{
 						Sequence:  types.NewOptionalInt(""),
-						ClusterID: "*",
+						ClusterID: "**optional**",
 					},
 					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
 				}

--- a/test/functional/normalization/eventrouter_test.go
+++ b/test/functional/normalization/eventrouter_test.go
@@ -75,7 +75,9 @@ var _ = Describe("[Functional][Normalization] Fluentd normalization for EventRou
 				Timestamp:        timestamp,
 				LogType:          "application",
 				ViaqMsgID:        "*",
-				OpenshiftLabels:  types.OpenshiftMeta{},
+				OpenshiftLabels: types.OpenshiftMeta{
+					ClusterID: "**optional**",
+				},
 			}
 		}
 	)

--- a/test/functional/normalization/message_format_test.go
+++ b/test/functional/normalization/message_format_test.go
@@ -42,9 +42,6 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 		outputLogTemplate.Timestamp = nanoTime
 		outputLogTemplate.Message = message
 		outputLogTemplate.Level = expLevel
-		if testfw.LogCollectionType == logging.LogCollectionTypeVector {
-			outputLogTemplate.Openshift.ClusterID = "*"
-		}
 
 		applicationLogLine := functional.NewCRIOLogMessage(timestamp, message, false)
 		Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 10)).To(BeNil())
@@ -73,9 +70,6 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 		outputLogTemplate.Timestamp = nanoTime
 		outputLogTemplate.Message = fmt.Sprintf("regex:^%s.*$", message)
 		outputLogTemplate.Level = "*"
-		if testfw.LogCollectionType == logging.LogCollectionTypeVector {
-			outputLogTemplate.Openshift.ClusterID = "*"
-		}
 
 		// Write log line as input to fluentd
 		applicationLogLine := functional.NewCRIOLogMessage(timestamp, message, false)
@@ -102,9 +96,6 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 		outputLogTemplate.Timestamp = nanoTime
 		outputLogTemplate.Message = fmt.Sprintf("regex:^%s.*$", message)
 		outputLogTemplate.Level = "*"
-		if testfw.LogCollectionType == logging.LogCollectionTypeVector {
-			outputLogTemplate.Openshift.ClusterID = "*"
-		}
 
 		// Write log line as input to fluentd
 		applicationLogLine := fmt.Sprintf("%s stdout F %s $n", timestamp, message)


### PR DESCRIPTION
### Description
Make clusterid optional until fluentd changes merge

### Links
* https://issues.redhat.com/browse/LOG-3112