### PR TITLE
LOG-694: Add make target to generate coverate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+test.cov
+coverage.html
 benchmark*/
 .make
 **/.kube/*

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,11 @@ test-unit: test-forwarder-generator
 	RELATED_IMAGE_FLUENTD=$(IMAGE_LOGGING_FLUENTD) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	RELATED_IMAGE_LOGGING_CONSOLE_PLUGIN=$(IMAGE_LOGGING_CONSOLE_PLUGIN) \
-	go test -cover -race ./apis/... ./internal/... `go list ./test/... | grep -Ev 'test/(e2e|functional|client|helpers)'`
+	go test -coverprofile=test.cov -race ./apis/... ./internal/... `go list ./test/... | grep -Ev 'test/(e2e|functional|client|helpers)'`
+
+.PHONY: coverage
+coverage: test-unit
+	go tool cover -html=test.cov -o $${ARTIFACTS_DIR:-.}/coverage.html
 
 .PHONY: test-cluster
 test-cluster:


### PR DESCRIPTION
### Description
This PR:
* adds a make target to generate coverage report

### Links
* https://issues.redhat.com/browse/LOG-694
