### PR TITLE
LOG-3106: Vector add sequence field to elasticsearch output

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -782,9 +782,15 @@ source = '''
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return
@@ -865,9 +871,15 @@ source = '''
 type = "lua"
 inputs = ["es_2_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -134,9 +134,15 @@ func FlattenLabels(id string, inputs []string) Element {
 type = "lua"
 inputs = {{.InLabel}}
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -73,9 +73,15 @@ source = '''
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return
@@ -180,9 +186,15 @@ source = '''
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return
@@ -277,9 +289,15 @@ source = '''
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return
@@ -410,9 +428,15 @@ source = '''
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return
@@ -493,9 +517,15 @@ source = '''
 type = "lua"
 inputs = ["es_2_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return
@@ -605,9 +635,15 @@ source = '''
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return
@@ -707,9 +743,15 @@ source = '''
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return
@@ -815,9 +857,15 @@ source = '''
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return
@@ -936,9 +984,15 @@ source = '''
 type = "lua"
 inputs = ["es_1_add_es_index"]
 version = "2"
+hooks.init = "init"
 hooks.process = "process"
 source = '''
+    function init()
+        count = 0
+    end
     function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
         if event.log.kubernetes == nil then
             emit(event)
             return


### PR DESCRIPTION
### Description
Vector is missing the field 'sequence', which was added to fluentd as a way to deal with a lack of actual nanoseconds precision.   We are confident this addition to the existing lua script will not penalize us, but we should be aware of any performance degradation.

/cc @vimalk78 @syedriko 
/assign @jcantrill 

### Links
- https://issues.redhat.com/browse/LOG-3106
