### PR TITLE
LOG-3331: Disable log view plugin if cluster does not have console en…

### DIFF
--- a/internal/visualization/console/plugin.go
+++ b/internal/visualization/console/plugin.go
@@ -12,7 +12,7 @@ import (
 // ReconcilePlugin reconciles the console plugin to expose log querying of storage
 func ReconcilePlugin(k8sClient client.Client, logStore *logging.LogStoreSpec, owner client.Object) error {
 	lokiService := LokiStackGatewayService(logStore)
-	r := consoleplugin.NewReconciler(k8sClient, consoleplugin.NewConfig(owner, lokiService))
+		r := consoleplugin.NewReconciler(k8sClient, consoleplugin.NewConfig(owner, lokiService))
 	if logStore != nil && logStore.Type == logging.LogStoreTypeLokiStack {
 		log.V(3).Info("Enabling logging console plugin", "created-by", r.CreatedBy(), "loki-service", lokiService)
 		return r.Reconcile(context.TODO())


### PR DESCRIPTION
…abled

### Description
This PR:
* skips log view plugin deployment if the cluster does not have the console enabled

### Links
* https://issues.redhat.com/browse/LOG-3321

cc @periklis 

@anpingli please test this PR directly.  There is no way to mock the client to throw errors so I am unable to write a proper test
