### PR TITLE
fix CSV to re-enable proper bundle building in CI

### DIFF
--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -416,9 +416,9 @@ spec:
                 - name: OPERATOR_NAME
                   value: cluster-logging-operator
                 - name: RELATED_IMAGE_VECTOR
-                  value: quay.io/openshift-logging/vector:0.21-rh
+                  value: quay.io/openshift-logging/vector:latest
                 - name: RELATED_IMAGE_FLUENTD
-                  value: quay.io/openshift-logging/fluentd:1.14.6
+                  value: quay.io/openshift-logging/fluentd:latest
                 - name: RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER
                   value: quay.io/openshift-logging/log-file-metric-exporter:latest
                 - name: RELATED_IMAGE_LOGGING_CONSOLE_PLUGIN
@@ -537,9 +537,9 @@ spec:
   provider:
     name: Red Hat, Inc
   relatedImages:
-  - image: quay.io/openshift-logging/vector:0.21-rh
+  - image: quay.io/openshift-logging/vector:latest
     name: vector
-  - image: quay.io/openshift-logging/fluentd:1.14.6
+  - image: quay.io/openshift-logging/fluentd:latest
     name: fluentd
   - image: quay.io/openshift-logging/log-file-metric-exporter:latest
     name: log-file-metric-exporter

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,10 +44,10 @@ spec:
           - name: OPERATOR_NAME
             value: "cluster-logging-operator"
           - name: RELATED_IMAGE_VECTOR
-            value: "quay.io/openshift-logging/vector:0.21-rh"
+            value: quay.io/openshift-logging/vector:latest
           - name: RELATED_IMAGE_FLUENTD
-            value: "quay.io/openshift-logging/fluentd:1.14.6"
+            value: quay.io/openshift-logging/fluentd:latest
           - name: RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER
-            value: "quay.io/openshift-logging/log-file-metric-exporter:latest"
+            value: quay.io/openshift-logging/log-file-metric-exporter:latest
           - name: RELATED_IMAGE_LOGGING_CONSOLE_PLUGIN
             value: quay.io/openshift-logging/logging-view-plugin:latest


### PR DESCRIPTION
### Description
This PR:
* modifies the CSV to ref "latest" in bundle/manifest to allow us to re-enable proper bundle creation in CI https://github.com/openshift/release/pull/31572 .  Current e2e and productization of the bundle already has logic to replace the images so this change should not regress bundle
