### PR TITLE
LOG-3398: Apply TLSSecurityProfile settings to TLS listeners in log collectors

### DIFF
--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,21 +1,24 @@
 package collector
 
 import (
+	"path"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
-	"path"
 
 	"fmt"
+	"os"
+
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/collector/fluentd"
 	vector "github.com/openshift/cluster-logging-operator/internal/collector/vector"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/tls"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
 )
 
 var _ = Describe("Factory#NewPodSpec", func() {
@@ -31,7 +34,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 			ImageName:     constants.FluentdName,
 			Visit:         fluentd.CollectorVisitor,
 		}
-		podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "")
+		podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetTLSProfileSpec(nil))
 		collector = podSpec.Containers[0]
 	})
 	Describe("when creating of the collector container", func() {
@@ -80,7 +83,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 						},
 					},
 				}
-				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "")
+				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetTLSProfileSpec(nil))
 				expTolerations := append(defaultTolerations, providedToleration)
 				Expect(podSpec.Tolerations).To(Equal(expTolerations))
 			})
@@ -104,7 +107,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 						},
 					},
 				}
-				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "")
+				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetTLSProfileSpec(nil))
 				Expect(podSpec.NodeSelector).To(Equal(expSelector))
 			})
 
@@ -170,7 +173,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 					Data: map[string]string{
 						constants.TrustedCABundleKey: caBundle,
 					},
-				}, logging.ClusterLogForwarderSpec{}, "1234", "")
+				}, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetTLSProfileSpec(nil))
 				collector = podSpec.Containers[0]
 
 				verifyEnvVar(collector, "HTTP_PROXY", httpproxy)
@@ -313,7 +316,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				}, "1234", "")
+				}, "1234", "", tls.GetTLSProfileSpec(nil))
 				collector := podSpec.Containers[0]
 
 				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
@@ -336,7 +339,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				}, "1234", "")
+				}, "1234", "", tls.GetTLSProfileSpec(nil))
 				collector := podSpec.Containers[0]
 
 				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
@@ -362,7 +365,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				}, "1234", "")
+				}, "1234", "", tls.GetTLSProfileSpec(nil))
 				collector := podSpec.Containers[0]
 
 				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
@@ -385,7 +388,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				}, "1234", "")
+				}, "1234", "", tls.GetTLSProfileSpec(nil))
 				collector := podSpec.Containers[0]
 
 				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)

--- a/internal/collector/daemonset.go
+++ b/internal/collector/daemonset.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
+	"github.com/openshift/cluster-logging-operator/internal/tls"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -13,7 +14,8 @@ import (
 func (f *Factory) ReconcileDaemonset(er record.EventRecorder, k8sClient client.Client, namespace, name string, owner metav1.OwnerReference) error {
 	trustedCABundle, trustHash := GetTrustedCABundle(k8sClient, namespace, constants.CollectorTrustedCAName)
 	f.TrustedCAHash = trustHash
-	desired := f.NewDaemonSet(namespace, name, trustedCABundle)
+	tlsProfile, _ := tls.FetchAPIServerTlsProfile(k8sClient)
+	desired := f.NewDaemonSet(namespace, name, trustedCABundle, tls.GetTLSProfileSpec(tlsProfile))
 	utils.AddOwnerRefToObject(desired, owner)
 	return reconcile.DaemonSet(er, k8sClient, desired)
 }

--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -3,8 +3,10 @@ package fluentd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"strings"
+
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/tls"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 	testhelpers "github.com/openshift/cluster-logging-operator/test/helpers"
@@ -22,7 +24,7 @@ import (
 var _ = Describe("Testing Complete Config Generation", func() {
 	var f = func(testcase testhelpers.ConfGenerateTest) {
 		g := generator.MakeGenerator()
-		e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, constants.OpenshiftNS, generator.NoOptions))
+		e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, constants.OpenshiftNS, generator.Options{generator.TlsProfileSpec: tls.GetTLSProfileSpec(nil)}))
 		conf, err := g.GenerateConf(e...)
 		Expect(err).To(BeNil())
 		diff := cmp.Diff(
@@ -95,6 +97,9 @@ var _ = Describe("Testing Complete Config Generation", func() {
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
+    min_version TLS1_2
+    max_version TLS1_3
+    ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
   </transport>
 </source>
 

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+	"github.com/openshift/cluster-logging-operator/internal/tls"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -18,7 +19,7 @@ var _ = Describe("Generating fluentd config", func() {
 	var (
 		forwarder  *logging.ClusterLogForwarderSpec
 		g          generator.Generator
-		op         generator.Options
+		op         generator.Options = generator.Options{generator.TlsProfileSpec: tls.GetTLSProfileSpec(nil)}
 		secret     corev1.Secret
 		secretData = map[string][]byte{
 			"tls.key":       []byte("test-key"),
@@ -54,7 +55,7 @@ var _ = Describe("Generating fluentd config", func() {
 	)
 	BeforeEach(func() {
 		g = generator.MakeGenerator()
-		op = generator.NoOptions
+		op = generator.Options{generator.TlsProfileSpec: tls.GetTLSProfileSpec(nil)}
 		forwarder = &logging.ClusterLogForwarderSpec{
 			Outputs: []logging.OutputSpec{
 				{
@@ -205,6 +206,9 @@ var _ = Describe("Generating fluentd config", func() {
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
+    min_version TLS1_2
+    max_version TLS1_3
+    ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
   </transport>
 </source>
 
@@ -954,6 +958,9 @@ var _ = Describe("Generating fluentd config", func() {
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
+    min_version TLS1_2
+    max_version TLS1_3
+    ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
   </transport>
 </source>
 
@@ -1688,6 +1695,9 @@ var _ = Describe("Generating fluentd config", func() {
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
+    min_version TLS1_2
+    max_version TLS1_3
+    ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
   </transport>
 </source>
 
@@ -2367,6 +2377,9 @@ var _ = Describe("Generating fluentd config", func() {
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
+    min_version TLS1_2
+    max_version TLS1_3
+    ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
   </transport>
 </source>
 
@@ -2724,6 +2737,9 @@ var _ = Describe("Generating fluentd config", func() {
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
+    min_version TLS1_2
+    max_version TLS1_3
+    ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
   </transport>
 </source>
 
@@ -3833,7 +3849,7 @@ var _ = Describe("Generating fluentd config", func() {
 			var spec logging.ClusterLogForwarderSpec
 			Expect(yaml.Unmarshal([]byte(yamlSpec), &spec)).To(Succeed())
 			g := generator.MakeGenerator()
-			s := Conf(nil, security.NoSecrets, &spec, constants.OpenshiftNS, generator.NoOptions)
+			s := Conf(nil, security.NoSecrets, &spec, constants.OpenshiftNS, op)
 			gotFluentdConf, err := g.GenerateConf(generator.MergeSections(s)...)
 			Expect(err).To(Succeed())
 			Expect(gotFluentdConf).To(EqualTrimLines(wantFluentdConf))
@@ -3867,6 +3883,9 @@ inputs:
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
+    min_version TLS1_2
+    max_version TLS1_3
+    ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
   </transport>
 </source>
 

--- a/internal/generator/fluentd/sources_test.go
+++ b/internal/generator/fluentd/sources_test.go
@@ -6,6 +6,7 @@ import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/tls"
 	"github.com/openshift/cluster-logging-operator/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -523,6 +524,7 @@ var _ = Describe("Testing Config Generation", func() {
 					},
 				},
 			},
+			Options: generator.Options{generator.TlsProfileSpec: tls.GetTLSProfileSpec(nil)},
 			ExpectedConf: `
 # Prometheus Monitoring
 <source>
@@ -531,6 +533,9 @@ var _ = Describe("Testing Config Generation", func() {
   <transport tls>
     cert_path /etc/collector/metrics/tls.crt
     private_key_path /etc/collector/metrics/tls.key
+    min_version TLS1_2
+    max_version TLS1_3
+    ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
   </transport>
 </source>
 

--- a/internal/generator/logging.go
+++ b/internal/generator/logging.go
@@ -9,6 +9,7 @@ import (
 const (
 	IncludeLegacyForwardConfig = "includeLegacyForwardConfig"
 	UseOldRemoteSyslogPlugin   = "useOldRemoteSyslogPlugin"
+	TlsProfileSpec             = "tlsProfileSpec"
 )
 
 // GatherSources collects the set of unique source types and namespaces

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/tls"
 	"github.com/openshift/cluster-logging-operator/test/matchers"
 
 	testhelpers "github.com/openshift/cluster-logging-operator/test/helpers"
@@ -26,7 +27,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
 		f = func(testcase testhelpers.ConfGenerateTest) {
 			g := generator.MakeGenerator()
 			if testcase.Options == nil {
-				testcase.Options = generator.Options{}
+				testcase.Options = generator.Options{generator.TlsProfileSpec: tls.GetTLSProfileSpec(nil)}
 			}
 			e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, constants.OpenshiftNS, testcase.Options))
 			conf, err := g.GenerateConf(e...)
@@ -412,6 +413,8 @@ default_namespace = "collector"
 enabled = true
 key_file = "/etc/collector/metrics/tls.key"
 crt_file = "/etc/collector/metrics/tls.crt"
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
 `,
 		}),
 		Entry("with complex spec for elasticsearch, without version specified", testhelpers.ConfGenerateTest{
@@ -462,6 +465,7 @@ crt_file = "/etc/collector/metrics/tls.crt"
 					},
 				},
 			},
+			Options: generator.Options{generator.TlsProfileSpec: tls.GetTLSProfileSpec(nil)},
 			ExpectedConf: `
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
@@ -990,6 +994,8 @@ default_namespace = "collector"
 enabled = true
 key_file = "/etc/collector/metrics/tls.key"
 crt_file = "/etc/collector/metrics/tls.crt"
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
 `,
 		}),
 		Entry("with complex spec for elasticsearch default v6 & latest version", testhelpers.ConfGenerateTest{
@@ -1586,6 +1592,8 @@ default_namespace = "collector"
 enabled = true
 key_file = "/etc/collector/metrics/tls.key"
 crt_file = "/etc/collector/metrics/tls.crt"
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
 `,
 		}),
 	)

--- a/internal/generator/vector/metrics.go
+++ b/internal/generator/vector/metrics.go
@@ -29,9 +29,11 @@ type = "internal_metrics"
 }
 
 type PrometheusExporter struct {
-	ID      string
-	Inputs  string
-	Address string
+	ID            string
+	Inputs        string
+	Address       string
+	TlsMinVersion string
+	CipherSuites  string
 }
 
 func (p PrometheusExporter) Name() string {
@@ -50,6 +52,8 @@ default_namespace = "collector"
 enabled = true
 key_file = "/etc/collector/metrics/tls.key"
 crt_file = "/etc/collector/metrics/tls.crt"
+min_tls_version = "{{.TlsMinVersion}}"
+ciphersuites = "{{.CipherSuites}}"
 {{end}}`
 }
 

--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -2,6 +2,7 @@ package k8shandler
 
 import (
 	"context"
+
 	"github.com/openshift/cluster-logging-operator/internal/collector"
 
 	"github.com/openshift/cluster-logging-operator/internal/collector/common"
@@ -11,6 +12,7 @@ import (
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
@@ -30,6 +32,7 @@ var _ = Describe("Reconciling", func() {
 	_ = loggingv1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	_ = monitoringv1.AddToScheme(scheme.Scheme)
 	_ = securityv1.AddToScheme(scheme.Scheme)
+	_ = configv1.AddToScheme(scheme.Scheme)
 
 	var (
 		cluster = &loggingv1.ClusterLogging{

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/cloudwatch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
 	"github.com/openshift/cluster-logging-operator/internal/status"
+	"github.com/openshift/cluster-logging-operator/internal/tls"
 	"github.com/openshift/cluster-logging-operator/internal/url"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -66,6 +67,8 @@ func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig(extras map[
 	if debug, ok := clusterRequest.ForwarderRequest.Annotations[AnnotationDebugOutput]; ok && strings.ToLower(debug) == "true" {
 		op[helpers.EnableDebugOutput] = "true"
 	}
+	tlsProfile, _ := tls.FetchAPIServerTlsProfile(clusterRequest.Client)
+	op[generator.TlsProfileSpec] = tls.GetTLSProfileSpec(tlsProfile)
 
 	var collectorType = clusterRequest.Cluster.Spec.Collection.Type
 	g := forwardergenerator.New(collectorType)

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -15,6 +15,7 @@ import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 	"github.com/openshift/cluster-logging-operator/internal/k8shandler"
+	"github.com/openshift/cluster-logging-operator/internal/tls"
 )
 
 const (
@@ -75,6 +76,7 @@ func Generate(collectionType logging.LogCollectionType, clfYaml string, includeD
 	if debugOutput {
 		op[helpers.EnableDebugOutput] = ""
 	}
+	op[generator.TlsProfileSpec] = tls.GetTLSProfileSpec(nil)
 	configGenerator := forwardergenerator.New(collectionType)
 	if configGenerator == nil {
 		return "", errors.New("unsupported collector implementation")

--- a/internal/tls/profile.go
+++ b/internal/tls/profile.go
@@ -32,7 +32,7 @@ CipherSuites = {{CipherSuites}}
 
 func OpenSSLConf(k8client client.Client) string {
 	pr, _ := FetchAPIServerTlsProfile(k8client)
-	tls := getTLSProfileSpec(pr)
+	tls := GetTLSProfileSpec(pr)
 	conf, _ := opensslConf(tls)
 	return conf
 }

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -49,7 +49,7 @@ func MinTLSVersion(profile configv1.TLSProfileSpec) string {
 }
 
 // getTLSProfileSpec returns TLSProfileSpec to be used for generating OPENSSL_CONF
-func getTLSProfileSpec(apiServerTLSProfile *configv1.TLSSecurityProfile) configv1.TLSProfileSpec {
+func GetTLSProfileSpec(apiServerTLSProfile *configv1.TLSSecurityProfile) configv1.TLSProfileSpec {
 	defaultProfile := *configv1.TLSProfiles[DefaultTLSProfileType]
 	if apiServerTLSProfile == nil || apiServerTLSProfile.Type == "" {
 		return defaultProfile


### PR DESCRIPTION
### Description
This PR passes TLS min version and ciphersuites from the TLSSecurityProfile to the log collectors and the log file metric exporter.
Depends on corresponding PRs in vector and log-file-metric-exporter repos.

/cc @alanconway 
/assign @jcantrill 

### Links
- Depending on PR(s): https://github.com/ViaQ/vector/pull/129, https://github.com/ViaQ/log-file-metric-exporter/pull/26
- JIRA: https://issues.redhat.com/browse/LOG-3398

