### PR TITLE
Disable adding OPENSSL_CONF for tlsSecurityProfile

### DIFF
--- a/internal/collector/config.go
+++ b/internal/collector/config.go
@@ -7,7 +7,6 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
-	"github.com/openshift/cluster-logging-operator/internal/tls"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -17,7 +16,6 @@ import (
 // ReconcileCollectorConfig reconciles a collector config specifically for the collector defined by the factory
 func (f *Factory) ReconcileCollectorConfig(er record.EventRecorder, k8sClient client.Client, namespace, name, collectorConfig string, owner metav1.OwnerReference) error {
 	log.V(3).Info("Updating ConfigMap and Secrets")
-	opensslConf := tls.OpenSSLConf(k8sClient)
 	if f.CollectorType == logging.LogCollectionTypeFluentd {
 		collectorConfigMap := runtime.NewConfigMap(
 			namespace,
@@ -26,7 +24,6 @@ func (f *Factory) ReconcileCollectorConfig(er record.EventRecorder, k8sClient cl
 				"fluent.conf":         collectorConfig,
 				"run.sh":              fluentd.RunScript,
 				"cleanInValidJson.rb": fluentd.CleanInValidJson,
-				"openssl.cnf":         opensslConf,
 			},
 		)
 		utils.AddOwnerRefToObject(collectorConfigMap, owner)
@@ -37,7 +34,6 @@ func (f *Factory) ReconcileCollectorConfig(er record.EventRecorder, k8sClient cl
 			constants.CollectorConfigSecretName,
 			map[string][]byte{
 				"vector.toml": []byte(collectorConfig),
-				"openssl.cnf": []byte(opensslConf),
 			})
 		return reconcile.Secret(er, k8sClient, secret)
 	}

--- a/internal/collector/fluentd/visitors.go
+++ b/internal/collector/fluentd/visitors.go
@@ -1,8 +1,6 @@
 package fluentd
 
 import (
-	"fmt"
-
 	"github.com/openshift/cluster-logging-operator/internal/collector/common"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
@@ -35,7 +33,6 @@ func CollectorVisitor(collectorContainer *v1.Container, podSpec *v1.PodSpec) {
 			},
 		},
 		v1.EnvVar{Name: "RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR", Value: "0.9"},
-		v1.EnvVar{Name: "OPENSSL_CONF", Value: fmt.Sprintf("%s/openssl.cnf", configVolumePath)},
 	)
 	collectorContainer.VolumeMounts = append(collectorContainer.VolumeMounts,
 		v1.VolumeMount{Name: certsVolumeName, ReadOnly: true, MountPath: certsVolumePath},

--- a/internal/collector/vector/visitors.go
+++ b/internal/collector/vector/visitors.go
@@ -1,8 +1,6 @@
 package vector
 
 import (
-	"fmt"
-
 	"github.com/openshift/cluster-logging-operator/internal/collector/common"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
@@ -25,7 +23,6 @@ func CollectorVisitor(collectorContainer *corev1.Container, podSpec *corev1.PodS
 				},
 			},
 		},
-		corev1.EnvVar{Name: "OPENSSL_CONF", Value: fmt.Sprintf("%s/openssl.cnf", vectorConfigPath)},
 	)
 	collectorContainer.VolumeMounts = append(collectorContainer.VolumeMounts,
 		corev1.VolumeMount{Name: common.ConfigVolumeName, ReadOnly: true, MountPath: vectorConfigPath},


### PR DESCRIPTION
### Description
This PR
-  disables adding generated openssl.cnf file to secret and configmap
-  disables adding env variable `OPENSSL_CONF` which points to the openssl.cnf file.

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
