### PR TITLE
LOG-3235: fix collector security context spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ COPY --from=origincli /usr/bin/oc /usr/bin
 COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/must-gather/collection-scripts/* /usr/bin/
 
 # this is required because the operator invokes a script as `bash scripts/cert_generation.sh`
+USER 1000
 WORKDIR /usr/bin
 CMD ["/usr/bin/cluster-logging-operator"]
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -62,6 +62,7 @@ COPY --from=origincli /usr/bin/oc /usr/bin
 COPY --from=builder /go/src/github.com/openshift/cluster-logging-operator/must-gather/collection-scripts/* /usr/bin/
 
 # this is required because the operator invokes a script as `bash scripts/cert_generation.sh`
+USER 1000
 WORKDIR /usr/bin
 CMD ["/usr/bin/cluster-logging-operator"]
 

--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -370,7 +370,7 @@ spec:
           resources:
           - securitycontextconstraints
           verbs:
-          - create
+          - '*'
         - apiGroups:
           - ""
           resources:

--- a/config/rbac/cluster-logging-operator_clusterrole.yaml
+++ b/config/rbac/cluster-logging-operator_clusterrole.yaml
@@ -50,7 +50,7 @@ rules:
   resources:
     - securitycontextconstraints
   verbs:
-    - create
+    - "*"
 - apiGroups:
     - ""
   resources:

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -256,11 +256,27 @@ func addSecretVolumes(podSpec *v1.PodSpec, pipelineSpec logging.ClusterLogForwar
 
 func addSecurityContextTo(container *v1.Container) *v1.Container {
 	container.SecurityContext = &v1.SecurityContext{
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{
+				"CHOWN",
+				"DAC_OVERRIDE",
+				"FSETID",
+				"FOWNER",
+				"SETGID",
+				"SETUID",
+				"SETPCAP",
+				"NET_BIND_SERVICE",
+				"KILL",
+			},
+		},
 		SELinuxOptions: &v1.SELinuxOptions{
 			Type: "spc_t",
 		},
 		ReadOnlyRootFilesystem:   utils.GetBool(true),
 		AllowPrivilegeEscalation: utils.GetBool(false),
+		SeccompProfile: &v1.SeccompProfile{
+			Type: v1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 	return container
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -42,11 +42,27 @@ var _ = Describe("Factory#NewPodSpec", func() {
 		})
 		It("should set a security context", func() {
 			Expect(collector.SecurityContext).To(Equal(&v1.SecurityContext{
+				Capabilities: &v1.Capabilities{
+					Drop: []v1.Capability{
+						"CHOWN",
+						"DAC_OVERRIDE",
+						"FSETID",
+						"FOWNER",
+						"SETGID",
+						"SETUID",
+						"SETPCAP",
+						"NET_BIND_SERVICE",
+						"KILL",
+					},
+				},
 				SELinuxOptions: &v1.SELinuxOptions{
 					Type: "spc_t",
 				},
 				ReadOnlyRootFilesystem:   utils.GetBool(true),
 				AllowPrivilegeEscalation: utils.GetBool(false),
+				SeccompProfile: &v1.SeccompProfile{
+					Type: v1.SeccompProfileTypeRuntimeDefault,
+				},
 			}))
 		})
 	})

--- a/internal/collector/scc.go
+++ b/internal/collector/scc.go
@@ -1,4 +1,4 @@
-package k8shandler
+package collector
 
 import (
 	. "github.com/openshift/api/security/v1"

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -3,6 +3,7 @@ package k8shandler
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/reconcile"
 	"path"
 	"reflect"
 	"time"
@@ -586,10 +587,9 @@ func (clusterRequest *ClusterLoggingRequest) createOrUpdateCollectorServiceAccou
 	}
 
 	// If needed create a custom SecurityContextConstraints object for the log collector to run with
-	scc := NewSCC(LogCollectorSCCName)
-	err := clusterRequest.Create(scc)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return nil, fmt.Errorf("Failure creating Log collector SecurityContextConstraints: %v", err)
+	scc := collector.NewSCC(collector.LogCollectorSCCName)
+	if err := reconcile.SecurityContextConstraints(clusterRequest.Client, scc); err != nil {
+		return nil, err
 	}
 
 	subject := NewSubject(

--- a/internal/reconcile/scc.go
+++ b/internal/reconcile/scc.go
@@ -1,0 +1,33 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	log "github.com/ViaQ/logerr/v2/log/static"
+	security "github.com/openshift/api/security/v1"
+	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/scc"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func SecurityContextConstraints(k8Client client.Client, desired *security.SecurityContextConstraints) error {
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &security.SecurityContextConstraints{}
+		key := client.ObjectKeyFromObject(desired)
+		if err := k8Client.Get(context.TODO(), key, current); err != nil {
+			if errors.IsNotFound(err) {
+				return k8Client.Create(context.TODO(), desired)
+			}
+			return fmt.Errorf("failed to get %v SecurityContextConstraints: %w", key, err)
+		}
+
+		same := false
+		if same, _ = scc.AreSame(*current, *desired); same {
+			log.V(3).Info("SecurityContextConstraints are the same skipping update")
+			return nil
+		}
+		return k8Client.Update(context.TODO(), current)
+	})
+	return retryErr
+}

--- a/internal/utils/comparators/scc/comparator.go
+++ b/internal/utils/comparators/scc/comparator.go
@@ -1,0 +1,109 @@
+package scc
+
+import (
+	log "github.com/ViaQ/logerr/v2/log/static"
+	security "github.com/openshift/api/security/v1"
+	"reflect"
+	"sort"
+)
+
+func AreSame(current, desired security.SecurityContextConstraints) (bool, string) {
+	log.V(3).Info("Comparing SCC current to desired", "current", current, "desired", desired)
+
+	if same, property := samePriority(current.Priority, desired.Priority); !same {
+		return same, property
+	}
+
+	if current.AllowPrivilegedContainer != desired.AllowPrivilegedContainer {
+		log.V(3).Info("SCC AllowPrivilegedContainer change", "current name", current.Name)
+		return false, "allowPrivilegedContainer"
+	}
+
+	sort.Slice(current.RequiredDropCapabilities, func(i, j int) bool { return current.RequiredDropCapabilities[i] < current.RequiredDropCapabilities[j] })
+	sort.Slice(desired.RequiredDropCapabilities, func(i, j int) bool { return desired.RequiredDropCapabilities[i] < desired.RequiredDropCapabilities[j] })
+	if !reflect.DeepEqual(current.RequiredDropCapabilities, desired.RequiredDropCapabilities) {
+		log.V(3).Info("SCC RequiredDropCapabilities change", "current name", current.Name)
+		return false, "requiredDropCapabilities"
+	}
+
+	if current.AllowHostDirVolumePlugin != desired.AllowHostDirVolumePlugin {
+		log.V(3).Info("SCC AllowHostDirVolumePlugin change", "current name", current.Name)
+		return false, "allowHostDirVolumePlugin"
+	}
+
+	sort.Slice(current.Volumes, func(i, j int) bool { return current.Volumes[i] < current.Volumes[j] })
+	sort.Slice(desired.Volumes, func(i, j int) bool { return desired.Volumes[i] < desired.Volumes[j] })
+	if !reflect.DeepEqual(current.Volumes, desired.Volumes) {
+		log.V(3).Info("SCC Volumes change", "current name", current.Name)
+		return false, "volumes"
+	}
+
+	if !sameAllowPrivilegeEscalation(current.DefaultAllowPrivilegeEscalation, desired.DefaultAllowPrivilegeEscalation) {
+		log.V(3).Info("SCC DefaultAllowPrivilegeEscalation change", "current", current.DefaultAllowPrivilegeEscalation, "desired", desired.DefaultAllowPrivilegeEscalation)
+		return false, "defaultAllowPrivilegeEscalation"
+	}
+
+	if !sameAllowPrivilegeEscalation(current.AllowPrivilegeEscalation, desired.AllowPrivilegeEscalation) {
+		log.V(3).Info("SCC AllowPrivilegeEscalation change", "current", current.AllowPrivilegeEscalation, "desired", desired.AllowPrivilegeEscalation)
+		return false, "allowPrivilegeEscalation"
+	}
+
+	if !reflect.DeepEqual(current.RunAsUser, desired.RunAsUser) {
+		log.V(3).Info("SCC RunAsUser change", "current name", current.Name)
+		return false, "runAsUser"
+	}
+	if !reflect.DeepEqual(current.SELinuxContext, desired.SELinuxContext) {
+		log.V(3).Info("SCC SELinuxContext change", "current name", current.Name)
+		return false, "SELinuxContext"
+	}
+
+	if current.ReadOnlyRootFilesystem != desired.ReadOnlyRootFilesystem {
+		log.V(3).Info("SCC ReadOnlyRootFilesystem change", "current name", current.Name)
+		return false, "allowPrivilegeEscalation"
+	}
+
+	sort.Slice(current.ForbiddenSysctls, func(i, j int) bool { return current.ForbiddenSysctls[i] < current.ForbiddenSysctls[j] })
+	sort.Slice(desired.ForbiddenSysctls, func(i, j int) bool { return desired.ForbiddenSysctls[i] < desired.ForbiddenSysctls[j] })
+	if !reflect.DeepEqual(current.ForbiddenSysctls, desired.ForbiddenSysctls) {
+		log.V(3).Info("SCC ForbiddenSysctls change", "current name", current.Name)
+		return false, "ForbiddenSysctls"
+	}
+
+	sort.Slice(current.SeccompProfiles, func(i, j int) bool { return current.SeccompProfiles[i] < current.SeccompProfiles[j] })
+	sort.Slice(desired.SeccompProfiles, func(i, j int) bool { return desired.SeccompProfiles[i] < desired.SeccompProfiles[j] })
+	if !reflect.DeepEqual(current.SeccompProfiles, desired.SeccompProfiles) {
+		log.V(3).Info("SCC SeccompProfiles change", "current name", current.Name)
+		return false, "SeccompProfiles"
+	}
+
+	return true, ""
+}
+
+func samePriority(current, desired *int32) (bool, string) {
+	if current == nil && desired != nil || current != nil && desired == nil {
+		log.V(3).Info("SCC AllowPrivilegedContainer change")
+		return false, "priority"
+	}
+	if current != nil && desired != nil && *current != *desired {
+		log.V(3).Info("SCC AllowPrivilegedContainer change")
+		return false, "priority"
+	}
+	return true, ""
+}
+
+func sameAllowPrivilegeEscalation(current, desired *bool) bool {
+	if (current != nil && desired == nil) ||
+		(current == nil && desired != nil) ||
+		(current != nil && desired != nil &&
+			*current != *desired) {
+		return false
+	}
+
+	if (desired != nil && current == nil) ||
+		(desired == nil && current != nil) ||
+		(desired != nil && current != nil &&
+			*desired != *current) {
+		return false
+	}
+	return true
+}

--- a/internal/utils/comparators/scc/comparator_test.go
+++ b/internal/utils/comparators/scc/comparator_test.go
@@ -1,0 +1,57 @@
+package scc_test
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	security "github.com/openshift/api/security/v1"
+	"github.com/openshift/cluster-logging-operator/internal/collector"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	. "github.com/openshift/cluster-logging-operator/internal/utils/comparators/scc"
+)
+
+var _ = Describe("scc#AreSame", func() {
+
+	It("should succeed when they are the same", func() {
+		left := collector.NewSCC("foo")
+		right := left.DeepCopy()
+		same, reason := AreSame(*left, *right)
+		Expect(same).To(BeTrue(), fmt.Sprintf("Exp. comparator to succeed when fields are the same, reason: %s are different", reason))
+	})
+
+	DescribeTable("should fail with different", func(modifications ...func(*security.SecurityContextConstraints)) {
+		left := collector.NewSCC("foo")
+		right := left.DeepCopy()
+		if len(modifications) > 0 {
+			modifications[0](right)
+		}
+		if len(modifications) > 1 {
+			modifications[1](left)
+		}
+		same, _ := AreSame(*left, *right)
+		Expect(same).To(BeFalse(), "Exp. comparator to fail for dissimilar property")
+	},
+		Entry("Priority nil", func(right *security.SecurityContextConstraints) { right.Priority = nil }, func(left *security.SecurityContextConstraints) { left.Priority = utils.GetInt32(12) }),
+		Entry("Priority different value", func(right *security.SecurityContextConstraints) { right.Priority = utils.GetInt32(12) }),
+		Entry("AllowPrivilegedContainer", func(right *security.SecurityContextConstraints) { right.AllowPrivilegedContainer = true }),
+		Entry("RequiredDropCapabilities", func(right *security.SecurityContextConstraints) {
+			right.RequiredDropCapabilities = append(right.RequiredDropCapabilities, "foo")
+		}),
+		Entry("AllowHostDirVolumePlugin", func(right *security.SecurityContextConstraints) { right.AllowHostDirVolumePlugin = false }),
+		Entry("Volumes", func(right *security.SecurityContextConstraints) { right.Volumes = right.Volumes[1:] }),
+		Entry("DefaultAllowPrivilegeEscalation", func(right *security.SecurityContextConstraints) {
+			right.DefaultAllowPrivilegeEscalation = utils.GetBool(true)
+		}),
+		Entry("AllowPrivilegeEscalation", func(right *security.SecurityContextConstraints) { right.AllowPrivilegeEscalation = utils.GetBool(true) }),
+		Entry("RunAsUser", func(right *security.SecurityContextConstraints) {
+			right.RunAsUser = security.RunAsUserStrategyOptions{}
+		}),
+		Entry("SELinuxContext", func(right *security.SecurityContextConstraints) {
+			right.SELinuxContext = security.SELinuxContextStrategyOptions{}
+		}),
+		Entry("ReadOnlyRootFilesystem", func(right *security.SecurityContextConstraints) { right.ReadOnlyRootFilesystem = false }),
+		Entry("ForbiddenSysctls", func(right *security.SecurityContextConstraints) { right.ForbiddenSysctls = []string{"abc"} }),
+		Entry("SeccompProfiles", func(right *security.SecurityContextConstraints) { right.SeccompProfiles = []string{"abc"} }),
+	)
+})

--- a/internal/utils/comparators/scc/suite_test.go
+++ b/internal/utils/comparators/scc/suite_test.go
@@ -1,0 +1,13 @@
+package scc_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SecurityContextConstraints Comparator Suite")
+}


### PR DESCRIPTION
### Description
This PR:
* sets the log collector security context spec so the logging SCC is more likely to apply versus others
* adds reconcile logic for the collector SCC other then just "create"
* Add SCC comparator and tests

### Links
* https://issues.redhat.com/browse/LOG-3235
