### PR TITLE
LOG-3463: fix namespace_labels when writing to Elasticsearch

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -560,13 +560,14 @@ var _ = Describe("Testing Complete Config Generation", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
 
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -606,13 +606,14 @@ var _ = Describe("Generating fluentd config", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
 
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -751,13 +752,14 @@ var _ = Describe("Generating fluentd config", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
 
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -1336,13 +1338,14 @@ var _ = Describe("Generating fluentd config", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
             
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
-	<record>
+    @type record_modifier
+    <record>
 	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
-	</record>
-	remove_keys _dummy_
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -1481,13 +1484,14 @@ var _ = Describe("Generating fluentd config", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
             
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
-	<record>
+    @type record_modifier
+    <record>
 	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
-	</record>
-	remove_keys _dummy_
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -2070,13 +2074,14 @@ var _ = Describe("Generating fluentd config", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
           
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
-	<record>
+    @type record_modifier
+    <record>
 	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
-	</record>
-	remove_keys _dummy_
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -2215,13 +2220,14 @@ var _ = Describe("Generating fluentd config", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
           
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
-	<record>
+    @type record_modifier
+    <record>
 	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
-	</record>
-	remove_keys _dummy_
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_
   </filter>
   
   #remove structured field if present
@@ -3201,13 +3207,14 @@ var _ = Describe("Generating fluentd config", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
            
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
-	<record>
+    @type record_modifier
+    <record>
 	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
-	</record>
-	remove_keys _dummy_
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_
   </filter>
   
   #remove structured field if present
@@ -3346,13 +3353,14 @@ var _ = Describe("Generating fluentd config", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
             
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
-	<record>
+    @type record_modifier
+    <record>
 	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
-	</record>
-	remove_keys _dummy_
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -3491,13 +3499,14 @@ var _ = Describe("Generating fluentd config", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
             
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
-	<record>
+    @type record_modifier
+    <record>
 	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
-	</record>
-	remove_keys _dummy_
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -3636,13 +3645,14 @@ var _ = Describe("Generating fluentd config", func() {
 	prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
             
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
-	<record>
+    @type record_modifier
+    <record>
 	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
-	</record>
-	remove_keys _dummy_
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -81,13 +81,14 @@ var _ = Describe("Generate fluentd config", func() {
     prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
 
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -247,13 +248,14 @@ var _ = Describe("Generate fluentd config", func() {
     prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
 
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -407,13 +409,14 @@ var _ = Describe("Generate fluentd config", func() {
     prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
   
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -556,13 +559,14 @@ var _ = Describe("Generate fluentd config", func() {
     prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
 
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -717,13 +721,14 @@ var _ = Describe("Generate fluentd config", func() {
     prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
 
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present
@@ -879,13 +884,14 @@ var _ = Describe("Generate fluentd config", func() {
     prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
 
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   <match retry_es_1>
@@ -1036,13 +1042,14 @@ var _ = Describe("Generate fluentd config", func() {
     prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
 
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   <match retry_es_1>
@@ -1185,13 +1192,14 @@ var _ = Describe("Generate fluentd config", func() {
     prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
   </filter>
 
-  #rebuild message field if present
+  #dedot namespace_labels and rebuild message field if present
   <filter **>
-	@type record_modifier
+    @type record_modifier
     <record>
-      _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+	  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
     </record>
-	remove_keys _dummy_
+    remove_keys _dummy_, _dummy2_
   </filter>
 
   #remove structured field if present

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -121,13 +121,14 @@ var _ = Describe("Generating fluentd config", func() {
 			prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
 		  </filter>
           
-          #rebuild message field if present
+		  #dedot namespace_labels and rebuild message field if present
 		  <filter **>
 			@type record_modifier
 			<record>
 			  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+			  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
 			</record>
-			remove_keys _dummy_
+			remove_keys _dummy_, _dummy2_
 		  </filter>
 		  
 		  #remove structured field if present
@@ -280,13 +281,14 @@ var _ = Describe("Generating fluentd config", func() {
 			prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
 		  </filter>
 		            
-          #rebuild message field if present
+		  #dedot namespace_labels and rebuild message field if present
 		  <filter **>
 			@type record_modifier
 			<record>
 			  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+			  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
 			</record>
-			remove_keys _dummy_
+			remove_keys _dummy_, _dummy2_
 		  </filter>
 
 		  #remove structured field if present
@@ -425,13 +427,14 @@ var _ = Describe("Generating fluentd config", func() {
 			prune_labels_exclusions app.kubernetes.io/name,app.kubernetes.io/instance,app.kubernetes.io/version,app.kubernetes.io/component,app.kubernetes.io/part-of,app.kubernetes.io/managed-by,app.kubernetes.io/created-by
 		  </filter>
 		            
-          #rebuild message field if present
+		  #dedot namespace_labels and rebuild message field if present
 		  <filter **>
 			@type record_modifier
 			<record>
 			  _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+			  _dummy2_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub('.','_')]=v}};end}
 			</record>
-			remove_keys _dummy_
+			remove_keys _dummy_, _dummy2_
 		  </filter>
 
 		  #remove structured field if present

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -802,7 +802,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -891,7 +913,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -1352,7 +1396,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -1445,7 +1511,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -159,7 +159,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -92,7 +92,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -205,7 +227,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -308,7 +352,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -447,7 +513,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -536,7 +624,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -657,7 +767,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -768,7 +900,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -885,7 +1039,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -1015,7 +1191,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -1112,7 +1310,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -1218,7 +1438,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -1324,7 +1566,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -1430,7 +1694,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)
@@ -1536,7 +1822,29 @@ source = '''
         end
         flatten_labels(event)
         prune_labels(event)
+		dedot(event.log.kubernetes.namespace_labels)
         emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "%.", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
     end
 
     function flatten_labels(event)


### PR DESCRIPTION
# Description

This PR:

* replaces dots with underscores for namespace_labels when writing to Elasticsearch
# Links
* https://issues.redhat.com/browse/LOG-3463
* replaces https://github.com/openshift/cluster-logging-operator/pull/1811
