### PR TITLE
LOG-3284: fix json parsing by vector when structuredtypename not defined

### DIFF
--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -112,6 +112,7 @@ if .log_type == "application" && .structured != null {
 		vrls = append(vrls, `
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+	 del(.structured)
   }
 `)
 	}

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -598,6 +598,7 @@ source = '''
 
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+ 	del(.structured)
   }
 '''
 
@@ -700,6 +701,7 @@ source = '''
   }
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+	 del(.structured)
   }
 '''
 
@@ -808,6 +810,7 @@ source = '''
   }
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+ 	del(.structured)
   }
 '''
 
@@ -929,6 +932,7 @@ source = '''
 
   if .structured != null && .write_index == "app-write" {
     .message = encode_json(.structured)
+	 del(.structured)
   }
 '''
 


### PR DESCRIPTION
### Description
This PR:
* fixes json parsing by vector when structuredType is not defined.  It sends message field as-is

### Links
* https://issues.redhat.com/browse/LOG-3284