### PR TITLE
LOG-3241: remove tag label from loki vector

### DIFF
--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -70,9 +70,16 @@ var _ = Describe("Generate vector config", func() {
 				},
 			},
 			ExpectedConf: `
+[transforms.loki_receiver_remap]
+type = "remap"
+inputs = ["application"]
+source = '''
+  del(.tag)
+'''
+
 [sinks.loki_receiver]
 type = "loki"
-inputs = ["application"]
+inputs = ["loki_receiver_remap"]
 endpoint = "https://logs-us-west1.grafana.net"
 out_of_order_action = "accept"
 healthcheck.enabled = false
@@ -119,9 +126,16 @@ password = "password"
 				},
 			},
 			ExpectedConf: `
+[transforms.loki_receiver_remap]
+type = "remap"
+inputs = ["application"]
+source = '''
+  del(.tag)
+'''
+
 [sinks.loki_receiver]
 type = "loki"
-inputs = ["application"]
+inputs = ["loki_receiver_remap"]
 endpoint = "https://logs-us-west1.grafana.net"
 out_of_order_action = "accept"
 healthcheck.enabled = false
@@ -166,9 +180,16 @@ password = "password"
 				},
 			},
 			ExpectedConf: `
+[transforms.loki_receiver_remap]
+type = "remap"
+inputs = ["application"]
+source = '''
+  del(.tag)
+'''
+
 [sinks.loki_receiver]
 type = "loki"
-inputs = ["application"]
+inputs = ["loki_receiver_remap"]
 endpoint = "https://logs-us-west1.grafana.net"
 out_of_order_action = "accept"
 healthcheck.enabled = false
@@ -213,9 +234,16 @@ password = "password"
 				},
 			},
 			ExpectedConf: `
+[transforms.loki_receiver_remap]
+type = "remap"
+inputs = ["application"]
+source = '''
+  del(.tag)
+'''
+
 [sinks.loki_receiver]
 type = "loki"
-inputs = ["application"]
+inputs = ["loki_receiver_remap"]
 endpoint = "http://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application"
 out_of_order_action = "accept"
 healthcheck.enabled = false
@@ -263,9 +291,16 @@ var _ = Describe("Generate vector config for in cluster loki", func() {
 				},
 			},
 			ExpectedConf: `
+[transforms.loki_receiver_remap]
+type = "remap"
+inputs = ["application"]
+source = '''
+  del(.tag)
+'''
+
 [sinks.loki_receiver]
 type = "loki"
-inputs = ["application"]
+inputs = ["loki_receiver_remap"]
 endpoint = "http://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application"
 out_of_order_action = "accept"
 healthcheck.enabled = false

--- a/test/functional/outputs/loki/audit_logs_vector_test.go
+++ b/test/functional/outputs/loki/audit_logs_vector_test.go
@@ -1,0 +1,100 @@
+//go:build vector
+// +build vector
+
+package loki
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	"github.com/openshift/cluster-logging-operator/test/helpers/loki"
+	"time"
+)
+
+var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
+	var (
+		f *functional.CollectorFunctionalFramework
+		l *loki.Receiver
+	)
+
+	BeforeEach(func() {
+		f = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
+		// Start a Loki server
+		l = loki.NewReceiver(f.Namespace, "loki-server")
+		Expect(l.Create(f.Test.Client)).To(Succeed())
+
+		// Set up the common template forwarder configuration.
+		f.Forwarder.Spec.Outputs = append(f.Forwarder.Spec.Outputs,
+			logging.OutputSpec{
+				Name: logging.OutputTypeLoki,
+				Type: logging.OutputTypeLoki,
+				URL:  l.InternalURL("").String(),
+				OutputTypeSpec: logging.OutputTypeSpec{
+					Loki: &logging.Loki{},
+				},
+			})
+		f.Forwarder.Spec.Pipelines = append(f.Forwarder.Spec.Pipelines,
+			logging.PipelineSpec{
+				OutputRefs: []string{logging.OutputTypeLoki},
+				InputRefs:  []string{logging.InputNameAudit},
+				Labels:     map[string]string{"logging": "logging-value"},
+			})
+
+		Expect(f.Deploy()).To(BeNil())
+	})
+
+	AfterEach(func() {
+		f.Cleanup()
+	})
+
+	writeAndVerifyLogs := func(writeLogs func() error) {
+
+		Expect(writeLogs()).To(Succeed())
+
+		// Verify we can query by Loki labels
+		query := fmt.Sprintf(`{log_type=%q, kubernetes_host=%q}`, "audit", f.Pod.Spec.NodeName)
+		r, err := l.QueryUntil(query, "", 1)
+		Expect(err).To(Succeed())
+		records := r[0].Records()
+		Expect(records).To(HaveCap(1), "Exp. the record to be ingested")
+
+		expLabels := map[string]string{
+			"kubernetes_host": f.Pod.Spec.NodeName,
+			"log_type":        "audit",
+		}
+		actualLabels := r[0].Stream
+		Expect(actualLabels).To(BeEquivalentTo(expLabels), "Exp. labels to be added to the log record")
+	}
+
+	Context("when writing Audit logs from different sources", func() {
+		It("should ingest kubernetes audit records from different audit sources without error", func() {
+			now := time.Now()
+			nowCrio := functional.CRIOTime(now)
+			openshiftAuditLogs := fmt.Sprintf(functional.OpenShiftAuditLogTemplate, nowCrio, nowCrio)
+			earlier := now.Add(-1 * 30 * time.Minute)
+			earlierLog := functional.NewKubeAuditLog(earlier)
+
+			writeAndVerifyLogs(func() error {
+				Expect(f.WriteMessagesToOpenshiftAuditLog(openshiftAuditLogs, 1)).To(Succeed())
+				return f.WriteMessagesTok8sAuditLog(earlierLog, 1)
+			})
+		})
+	})
+
+	Context("when writing Audit logs", func() {
+		It("should ingest linux audit records without error", func() {
+			writeAndVerifyLogs(func() error { return f.WriteAuditHostLog(1) })
+		})
+		It("should ingest kubernetes audit records without error", func() {
+			writeAndVerifyLogs(func() error { return f.WriteK8sAuditLog(1) })
+		})
+		It("should ingest openshift audit records without error", func() {
+			writeAndVerifyLogs(func() error { return f.WriteOpenshiftAuditLog(1) })
+		})
+		It("should ingest OVN audit records without error", func() {
+			writeAndVerifyLogs(func() error { return f.WriteOVNAuditLog(1) })
+		})
+	})
+})


### PR DESCRIPTION
### Description
'tag' is un-documented as a label key, nor is it part of viaq data model   It needs to be removed from Loki output.  Our Loki output needs to be aligned with our ES logstore output, which does not contain 'tag'. 

This vector task aligns with the same already merged for fluentd.

/cc @syedriko @vimalk78 
/assign  @jcantrill 

### Links
- JIRA task: https://issues.redhat.com/browse/LOG-3241
- Loki labelKeys: https://github.com/openshift/cluster-logging-operator/blob/master/apis/logging/v1/output_types.go#L233
- Viaq data model:  https://viaq.github.io/documentation/data_model/public/data_model.html
