### PR TITLE
LOG-3176: refactor service reconciliation to get before create

### DIFF
--- a/internal/collector/service.go
+++ b/internal/collector/service.go
@@ -1,0 +1,41 @@
+package collector
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
+	"github.com/openshift/cluster-logging-operator/internal/reconcile"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReconcileService reconciles the service specifically for the collector that exposes the collector metrics
+func ReconcileService(er record.EventRecorder, k8sClient client.Client, namespace, name string, owner metav1.OwnerReference) error {
+	desired := factory.NewService(
+		constants.CollectorName,
+		namespace,
+		constants.CollectorName,
+		[]v1.ServicePort{
+			{
+				Port:       MetricsPort,
+				TargetPort: intstr.FromString(MetricsPortName),
+				Name:       MetricsPortName,
+			},
+			{
+				Port:       ExporterPort,
+				TargetPort: intstr.FromString(ExporterPortName),
+				Name:       ExporterPortName,
+			},
+		},
+	)
+
+	desired.Annotations = map[string]string{
+		constants.AnnotationServingCertSecretName: constants.CollectorMetricSecretName,
+	}
+
+	utils.AddOwnerRefToObject(desired, owner)
+	return reconcile.Service(er, k8sClient, desired)
+}

--- a/internal/collector/service_monitor.go
+++ b/internal/collector/service_monitor.go
@@ -54,11 +54,10 @@ func NewServiceMonitor(namespace, name string, owner metav1.OwnerReference) *mon
 	return desired
 }
 
-func ReconcileServiceMonitor(er record.EventRecorder, k8sClient client.Client, namespace, name string, owner metav1.OwnerReference) {
+// ReconcileServiceMonitor reconciles the service monitor specifically for exposing collector metrics
+func ReconcileServiceMonitor(er record.EventRecorder, k8sClient client.Client, namespace, name string, owner metav1.OwnerReference) error {
 	desired := NewServiceMonitor(namespace, name, owner)
-	if err := reconcile.ServiceMonitor(er, k8sClient, desired); err != nil {
-		log.Error(err, "collector.ReconcileServiceMonitor")
-	}
+	return reconcile.ServiceMonitor(er, k8sClient, desired)
 }
 
 func RemoveServiceMonitor(er record.EventRecorder, k8sClient client.Client, namespace, name string) {

--- a/internal/reconcile/service.go
+++ b/internal/reconcile/service.go
@@ -1,0 +1,56 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/services"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Service reconciles a Service to the desired spec returning an error
+// if there is an issue creating or updating to the desired state
+func Service(er record.EventRecorder, k8Client client.Client, desired *corev1.Service) error {
+	reason := constants.EventReasonGetObject
+	updateReason := ""
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &corev1.Service{}
+		key := client.ObjectKeyFromObject(desired)
+		if err := k8Client.Get(context.TODO(), key, current); err != nil {
+			if errors.IsNotFound(err) {
+				reason = constants.EventReasonCreateObject
+				return k8Client.Create(context.TODO(), desired)
+			}
+			return fmt.Errorf("failed to get %v Service: %w", key, err)
+		}
+		same := false
+
+		if same, updateReason = services.AreSame(current, desired); same {
+			log.V(3).Info("Service is the same skipping update")
+			return nil
+		}
+		reason = constants.EventReasonUpdateObject
+		//Explicitly copying because services are immutable
+		current.Labels = desired.Labels
+		current.Spec.Selector = desired.Spec.Selector
+		current.Spec.Ports = desired.Spec.Ports
+		return k8Client.Update(context.TODO(), current)
+	})
+
+	eventType := corev1.EventTypeNormal
+	msg := fmt.Sprintf("%s Service %s/%s", reason, desired.Namespace, desired.Name)
+	if updateReason != "" {
+		msg = fmt.Sprintf("%s because of change in %s.", msg, updateReason)
+	}
+	if retryErr != nil {
+		eventType = corev1.EventTypeWarning
+		msg = fmt.Sprintf("Unable to %s: %v", msg, retryErr)
+	}
+	er.Event(desired, eventType, reason, msg)
+	return retryErr
+}

--- a/internal/utils/comparators/services/comparator.go
+++ b/internal/utils/comparators/services/comparator.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"reflect"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -9,26 +10,26 @@ import (
 )
 
 //AreSame compares for equality and return true equal otherwise false
-func AreSame(current *v1.Service, desired *v1.Service) bool {
+func AreSame(current *v1.Service, desired *v1.Service) (bool, string) {
 	log.V(3).Info("Comparing Services current to desired", "current", current, "desired", desired)
 
 	if !utils.AreMapsSame(current.ObjectMeta.Labels, desired.ObjectMeta.Labels) {
 		log.V(3).Info("Service label change", "current name", current.Name)
-		return false
+		return false, "meta.labels"
 	}
 	if !utils.AreMapsSame(current.Spec.Selector, desired.Spec.Selector) {
 		log.V(3).Info("Service Selector change", "current name", current.Name)
-		return false
+		return false, "spec.selector"
 	}
 	if len(current.Spec.Ports) != len(desired.Spec.Ports) {
-		return false
+		return false, "spec.ports"
 	}
 	for i, port := range current.Spec.Ports {
 		dPort := desired.Spec.Ports[i]
 		if !reflect.DeepEqual(port, dPort) {
-			return false
+			return false, fmt.Sprintf("spec.ports[%d]", i)
 		}
 	}
 
-	return true
+	return true, ""
 }

--- a/internal/utils/comparators/services/comparator_test.go
+++ b/internal/utils/comparators/services/comparator_test.go
@@ -6,7 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/openshift/cluster-logging-operator/internal/utils/comparators/services"
+	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/services"
 )
 
 var _ = Describe("services#AreSame", func() {
@@ -31,38 +31,45 @@ var _ = Describe("services#AreSame", func() {
 
 	Context("when evaluating labels", func() {
 		It("should recognize they are the same", func() {
-			Expect(AreSame(current, desired)).To(BeTrue())
+			ok, _ := services.AreSame(current, desired)
+			Expect(ok).To(BeTrue())
 		})
 
 		It("should recognize they are different", func() {
 			desired.Labels["foo"] = "bar"
-			Expect(AreSame(current, desired)).To(BeFalse())
+			ok, _ := services.AreSame(current, desired)
+			Expect(ok).To(BeFalse())
 		})
 	})
 	Context("when evaluating selectors", func() {
 		It("should recognize they are the same", func() {
-			Expect(AreSame(current, desired)).To(BeTrue())
+			ok, _ := services.AreSame(current, desired)
+			Expect(ok).To(BeTrue())
 		})
 
 		It("should recognize they are different", func() {
 			desired.Spec.Selector["foo"] = "bar"
-			Expect(AreSame(current, desired)).To(BeFalse())
+			ok, _ := services.AreSame(current, desired)
+			Expect(ok).To(BeFalse())
 		})
 	})
 	Context("when evaluating ServicePorts", func() {
 		It("should recognize they are the same", func() {
-			Expect(AreSame(current, desired)).To(BeTrue())
+			ok, _ := services.AreSame(current, desired)
+			Expect(ok).To(BeTrue())
 		})
 
 		It("should recognize they are different lengths", func() {
 			desired.Spec.Ports = append(desired.Spec.Ports, v1.ServicePort{})
-			Expect(AreSame(current, desired)).To(BeFalse())
+			ok, _ := services.AreSame(current, desired)
+			Expect(ok).To(BeFalse())
 		})
 
 		It("should recognize they are different content", func() {
 			current.Spec.Ports = append(desired.Spec.Ports, v1.ServicePort{Name: "bar", Port: 1051})
 			desired.Spec.Ports = append(desired.Spec.Ports, v1.ServicePort{Name: "bar", Port: 1050})
-			Expect(AreSame(current, desired)).To(BeFalse())
+			ok, _ := services.AreSame(current, desired)
+			Expect(ok).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
### Description
This PR:
* refactors collector service reconciliation to try to get a service before trying to create
* Adds events to service reconciliation

### Links
* https://issues.redhat.com/browse/LOG-3176
