### PR TITLE
LOG-3407: fix crash when console is not enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ lint-dockerfile:
 .PHONY: fmt
 fmt:
 	@echo gofmt		# Show progress, real gofmt line is too long
-	find version test internal controllers apis -name '*.go' | xargs gofmt -s -l -w
+	find . version test internal controllers apis -name '*.go' | xargs gofmt -s -l -w
 
 # Do all code/CRD generation at once, with timestamp file to check out-of-date.
 GEN_TIMESTAMP=.target/codegen

--- a/controllers/clusterlogging/clusterlogging_controller.go
+++ b/controllers/clusterlogging/clusterlogging_controller.go
@@ -15,7 +15,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
-	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/k8shandler"
@@ -187,10 +186,6 @@ func (r *ReconcileClusterLogging) SetupWithManager(mgr ctrl.Manager) error {
 			OwnerType:    &loggingv1.ClusterLogging{},
 		}).
 		Watches(&source.Kind{Type: &appsv1.DaemonSet{}}, &handler.EnqueueRequestForOwner{
-			IsController: true,
-			OwnerType:    &loggingv1.ClusterLogging{},
-		}).
-		Watches(&source.Kind{Type: &consolev1alpha1.ConsolePlugin{}}, &handler.EnqueueRequestForOwner{
 			IsController: true,
 			OwnerType:    &loggingv1.ClusterLogging{},
 		}).

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -93,6 +94,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	// https://issues.redhat.com/browse/LOG-3321
+	syncPeriod := time.Minute * 3
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Namespace:              namespace,
@@ -101,6 +104,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b430cc2e.openshift.io",
+		SyncPeriod:             &syncPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
### Description
This PR:

fixes the crash by adding the console plugin to the watch for CL
sets a sync period to 3 minutes which is the maximum time to notice changes in the console plugin

### Links
* https://issues.redhat.com/browse/LOG-3407
* backport of https://github.com/openshift/cluster-logging-operator/pull/1794

cc @alanconway 