### PR TITLE
LOG-3195: fix json parsing by vector when structuredtypename not defined

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -1325,6 +1325,7 @@ source = '''
   del(.source_type)
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 '''
 
@@ -1417,6 +1418,7 @@ source = '''
   del(.source_type)
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 '''
 

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -117,6 +117,7 @@ if .log_type == "application" && .structured != null {
 		vrls = append(vrls, `
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 `)
 	}

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -633,6 +633,7 @@ source = '''
 
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 '''
 
@@ -742,6 +743,7 @@ source = '''
   }
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 '''
 
@@ -857,6 +859,7 @@ source = '''
   }
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 '''
 
@@ -985,6 +988,7 @@ source = '''
 
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 '''
 
@@ -1189,6 +1193,7 @@ source = '''
   del(.source_type)
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 '''
 
@@ -1294,6 +1299,7 @@ source = '''
   del(.source_type)
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 '''
 
@@ -1399,6 +1405,7 @@ source = '''
   del(.source_type)
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 '''
 
@@ -1505,6 +1512,7 @@ source = '''
   del(.source_type)
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+    del(.structured)
   }
 '''
 

--- a/test/functional/outputs/elasticsearch/forward_to_elasticsearch_index_test.go
+++ b/test/functional/outputs/elasticsearch/forward_to_elasticsearch_index_test.go
@@ -275,6 +275,7 @@ var _ = Describe("[Functional][Outputs][ElasticSearch] forwarding to specific in
 				outputTestLog := logs[0]
 				outputLogTemplate.ViaqIndexName = ""
 				Expect(outputTestLog).To(matchers.FitLogFormatTemplate(outputLogTemplate))
+				Expect(outputTestLog.Structured).To(BeEmpty())
 			})
 		})
 


### PR DESCRIPTION
### Description
This PR:
* fixes json parsing by vector when structuredType is not defined.  It sends message field as-is

### Links
* https://issues.redhat.com/browse/LOG-3195
