### PR TITLE
LOG-3396: fix pod security changes that were removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ COPY --from=builder $APP_DIR/files/ /usr/share/logging/
 COPY --from=origincli /usr/bin/oc /usr/bin
 COPY $SRC_DIR/must-gather/collection-scripts/* /usr/bin/
 
+USER 1000
 # this is required because the operator invokes a script as `bash scripts/cert_generation.sh`
 WORKDIR /usr/bin
 CMD ["/usr/bin/cluster-logging-operator"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -71,6 +71,7 @@ COPY --from=builder $APP_DIR/files/ /usr/share/logging/
 COPY --from=origincli /usr/bin/oc /usr/bin
 COPY $SRC_DIR/must-gather/collection-scripts/* /usr/bin/
 
+USER 1000
 # this is required because the operator invokes a script as `bash scripts/cert_generation.sh`
 WORKDIR /usr/bin
 CMD ["/usr/bin/cluster-logging-operator"]

--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -434,6 +434,8 @@ spec:
                     - ALL
               nodeSelector:
                 kubernetes.io/os: linux
+              securityContext:
+                runAsNonRoot: true
               serviceAccountName: cluster-logging-operator
       permissions:
       - rules:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         name: cluster-logging-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: cluster-logging-operator


### PR DESCRIPTION
### Description
This PR:
* fixes pod security changes reverted in https://github.com/openshift/cluster-logging-operator/commit/a9f435e8810116e4ecd6cfa5e3a3e7b9ae7f8a22
* fixes the USER in the Dockerfile to address CLO not starting


### Links
* https://issues.redhat.com/browse/LOG-3396