### PR TITLE
LOG-3342: fix applying OutputDefault to unmanaged Elasticsearch logSt…

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder_types.go
+++ b/apis/logging/v1/cluster_log_forwarder_types.go
@@ -49,7 +49,16 @@ type ClusterLogForwarderSpec struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Forwarder Pipelines",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:forwarderPipelines"}
 	Pipelines []PipelineSpec `json:"pipelines,omitempty"`
 
-	// OutputDefaults are used to specify default values for OutputSpec
+	// DEPRECATED OutputDefaults specify forwarder config explicitly for the
+	// default managed log store named 'default'.  If there is a need to spec
+	// the managed logstore, define an outputSpec like the following where the
+	// managed fields (e.g. URL, Secret.Name) will be replaced with the required values:
+	// spec:
+	//   - outputs:
+	//     - name: default
+	//       type: elasticsearch
+	//       elasticsearch:
+	//         structuredTypeKey: kubernetes.labels.myvalue
 	//
 	// +optional
 	OutputDefaults *OutputDefaults `json:"outputDefaults,omitempty"`

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -134,8 +134,12 @@ spec:
                   type: object
                 type: array
               outputDefaults:
-                description: OutputDefaults are used to specify default values for
-                  OutputSpec
+                description: 'DEPRECATED OutputDefaults specify forwarder config explicitly
+                  for the default managed log store named ''default''.  If there is
+                  a need to spec the managed logstore, define an outputSpec like the
+                  following where the managed fields (e.g. URL, Secret.Name) will
+                  be replaced with the required values: spec: - outputs: - name: default
+                  type: elasticsearch elasticsearch: structuredTypeKey: kubernetes.labels.myvalue'
                 properties:
                   elasticsearch:
                     description: "Elasticsearch OutputSpec default values \n Values

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -130,8 +130,12 @@ spec:
                   type: object
                 type: array
               outputDefaults:
-                description: OutputDefaults are used to specify default values for
-                  OutputSpec
+                description: 'DEPRECATED OutputDefaults specify forwarder config explicitly
+                  for the default managed log store named ''default''.  If there is
+                  a need to spec the managed logstore, define an outputSpec like the
+                  following where the managed fields (e.g. URL, Secret.Name) will
+                  be replaced with the required values: spec: - outputs: - name: default
+                  type: elasticsearch elasticsearch: structuredTypeKey: kubernetes.labels.myvalue'
                 properties:
                   elasticsearch:
                     description: "Elasticsearch OutputSpec default values \n Values

--- a/internal/cmd/forwarder-generator/main.go
+++ b/internal/cmd/forwarder-generator/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
@@ -60,7 +61,8 @@ func main() {
 
 	log.Info("Finished reading yaml", "content", string(content))
 
-	generatedConfig, err := forwarder.Generate(logCollectorType, string(content), *includeDefaultLogStore, *debugOutput, nil)
+	client := fake.NewClientBuilder().Build()
+	generatedConfig, err := forwarder.Generate(logCollectorType, string(content), *includeDefaultLogStore, *debugOutput, client)
 	if err != nil {
 		log.Error(err, "Unable to generate log configuration")
 		os.Exit(1)

--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -118,8 +118,9 @@ var _ = Describe("Reconciling", func() {
 					namespace,
 				)
 				clusterRequest = &ClusterLoggingRequest{
-					Client:  client,
-					Cluster: cluster,
+					Client:           client,
+					Cluster:          cluster,
+					ForwarderRequest: &loggingv1.ClusterLogForwarder{},
 				}
 			})
 

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -271,7 +271,7 @@ func (clusterRequest *ClusterLoggingRequest) getLogForwarder() *logging.ClusterL
 		}
 		return nil
 	}
-
+	forwarder.Spec = migrations.MigrateClusterLogForwarderSpec(forwarder.Spec)
 	return forwarder
 }
 

--- a/internal/migrations/migrate_clusterlogforwarder.go
+++ b/internal/migrations/migrate_clusterlogforwarder.go
@@ -1,0 +1,59 @@
+package migrations
+
+import (
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+)
+
+func MigrateClusterLogForwarderSpec(spec logging.ClusterLogForwarderSpec) logging.ClusterLogForwarderSpec {
+	spec.Outputs = MigrateDefaultOutput(spec)
+	return spec
+}
+
+// MigrateDefaultOutput adds the 'default' output spec to the list of outputs if it is not defined or
+// selectively replaces it if it is.  It will apply OutputDefaults unless they are already defined.
+func MigrateDefaultOutput(spec logging.ClusterLogForwarderSpec) []logging.OutputSpec {
+
+	refDefault := false
+	for _, p := range spec.Pipelines {
+		for _, ref := range p.OutputRefs {
+			if ref == logging.OutputNameDefault {
+				refDefault = true
+				break
+			}
+		}
+	}
+	if !refDefault {
+		return spec.Outputs
+	}
+	defaultReplaced := false
+	defaultOutput := NewDefaultOutput(spec.OutputDefaults)
+	outputs := []logging.OutputSpec{}
+	for _, output := range spec.Outputs {
+		if output.Name == logging.OutputNameDefault {
+			if output.Elasticsearch != nil {
+				defaultOutput.Elasticsearch = output.Elasticsearch
+			}
+			defaultReplaced = true
+			output = defaultOutput
+		}
+		outputs = append(outputs, output)
+	}
+	if !defaultReplaced {
+		outputs = append(outputs, defaultOutput)
+	}
+	return outputs
+}
+
+func NewDefaultOutput(defaults *logging.OutputDefaults) logging.OutputSpec {
+	spec := logging.OutputSpec{
+		Name:   logging.OutputNameDefault,
+		Type:   logging.OutputTypeElasticsearch,
+		URL:    constants.LogStoreURL,
+		Secret: &logging.OutputSecretSpec{Name: constants.CollectorSecretName},
+	}
+	if defaults != nil && defaults.Elasticsearch != nil {
+		spec.Elasticsearch = defaults.Elasticsearch
+	}
+	return spec
+}

--- a/internal/migrations/migrate_clusterlogforwarder_test.go
+++ b/internal/migrations/migrate_clusterlogforwarder_test.go
@@ -1,0 +1,113 @@
+package migrations
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+)
+
+var _ = Describe("MigrateDefaultOutput", func() {
+
+	var (
+		pipelines []logging.PipelineSpec
+		outputs   []logging.OutputSpec
+		spec      logging.ClusterLogForwarderSpec
+		esSpec    *logging.Elasticsearch
+	)
+
+	BeforeEach(func() {
+		esSpec = &logging.Elasticsearch{
+			StructuredTypeKey: "foo.bar",
+		}
+		pipelines = []logging.PipelineSpec{
+			{
+				Name:       "test",
+				OutputRefs: []string{"first", "second"},
+			},
+		}
+		outputs = []logging.OutputSpec{
+			{
+				Name: "first",
+				Type: logging.OutputTypeElasticsearch,
+				OutputTypeSpec: logging.OutputTypeSpec{
+					Elasticsearch: esSpec,
+				},
+			},
+		}
+		spec = logging.ClusterLogForwarderSpec{
+			Outputs:   outputs,
+			Pipelines: pipelines,
+		}
+	})
+
+	It("should not add the default OutputSpec when it is not referenced by a pipeline", func() {
+		Expect(MigrateDefaultOutput(spec)).To(Equal(outputs))
+	})
+
+	Context("when a pipeline references 'default'", func() {
+
+		var exp []logging.OutputSpec
+		BeforeEach(func() {
+			pipelines[0].OutputRefs = append(spec.Pipelines[0].OutputRefs, logging.OutputNameDefault)
+			spec = logging.ClusterLogForwarderSpec{
+				Outputs:   outputs,
+				Pipelines: pipelines,
+			}
+		})
+
+		Context("and outputs does not explicitly spec 'default'", func() {
+			BeforeEach(func() {
+				exp = append(outputs, NewDefaultOutput(nil))
+			})
+
+			It("should add the default OutputSpec", func() {
+				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+			})
+			It("should add the default OutputSpec and OutputDefaults when OutputDefaults are spec'd", func() {
+				spec.OutputDefaults = &logging.OutputDefaults{
+					Elasticsearch: &logging.Elasticsearch{
+						StructuredTypeKey: "foo.bar",
+					},
+				}
+				exp[1].Elasticsearch = spec.OutputDefaults.Elasticsearch
+				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
+			})
+		})
+
+		Context("and outputs includes an OutputSpec named 'default'", func() {
+			var tobereplaced logging.OutputSpec
+			BeforeEach(func() {
+				tobereplaced = logging.OutputSpec{
+					Name:   logging.OutputNameDefault,
+					Type:   logging.OutputTypeElasticsearch,
+					URL:    "thiswillgetreplaced",
+					Secret: &logging.OutputSecretSpec{Name: "replacem"},
+				}
+
+			})
+
+			It("should replace the OutputSpec with the default OutputSpec", func() {
+				exp = append(outputs, NewDefaultOutput(nil))
+				spec = logging.ClusterLogForwarderSpec{
+					Outputs:   append(outputs, tobereplaced),
+					Pipelines: pipelines,
+				}
+				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+			})
+
+			It("should replace the OutputSpec with the default OutputSpec and use the config (e.g. structureTypeKey) defined in the original OutputSpec", func() {
+				tobereplaced.Elasticsearch = esSpec
+				exp = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: esSpec}))
+				spec = logging.ClusterLogForwarderSpec{
+					Outputs:        append(outputs, tobereplaced),
+					Pipelines:      pipelines,
+					OutputDefaults: &logging.OutputDefaults{Elasticsearch: &logging.Elasticsearch{StructuredTypeKey: "abc"}},
+				}
+				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
+			})
+		})
+
+	})
+
+})

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -32,7 +32,7 @@ func UnMarshalClusterLogForwarder(clfYaml string) (forwarder *logging.ClusterLog
 	return forwarder, err
 }
 
-func Generate(collectionType logging.LogCollectionType, clfYaml string, includeDefaultLogStore, debugOutput bool, client *client.Client) (string, error) {
+func Generate(collectionType logging.LogCollectionType, clfYaml string, includeDefaultLogStore, debugOutput bool, client client.Client) (string, error) {
 	var err error
 	forwarder, err := UnMarshalClusterLogForwarder(clfYaml)
 	if err != nil {
@@ -51,7 +51,7 @@ func Generate(collectionType logging.LogCollectionType, clfYaml string, includeD
 	}
 
 	if client != nil {
-		clRequest.Client = *client
+		clRequest.Client = client
 	}
 
 	if includeDefaultLogStore {

--- a/test/framework/e2e/framework.go
+++ b/test/framework/e2e/framework.go
@@ -473,7 +473,7 @@ func (tc *E2ETestFramework) Cleanup() {
 		clolog.Info("Test failed", "TestText", g.FullTestText)
 		//allow caller to cleanup if unset (e.g script cleanup())
 		doCleanup := strings.TrimSpace(os.Getenv("DO_CLEANUP"))
-		clolog.Info("Running Cleanup script ....", "DO_CLEANUP", "doCleanup")
+		clolog.Info("Running Cleanup script ....", "DO_CLEANUP", doCleanup)
 		if doCleanup == "" || strings.ToLower(doCleanup) == "true" {
 			RunCleanupScript()
 		}

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -178,7 +178,7 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 	debugOutput := false
 	testClient := client.Get().ControllerRuntimeClient()
 	if strings.TrimSpace(f.Conf) == "" {
-		if f.Conf, err = forwarder.Generate(logging.LogCollectionType(f.collector.String()), string(clfYaml), false, debugOutput, &testClient); err != nil {
+		if f.Conf, err = forwarder.Generate(logging.LogCollectionType(f.collector.String()), string(clfYaml), false, debugOutput, testClient); err != nil {
 			return err
 		}
 		//remove journal for now since we can not mimic it


### PR DESCRIPTION
# Description
This PR:
* fixes the issue where OutputDefaults are applied generically to all ES output types instead of only the managed Elasticsearch offering.

# Links
* https://issues.redhat.com/browse/LOG-3342
