### PR TITLE
LOG-3406: fix CLO crash when EO is not deployed

### DIFF
--- a/controllers/clusterlogging/clusterlogging_controller.go
+++ b/controllers/clusterlogging/clusterlogging_controller.go
@@ -2,7 +2,7 @@ package clusterlogging
 
 import (
 	"context"
-	v1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -157,10 +157,6 @@ func (r *ReconcileClusterLogging) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		Watches(&source.Kind{Type: &loggingv1.ClusterLogging{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &loggingv1.ClusterLogForwarder{}}, &handler.EnqueueRequestForObject{}).
-		Watches(&source.Kind{Type: &v1.Elasticsearch{}}, &handler.EnqueueRequestForOwner{
-			IsController: true,
-			OwnerType:    &loggingv1.ClusterLogging{},
-		}).
 		Watches(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
 			IsController: true,
 			OwnerType:    &loggingv1.ClusterLogging{},

--- a/internal/k8shandler/clusterloggingrequest.go
+++ b/internal/k8shandler/clusterloggingrequest.go
@@ -40,7 +40,7 @@ func (clusterRequest *ClusterLoggingRequest) IncludesManagedStorage() bool {
 	return clusterRequest.Cluster != nil && clusterRequest.Cluster.Spec.LogStore != nil
 }
 
-// true if equals "Managed" or empty
+//true if equals "Managed" or empty
 func (clusterRequest *ClusterLoggingRequest) isManaged() bool {
 	return clusterRequest.Cluster.Spec.ManagementState == logging.ManagementStateManaged ||
 		clusterRequest.Cluster.Spec.ManagementState == ""
@@ -51,7 +51,7 @@ func (clusterRequest *ClusterLoggingRequest) Create(object client.Object) error 
 	return err
 }
 
-// Update the runtime Object or return error
+//Update the runtime Object or return error
 func (clusterRequest *ClusterLoggingRequest) Update(object client.Object) (err error) {
 	if err = clusterRequest.Client.Update(context.TODO(), object); err != nil {
 		log.Error(err, "Error updating ", object.GetObjectKind())

--- a/internal/k8shandler/status.go
+++ b/internal/k8shandler/status.go
@@ -69,7 +69,7 @@ func (clusterRequest *ClusterLoggingRequest) getElasticsearchStatus() ([]logging
 	}
 
 	err := clusterRequest.List(map[string]string{}, esList)
-	var status []logging.ElasticsearchStatus
+	status := []logging.ElasticsearchStatus{}
 
 	if err != nil {
 		return status, fmt.Errorf("Unable to get Elasticsearches: %v", err)

--- a/internal/visualization/console/plugin.go
+++ b/internal/visualization/console/plugin.go
@@ -12,7 +12,7 @@ import (
 // ReconcilePlugin reconciles the console plugin to expose log querying of storage
 func ReconcilePlugin(k8sClient client.Client, logStore *logging.LogStoreSpec, owner client.Object) error {
 	lokiService := LokiStackGatewayService(logStore)
-		r := consoleplugin.NewReconciler(k8sClient, consoleplugin.NewConfig(owner, lokiService))
+	r := consoleplugin.NewReconciler(k8sClient, consoleplugin.NewConfig(owner, lokiService))
 	if logStore != nil && logStore.Type == logging.LogStoreTypeLokiStack {
 		log.V(3).Info("Enabling logging console plugin", "created-by", r.CreatedBy(), "loki-service", lokiService)
 		return r.Reconcile(context.TODO())


### PR DESCRIPTION
Revert "[LOG-2999](https://issues.redhat.com//browse/LOG-2999):Add watcher for Elasticsearch object"

This reverts commit 218e39bf382bd3bcb8ddfa42fa3ec45f1effbe60.

### Description
This PR:
* fixes the crash by reverting the PR which  fails when EO is not installed

### Links
* https://issues.redhat.com/browse/LOG-3406