### PR TITLE
LOG-2962: add suffix '/must-gather' to the product name

### DIFF
--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -45,7 +45,7 @@ fi
 
 oc -n $NAMESPACE get deployments -o wide > ${clo_folder}/deployments.txt 2>&1
 oc -n $NAMESPACE get ds -o wide > ${clo_folder}/daemonsets.txt 2>&1
-oc -n $NAMESPACE get "${csv_name}" -o jsonpath='{.spec.displayName}{"\n"}{.spec.version}' > "${clo_folder}/version"
+oc -n $NAMESPACE get "${csv_name}" -o jsonpath='{.spec.displayName}{"/must-gather\n"}{.spec.version}' > "${clo_folder}/version"
 
 for r in "secret/elasticsearch" "configmap/collector" ; do
   result="$(oc -n $NAMESPACE get $r --ignore-not-found)"


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
The current implementation in Logging must-gather is:
```
Red Hat OpenShift Logging
5.6.0
```
QE expect:
```
Red Hat OpenShift Logging/must-gather
5.6.0
```

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-2962
- Enhancement proposal:
