### PR TITLE
LOG-3224: ES suppress type fix 

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -415,7 +415,7 @@ key_file = "/etc/collector/metrics/tls.key"
 crt_file = "/etc/collector/metrics/tls.crt"
 `,
 		}),
-		Entry("with complex spec for elasticsearch", testhelpers.ConfGenerateTest{
+		Entry("with complex spec for elasticsearch, without version specified", testhelpers.ConfGenerateTest{
 			CLSpec: logging.CollectionSpec{},
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
@@ -837,7 +837,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 
 [sinks.es_1.tls]
 enabled = true
@@ -927,7 +926,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 
 [sinks.es_2.tls]
 enabled = true

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -15,14 +15,14 @@ import (
 )
 
 type Elasticsearch struct {
-	ID_Key         string
-	Desc           string
-	ComponentID    string
-	Inputs         string
-	Index          string
-	Endpoint       string
-	Version        int
-	DefaultVersion int
+	ID_Key          string
+	Desc            string
+	ComponentID     string
+	Inputs          string
+	Index           string
+	Endpoint        string
+	Version         int
+	SuppressVersion int
 }
 
 func (e Elasticsearch) Name() string {
@@ -40,7 +40,7 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-{{ if or (gt .Version .DefaultVersion) (eq .Version 0) -}}
+{{ if ge .Version .SuppressVersion -}}
 suppress_type_name = true
 {{ end -}}
 {{end}}`
@@ -218,10 +218,10 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 
 func Output(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) Element {
 	es := Elasticsearch{
-		ComponentID:    helpers.FormatComponentID(o.Name),
-		Endpoint:       o.URL,
-		Inputs:         helpers.MakeInputs(inputs...),
-		DefaultVersion: logging.DefaultESVersion,
+		ComponentID:     helpers.FormatComponentID(o.Name),
+		Endpoint:        o.URL,
+		Inputs:          helpers.MakeInputs(inputs...),
+		SuppressVersion: logging.LatestESVersion,
 	}
 	// If valid version is specified
 	if o.Elasticsearch != nil && o.Elasticsearch.Version > 0 {

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -129,7 +129,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 
 # Basic Auth Config
 [sinks.es_1.auth]
@@ -243,7 +242,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 
 [sinks.es_1.tls]
 enabled = true
@@ -347,7 +345,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 `,
 		}),
 		Entry("with multiple pipelines for elastic-search", helpers.ConfGenerateTest{
@@ -487,7 +484,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 
 [sinks.es_1.tls]
 enabled = true
@@ -577,7 +573,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 
 [sinks.es_2.tls]
 enabled = true
@@ -696,7 +691,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 `,
 		}),
 		Entry("with StructuredTypeName", helpers.ConfGenerateTest{
@@ -805,7 +799,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 `,
 		}),
 		Entry("with both StructuredTypeKey and StructuredTypeName", helpers.ConfGenerateTest{
@@ -920,7 +913,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 `,
 		}),
 		Entry("with StructuredTypeKey, StructuredTypeName, container annotations enabled", helpers.ConfGenerateTest{
@@ -1048,7 +1040,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 `,
 		}),
 		Entry("without an Elasticsearch version", helpers.ConfGenerateTest{
@@ -1146,7 +1137,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 `,
 		}),
 		Entry("with an Elasticsearch version less than our default", helpers.ConfGenerateTest{
@@ -1462,7 +1452,6 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 request.timeout_secs = 2147483648
 id_key = "_id"
-suppress_type_name = true
 `,
 		}),
 		Entry("with an Elasticsearch version greater than latest version", helpers.ConfGenerateTest{

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -34,7 +34,6 @@ func (clusterRequest *ClusterLoggingRequest) useOldRemoteSyslogPlugin() bool {
 }
 
 func applyOutputDefaults(outputDefaults *logging.OutputDefaults, out logging.OutputSpec) logging.OutputSpec {
-
 	if outputDefaults != nil && outputDefaults.Elasticsearch != nil {
 		// TODO: fix - outputDefaults should only apply to default output
 		if out.Elasticsearch == nil {
@@ -43,7 +42,6 @@ func applyOutputDefaults(outputDefaults *logging.OutputDefaults, out logging.Out
 			out.Elasticsearch = mergeDefaults(outputDefaults, out)
 		}
 	}
-	out = setESVersion(out)
 	return out
 }
 
@@ -62,21 +60,6 @@ func mergeDefaults(outputDefaults *logging.OutputDefaults, out logging.OutputSpe
 		outES.EnableStructuredContainerLogs = defaults.EnableStructuredContainerLogs
 	}
 	return outES
-}
-
-func setESVersion(out logging.OutputSpec) logging.OutputSpec {
-	// Always set the version for our default output
-	if out.Name == logging.OutputNameDefault {
-		if out.Elasticsearch != nil {
-			out.Elasticsearch.Version = logging.DefaultESVersion
-		} else {
-			out.Elasticsearch = &logging.Elasticsearch{
-				Version: logging.DefaultESVersion,
-			}
-		}
-	}
-
-	return out
 }
 
 func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config string, err error) {
@@ -435,11 +418,6 @@ func (clusterRequest *ClusterLoggingRequest) verifyOutputs(spec *logging.Cluster
 					Type:   logging.OutputTypeElasticsearch,
 					URL:    constants.LogStoreURL,
 					Secret: &logging.OutputSecretSpec{Name: constants.CollectorSecretName},
-					OutputTypeSpec: logging.OutputTypeSpec{
-						Elasticsearch: &logging.Elasticsearch{
-							Version: logging.DefaultESVersion,
-						},
-					},
 				})
 				status.Outputs.Set(name, condReady)
 			case logging.LogStoreTypeLokiStack:


### PR DESCRIPTION
### Description
This is a correction of the logic from [LOG-2769](https://issues.redhat.com//browse/LOG-2769).   We are adding 'suppress_type_name = true' only if the version is specified and is 8 or greater.

/cc @syedriko @vimalk78 
/assign @jcantrill 

### Links
- https://issues.redhat.com/browse/LOG-3224
- original PR:  https://issues.redhat.com/browse/LOG-2769
