### PR TITLE
LOG-3074: fix unused parameter warning

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -362,7 +362,6 @@ var _ = Describe("Testing Complete Config Generation", func() {
   # Viaq Data Model
   <filter **>
     @type viaq_data_model
-    enable_prune_empty_fields false
     default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
     keep_empty_fields 'message'
     rename_time true

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -401,7 +401,6 @@ var _ = Describe("Generating fluentd config", func() {
   # Viaq Data Model
   <filter **>
     @type viaq_data_model
-    enable_prune_empty_fields false
     default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
     keep_empty_fields 'message'
     rename_time true
@@ -1120,7 +1119,6 @@ var _ = Describe("Generating fluentd config", func() {
   # Viaq Data Model
   <filter **>
     @type viaq_data_model
-    enable_prune_empty_fields false
     default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
     keep_empty_fields 'message'
     rename_time true
@@ -1824,7 +1822,6 @@ var _ = Describe("Generating fluentd config", func() {
   # Viaq Data Model
   <filter **>
     @type viaq_data_model
-    enable_prune_empty_fields false
     default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
     keep_empty_fields 'message'
     rename_time true
@@ -2473,7 +2470,6 @@ var _ = Describe("Generating fluentd config", func() {
   # Viaq Data Model
   <filter **>
     @type viaq_data_model
-    enable_prune_empty_fields false
     default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
     keep_empty_fields 'message'
     rename_time true
@@ -2905,7 +2901,6 @@ var _ = Describe("Generating fluentd config", func() {
   # Viaq Data Model
   <filter **>
     @type viaq_data_model
-    enable_prune_empty_fields false
     default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
     keep_empty_fields 'message'
     rename_time true
@@ -3911,7 +3906,6 @@ inputs:
   # Viaq Data Model
   <filter **>
     @type viaq_data_model
-    enable_prune_empty_fields false
     default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
     keep_empty_fields 'message'
     rename_time true

--- a/internal/generator/fluentd/ingress.go
+++ b/internal/generator/fluentd/ingress.go
@@ -233,7 +233,6 @@ const ViaQDataModel string = `
 # {{.Desc}}
 <filter **>
   @type viaq_data_model
-  enable_prune_empty_fields false
   default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
   keep_empty_fields 'message'
   rename_time true


### PR DESCRIPTION
### Description
This PR:
* fixes an unused parameter warning for fluentd by removing the parameter

### Links
* https://issues.redhat.com/browse/LOG-3074