### PR TITLE
LOG-3428: fix CLO crash when EO is not deployed

### DIFF
--- a/controllers/clusterlogging/clusterlogging_controller.go
+++ b/controllers/clusterlogging/clusterlogging_controller.go
@@ -2,7 +2,6 @@ package clusterlogging
 
 import (
 	"context"
-	v1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -154,10 +153,6 @@ func (r *ReconcileClusterLogging) SetupWithManager(mgr ctrl.Manager) error {
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		Watches(&source.Kind{Type: &loggingv1.ClusterLogging{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &loggingv1.ClusterLogForwarder{}}, &handler.EnqueueRequestForObject{}).
-		Watches(&source.Kind{Type: &v1.Elasticsearch{}}, &handler.EnqueueRequestForOwner{
-			IsController: true,
-			OwnerType:    &loggingv1.ClusterLogging{},
-		}).
 		Watches(&source.Kind{Type: &corev1.Service{}}, &handler.EnqueueRequestForOwner{
 			IsController: true,
 			OwnerType:    &loggingv1.ClusterLogging{},


### PR DESCRIPTION
this commit reverts 67444b550af256eb34aef9fd49bac31d65c826d0

### Description
This PR:
* fixes the case where clo crashes when EO is not deployed
* backport of #1791 

### Links
*  https://issues.redhat.com/browse/LOG-3428
