### PR TITLE
LOG-2962: fix command for getting product version: using regexp to grep CSV name

### DIFF
--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -43,7 +43,7 @@ if [ "$data" != "" ] ; then
   echo $data | base64 -d > ${clo_folder}/vector.toml 2>&1
 fi
 
-csv_name="$(oc -n $NAMESPACE get csv -o name | grep 'clusterlogging')"
+csv_name="$(oc -n $NAMESPACE get csv -o name | grep -E 'cluster(-?)logging')"
 oc -n $NAMESPACE get deployments -o wide > ${clo_folder}/deployments.txt 2>&1
 oc -n $NAMESPACE get ds -o wide > ${clo_folder}/daemonsets.txt 2>&1
 oc -n $NAMESPACE get "${csv_name}" -o jsonpath='{.spec.displayName}{"/must-gather\n"}{.spec.version}' > "${clo_folder}/version"


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
This PR fix command for getting product version, now it will use regexp to grep CSV name. This is need because CSV can be different dependent of build `clustrerlogging | cluster-logging`


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
