### PR TITLE
LOG-3469: [release-5.5] fix collector restarting and degraded pipeline status

### DIFF
--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -174,6 +174,7 @@ func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, req
 	if clusterLogging == nil {
 		return nil
 	}
+	clusterLoggingRequest.ForwarderSpec = migrations.MigrateClusterLogForwarderSpec(forwarder.Spec, clusterLogging.Spec.LogStore)
 	clusterLoggingRequest.Cluster = clusterLogging
 
 	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {


### PR DESCRIPTION
### Description
Same issue and fix as 5.6, this fixes the degraded pipeline status when adding default to an existing CLF pipeline.  Also, the collector pod was restarting every 8-10 seconds.  This resolves.

/cc @vimalk78 @syedriko
/assign @jcantrill 

### Links
- https://issues.redhat.com/browse/LOG-3469
