### PR TITLE
LOG-3213: fix empty logging must-gather

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,6 +1,6 @@
 #!/bin/bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-BASE_COLLECTION_PATH="${1:-./_artifacts}"
+BASE_COLLECTION_PATH="${1:-/must-gather}"
 mkdir -p "${BASE_COLLECTION_PATH}"
 
 LOGGING_NS="${2:-openshift-logging}"


### PR DESCRIPTION
### Description
This PR:
* fixes an empty logging must-gather by reverting changes introduced in previous commit

### Links
* https://issues.redhat.com/browse/LOG-3213
