### PR TITLE
Fix issue with waiting on delete CL and CLF instance

### DIFF
--- a/hack/testing-olm/assertions
+++ b/hack/testing-olm/assertions
@@ -25,3 +25,25 @@ assert_resources_does_not_exist(){
 assert_kibana_instance_does_not_exists() {
 	os::cmd::try_until_failure "oc -n $LOGGING_NS get kibana kibana"
 }
+
+# assert_cl_clf_instance_does_not_exist checking is
+# 'oc -n $LOGGING_NS get clusterlogging instance' and 'oc -n $LOGGING_NS get clusterlogforwarder instance'
+# both will failure or or times out (60 sec)
+# Returns:
+#  - 0: success - resources was deleted in given timeout
+#  - 1: if clusterlogging instance still exist after 60 sec
+#  - 2: if clusterlogforwarder instance still exist after 60 sec
+assert_cl_clf_instance_does_not_exist(){
+  local return_code1=os::cmd::try_until_failure "oc -n $LOGGING_NS get clusterlogging instance"
+  local return_code2=os::cmd::try_until_failure "oc -n $LOGGING_NS get clusterlogforwarder instance"
+  ret_code=0
+  if [ ${return_code1} -qt 0 ]; then
+    os::log::warning "waiting for deleting clusterlogging instance"
+    ret_code=${return_code1}
+  fi
+  if [ ${return_code2} -qt 0 ]; then
+    os::log::warning "waiting for deleting clusterlogforwarder instance"
+    ret_code=${return_code2}
+  fi
+  return ${ret_code}
+}

--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 source "$(dirname $0)/../common"
+source "$(dirname $0)/assertions"
 
 mkdir -p /tmp/artifacts/junit
 os::test::junit::declare_suite_start "[ClusterLogging] Log Forwarding"
@@ -55,8 +56,14 @@ fi
 
 reset_logging(){
     oc delete --ignore-not-found --force --grace-period=0 "ns/$GENERATOR_NS" "clusterlogging/instance" "clusterlogforwarder/instance"||:
-    oc wait --for=delete "clusterlogging/instance" --timeout=30s
-    oc wait --for=delete "clusterlogforwarder/instance" --timeout=30s
+    while :; do
+      local code=assert_cl_clf_instance_does_not_exist
+      if [ ${code} -gt 0 ]; then
+        continue
+      else
+        break
+      fi
+    done
 }
 
 failed=0


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
Sometimes got exceptions with `oc wait --for=delete` in case deleting going to fast command this PR replace it with periodic `oc get` command 
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
