### PR TITLE
LOG-3242: remove loki tag label from fluentd

### DIFF
--- a/internal/generator/fluentd/output/loki/loki.go
+++ b/internal/generator/fluentd/output/loki/loki.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	lokiLabelKubernetesHost = "kubernetes.host"
-	lokiLabelTag            = "tag"
 )
 
 var (
@@ -35,7 +34,6 @@ var (
 	}
 	requiredLabelKeys = []string{
 		lokiLabelKubernetesHost,
-		lokiLabelTag,
 	}
 )
 
@@ -85,7 +83,7 @@ func Output(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o logging
 	if genhelper.IsDebugOutput(op) {
 		return genhelper.DebugOutput
 	}
-	// url is parasable, checked at input sanitization
+	// url is parsable, checked at input sanitization
 	u, _ := urlhelper.Parse(o.URL)
 	urlBase := fmt.Sprintf("%v://%v%v", u.Scheme, u.Host, u.Path)
 	storeID := helpers.StoreID("", o.Name, "")
@@ -163,11 +161,6 @@ func LokiLabelFilter(l *logging.Loki) Element {
 		recordKeys := strings.Replace(k, ".", `","`, -1)
 		var r Record
 		switch k {
-		case lokiLabelTag:
-			r = Record{
-				Key:        "_tag",
-				Expression: "${tag}",
-			}
 		case lokiLabelKubernetesHost:
 			r = Record{
 				Key:        fmt.Sprintf("_%v", tempName),

--- a/internal/generator/fluentd/output/loki/loki_conf_test.go
+++ b/internal/generator/fluentd/output/loki/loki_conf_test.go
@@ -81,7 +81,6 @@ var _ = Describe("Generate fluentd config", func() {
       _kubernetes_namespace_name ${record.dig("kubernetes","namespace_name")}
       _kubernetes_pod_name ${record.dig("kubernetes","pod_name")}
       _log_type ${record.dig("log_type")}
-      _tag ${tag}
     </record>
   </filter>
   
@@ -98,7 +97,6 @@ var _ = Describe("Generate fluentd config", func() {
       kubernetes_namespace_name _kubernetes_namespace_name
       kubernetes_pod_name _kubernetes_pod_name
       log_type _log_type
-      tag _tag
     </label>
     <buffer>
       @type file
@@ -152,7 +150,6 @@ var _ = Describe("Generate fluentd config", func() {
       _kubernetes_container_name ${record.dig("kubernetes","container_name")}
       _kubernetes_host "#{ENV['NODE_NAME']}"
       _kubernetes_labels_app ${record.dig("kubernetes","labels","app")}
-      _tag ${tag}
     </record>
   </filter>
   
@@ -167,7 +164,6 @@ var _ = Describe("Generate fluentd config", func() {
       kubernetes_container_name _kubernetes_container_name
       kubernetes_host _kubernetes_host
       kubernetes_labels_app _kubernetes_labels_app
-      tag _tag
     </label>
     <buffer>
       @type file

--- a/internal/generator/fluentd/output/loki/output_conf_loki_test.go
+++ b/internal/generator/fluentd/output/loki/output_conf_loki_test.go
@@ -60,7 +60,6 @@ func TestLokiOutput(t *testing.T) {
          _kubernetes_namespace_name ${record.dig("kubernetes","namespace_name")}
          _kubernetes_pod_name ${record.dig("kubernetes","pod_name")}
          _log_type ${record.dig("log_type")}
-         _tag ${tag}
 `,
 				label: `
        kubernetes_container_name _kubernetes_container_name
@@ -68,7 +67,6 @@ func TestLokiOutput(t *testing.T) {
        kubernetes_namespace_name _kubernetes_namespace_name
        kubernetes_pod_name _kubernetes_pod_name
        log_type _log_type
-       tag _tag
 `,
 				buffer: `
      @type file
@@ -162,13 +160,11 @@ bearer_token_file /var/run/secrets/kubernetes.io/serviceaccount/token`
       _kubernetes_container_name ${record.dig("kubernetes","container_name")}
       _kubernetes_host "#{ENV['NODE_NAME']}"
       _kubernetes_labels_app ${record.dig("kubernetes","labels","app")}
-      _tag ${tag}
 `
 		config.label = `
       kubernetes_container_name _kubernetes_container_name
       kubernetes_host _kubernetes_host
       kubernetes_labels_app _kubernetes_labels_app
-      tag _tag
 `
 		require.Equal(t, test.TrimLines(config.String()), test.TrimLines(results), results)
 	})

--- a/test/functional/outputs/loki/application_logs_test.go
+++ b/test/functional/outputs/loki/application_logs_test.go
@@ -5,7 +5,6 @@ package loki
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"testing"
@@ -28,16 +27,6 @@ func TestLokiOutput(t *testing.T) {
 		l      *loki.Receiver
 		tsTime = time.Now()
 		ts     = functional.CRIOTime(tsTime)
-
-		containerTag = func(f *functional.CollectorFunctionalFramework) string {
-			for _, s := range f.Pod.Status.ContainerStatuses {
-				if s.Name == constants.CollectorName {
-					return fmt.Sprintf("kubernetes.var.log.pods.%s_%s_%s.%s.0.log", f.Pod.Namespace, f.Pod.Name, f.Pod.UID, f.Pod.Spec.Containers[0].Name)
-				}
-			}
-			assert.Fail(t, "Unable to find the container id to create a tag for the test")
-			return ""
-		}
 	)
 
 	// testCase does common setup/teardown around a testFunc
@@ -93,7 +82,6 @@ func TestLokiOutput(t *testing.T) {
 			"kubernetes_namespace_name": f.Namespace,
 			"kubernetes_pod_name":       f.Name,
 			"kubernetes_container_name": f.Pod.Spec.Containers[0].Name,
-			"tag":                       containerTag(f),
 		}
 		assert.Equal(t, want, labels)
 
@@ -139,7 +127,6 @@ func TestLokiOutput(t *testing.T) {
 				"kubernetes_labels_k8s":     "k8s-value",
 				"openshift_labels_logging":  "logging-value",
 				"kubernetes_host":           functional.FunctionalNodeName,
-				"tag":                       containerTag(f),
 			}
 			labels := r[0].Stream
 			delete(labels, "fluentd_thread") // Added by loki plugin.


### PR DESCRIPTION
### Description
'tag' is un-documented as a label key, nor is it part of viaq data model   It needs to be removed from Loki output.  Our Loki output needs to be aligned with our ES logstore output, which does not contain 'tag'. 

/cc @syedriko @vimalk78 
/assign  @jcantrill 

### Links
- JIRA task: https://issues.redhat.com/browse/LOG-3242
- Loki labelKeys: https://github.com/openshift/cluster-logging-operator/blob/master/apis/logging/v1/output_types.go#L233
- Viaq data model:  https://viaq.github.io/documentation/data_model/public/data_model.html

