### PR TITLE
LOG-3228: fix applying OutputDefault to unmanaged Elasticsearch logStores

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder_types.go
+++ b/apis/logging/v1/cluster_log_forwarder_types.go
@@ -49,7 +49,16 @@ type ClusterLogForwarderSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Forwarder Pipelines",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:forwarderPipelines"}
 	Pipelines []PipelineSpec `json:"pipelines,omitempty"`
 
-	// OutputDefaults are used to specify default values for OutputSpec
+	// DEPRECATED OutputDefaults specify forwarder config explicitly for the
+	// default managed log store named 'default'.  If there is a need to spec
+	// the managed logstore, define an outputSpec like the following where the
+	// managed fields (e.g. URL, Secret.Name) will be replaced with the required values:
+	// spec:
+	//   - outputs:
+	//     - name: default
+	//       type: elasticsearch
+	//       elasticsearch:
+	//         structuredTypeKey: kubernetes.labels.myvalue
 	//
 	// +optional
 	OutputDefaults *OutputDefaults `json:"outputDefaults,omitempty"`

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -102,8 +102,12 @@ spec:
                   type: object
                 type: array
               outputDefaults:
-                description: OutputDefaults are used to specify default values for
-                  OutputSpec
+                description: 'DEPRECATED OutputDefaults specify forwarder config explicitly
+                  for the default managed log store named ''default''.  If there is
+                  a need to spec the managed logstore, define an outputSpec like the
+                  following where the managed fields (e.g. URL, Secret.Name) will
+                  be replaced with the required values: spec: - outputs: - name: default
+                  type: elasticsearch elasticsearch: structuredTypeKey: kubernetes.labels.myvalue'
                 properties:
                   elasticsearch:
                     description: "Elasticsearch OutputSpec default values \n Values

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -98,8 +98,12 @@ spec:
                   type: object
                 type: array
               outputDefaults:
-                description: OutputDefaults are used to specify default values for
-                  OutputSpec
+                description: 'DEPRECATED OutputDefaults specify forwarder config explicitly
+                  for the default managed log store named ''default''.  If there is
+                  a need to spec the managed logstore, define an outputSpec like the
+                  following where the managed fields (e.g. URL, Secret.Name) will
+                  be replaced with the required values: spec: - outputs: - name: default
+                  type: elasticsearch elasticsearch: structuredTypeKey: kubernetes.labels.myvalue'
                 properties:
                   elasticsearch:
                     description: "Elasticsearch OutputSpec default values \n Values

--- a/internal/cmd/forwarder-generator/main.go
+++ b/internal/cmd/forwarder-generator/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
@@ -60,7 +61,8 @@ func main() {
 
 	log.Info("Finished reading yaml", "content", string(content))
 
-	generatedConfig, err := forwarder.Generate(logCollectorType, string(content), *includeDefaultLogStore, *debugOutput, nil)
+	client := fake.NewClientBuilder().Build()
+	generatedConfig, err := forwarder.Generate(logCollectorType, string(content), *includeDefaultLogStore, *debugOutput, client)
 	if err != nil {
 		log.Error(err, "Unable to generate log configuration")
 		os.Exit(1)

--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -120,9 +120,10 @@ var _ = Describe("Reconciling", func() {
 					namespace,
 				)
 				clusterRequest = &ClusterLoggingRequest{
-					Client:        client,
-					Cluster:       cluster,
-					EventRecorder: record.NewFakeRecorder(100),
+					Client:           client,
+					Cluster:          cluster,
+					EventRecorder:    record.NewFakeRecorder(100),
+					ForwarderRequest: &loggingv1.ClusterLogForwarder{},
 				}
 			})
 

--- a/internal/k8shandler/forwarding_test.go
+++ b/internal/k8shandler/forwarding_test.go
@@ -2,6 +2,8 @@ package k8shandler
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/migrations"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/collector/fluentd"
@@ -195,6 +197,32 @@ var _ = Describe("Normalizing forwarder", func() {
 		})
 
 		Context("outputs", func() {
+
+			// Ref: https://issues.redhat.com/browse/LOG-3228
+			It("should validate the default output as any other without adding a new one", func() {
+				request.Cluster.Namespace = constants.OpenshiftNS
+				request.Client = fake.NewClientBuilder().WithRuntimeObjects(runtime.NewSecret(
+					constants.OpenshiftNS, constants.CollectorSecretName, nil,
+				)).Build()
+				request.Cluster.Spec.LogStore = &logging.LogStoreSpec{
+					Type: logging.LogStoreTypeElasticsearch,
+				}
+				request.ForwarderSpec.Outputs = []logging.OutputSpec{
+					migrations.NewDefaultOutput(nil),
+				}
+				request.ForwarderSpec.Pipelines = []logging.PipelineSpec{
+					{
+						Name:       "aPipeline",
+						OutputRefs: []string{logging.OutputNameDefault},
+						InputRefs:  []string{logging.InputNameApplication},
+					},
+				}
+				// sanity check
+				Expect(request.ForwarderSpec.Outputs).To(HaveLen(1))
+				spec, status := request.NormalizeForwarder()
+				Expect(status.Outputs[logging.OutputNameDefault]).To(HaveCondition(logging.ConditionReady, true, "", ""))
+				Expect(spec.Outputs).To(HaveLen(1), "Exp. the number of outputs to remain unchanged")
+			})
 			It("should drop outputs that do not have unique names", func() {
 				request.ForwarderSpec.Outputs = append(request.ForwarderSpec.Outputs, logging.OutputSpec{
 					Name: "myOutput",
@@ -220,16 +248,15 @@ var _ = Describe("Normalizing forwarder", func() {
 				Expect(status.Outputs["output_2_"]).To(HaveCondition("Ready", false, "Invalid", "must have a name"))
 			})
 
-			It("should drop outputs that conflict with the internally reserved name", func() {
-				request.ForwarderSpec.Outputs = append(request.ForwarderSpec.Outputs, logging.OutputSpec{
+			It("should not drop outputs that conflict with the internally reserved name 'default' ", func() {
+				outputs := append(request.ForwarderSpec.Outputs, logging.OutputSpec{
 					Name: "default",
 					Type: "elasticsearch",
 					URL:  "http://here",
 				})
-				spec, status := request.NormalizeForwarder()
-				Expect(spec.Outputs).To(HaveLen(2), "Exp. outputs with an internal name conflict to be dropped")
-				Expect(status.Outputs).To(HaveKey("output_2_"))
-				Expect(status.Outputs["output_2_"]).To(HaveCondition("Ready", false, "Invalid", "reserved"))
+				request.ForwarderSpec.Outputs = outputs
+				spec, _ := request.NormalizeForwarder()
+				Expect(len(spec.Outputs)).To(Equal(len(outputs)), "Exp. outputs with an internal name of 'default' do be kept")
 			})
 
 			It("should drop outputs that have empty types", func() {
@@ -521,73 +548,6 @@ var _ = Describe("Normalizing forwarder", func() {
 			})
 
 			Context("with outputDefaults specified", func() {
-				It("should accept default output", func() {
-					cluster.Spec = logging.ClusterLoggingSpec{
-						Collection: &logging.CollectionSpec{
-							Type: "fluentd",
-						},
-						LogStore: &logging.LogStoreSpec{
-							Type: logging.LogStoreTypeElasticsearch,
-						},
-					}
-					request.ForwarderSpec = logging.ClusterLogForwarderSpec{
-						OutputDefaults: &logging.OutputDefaults{
-							Elasticsearch: &logging.Elasticsearch{
-								StructuredTypeKey: "kubernetes.labels.mylabel",
-							},
-						},
-						Pipelines: []logging.PipelineSpec{
-							{
-								InputRefs:  []string{"application"},
-								OutputRefs: []string{"default"},
-								Name:       "mypipe",
-							},
-						},
-					}
-					_, _ = request.generateCollectorConfig()
-
-					Expect(len(request.ForwarderSpec.Outputs) == 1).To(BeTrue())
-					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch).ToNot(BeNil(), "Expected an Elasticsearch specific config")
-					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.StructuredTypeKey).To(Equal("kubernetes.labels.mylabel"))
-
-				})
-				It("should setup values for elasticsearch output", func() {
-					cluster.Spec = logging.ClusterLoggingSpec{
-						Collection: &logging.CollectionSpec{
-							Type: "fluentd",
-						},
-						LogStore: &logging.LogStoreSpec{
-							Type: logging.LogStoreTypeElasticsearch,
-						},
-					}
-					request.ForwarderSpec = logging.ClusterLogForwarderSpec{
-						OutputDefaults: &logging.OutputDefaults{
-							Elasticsearch: &logging.Elasticsearch{
-								StructuredTypeKey: "kubernetes.labels.mylabel",
-							},
-						},
-						Outputs: []logging.OutputSpec{
-							{
-								Type: logging.OutputTypeElasticsearch,
-								Name: "es-out",
-								URL:  "http://some-url",
-							},
-						},
-						Pipelines: []logging.PipelineSpec{
-							{
-								InputRefs:  []string{"application"},
-								OutputRefs: []string{"es-out"},
-								Name:       "mypipe",
-							},
-						},
-					}
-					_, _ = request.generateCollectorConfig()
-
-					Expect(len(request.ForwarderSpec.Outputs) == 1).To(BeTrue())
-					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.StructuredTypeKey).To(Equal("kubernetes.labels.mylabel"))
-					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.Version).To(Equal(0)) // not set
-				})
-
 				It("should not change elasticsearch version to latest if defined in default outputs", func() {
 					cluster.Spec = logging.ClusterLoggingSpec{
 						Collection: &logging.CollectionSpec{
@@ -622,8 +582,7 @@ var _ = Describe("Normalizing forwarder", func() {
 					_, _ = request.generateCollectorConfig()
 
 					Expect(len(request.ForwarderSpec.Outputs) == 1).To(BeTrue())
-					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.StructuredTypeKey).To(Equal("kubernetes.labels.mylabel"))
-					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch.Version).To(Equal(11))
+					Expect(request.ForwarderSpec.Outputs[0].Elasticsearch).To(BeNil())
 				})
 			})
 
@@ -645,6 +604,10 @@ var _ = Describe("Normalizing forwarder", func() {
 		})
 
 		It("generates default configuration for empty spec with default log store", func() {
+			request.Cluster.Namespace = constants.OpenshiftNS
+			request.Client = fake.NewClientBuilder().WithRuntimeObjects(runtime.NewSecret(
+				constants.OpenshiftNS, constants.CollectorSecretName, nil,
+			)).Build()
 			cluster.Spec.LogStore = &logging.LogStoreSpec{
 				Type: logging.LogStoreTypeElasticsearch,
 			}
@@ -734,6 +697,10 @@ pipelines:
 		})
 
 		It("forwards logs to an explicit default logstore", func() {
+			request.Cluster.Namespace = constants.OpenshiftNS
+			request.Client = fake.NewClientBuilder().WithRuntimeObjects(runtime.NewSecret(
+				constants.OpenshiftNS, constants.CollectorSecretName, nil,
+			)).Build()
 			cluster.Spec.LogStore = &logging.LogStoreSpec{
 				Type: logging.LogStoreTypeElasticsearch,
 			}
@@ -785,95 +752,6 @@ pipelines:
 		Expect(status.Conditions).NotTo(HaveCondition("Degraded", true, "", ""), "unexpected "+YAMLString(status))
 		Expect(*spec).To(EqualDiff(request.ForwarderSpec))
 	})
-})
-
-var _ = Describe("#applyOutputDefaults", func() {
-	var (
-		outputDefault *logging.OutputDefaults
-		esOutput      = logging.OutputSpec{
-			Name: "external-elasticsearch",
-			Type: logging.OutputTypeElasticsearch,
-			OutputTypeSpec: logging.OutputTypeSpec{
-				Elasticsearch: &logging.Elasticsearch{
-					Version: logging.LatestESVersion,
-				},
-			},
-			Secret: &logging.OutputSecretSpec{
-				Name: "log-forward-secret",
-			},
-		}
-		esOutWithoutVersion = logging.OutputSpec{
-			Name: "external-elasticsearch",
-			Type: logging.OutputTypeElasticsearch,
-			Secret: &logging.OutputSecretSpec{
-				Name: "log-forward-secret",
-			},
-		}
-	)
-
-	It("should do nothing when no OutputDefaults are defined", func() {
-		Expect(applyOutputDefaults(nil, esOutput)).To(Equal(esOutput))
-	})
-
-	It("should not set ES version when no OutputDefaults are defined", func() {
-		result := applyOutputDefaults(nil, esOutWithoutVersion)
-		Expect(result).To(Equal(esOutWithoutVersion))
-	})
-
-	Context("when Elasticsearch OutputDefaults are defined", func() {
-
-		BeforeEach(func() {
-			outputDefault = &logging.OutputDefaults{
-				Elasticsearch: &logging.Elasticsearch{
-					StructuredTypeKey:  "kubernetes.labels.app",
-					StructuredTypeName: "nologformat",
-					Version:            logging.DefaultESVersion,
-				},
-			}
-		})
-		It("should not set ES version if not defined in OutputDefaults and the output does not define them", func() {
-			outputDefaultNoVersion := &logging.OutputDefaults{
-				Elasticsearch: &logging.Elasticsearch{
-					StructuredTypeKey:  "some.other.label.value",
-					StructuredTypeName: "anotherTypeName",
-				},
-			}
-			act := applyOutputDefaults(outputDefaultNoVersion, esOutWithoutVersion)
-			esOutput.Elasticsearch = &logging.Elasticsearch{
-				StructuredTypeKey:  outputDefaultNoVersion.Elasticsearch.StructuredTypeKey,
-				StructuredTypeName: outputDefaultNoVersion.Elasticsearch.StructuredTypeName,
-			}
-			Expect(act).To(Equal(esOutput))
-		})
-
-		It("should set the values on the output from OutputDefaults when the output does not define them", func() {
-			esOutputNoES := logging.OutputSpec{
-				Name: "external-elasticsearch",
-				Type: logging.OutputTypeElasticsearch,
-				Secret: &logging.OutputSecretSpec{
-					Name: "log-forward-secret",
-				},
-			}
-			act := applyOutputDefaults(outputDefault, esOutputNoES)
-			esOutput.Elasticsearch = &logging.Elasticsearch{
-				StructuredTypeKey:  "kubernetes.labels.app",
-				StructuredTypeName: "nologformat",
-				Version:            logging.DefaultESVersion,
-			}
-			Expect(act).To(Equal(esOutput))
-		})
-
-		It("should not set the values on the output from the default when the output defines them", func() {
-			esOutput.Elasticsearch = &logging.Elasticsearch{
-				StructuredTypeKey:  "some.label.value",
-				StructuredTypeName: "someTypeName",
-				Version:            logging.LatestESVersion,
-			}
-			act := applyOutputDefaults(outputDefault, esOutput)
-			Expect(act).To(Equal(esOutput))
-		})
-	})
-
 })
 
 var _ = DescribeTable("#generateCollectorConfig",

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -223,7 +223,7 @@ func (clusterRequest *ClusterLoggingRequest) getLogForwarder() *logging.ClusterL
 		}
 		return nil
 	}
-
+	forwarder.Spec = migrations.MigrateClusterLogForwarderSpec(forwarder.Spec)
 	return forwarder
 }
 

--- a/internal/migrations/migrate_clusterlogforwarder.go
+++ b/internal/migrations/migrate_clusterlogforwarder.go
@@ -1,0 +1,59 @@
+package migrations
+
+import (
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+)
+
+func MigrateClusterLogForwarderSpec(spec logging.ClusterLogForwarderSpec) logging.ClusterLogForwarderSpec {
+	spec.Outputs = MigrateDefaultOutput(spec)
+	return spec
+}
+
+// MigrateDefaultOutput adds the 'default' output spec to the list of outputs if it is not defined or
+// selectively replaces it if it is.  It will apply OutputDefaults unless they are already defined.
+func MigrateDefaultOutput(spec logging.ClusterLogForwarderSpec) []logging.OutputSpec {
+
+	refDefault := false
+	for _, p := range spec.Pipelines {
+		for _, ref := range p.OutputRefs {
+			if ref == logging.OutputNameDefault {
+				refDefault = true
+				break
+			}
+		}
+	}
+	if !refDefault {
+		return spec.Outputs
+	}
+	defaultReplaced := false
+	defaultOutput := NewDefaultOutput(spec.OutputDefaults)
+	outputs := []logging.OutputSpec{}
+	for _, output := range spec.Outputs {
+		if output.Name == logging.OutputNameDefault {
+			if output.Elasticsearch != nil {
+				defaultOutput.Elasticsearch = output.Elasticsearch
+			}
+			defaultReplaced = true
+			output = defaultOutput
+		}
+		outputs = append(outputs, output)
+	}
+	if !defaultReplaced {
+		outputs = append(outputs, defaultOutput)
+	}
+	return outputs
+}
+
+func NewDefaultOutput(defaults *logging.OutputDefaults) logging.OutputSpec {
+	spec := logging.OutputSpec{
+		Name:   logging.OutputNameDefault,
+		Type:   logging.OutputTypeElasticsearch,
+		URL:    constants.LogStoreURL,
+		Secret: &logging.OutputSecretSpec{Name: constants.CollectorSecretName},
+	}
+	if defaults != nil && defaults.Elasticsearch != nil {
+		spec.Elasticsearch = defaults.Elasticsearch
+	}
+	return spec
+}

--- a/internal/migrations/migrate_clusterlogforwarder_test.go
+++ b/internal/migrations/migrate_clusterlogforwarder_test.go
@@ -1,0 +1,113 @@
+package migrations
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+)
+
+var _ = Describe("MigrateDefaultOutput", func() {
+
+	var (
+		pipelines []logging.PipelineSpec
+		outputs   []logging.OutputSpec
+		spec      logging.ClusterLogForwarderSpec
+		esSpec    *logging.Elasticsearch
+	)
+
+	BeforeEach(func() {
+		esSpec = &logging.Elasticsearch{
+			StructuredTypeKey: "foo.bar",
+		}
+		pipelines = []logging.PipelineSpec{
+			{
+				Name:       "test",
+				OutputRefs: []string{"first", "second"},
+			},
+		}
+		outputs = []logging.OutputSpec{
+			{
+				Name: "first",
+				Type: logging.OutputTypeElasticsearch,
+				OutputTypeSpec: logging.OutputTypeSpec{
+					Elasticsearch: esSpec,
+				},
+			},
+		}
+		spec = logging.ClusterLogForwarderSpec{
+			Outputs:   outputs,
+			Pipelines: pipelines,
+		}
+	})
+
+	It("should not add the default OutputSpec when it is not referenced by a pipeline", func() {
+		Expect(MigrateDefaultOutput(spec)).To(Equal(outputs))
+	})
+
+	Context("when a pipeline references 'default'", func() {
+
+		var exp []logging.OutputSpec
+		BeforeEach(func() {
+			pipelines[0].OutputRefs = append(spec.Pipelines[0].OutputRefs, logging.OutputNameDefault)
+			spec = logging.ClusterLogForwarderSpec{
+				Outputs:   outputs,
+				Pipelines: pipelines,
+			}
+		})
+
+		Context("and outputs does not explicitly spec 'default'", func() {
+			BeforeEach(func() {
+				exp = append(outputs, NewDefaultOutput(nil))
+			})
+
+			It("should add the default OutputSpec", func() {
+				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+			})
+			It("should add the default OutputSpec and OutputDefaults when OutputDefaults are spec'd", func() {
+				spec.OutputDefaults = &logging.OutputDefaults{
+					Elasticsearch: &logging.Elasticsearch{
+						StructuredTypeKey: "foo.bar",
+					},
+				}
+				exp[1].Elasticsearch = spec.OutputDefaults.Elasticsearch
+				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
+			})
+		})
+
+		Context("and outputs includes an OutputSpec named 'default'", func() {
+			var tobereplaced logging.OutputSpec
+			BeforeEach(func() {
+				tobereplaced = logging.OutputSpec{
+					Name:   logging.OutputNameDefault,
+					Type:   logging.OutputTypeElasticsearch,
+					URL:    "thiswillgetreplaced",
+					Secret: &logging.OutputSecretSpec{Name: "replacem"},
+				}
+
+			})
+
+			It("should replace the OutputSpec with the default OutputSpec", func() {
+				exp = append(outputs, NewDefaultOutput(nil))
+				spec = logging.ClusterLogForwarderSpec{
+					Outputs:   append(outputs, tobereplaced),
+					Pipelines: pipelines,
+				}
+				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+			})
+
+			It("should replace the OutputSpec with the default OutputSpec and use the config (e.g. structureTypeKey) defined in the original OutputSpec", func() {
+				tobereplaced.Elasticsearch = esSpec
+				exp = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: esSpec}))
+				spec = logging.ClusterLogForwarderSpec{
+					Outputs:        append(outputs, tobereplaced),
+					Pipelines:      pipelines,
+					OutputDefaults: &logging.OutputDefaults{Elasticsearch: &logging.Elasticsearch{StructuredTypeKey: "abc"}},
+				}
+				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
+			})
+		})
+
+	})
+
+})

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -32,7 +32,7 @@ func UnMarshalClusterLogForwarder(clfYaml string) (forwarder *logging.ClusterLog
 	return forwarder, err
 }
 
-func Generate(collectionType logging.LogCollectionType, clfYaml string, includeDefaultLogStore, debugOutput bool, client *client.Client) (string, error) {
+func Generate(collectionType logging.LogCollectionType, clfYaml string, includeDefaultLogStore, debugOutput bool, client client.Client) (string, error) {
 	var err error
 	forwarder, err := UnMarshalClusterLogForwarder(clfYaml)
 	if err != nil {
@@ -51,7 +51,7 @@ func Generate(collectionType logging.LogCollectionType, clfYaml string, includeD
 	}
 
 	if client != nil {
-		clRequest.Client = *client
+		clRequest.Client = client
 	}
 
 	if includeDefaultLogStore {

--- a/test/framework/e2e/framework.go
+++ b/test/framework/e2e/framework.go
@@ -470,7 +470,7 @@ func (tc *E2ETestFramework) Cleanup() {
 		clolog.Info("Test failed", "TestText", g.FullTestText)
 		//allow caller to cleanup if unset (e.g script cleanup())
 		doCleanup := strings.TrimSpace(os.Getenv("DO_CLEANUP"))
-		clolog.Info("Running Cleanup script ....", "DO_CLEANUP", "doCleanup")
+		clolog.Info("Running Cleanup script ....", "DO_CLEANUP", doCleanup)
 		if doCleanup == "" || strings.ToLower(doCleanup) == "true" {
 			RunCleanupScript()
 		}

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -178,7 +178,7 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 	debugOutput := false
 	testClient := client.Get().ControllerRuntimeClient()
 	if strings.TrimSpace(f.Conf) == "" {
-		if f.Conf, err = forwarder.Generate(logging.LogCollectionType(f.collector.String()), string(clfYaml), false, debugOutput, &testClient); err != nil {
+		if f.Conf, err = forwarder.Generate(logging.LogCollectionType(f.collector.String()), string(clfYaml), false, debugOutput, testClient); err != nil {
 			return err
 		}
 		//remove journal for now since we can not mimic it


### PR DESCRIPTION
### Description
This PR:
* fixes the issue where OutputDefaults are applied generically to all ES output types instead of only the managed Elasticsearch offering.

### Links
* https://issues.redhat.com/browse/LOG-3228
