### PR TITLE
LOG-3302: fix collector security context spec

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -253,11 +253,17 @@ func addSecretVolumes(podSpec *v1.PodSpec, pipelineSpec logging.ClusterLogForwar
 
 func addSecurityContextTo(container *v1.Container) *v1.Container {
 	container.SecurityContext = &v1.SecurityContext{
+		Capabilities: &v1.Capabilities{
+			Drop: RequiredDropCapabilities,
+		},
 		SELinuxOptions: &v1.SELinuxOptions{
 			Type: "spc_t",
 		},
 		ReadOnlyRootFilesystem:   utils.GetBool(true),
 		AllowPrivilegeEscalation: utils.GetBool(false),
+		SeccompProfile: &v1.SeccompProfile{
+			Type: v1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 	return container
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -44,11 +44,17 @@ var _ = Describe("Factory#NewPodSpec", func() {
 		})
 		It("should set a security context", func() {
 			Expect(collector.SecurityContext).To(Equal(&v1.SecurityContext{
+				Capabilities: &v1.Capabilities{
+					Drop: RequiredDropCapabilities,
+				},
 				SELinuxOptions: &v1.SELinuxOptions{
 					Type: "spc_t",
 				},
 				ReadOnlyRootFilesystem:   utils.GetBool(true),
 				AllowPrivilegeEscalation: utils.GetBool(false),
+				SeccompProfile: &v1.SeccompProfile{
+					Type: v1.SeccompProfileTypeRuntimeDefault,
+				},
 			}))
 		})
 	})

--- a/internal/collector/service_account.go
+++ b/internal/collector/service_account.go
@@ -15,6 +15,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	RequiredDropCapabilities = []corev1.Capability{
+		"CHOWN",
+		"DAC_OVERRIDE",
+		"FSETID",
+		"FOWNER",
+		"SETGID",
+		"SETUID",
+		"SETPCAP",
+		"NET_BIND_SERVICE",
+		"KILL",
+	}
+)
+
 // ReconcileServiceAccount reconciles the serviceaccount specifically for a collector deployment
 func ReconcileServiceAccount(er record.EventRecorder, k8sClient client.Client, namespace, name string, owner metav1.OwnerReference) (err error) {
 	serviceAccount := runtime.NewServiceAccount(namespace, name)
@@ -66,17 +80,7 @@ func NewSCC() *security.SecurityContextConstraints {
 
 	scc := runtime.NewSCC("log-collector-scc")
 	scc.AllowPrivilegedContainer = false
-	scc.RequiredDropCapabilities = []corev1.Capability{
-		"CHOWN",
-		"DAC_OVERRIDE",
-		"FSETID",
-		"FOWNER",
-		"SETGID",
-		"SETUID",
-		"SETPCAP",
-		"NET_BIND_SERVICE",
-		"KILL",
-	}
+	scc.RequiredDropCapabilities = RequiredDropCapabilities
 	scc.AllowHostDirVolumePlugin = true
 	scc.Volumes = []security.FSType{"configMap", "secret", "emptyDir", "projected"}
 	scc.DefaultAllowPrivilegeEscalation = utils.GetBool(false)

--- a/internal/utils/comparators/scc/comparator_test.go
+++ b/internal/utils/comparators/scc/comparator_test.go
@@ -20,13 +20,20 @@ var _ = Describe("scc#AreSame", func() {
 		Expect(same).To(BeTrue(), fmt.Sprintf("Exp. comparator to succeed when fields are the same, reason: %s are different", reason))
 	})
 
-	DescribeTable("should fail with different", func(modify func(*security.SecurityContextConstraints)) {
+	DescribeTable("should fail with different", func(modifications ...func(*security.SecurityContextConstraints)) {
 		left := collector.NewSCC()
 		right := left.DeepCopy()
-		modify(right)
+		if len(modifications) > 0 {
+			modifications[0](right)
+		}
+		if len(modifications) > 1 {
+			modifications[1](left)
+		}
 		same, _ := AreSame(*left, *right)
 		Expect(same).To(BeFalse(), "Exp. comparator to fail for dissimilar property")
 	},
+		Entry("Priority nil", func(right *security.SecurityContextConstraints) { right.Priority = nil }, func(left *security.SecurityContextConstraints) { left.Priority = utils.GetInt32(12) }),
+		Entry("Priority different value", func(right *security.SecurityContextConstraints) { right.Priority = utils.GetInt32(12) }),
 		Entry("AllowPrivilegedContainer", func(right *security.SecurityContextConstraints) { right.AllowPrivilegedContainer = true }),
 		Entry("RequiredDropCapabilities", func(right *security.SecurityContextConstraints) {
 			right.RequiredDropCapabilities = append(right.RequiredDropCapabilities, "foo")


### PR DESCRIPTION
### Description
This PR:
* sets the log collector security context spec so the logging SCC is more likely to apply versus others
* adds reconcile logic for the collector SCC other then just "create"
* Add SCC comparator and tests

### Links
* https://issues.redhat.com/browse/LOG-3302
* forward port of https://github.com/openshift/cluster-logging-operator/pull/1759