### PR TITLE
LOG-3145:  dedot vector tag value

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -167,7 +167,7 @@ type = "remap"
 inputs = ["raw_journal_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".journal.system"
+  .tag = "journal.system"
   
   del(.source_type)
   del(._CPU_USAGE_NSEC)
@@ -261,7 +261,7 @@ type = "remap"
 inputs = ["raw_host_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".linux-audit.log"
+  .tag = "linux-audit.log"
   
   match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
   envelop = {}
@@ -288,7 +288,7 @@ type = "remap"
 inputs = ["raw_k8s_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".k8s-audit.log"
+  .tag = "k8s-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
@@ -300,7 +300,7 @@ type = "remap"
 inputs = ["raw_openshift_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".openshift-audit.log"
+  .tag = "openshift-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
@@ -312,7 +312,7 @@ type = "remap"
 inputs = ["raw_ovn_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".ovn-audit.log"
+  .tag = "ovn-audit.log"
   if !exists(.level) {
     .level = "default"
     if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
@@ -548,7 +548,7 @@ inputs = ["raw_journal_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   
-  .tag = ".journal.system"
+  .tag = "journal.system"
   
   del(.source_type)
   del(._CPU_USAGE_NSEC)
@@ -642,7 +642,7 @@ type = "remap"
 inputs = ["raw_host_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".linux-audit.log"
+  .tag = "linux-audit.log"
   
   match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
   envelop = {}
@@ -669,7 +669,7 @@ type = "remap"
 inputs = ["raw_k8s_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".k8s-audit.log"
+  .tag = "k8s-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
@@ -681,7 +681,7 @@ type = "remap"
 inputs = ["raw_openshift_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".openshift-audit.log"
+  .tag = "openshift-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
@@ -693,7 +693,7 @@ type = "remap"
 inputs = ["raw_ovn_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".ovn-audit.log"
+  .tag = "ovn-audit.log"
   if !exists(.level) {
     .level = "default"
     if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
@@ -1096,7 +1096,7 @@ type = "remap"
 inputs = ["raw_journal_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".journal.system"
+  .tag = "journal.system"
   
   del(.source_type)
   del(._CPU_USAGE_NSEC)
@@ -1190,7 +1190,7 @@ type = "remap"
 inputs = ["raw_host_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".linux-audit.log"
+  .tag = "linux-audit.log"
   
   match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
   envelop = {}
@@ -1217,7 +1217,7 @@ type = "remap"
 inputs = ["raw_k8s_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".k8s-audit.log"
+  .tag = "k8s-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
@@ -1229,7 +1229,7 @@ type = "remap"
 inputs = ["raw_openshift_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".openshift-audit.log"
+  .tag = "openshift-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
@@ -1241,7 +1241,7 @@ type = "remap"
 inputs = ["raw_ovn_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".ovn-audit.log"
+  .tag = "ovn-audit.log"
   if !exists(.level) {
     .level = "default"
     if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {

--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -38,7 +38,7 @@ if !exists(.level) {
 	RemoveStream      = `del(.stream)`
 	RemovePodIPs      = `del(.kubernetes.pod_ips)`
 	FixTimestampField = `ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}`
-	AddJournalLogTag  = `.tag = ".journal.system"`
+	AddJournalLogTag  = `.tag = "journal.system"`
 	AddHostName       = `.hostname = del(.host)`
 	AddTime           = `.time = format_timestamp!(.timestamp, format: "%FT%T%:z")`
 
@@ -123,10 +123,10 @@ if err == null {
   log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
 }
 `
-	HostAuditLogTag = ".linux-audit.log"
-	K8sAuditLogTag  = ".k8s-audit.log"
-	OpenAuditLogTag = ".openshift-audit.log"
-	OvnAuditLogTag  = ".ovn-audit.log"
+	HostAuditLogTag = "linux-audit.log"
+	K8sAuditLogTag  = "k8s-audit.log"
+	OpenAuditLogTag = "openshift-audit.log"
+	OvnAuditLogTag  = "ovn-audit.log"
 	ParseAndFlatten = `. = merge(., parse_json!(string!(.message))) ?? .
 del(.message)
 `

--- a/internal/generator/vector/normalize_test.go
+++ b/internal/generator/vector/normalize_test.go
@@ -113,7 +113,7 @@ type = "remap"
 inputs = ["raw_journal_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".journal.system"
+  .tag = "journal.system"
   
   del(.source_type)
   del(._CPU_USAGE_NSEC)
@@ -222,7 +222,7 @@ type = "remap"
 inputs = ["raw_host_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".linux-audit.log"
+  .tag = "linux-audit.log"
   
   match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
   envelop = {}
@@ -249,7 +249,7 @@ type = "remap"
 inputs = ["raw_k8s_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".k8s-audit.log"
+  .tag = "k8s-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
@@ -261,7 +261,7 @@ type = "remap"
 inputs = ["raw_openshift_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".openshift-audit.log"
+  .tag = "openshift-audit.log"
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
@@ -273,7 +273,7 @@ type = "remap"
 inputs = ["raw_ovn_audit_logs"]
 source = '''
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
-  .tag = ".ovn-audit.log"
+  .tag = "ovn-audit.log"
   if !exists(.level) {
     .level = "default"
     if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {

--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -131,14 +131,14 @@ if ( .log_type == "application" ) {
 }
 if ( .log_type == "audit" ) {
  .group_name = "` + auditGroupName + `"
- .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + .tag ) ?? .stream_name
+ .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + "." + .tag ) ?? .stream_name
 }
 if ( .log_type == "infrastructure" ) {
  .group_name = "` + infraGroupName + `"
  .stream_name = ( .hostname + "." + .stream_name ) ?? .stream_name
 }
-if ( .tag == ".journal.system" ) {
- .stream_name =  ( .hostname + .tag ) ?? .stream_name
+if ( .tag == "journal.system" ) {
+ .stream_name =  ( .hostname + "." + .tag ) ?? .stream_name
 }
 del(.tag)
 del(.source_type)

--- a/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
@@ -30,8 +30,8 @@ source = '''
   }
 `
 	transformEnd = `
-  if ( .tag == ".journal.system" ) {
-   .stream_name =  ( .hostname + .tag ) ?? .stream_name
+  if ( .tag == "journal.system" ) {
+   .stream_name =  ( .hostname + "." + .tag ) ?? .stream_name
   }
   del(.tag)
   del(.source_type)
@@ -119,7 +119,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
   }
   if ( .log_type == "audit" ) {
    .group_name = "` + groupPrefix + `.audit"
-   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + .tag ) ?? .stream_name
+   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + "." + .tag ) ?? .stream_name
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "` + groupPrefix + `.infrastructure"
@@ -151,7 +151,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
   }
   if ( .log_type == "audit" ) {
    .group_name = "` + groupPrefix + `.audit"
-   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + .tag ) ?? .stream_name
+   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + "." + .tag ) ?? .stream_name
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "` + groupPrefix + `.infrastructure"
@@ -183,7 +183,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
   }
   if ( .log_type == "audit" ) {
    .group_name = "` + groupPrefix + `.audit"
-   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + .tag ) ?? .stream_name
+   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + "." + .tag ) ?? .stream_name
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "` + groupPrefix + `.infrastructure"
@@ -222,7 +222,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
   }
   if ( .log_type == "audit" ) {
    .group_name = "audit"
-   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + .tag ) ?? .stream_name
+   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + "." + .tag ) ?? .stream_name
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "infrastructure"
@@ -256,7 +256,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
   }
   if ( .log_type == "audit" ) {
    .group_name = "audit"
-   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + .tag ) ?? .stream_name
+   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + "." + .tag ) ?? .stream_name
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "infrastructure"
@@ -327,7 +327,7 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
   }
   if ( .log_type == "audit" ) {
    .group_name = "` + groupPrefix + `.audit"
-   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + .tag ) ?? .stream_name
+   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + "." + .tag ) ?? .stream_name
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "` + groupPrefix + `.infrastructure"
@@ -369,7 +369,7 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
   }
   if ( .log_type == "audit" ) {
    .group_name = "` + groupPrefix + `.audit"
-   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + .tag ) ?? .stream_name
+   .stream_name = ( "${VECTOR_SELF_NODE_NAME}" + "." + .tag ) ?? .stream_name
   }
   if ( .log_type == "infrastructure" ) {
    .group_name = "` + groupPrefix + `.infrastructure"


### PR DESCRIPTION
### Description
A customer who has switched collectors found that in vector the value of the "tag" field has a dot pre-pended.  In fluentd this field value was without the dot.  
This is the first I've heard of a customer actually using this field, as it is not intended to be part of our data model.   It's used to create stream names (based on the type of file) when using cloudwatch, then the tag field is deleted.  In this case, the customer is not using CW output, and thus the tag field remains.   As with a few other fields, this only remains for feature parity with fluentd.



/cc @vimalk78 @syedriko 
/assign @jcantrill 

### Links
- https://issues.redhat.com/browse/LOG-3145
