### PR TITLE
LOG-3298: Fix Passphrase config template

### DIFF
--- a/internal/generator/vector/output/security/passphrase.go
+++ b/internal/generator/vector/output/security/passphrase.go
@@ -6,7 +6,7 @@ func (p Passphrase) Name() string {
 
 func (p Passphrase) Template() string {
 	return `{{define "` + p.Name() + `" -}}
-key_pass = "{{p.PassphrasePath}}"
+key_pass = {{.PassphrasePath}}
 {{- end}}
 `
 }

--- a/internal/generator/vector/output/splunk/splunk_test.go
+++ b/internal/generator/vector/output/splunk/splunk_test.go
@@ -1,13 +1,14 @@
 package splunk
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
 )
 
 // #nosec G101
@@ -41,6 +42,21 @@ key_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/ca-bundle.crt"
 `
+		splunkSinkPassphrase = `
+[sinks.splunk_hec]
+type = "splunk_hec"
+inputs = ["pipelineName"]
+endpoint = "https://splunk-web:8088/endpoint"
+compression = "none"
+default_token = "` + hecToken + `"
+
+[sinks.splunk_hec.encoding]
+codec = "json"
+
+[sinks.splunk_hec.tls]
+enabled = true
+key_pass = "/var/run/ocp-collector/secrets/vector-splunk-secret-passphrase/passphrase"
+`
 	)
 
 	var (
@@ -58,6 +74,17 @@ ca_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/ca-bundle.crt
 			},
 		}
 
+		outputWithPassphrase = loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeSplunk,
+			Name: "splunk_hec",
+			URL:  "https://splunk-web:8088/endpoint",
+			OutputTypeSpec: loggingv1.OutputTypeSpec{
+				Splunk: &loggingv1.Splunk{},
+			},
+			Secret: &loggingv1.OutputSecretSpec{
+				Name: "vector-splunk-secret-passphrase",
+			},
+		}
 		outputWithTls = loggingv1.OutputSpec{
 			Type: loggingv1.OutputTypeSplunk,
 			Name: "splunk_hec",
@@ -84,6 +111,12 @@ ca_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/ca-bundle.crt
 					"ca-bundle.crt": []byte("junk"),
 				},
 			},
+			outputWithPassphrase.Secret.Name: {
+				Data: map[string][]byte{
+					"hecToken":   []byte(hecToken),
+					"passphrase": []byte("junk"),
+				},
+			},
 		}
 	)
 
@@ -97,6 +130,13 @@ ca_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/ca-bundle.crt
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(splunkSink))
+		})
+
+		It("should provide a valid config with passphrase", func() {
+			element := Conf(outputWithPassphrase, []string{"pipelineName"}, secrets[outputWithPassphrase.Secret.Name], nil)
+			results, err := g.GenerateConf(element...)
+			Expect(err).To(BeNil())
+			Expect(results).To(EqualTrimLines(splunkSinkPassphrase))
 		})
 
 		It("should provide a valid config with TLS", func() {


### PR DESCRIPTION
### Description
- Fixed vector config template for Passphrase.
- Added Unit tests for reproducing, and fixing  the problem.

/cc @vparfonov 
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3298
- Enhancement proposal:
