### PR TITLE
LOG-3446: Fix k8s client throttling in must-gather scripts

### DIFF
--- a/must-gather/collection-scripts/common
+++ b/must-gather/collection-scripts/common
@@ -1,6 +1,16 @@
 #!/bin/bash
 
+
+get_timestamp(){
+  date '+%Y-%m-%d %H:%M:%S'
+}
+
+log(){
+  echo "$(get_timestamp) ${*}"
+}
+
 get_env() {
+  echo "BEGIN get_env ..."
   local pod=$1
   local env_file=$2/$pod
   local ns=${3:-$NAMESPACE}
@@ -18,4 +28,5 @@ get_env() {
     echo -- Environment Variables >> $env_file
     oc -n $ns exec $pod -c $container -- env | sort >> $env_file
   done
+  echo "END get_env ..."
 }

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,7 +1,18 @@
 #!/bin/bash
+
+echo "must-gather script started ....."
+echo "for must-gather logs check /must-gather/gather-debug.log"
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 BASE_COLLECTION_PATH="${1:-/must-gather}"
 mkdir -p "${BASE_COLLECTION_PATH}"
+
+cd $BASE_COLLECTION_PATH
+
+mkdir ${BASE_COLLECTION_PATH}/cache-dir
+export KUBECACHEDIR=${BASE_COLLECTION_PATH}/cache-dir
+
+source ${SCRIPT_DIR}/common
 
 LOGGING_NS="${2:-openshift-logging}"
 
@@ -20,9 +31,13 @@ cluster_resources+=(clusterroles)
 cluster_resources+=(clusterrolebindings)
 cluster_resources+=(persistentvolumes)
 
+log "BEGIN inspecting CRs..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 for cr in "${cluster_resources[@]}" ; do
-  oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" "${cr}" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  log "BEGIN inspecting CR ${cr} ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" "${cr}"  >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  log "END inspecting CR ${cr} ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 done
+log "END inspecting CRs..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 
 # namespace-scoped resources
 resources=(pods)
@@ -32,40 +47,51 @@ resources+=(configmaps)
 resources+=(serviceaccounts)
 resources+=(events)
 
+log "BEGIN inspecting namespaces ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 # run the collection of resources using must-gather
 for ns in "${LOGGING_NS}" openshift-operator-lifecycle-manager openshift-operators-redhat ; do
   for resource in "${resources[@]}" ; do
-    oc adm inspect --dest-dir="${BASE_COLLECTION_PATH}" -n "$ns" "${resource}" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+    log "BEGIN inspecting namespace ${ns}/${resource} ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
+    oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" -n "$ns" "${resource}"  >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+    log "END inspecting namespace ${ns}/${resource} ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
   done
 done
+log "END inspecting namespaces ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 
+
+log "BEGIN inspecting install resources ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 eo_found="$(oc -n openshift-operators-redhat get deployment elasticsearch-operator --ignore-not-found --no-headers)"
 clo_found="$(oc -n "$LOGGING_NS" get deployment cluster-logging-operator --ignore-not-found --no-headers)"
 if [ "$clo_found" != "" ] || [ "$eo_found" != "" ] ; then
     ${SCRIPT_DIR}/gather_install_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 else
-  echo "Skipping install inspection.  No CLO or EO deployment found" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  log "Skipping install inspection.  No CLO or EO deployment found" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 fi
+log "END inspecting install resources ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 
 if [ "$clo_found" != "" ] ; then
+  log "BEGIN gathering CLO resources ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
   ${SCRIPT_DIR}/gather_cluster_logging_operator_resources "$BASE_COLLECTION_PATH" "$LOGGING_NS" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
   ${SCRIPT_DIR}/gather_collection_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  log "END gathering CLO resources ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 else
-  echo "Skipping collection inspection.  No CLO found" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  log "Skipping collection inspection.  No CLO found" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 fi
 
 found="$(oc -n $LOGGING_NS get elasticsearch elasticsearch --ignore-not-found --no-headers)"
 if [ "$found" != "" ] ; then
   # Call per component gather scripts
+  log "BEGIN gathering EO resources ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
   ${SCRIPT_DIR}/gather_elasticsearch_operator_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
   ${SCRIPT_DIR}/gather_logstore_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 
   found="$(oc -n $LOGGING_NS get kibana kibana --ignore-not-found --no-headers)"
   if [ "$found" != "" ] ; then
-    ${SCRIPT_DIR}/gather_visualization_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+    KUBECACHEDIR=${BASE_COLLECTION_PATH}/cache-dir ${SCRIPT_DIR}/gather_visualization_resources "$BASE_COLLECTION_PATH" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
   fi
+  log "BEGIN gathering CLO resources ..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 else
-  echo "Skipping logstorage inspection.  No Elasticsearch deployment found" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  log "Skipping logstorage inspection.  No Elasticsearch deployment found" >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
 fi
 
 exit 0

--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -6,6 +6,8 @@ source ${SCRIPT_DIR}/common
 BASE_COLLECTION_PATH=$1
 NAMESPACE=${2:-openshift-logging}
 
+log "BEGIN gather_cluster_logging_operator_resources ..."
+
 # Use PWD as base path if no argument is passed
 if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
@@ -14,7 +16,7 @@ fi
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 clo_folder="$CLO_COLLECTION_PATH/clo"
 
-echo "Gathering data for cluster-logging-operator"
+log "Gathering data for cluster-logging-operator"
 mkdir -p "$clo_folder"
 
 pods=$(oc -n $NAMESPACE get pods -l name=cluster-logging-operator -o jsonpath='{.items[*].metadata.name}')
@@ -23,16 +25,18 @@ do
     get_env $pod $clo_folder $NAMESPACE "Dockerfile-*operator*"
 done
 
-oc -n $NAMESPACE get deployment cluster-logging-operator -o yaml > $clo_folder/deployment
+oc -n $NAMESPACE get deployment cluster-logging-operator -o yaml --cache-dir=${KUBECACHEDIR} > $clo_folder/deployment
 
 for csv in $(oc -n $NAMESPACE get csv -o name) ; do
-  oc -n $NAMESPACE get "${csv}" -o yaml > "${clo_folder}/${csv}.yaml"
+  mkdir -p "$(dirname ${clo_folder}/$csv)"
+  oc -n $NAMESPACE get "${csv}" -o yaml --cache-dir=${KUBECACHEDIR} > ${clo_folder}/"${csv}.yaml"
 done
+
 
 for r in "clusterlogging" "clusterlogforwarder" ; do
   data="$(oc -n $NAMESPACE get $r --ignore-not-found -o yaml)"
   if [ "$data" != "" ] ; then
-    echo "${data}" > "${clo_folder}/$r_instance.yaml"
+    echo "${data}" > "${clo_folder}/"$r"_instance.yaml"
   fi
 done
 
@@ -44,13 +48,14 @@ if [ "$data" != "" ] ; then
 fi
 
 csv_name="$(oc -n $NAMESPACE get csv -o name | grep -E 'cluster(-?)logging')"
-oc -n $NAMESPACE get deployments -o wide > ${clo_folder}/deployments.txt 2>&1
-oc -n $NAMESPACE get ds -o wide > ${clo_folder}/daemonsets.txt 2>&1
-oc -n $NAMESPACE get "${csv_name}" -o jsonpath='{.spec.displayName}{"/must-gather\n"}{.spec.version}' > "${clo_folder}/version"
+oc -n $NAMESPACE get deployments -o wide > ${clo_folder}/deployments.txt --cache-dir=${KUBECACHEDIR} 2>&1
+oc -n $NAMESPACE get ds -o wide > ${clo_folder}/daemonsets.txt --cache-dir=${KUBECACHEDIR} 2>&1
+oc -n $NAMESPACE get "${csv_name}" -o jsonpath='{.spec.displayName}{"/must-gather\n"}{.spec.version}' --cache-dir=${KUBECACHEDIR} > "${clo_folder}/version"
 
 for r in "secret/elasticsearch" "configmap/collector" ; do
   result="$(oc -n $NAMESPACE get $r --ignore-not-found)"
   if [ "$result" != "" ] ; then
-    oc -n $NAMESPACE extract $r --to=${clo_folder}
+    oc -n $NAMESPACE extract $r --to=${clo_folder} --cache-dir=${KUBECACHEDIR}
   fi
 done
+log "END gather_cluster_logging_operator_resources ..."

--- a/must-gather/collection-scripts/gather_collection_resources
+++ b/must-gather/collection-scripts/gather_collection_resources
@@ -16,6 +16,8 @@ NAMESPACE=${2:-openshift-logging}
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 collector_folder="$CLO_COLLECTION_PATH/collector"
 
+log "BEGIN gather_collection_resources..."
+
 check_collector_connectivity() {
   local pod=$1
   echo "--Connectivity between $pod and elasticsearch" >> $collector_folder/$pod
@@ -26,10 +28,10 @@ check_collector_connectivity() {
   local collector=fluent
   local container=$2
   echo "  with ca" >> $collector_folder/$pod
-  oc -n $NAMESPACE exec $pod -c $container -- curl -ILvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert --cacert /etc/$collector/keys/ca -XGET https://$es_host:$es_port &>> $collector_folder/$pod
+  oc -n $NAMESPACE exec $pod -c $container --cache-dir=${KUBECACHEDIR} -- curl -ILvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert --cacert /etc/$collector/keys/ca -XGET https://$es_host:$es_port & >> $collector_folder/$pod
 
   echo "  without ca" >> $collector_folder/$pod
-  oc -n $NAMESPACE exec $pod -c $container -- curl -ILkvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert -XGET https://$es_host:$es_port &>> $collector_folder/$pod
+  oc -n $NAMESPACE exec $pod -c $container --cache-dir=${KUBECACHEDIR} -- curl -ILkvs --key /etc/$collector/keys/key --cert /etc/$collector/keys/cert -XGET https://$es_host:$es_port & >> $collector_folder/$pod
 }
 
 check_collector_persistence() {
@@ -42,13 +44,13 @@ check_collector_persistence() {
   if [ -z "$fbstoragePath" ] ; then
     echo "No filebuffer storage defined" >>  $collector_folder/$pod
   else
-    oc -n $NAMESPACE exec $pod -c $container -- df -h $fbstoragePath >> $collector_folder/$pod
-    oc -n $NAMESPACE exec $pod -c $container -- ls -lr $fbstoragePath >> $collector_folder/$pod
+    oc -n $NAMESPACE exec $pod -c $container --cache-dir=${KUBECACHEDIR} -- df -h $fbstoragePath >> $collector_folder/$pod
+    oc -n $NAMESPACE exec $pod -c $container --cache-dir=${KUBECACHEDIR} -- ls -lr $fbstoragePath >> $collector_folder/$pod
   fi
 }
 
-echo "if the collector 'fluentd' or 'collector' is missing thats OK"
-echo "this must gather is trying to cover all cases for name migration"
+log "if the collector 'fluentd' or 'collector' is missing thats OK"
+log "this must gather is trying to cover all cases for name migration"
 for collector in "fluentd" "collector"; do
   yaml="$(oc -n $NAMESPACE get ds/$collector --ignore-not-found -o yaml)"
   if [ "$yaml" == "" ] ; then
@@ -57,23 +59,24 @@ for collector in "fluentd" "collector"; do
 
   is_fluent=$(echo $yaml|grep fluent)
 
-  echo "Gathering data for collection component: $collector"
+  log "Gathering data for collection component: $collector"
   mkdir -p $collector_folder
 
-  echo "-- Checking Collector health: $collector"
+  log "-- Checking Collector health: $collector"
   pods="$(oc -n $NAMESPACE get pods -l component=collector -o jsonpath='{.items[*].metadata.name}')"
   for pod in $pods
   do
-      echo "---- Collector pod: $pod"
-      oc -n $NAMESPACE describe pod/$pod > $collector_folder/$pod.describe 2>&1
+      log "---- Collector pod: $pod"
+      oc -n $NAMESPACE describe pod/$pod > $collector_folder/$pod.describe --cache-dir=${KUBECACHEDIR} 2>&1
       if [ "$is_fluent" != "" ] ; then
         check_collector_connectivity $pod $collector
         check_collector_persistence $pod $collector
-        oc -n $NAMESPACE exec $pod -c $collector -- ls -l /var/lib/fluentd/default > $collector_folder/$pod.es-buffers.txt
-        oc -n $NAMESPACE exec $pod -c $collector -- ls -l /var/lib/fluentd/retry_default > $collector_folder/$pod.buffers.es-retry.txt
+        oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec $pod -c $collector -- ls -l /var/lib/fluentd/default  > $collector_folder/$pod.es-buffers.txt
+        oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec $pod -c $collector -- ls -l /var/lib/fluentd/retry_default > $collector_folder/$pod.buffers.es-retry.txt
         echo "$pod" >> $collector_folder/output-buffer-size.txt
         echo "---------------" >> $collector_folder/output-buffer-size.txt
-        oc -n $NAMESPACE exec $pod -c $collector -- bash -c ' du -sh /var/lib/fluentd/*' >> $collector_folder/output-buffer-size.txt
+        oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec $pod -c $collector -- bash -c ' du -sh /var/lib/fluentd/*' >> $collector_folder/output-buffer-size.txt
       fi
   done
 done
+log "END gather_collection_resources..."

--- a/must-gather/collection-scripts/gather_elasticsearch_operator_resources
+++ b/must-gather/collection-scripts/gather_elasticsearch_operator_resources
@@ -2,6 +2,8 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/common
 
+log "BEGIN gather_elasticsearch_operator_resources ..."
+
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 
@@ -16,7 +18,7 @@ LOGGING_NS=${2:-openshift-logging}
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 eo_folder="$CLO_COLLECTION_PATH/eo"
 
-echo "Gathering data for elasticsearch-operator"
+log "Gathering data for elasticsearch-operator"
 mkdir -p "$eo_folder"
 
 pods=$(oc -n $NAMESPACE get pods -l name=elasticsearch-operator -o jsonpath='{.items[*].metadata.name}')
@@ -25,8 +27,9 @@ do
     get_env $pod $eo_folder $NAMESPACE "Dockerfile-*operator*"
 done
 
-oc -n $LOGGING_NS-logging exec -c elasticsearch \
-    $(oc -n $LOGGING_NS get pods -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}') \
+oc -n $LOGGING_NS --cache-dir=${KUBECACHEDIR} exec -c elasticsearch \
+    $(oc -n $LOGGING_NS --cache-dir=${KUBECACHEDIR} get pods -l component=elasticsearch -o jsonpath='{.items[0].metadata.name}') \
     -- indices > ${eo_folder}/indices.txt
 
-oc -n $NAMESPACE describe deployment elasticsearch-operator > ${eo_folder}/eo-deployment.describe 2>&1
+oc -n $NAMESPACE describe deployment elasticsearch-operator --cache-dir=${KUBECACHEDIR} > ${eo_folder}/eo-deployment.describe 2>&1
+log "END gather_elasticsearch_operator_resources ..."

--- a/must-gather/collection-scripts/gather_install_resources
+++ b/must-gather/collection-scripts/gather_install_resources
@@ -3,6 +3,8 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/common
 
+log "BEGIN gather_install_resources ..."
+
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 
@@ -16,14 +18,16 @@ NAMESPACE=${2:-openshift-logging}
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 install_folder="$CLO_COLLECTION_PATH/install"
 
-echo "Gathering data for install info"
+log "BEGIN gather_install_resources..."
+log "Gathering data for install info"
 mkdir -p "$install_folder"
 
-echo "-- Subscription"
-oc get -n ${NAMESPACE} subscriptions.operators.coreos.com -o yaml > "$install_folder/subscription-clo"
-oc get -n openshift-operators-redhat subscriptions.operators.coreos.com -o yaml > "$install_folder/subscription-eo"
+log "-- Subscription"
+oc get -n ${NAMESPACE} subscriptions.operators.coreos.com -o yaml --cache-dir=${KUBECACHEDIR} > "$install_folder/subscription-clo"
+oc get -n openshift-operators-redhat subscriptions.operators.coreos.com -o yaml --cache-dir=${KUBECACHEDIR} > "$install_folder/subscription-eo"
 
-echo "-- Install Plan"
-oc get -n ${NAMESPACE} installplans.operators.coreos.com -o yaml > "$install_folder/install_plan-clo"
-oc get -n openshift-operators-redhat installplans.operators.coreos.com -o yaml > "$install_folder/install_plan-eo"
+log "-- Install Plan"
+oc get -n ${NAMESPACE} installplans.operators.coreos.com -o yaml --cache-dir=${KUBECACHEDIR} > "$install_folder/install_plan-clo"
+oc get -n openshift-operators-redhat installplans.operators.coreos.com -o yaml --cache-dir=${KUBECACHEDIR} > "$install_folder/install_plan-eo"
 
+log "END gather_install_resources..."

--- a/must-gather/collection-scripts/gather_logstore_resources
+++ b/must-gather/collection-scripts/gather_logstore_resources
@@ -2,6 +2,8 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/common
 
+log "BEGIN gather_logstore_resources ..."
+
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 
@@ -20,11 +22,11 @@ list_es_storage() {
   local mountPath=$(oc -n $NAMESPACE get pod $pod -o jsonpath='{.spec.containers[0].volumeMounts[?(@.name=="elasticsearch-storage")].mountPath}')
   echo "-- Persistence files" >> $es_folder/$pod
 
-  oc -n $NAMESPACE exec -c elasticsearch $pod -- ls -lR $mountPath >> $es_folder/$pod
+  oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR}  exec -c elasticsearch $pod -- ls -lR $mountPath >> $es_folder/$pod
   
   echo "-- Persistence  storage size " >> $es_folder/$pod-storage
 
-  oc -n $NAMESPACE exec -c elasticsearch $pod -- df -h $mountPath >> $es_folder/$pod-storage
+  oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR}  exec -c elasticsearch $pod -- df -h $mountPath >> $es_folder/$pod-storage
 
 }
 
@@ -44,45 +46,45 @@ get_elasticsearch_status() {
   local cat_items=(health nodes aliases thread_pool)
   for cat_item in "${cat_items[@]}"
   do
-    oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/${cat_item}.cat
+    oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/${cat_item}.cat
   done
 
-  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_nodes/hot_threads &> $cluster_folder/hot_threads.txt
-  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/indices?v\&bytes=m &> $cluster_folder/indices.cat
-  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/indices?h=i,creation.date,creation.date.string,store.size,pri.store.size > $cluster_folder/indices_size.cat
-  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_search?sort=@timestamp:desc\&pretty > $cluster_folder/latest_documents.json
-  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_nodes/?pretty > $cluster_folder/nodes_state.json
-  oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_nodes/stats?pretty > $cluster_folder/nodes_stats.json
-  local health=$(oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/health?h=status)
+  oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec -c elasticsearch $pod -- $curl_es/_nodes/hot_threads &> $cluster_folder/hot_threads.txt
+  oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec -c elasticsearch $pod -- $curl_es/_cat/indices?v\&bytes=m &> $cluster_folder/indices.cat
+  oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec -c elasticsearch $pod -- $curl_es/_cat/indices?h=i,creation.date,creation.date.string,store.size,pri.store.size > $cluster_folder/indices_size.cat
+  oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec -c elasticsearch $pod -- $curl_es/_search?sort=@timestamp:desc\&pretty > $cluster_folder/latest_documents.json
+  oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec -c elasticsearch $pod -- $curl_es/_nodes/?pretty > $cluster_folder/nodes_state.json
+  oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec -c elasticsearch $pod -- $curl_es/_nodes/stats?pretty > $cluster_folder/nodes_stats.json
+  local health=$(oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec -c elasticsearch $pod -- $curl_es/_cat/health?h=status)
   if [ -z "$health" ]
   then
-    echo "Unable to get health from $1"
+    log "Unable to get health from $1"
   elif [ $health != "green" ]
   then
-    echo "Gathering additional cluster information Cluster status is $health"
+    log "Gathering additional cluster information Cluster status is $health"
 
     cat_items=(recovery shards pending_tasks)
     for cat_item in "${cat_items[@]}"
     do
-      oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v &> $cluster_folder/${cat_item}.cat
+      oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec -c elasticsearch $pod -- $curl_es/_cat/$cat_item?v --cache-dir=${KUBECACHEDIR} &> $cluster_folder/${cat_item}.cat
     done
 
-    oc -n $NAMESPACE exec -c elasticsearch $pod -- $curl_es/_cat/shards?h=index,shard,prirep,state,unassigned.reason,unassigned.description | grep UNASSIGNED &> $cluster_folder/unassigned_shards.cat
+    oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec -c elasticsearch $pod -- $curl_es/_cat/shards?h=index,shard,prirep,state,unassigned.reason,unassigned.description | grep UNASSIGNED &> $cluster_folder/unassigned_shards.cat
   fi
 }
 
 get_elasticsearch_cr() {
-  oc get -n $NAMESPACE elasticsearch.logging.openshift.io elasticsearch -o yaml > $es_folder/cr
+  oc get -n $NAMESPACE --cache-dir=${KUBECACHEDIR} elasticsearch.logging.openshift.io elasticsearch -o yaml > $es_folder/elasticsearch_cr.yaml
 }
 
-echo "Gathering data for logstore component"
-echo "-- Checking Elasticsearch health"
+log "Gathering data for logstore component"
+log "-- Checking Elasticsearch health"
 mkdir -p $es_folder
 
 es_pods=$(oc -n $NAMESPACE get pods -l component=elasticsearch -o jsonpath='{.items[*].metadata.name}')
 for pod in $es_pods
 do
-    echo "---- Elasticsearch pod: $pod"
+    log "---- Elasticsearch pod: $pod"
     get_env $pod $es_folder "$NAMESPACE"
     list_es_storage $pod
 done
@@ -91,9 +93,11 @@ anypod=""
 for comp in "elasticsearch"
 do
     echo "-- Getting Elasticsearch cluster info from logging-${comp} pod"
-    anypod=$(oc -n $NAMESPACE get pod --selector="component=${comp}" --no-headers | grep Running | awk '{print$1}' | tail -1)
+    anypod=$(oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} get pod --selector="component=${comp}" --no-headers | grep Running | awk '{print$1}' | tail -1)
     get_elasticsearch_status ${comp} ${anypod}
 done
 
-echo "-- Gather Elasticsearch CR"
+log "-- Gather Elasticsearch CR"
 get_elasticsearch_cr
+
+log "END gather_logstore_resources ..."

--- a/must-gather/collection-scripts/gather_visualization_resources
+++ b/must-gather/collection-scripts/gather_visualization_resources
@@ -2,6 +2,8 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/common
 
+log "BEGIN gather_visualization_resources ..."
+
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 
@@ -19,30 +21,31 @@ check_kibana_connectivity() {
   pod=$1
 
   echo "---- Connectivity between $pod and elasticsearch" >> $kibana_folder/$pod
-  es_url=$(oc -n $NAMESPACE get pod $pod  -o jsonpath='{.spec.containers[?(@.name=="kibana")].env[?(@.name=="ELASTICSEARCH_URL")].value}')
+  es_url=$(oc -n $NAMESPACE get pod $pod  -o jsonpath='{.spec.containers[?(@.name=="kibana")].env[?(@.name=="ELASTICSEARCH_URL")].value}' --cache-dir=${KUBECACHEDIR})
 
   echo "  with ca" >> $kibana_folder/$pod
-  oc -n $NAMESPACE exec $pod -c kibana -- curl -ILvs --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert --cacert /etc/kibana/keys/ca -XGET $es_url &>> $kibana_folder/$pod
+  oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec $pod -c kibana -- curl -ILvs --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert --cacert /etc/kibana/keys/ca -XGET $es_url &>> $kibana_folder/$pod
 
   echo "  without ca" >> $kibana_folder/$pod
-  oc -n $NAMESPACE exec $pod -c kibana -- curl -ILkvs --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert -XGET $es_url &>> $kibana_folder/$pod
+  oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR} exec $pod -c kibana -- curl -ILkvs --key /etc/kibana/keys/key --cert /etc/kibana/keys/cert -XGET $es_url &>> $kibana_folder/$pod
 }
 
 get_kibana_cr() {
-  oc get -n ${NAMESPACE} kibana.logging.openshift.io kibana -o yaml > $kibana_folder/cr
+  oc get -n ${NAMESPACE} kibana.logging.openshift.io kibana -o yaml --cache-dir=${KUBECACHEDIR} > $kibana_folder/cr
 }
 
-echo "Gathering data for visualization component"
-echo "-- Checking Kibana health"
+log "Gathering data for visualization component"
+log "-- Checking Kibana health"
 mkdir -p $kibana_folder
 
 kibana_pods=$(oc -n $NAMESPACE get pods -l logging-infra=kibana -o jsonpath='{.items[*].metadata.name}')
 for pod in $kibana_pods
 do
-    echo "---- Kibana pod: $pod"
+    log "---- Kibana pod: $pod"
     get_env $pod $kibana_folder "$NAMESPACE"
     check_kibana_connectivity $pod
 done
 
-echo "-- Gather Kibana CR"
+log "-- Gather Kibana CR"
 get_kibana_cr
+log "END gather_visualization_resources ..."


### PR DESCRIPTION
### Description
`oc` commands in must-gather were getting client throttled because oc commands could not create the kube cache.

```
I0103 09:08:12.495844      18 cached_discovery.go:92] failed to write cache to /.kube/cache/discovery/10.217.4.1_443/imageregistry.operator.openshift.io/v1/serverresources.json due to mkdir /.kube: permission denied
```
 - Added a kube cache folder to `/must-gather` and use this in oc commads with `--cache-dir` flag.
 - Added BEGIN/END `log` statements in gather scripts which prints timestamped echo statements to monitor time taken by each step
 - Fixed small errors in gather scripts


/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-3446

