### PR TITLE
LOG-3228: fix validation on empty spec

### DIFF
--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/collector"
 
 	"github.com/openshift/cluster-logging-operator/internal/collector/common"
+	"github.com/openshift/cluster-logging-operator/internal/migrations"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -125,6 +126,7 @@ var _ = Describe("Reconciling", func() {
 					EventRecorder:    record.NewFakeRecorder(100),
 					ForwarderRequest: &loggingv1.ClusterLogForwarder{},
 				}
+				clusterRequest.ForwarderSpec = migrations.MigrateClusterLogForwarderSpec(clusterRequest.ForwarderSpec, clusterRequest.Cluster.Spec.LogStore)
 			})
 
 			It("should use the injected custom CA bundle for the collector", func() {
@@ -186,6 +188,7 @@ var _ = Describe("Reconciling", func() {
 					Cluster:       cluster,
 					EventRecorder: record.NewFakeRecorder(100),
 				}
+				clusterRequest.ForwarderSpec = migrations.MigrateClusterLogForwarderSpec(clusterRequest.ForwarderSpec, clusterRequest.Cluster.Spec.LogStore)
 			})
 
 			//https://issues.redhat.com/browse/LOG-1859
@@ -217,10 +220,12 @@ var _ = Describe("Reconciling", func() {
 					namespace,
 				)
 				clusterRequest = &ClusterLoggingRequest{
-					Client:        client,
-					Cluster:       cluster,
-					EventRecorder: record.NewFakeRecorder(100),
+					Client:           client,
+					Cluster:          cluster,
+					EventRecorder:    record.NewFakeRecorder(100),
+					ForwarderRequest: &loggingv1.ClusterLogForwarder{},
 				}
+				clusterRequest.ForwarderSpec = migrations.MigrateClusterLogForwarderSpec(clusterRequest.ForwarderSpec, clusterRequest.Cluster.Spec.LogStore)
 			})
 
 			It("a fluentd collector should create the logging_fluentd alerts", func() {

--- a/internal/migrations/logstore_lokistack_test.go
+++ b/internal/migrations/logstore_lokistack_test.go
@@ -1,11 +1,10 @@
-package k8shandler
+package migrations
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestProcessPipelinesForLokiStack(t *testing.T) {
@@ -203,23 +202,13 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-
-			cr := &ClusterLoggingRequest{
-				Cluster: &loggingv1.ClusterLogging{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: aNamespace,
-					},
-					Spec: loggingv1.ClusterLoggingSpec{
-						LogStore: &loggingv1.LogStoreSpec{
-							Type: loggingv1.LogStoreTypeLokiStack,
-							LokiStack: loggingv1.LokiStackStoreSpec{
-								Name: "lokistack-testing",
-							},
-						},
-					},
+			logStore := &loggingv1.LogStoreSpec{
+				Type: loggingv1.LogStoreTypeLokiStack,
+				LokiStack: loggingv1.LokiStackStoreSpec{
+					Name: "lokistack-testing",
 				},
 			}
-			outputs, pipelines := cr.processPipelinesForLokiStack(tc.in)
+			outputs, pipelines := processPipelinesForLokiStack(logStore, "aNamespace", tc.in)
 
 			if diff := cmp.Diff(outputs, tc.wantOutputs); diff != "" {
 				t.Errorf("outputs differ: -got+want\n%s", diff)

--- a/internal/migrations/migrate_clusterlogforwarder.go
+++ b/internal/migrations/migrate_clusterlogforwarder.go
@@ -1,48 +1,74 @@
 package migrations
 
 import (
+	"fmt"
+	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"k8s.io/utils/strings/slices"
+	"sort"
+	"strings"
 )
 
-func MigrateClusterLogForwarderSpec(spec logging.ClusterLogForwarderSpec) logging.ClusterLogForwarderSpec {
-	spec.Outputs = MigrateDefaultOutput(spec)
+func MigrateClusterLogForwarderSpec(spec logging.ClusterLogForwarderSpec, logStore *logging.LogStoreSpec) logging.ClusterLogForwarderSpec {
+	spec = MigrateDefaultOutput(spec, logStore)
 	return spec
 }
 
 // MigrateDefaultOutput adds the 'default' output spec to the list of outputs if it is not defined or
 // selectively replaces it if it is.  It will apply OutputDefaults unless they are already defined.
-func MigrateDefaultOutput(spec logging.ClusterLogForwarderSpec) []logging.OutputSpec {
+func MigrateDefaultOutput(spec logging.ClusterLogForwarderSpec, logStore *logging.LogStoreSpec) logging.ClusterLogForwarderSpec {
+	// ClusterLogging without ClusterLogForwarder
+	if len(spec.Pipelines) == 0 && len(spec.Inputs) == 0 && len(spec.Outputs) == 0 && spec.OutputDefaults == nil {
+		if logStore != nil {
+			log.V(2).Info("ClusterLogForwarder forwarding to default store")
+			spec.Pipelines = []logging.PipelineSpec{
+				{
+					InputRefs:  []string{logging.InputNameApplication, logging.InputNameInfrastructure},
+					OutputRefs: []string{logging.OutputNameDefault},
+				},
+			}
+			if logStore.Type == logging.LogStoreTypeElasticsearch {
+				spec.Outputs = []logging.OutputSpec{NewDefaultOutput(nil)}
+			}
+		}
+	}
 
-	refDefault := false
-	for _, p := range spec.Pipelines {
-		for _, ref := range p.OutputRefs {
-			if ref == logging.OutputNameDefault {
-				refDefault = true
-				break
+	if logStore != nil && logStore.Type == logging.LogStoreTypeLokiStack {
+		outputs, pipelines := processPipelinesForLokiStack(logStore, constants.OpenshiftNS, spec.Pipelines)
+		spec.Outputs = append(spec.Outputs, outputs...)
+		spec.Pipelines = pipelines
+	}
+
+	// Migrate ClusterLogForwarder
+	routes := logging.NewRoutes(spec.Pipelines)
+	if _, ok := routes.ByOutput[logging.OutputNameDefault]; ok {
+		if logStore == nil {
+			log.V(1).Info("ClusterLogForwarder references default logstore but one is not spec'd")
+			return spec
+		} else {
+			replaced := false
+			defaultOutput := NewDefaultOutput(spec.OutputDefaults)
+			outputs := []logging.OutputSpec{}
+			for _, output := range spec.Outputs {
+				if output.Name == logging.OutputNameDefault {
+					if output.Elasticsearch != nil {
+						defaultOutput.Elasticsearch = output.Elasticsearch
+					}
+					output = defaultOutput
+					replaced = true
+				}
+				outputs = append(outputs, output)
 			}
+			if !replaced {
+				outputs = append(outputs, defaultOutput)
+			}
+			spec.Outputs = outputs
+			return spec
 		}
 	}
-	if !refDefault {
-		return spec.Outputs
-	}
-	defaultReplaced := false
-	defaultOutput := NewDefaultOutput(spec.OutputDefaults)
-	outputs := []logging.OutputSpec{}
-	for _, output := range spec.Outputs {
-		if output.Name == logging.OutputNameDefault {
-			if output.Elasticsearch != nil {
-				defaultOutput.Elasticsearch = output.Elasticsearch
-			}
-			defaultReplaced = true
-			output = defaultOutput
-		}
-		outputs = append(outputs, output)
-	}
-	if !defaultReplaced {
-		outputs = append(outputs, defaultOutput)
-	}
-	return outputs
+	return spec
 }
 
 func NewDefaultOutput(defaults *logging.OutputDefaults) logging.OutputSpec {
@@ -58,4 +84,92 @@ func NewDefaultOutput(defaults *logging.OutputDefaults) logging.OutputSpec {
 		}
 	}
 	return spec
+}
+
+func processPipelinesForLokiStack(logStore *loggingv1.LogStoreSpec, namespace string, inPipelines []loggingv1.PipelineSpec) ([]loggingv1.OutputSpec, []loggingv1.PipelineSpec) {
+	needOutput := make(map[string]bool)
+	pipelines := []loggingv1.PipelineSpec{}
+
+	for _, p := range inPipelines {
+		if !slices.Contains(p.OutputRefs, loggingv1.OutputNameDefault) {
+			// Skip pipelines that do not reference "default" output
+			pipelines = append(pipelines, p)
+			continue
+		}
+
+		for _, i := range p.InputRefs {
+			needOutput[i] = true
+		}
+
+		for i, input := range p.InputRefs {
+			pOut := p.DeepCopy()
+			pOut.InputRefs = []string{input}
+
+			for i, output := range pOut.OutputRefs {
+				if output != loggingv1.OutputNameDefault {
+					// Leave non-default output names as-is
+					continue
+				}
+
+				pOut.OutputRefs[i] = lokiStackOutput(input)
+			}
+
+			if pOut.Name != "" && i > 0 {
+				// Generate new name for named pipelines as duplicate names are not allowed
+				pOut.Name = fmt.Sprintf("%s-%d", pOut.Name, i)
+			}
+
+			pipelines = append(pipelines, *pOut)
+		}
+	}
+
+	outputs := []loggingv1.OutputSpec{}
+	for input := range needOutput {
+		outputs = append(outputs, loggingv1.OutputSpec{
+			Name: lokiStackOutput(input),
+			Type: loggingv1.OutputTypeLoki,
+			URL:  LokiStackURL(logStore, namespace, input),
+		})
+	}
+
+	// Sort outputs, because we have tests depending on the exact generated configuration
+	sort.Slice(outputs, func(i, j int) bool {
+		return strings.Compare(outputs[i].Name, outputs[j].Name) < 0
+	})
+
+	return outputs, pipelines
+}
+
+func lokiStackOutput(inputName string) string {
+	switch inputName {
+	case loggingv1.InputNameApplication:
+		return loggingv1.OutputNameDefault + "-loki-apps"
+	case loggingv1.InputNameInfrastructure:
+		return loggingv1.OutputNameDefault + "-loki-infra"
+	case loggingv1.InputNameAudit:
+		return loggingv1.OutputNameDefault + "-loki-audit"
+	}
+
+	return ""
+}
+
+// LokiStackGatewayService returns the name of LokiStack gateway service.
+// Returns an empty string if ClusterLogging is not configured for a LokiStack log store.
+func LokiStackGatewayService(logStore *loggingv1.LogStoreSpec) string {
+	if logStore == nil || logStore.LokiStack.Name == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s-gateway-http", logStore.LokiStack.Name)
+}
+
+// LokiStackURL returns the URL of the LokiStack API for a specific tenant.
+// Returns an empty string if ClusterLogging is not configured for a LokiStack log store.
+func LokiStackURL(logStore *loggingv1.LogStoreSpec, namespace, tenant string) string {
+	service := LokiStackGatewayService(logStore)
+	if service == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("https://%s.%s.svc:8080/api/logs/v1/%s", service, namespace, tenant)
 }

--- a/internal/migrations/migrate_clusterlogforwarder_test.go
+++ b/internal/migrations/migrate_clusterlogforwarder_test.go
@@ -14,6 +14,7 @@ var _ = Describe("MigrateDefaultOutput", func() {
 		outputs   []logging.OutputSpec
 		spec      logging.ClusterLogForwarderSpec
 		esSpec    *logging.Elasticsearch
+		logstore  *logging.LogStoreSpec
 	)
 
 	BeforeEach(func() {
@@ -26,6 +27,7 @@ var _ = Describe("MigrateDefaultOutput", func() {
 			{
 				Name:       "test",
 				OutputRefs: []string{"first", "second"},
+				InputRefs:  []string{logging.InputNameApplication},
 			},
 		}
 		outputs = []logging.OutputSpec{
@@ -44,13 +46,97 @@ var _ = Describe("MigrateDefaultOutput", func() {
 	})
 
 	It("should not add the default OutputSpec when it is not referenced by a pipeline", func() {
-		Expect(MigrateDefaultOutput(spec)).To(Equal(outputs))
+		Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(spec))
+	})
+
+	It("should add the default OutputSpec when default logstore exists and spec is empty ", func() {
+		logstore = &logging.LogStoreSpec{Type: logging.OutputTypeElasticsearch}
+		Expect(MigrateDefaultOutput(logging.ClusterLogForwarderSpec{}, logstore)).To(Equal(
+			logging.ClusterLogForwarderSpec{
+				Pipelines: []logging.PipelineSpec{
+					{
+						InputRefs:  []string{logging.InputNameApplication, logging.InputNameInfrastructure},
+						OutputRefs: []string{logging.OutputNameDefault},
+					},
+				},
+				Outputs: []logging.OutputSpec{NewDefaultOutput(nil)},
+			},
+		))
+	})
+
+	It("generates default configuration for empty spec with LokiStack log store", func() {
+		logstore = &logging.LogStoreSpec{
+			Type: logging.LogStoreTypeLokiStack,
+			LokiStack: logging.LokiStackStoreSpec{
+				Name: "lokistack-testing",
+			},
+		}
+		Expect(MigrateDefaultOutput(logging.ClusterLogForwarderSpec{}, logstore)).To(Equal(
+			logging.ClusterLogForwarderSpec{
+				Pipelines: []logging.PipelineSpec{
+					{
+						InputRefs:  []string{logging.InputNameApplication},
+						OutputRefs: []string{"default-loki-apps"},
+					},
+					{
+						InputRefs:  []string{logging.InputNameInfrastructure},
+						OutputRefs: []string{"default-loki-infra"},
+					},
+				},
+				Outputs: []logging.OutputSpec{
+					{
+						Name: "default-loki-apps",
+						Type: logging.OutputTypeLoki,
+						URL:  "https://lokistack-testing-gateway-http.openshift-logging.svc:8080/api/logs/v1/application",
+					},
+					{
+						Name: "default-loki-infra",
+						Type: logging.OutputTypeLoki,
+						URL:  "https://lokistack-testing-gateway-http.openshift-logging.svc:8080/api/logs/v1/infrastructure",
+					},
+				},
+			},
+		))
+	})
+	It("processes custom pipelines to default LokiStack log store", func() {
+		logstore = &logging.LogStoreSpec{
+			Type: logging.LogStoreTypeLokiStack,
+			LokiStack: logging.LokiStackStoreSpec{
+				Name: "lokistack-testing",
+			},
+		}
+		spec = logging.ClusterLogForwarderSpec{
+			Pipelines: []logging.PipelineSpec{
+				{
+					InputRefs:  []string{"audit"},
+					OutputRefs: []string{"default"},
+				},
+			},
+		}
+		Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(
+			logging.ClusterLogForwarderSpec{
+				Pipelines: []logging.PipelineSpec{
+					{
+						InputRefs:  []string{logging.InputNameAudit},
+						OutputRefs: []string{"default-loki-audit"},
+					},
+				},
+				Outputs: []logging.OutputSpec{
+					{
+						Name: "default-loki-audit",
+						Type: logging.OutputTypeLoki,
+						URL:  "https://lokistack-testing-gateway-http.openshift-logging.svc:8080/api/logs/v1/audit",
+					},
+				},
+			},
+		))
 	})
 
 	Context("when a pipeline references 'default'", func() {
 
-		var exp []logging.OutputSpec
+		var exp logging.ClusterLogForwarderSpec
 		BeforeEach(func() {
+			logstore = &logging.LogStoreSpec{Type: logging.OutputTypeElasticsearch}
 			pipelines[0].OutputRefs = append(spec.Pipelines[0].OutputRefs, logging.OutputNameDefault)
 			spec = logging.ClusterLogForwarderSpec{
 				Outputs:   outputs,
@@ -60,11 +146,12 @@ var _ = Describe("MigrateDefaultOutput", func() {
 
 		Context("and outputs does not explicitly spec 'default'", func() {
 			BeforeEach(func() {
-				exp = append(outputs, NewDefaultOutput(nil))
+				exp = *spec.DeepCopy()
+				exp.Outputs = append(outputs, NewDefaultOutput(nil))
 			})
 
 			It("should add the default OutputSpec", func() {
-				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				Expect((MigrateDefaultOutput(spec, logstore))).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
 			})
 			It("should add the default OutputSpec and OutputDefaults when OutputDefaults are spec'd", func() {
 				spec.OutputDefaults = &logging.OutputDefaults{
@@ -72,11 +159,9 @@ var _ = Describe("MigrateDefaultOutput", func() {
 						StructuredTypeKey: "foo.bar",
 					},
 				}
-				exp[1].Elasticsearch = &logging.Elasticsearch{
-					ElasticsearchStructuredSpec: *spec.OutputDefaults.Elasticsearch,
-				}
-
-				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
+				exp.Outputs[1].Elasticsearch = &logging.Elasticsearch{ElasticsearchStructuredSpec: *spec.OutputDefaults.Elasticsearch}
+				exp.OutputDefaults = spec.OutputDefaults
+				Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
 			})
 		})
 
@@ -93,23 +178,25 @@ var _ = Describe("MigrateDefaultOutput", func() {
 			})
 
 			It("should replace the OutputSpec with the default OutputSpec", func() {
-				exp = append(outputs, NewDefaultOutput(nil))
 				spec = logging.ClusterLogForwarderSpec{
 					Outputs:   append(outputs, tobereplaced),
 					Pipelines: pipelines,
 				}
-				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				exp = *spec.DeepCopy()
+				exp.Outputs = append(outputs, NewDefaultOutput(nil))
+				Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
 			})
 
 			It("should replace the OutputSpec with the default OutputSpec and use the config (e.g. structureTypeKey) defined in the original OutputSpec", func() {
 				tobereplaced.Elasticsearch = esSpec
-				exp = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: &esSpec.ElasticsearchStructuredSpec}))
 				spec = logging.ClusterLogForwarderSpec{
 					Outputs:        append(outputs, tobereplaced),
 					Pipelines:      pipelines,
 					OutputDefaults: &logging.OutputDefaults{Elasticsearch: &logging.ElasticsearchStructuredSpec{StructuredTypeKey: "abc"}},
 				}
-				Expect(MigrateDefaultOutput(spec)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
+				exp = *spec.DeepCopy()
+				exp.Outputs = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: &esSpec.ElasticsearchStructuredSpec}))
+				Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
 			})
 		})
 

--- a/internal/runtime/logging.go
+++ b/internal/runtime/logging.go
@@ -1,0 +1,12 @@
+package runtime
+
+import (
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+)
+
+// NewClusterLogForwarder returns a ClusterLogForwarder with default name and namespace.
+func NewClusterLogForwarder(namespace, name string) *loggingv1.ClusterLogForwarder {
+	clf := &loggingv1.ClusterLogForwarder{}
+	Initialize(clf, namespace, name)
+	return clf
+}

--- a/test/runtime/logging.go
+++ b/test/runtime/logging.go
@@ -9,9 +9,7 @@ import (
 
 // NewClusterLogForwarder returns a ClusterLogForwarder with default name and namespace.
 func NewClusterLogForwarder() *loggingv1.ClusterLogForwarder {
-	clf := &loggingv1.ClusterLogForwarder{}
-	runtime.Initialize(clf, constants.WatchNamespace, constants.SingletonName)
-	return clf
+	return runtime.NewClusterLogForwarder(constants.WatchNamespace, constants.SingletonName)
 }
 
 // NewClusterLogging returns a ClusterLogging with default name, namespace and


### PR DESCRIPTION
This PR:

fixes a merge issue where we always validate against an empty spec which causes logging to never deploy
Links
https://issues.redhat.com/browse/LOG-3228
forward pick of #1801
