### PR TITLE
LOG-3440: Update metrics endpoint for vector to use IPV6

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -2,9 +2,10 @@ package vector
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/test/matchers"
-	"strings"
 
 	testhelpers "github.com/openshift/cluster-logging-operator/test/helpers"
 
@@ -407,7 +408,7 @@ source = '''
 [sinks.prometheus_output]
 type = "prometheus_exporter"
 inputs = ["add_nodename_to_metric"]
-address = "0.0.0.0:24231"
+address = "[::]:24231"
 default_namespace = "collector"
 
 [sinks.prometheus_output.tls]
@@ -944,7 +945,7 @@ source = '''
 [sinks.prometheus_output]
 type = "prometheus_exporter"
 inputs = ["add_nodename_to_metric"]
-address = "0.0.0.0:24231"
+address = "[::]:24231"
 default_namespace = "collector"
 
 [sinks.prometheus_output.tls]
@@ -1499,7 +1500,7 @@ source = '''
 [sinks.prometheus_output]
 type = "prometheus_exporter"
 inputs = ["add_nodename_to_metric"]
-address = "0.0.0.0:24231"
+address = "[::]:24231"
 default_namespace = "collector"
 
 [sinks.prometheus_output.tls]

--- a/internal/generator/vector/metrics.go
+++ b/internal/generator/vector/metrics.go
@@ -3,7 +3,7 @@ package vector
 const (
 	InternalMetricsSourceName = "internal_metrics"
 	PrometheusOutputSinkName  = "prometheus_output"
-	PrometheusExporterAddress = "0.0.0.0:24231"
+	PrometheusExporterAddress = "[::]:24231"
 
 	AddNodenameToMetricTransformName = "add_nodename_to_metric"
 )


### PR DESCRIPTION
### Description
Updated vector conf generator to use `[::]:24231` as the metrics endpoint.
This address works for both IPV4 and IPV6 clusters.


/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-3440
