### PR TITLE
LOG-3112: fix fluentd audit tests for clusterID

### DIFF
--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -51,6 +51,10 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 						RequestReceivedTimestamp: nanoTime,
 						ViaqMsgID:                "*",
 						PipelineMetadata:         functional.TemplateForAnyPipelineMetadata,
+						OpenshiftLabels: types.OpenshiftMeta{
+							Sequence:  types.NewOptionalInt(""),
+							ClusterID: "**optional**",
+						},
 					},
 					K8SAuditLevel: "debug",
 				}
@@ -85,6 +89,10 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 					Timestamp:        testTime,
 					ViaqMsgID:        "*",
 					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
+					Openshift: types.OpenshiftMeta{
+						Sequence:  types.NewOptionalInt(""),
+						ClusterID: "**optional**",
+					},
 				}
 				// Write log line as input to fluentd
 				Expect(framework.WriteMessagesToAuditLog(auditLogLine, 10)).To(BeNil())
@@ -112,7 +120,8 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 					Timestamp: time.Time{},
 					LogType:   "audit",
 					Openshift: types.OpenshiftMeta{
-						Sequence: types.NewOptionalInt(""),
+						ClusterID: "**optional**",
+						Sequence:  types.NewOptionalInt(""),
 					},
 					ViaqMsgID:        "*",
 					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
@@ -237,7 +246,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 					},
 					Timestamp:        testTime,
 					PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
-					OpenshiftLabels: types.OpenshiftMeta{
+					Openshift: types.OpenshiftMeta{
 						ClusterID: "**optional**",
 					},
 				}

--- a/test/helpers/types/types.go
+++ b/test/helpers/types/types.go
@@ -177,7 +177,7 @@ type LinuxAuditLog struct {
 	ViaqIndexName    string           `json:"viaq_index_name"`
 	ViaqMsgID        string           `json:"viaq_msg_id"`
 	Kubernetes       Kubernetes       `json:"kubernetes"`
-	OpenshiftLabels  OpenshiftMeta    `json:"openshift"`
+	Openshift        OpenshiftMeta    `json:"openshift"`
 	Timing           `json:",inline"`
 	Level            string `json:"level,omitempty"`
 }


### PR DESCRIPTION
### Description
This PR:
* fixes additional audit log functional tests to make clusterid optional until we can merge the fluent changes

### Links
* https://issues.redhat.com/browse/LOG-3112
* blocks https://github.com/ViaQ/logging-fluentd/pull/50