### PR TITLE
LOG-3194: Add pod security sync label

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -80,6 +80,7 @@ const (
 	PodSecurityLabelAudit      = "pod-security.kubernetes.io/audit"
 	PodSecurityLabelWarn       = "pod-security.kubernetes.io/warn"
 	PodSecurityLabelValue      = "privileged"
+	PodSecuritySyncLabel       = "security.openshift.io/scc.podSecurityLabelSync"
 	// Disable gosec linter, complains "possible hard-coded secret"
 	CollectorSecretsDir     = "/var/run/ocp-collector/secrets" //nolint:gosec
 	KibanaSessionSecretName = "kibana-session-secret"          //nolint:gosec

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -331,11 +331,12 @@ func (clusterRequest *ClusterLoggingRequest) addSecurityLabelsToNamespace() erro
 		ns.Labels[constants.PodSecurityLabelEnforce] = constants.PodSecurityLabelValue
 		ns.Labels[constants.PodSecurityLabelAudit] = constants.PodSecurityLabelValue
 		ns.Labels[constants.PodSecurityLabelWarn] = constants.PodSecurityLabelValue
+		ns.Labels[constants.PodSecuritySyncLabel] = "false"
 
 		if err := clusterRequest.Client.Update(context.TODO(), ns); err != nil && !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("error updating namespace: %w", err)
 		}
-		log.V(1).Info("Successfully added pod security labels", "namespace.Labels", ns.Labels)
+		log.V(1).Info("Successfully added pod security labels", "labels", ns.Labels)
 	}
 
 	return nil

--- a/olm_deploy/scripts/operator-install.sh
+++ b/olm_deploy/scripts/operator-install.sh
@@ -15,6 +15,7 @@ oc annotate ns/${CLUSTER_LOGGING_OPERATOR_NAMESPACE} openshift.io/node-selector=
 oc label ns/${CLUSTER_LOGGING_OPERATOR_NAMESPACE} pod-security.kubernetes.io/enforce=privileged --overwrite
 oc label ns/${CLUSTER_LOGGING_OPERATOR_NAMESPACE} pod-security.kubernetes.io/audit=privileged --overwrite
 oc label ns/${CLUSTER_LOGGING_OPERATOR_NAMESPACE} pod-security.kubernetes.io/warn=privileged --overwrite
+oc label ns/${CLUSTER_LOGGING_OPERATOR_NAMESPACE} security.openshift.io/scc.podSecurityLabelSync=false --overwrite
 
 set -e
 


### PR DESCRIPTION
### Description
For some reason the olm operator has begun adding the label 'podSecurityLabelSync' = true to the openshift-logging namespace.   This results in our pod security labels being overwritten.  These new labels prevent our pods from starting.
This change adds the "false" sync label so that our privileged policy is maintained.  

Note:  This should not need to be done according to the IMPORTANT section in our docs, as well as several internal resources

/cc @syedriko @vimalk78 
/assign @jcantrill 

### Links
- JIRA:   https://issues.redhat.com/browse/LOG-3194
- OLM Controller change: https://issues.redhat.com//browse/OLM-2695
- Docs:  https://docs.openshift.com/container-platform/4.11/authentication/understanding-and-managing-pod-security-admission.html