### PR TITLE
LOG-3474:  fix custom input in clf spec when using loki

### DIFF
--- a/internal/consoleplugin/reconciler.go
+++ b/internal/consoleplugin/reconciler.go
@@ -85,7 +85,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		return err
 	}
 	if modified {
-		log.Info("reconciled console", "plugin", runtime.ID(&r.consolePlugin))
+		log.V(3).Info("reconciled console", "plugin", runtime.ID(&r.consolePlugin))
 	}
 	return nil
 }

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -302,6 +302,10 @@ func (clusterRequest *ClusterLoggingRequest) LokiStackURL(tenant string) string 
 	if service == "" {
 		return ""
 	}
+	if !logging.ReservedInputNames.Has(tenant) {
+		log.V(3).Info("url tenant must be one of our reserved input names", "tenant", tenant)
+		return ""
+	}
 
 	return fmt.Sprintf("https://%s.%s.svc:8080/api/logs/v1/%s", service, clusterRequest.Cluster.Namespace, tenant)
 }

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -174,6 +174,7 @@ func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, req
 	if clusterLogging == nil {
 		return nil
 	}
+	clusterLoggingRequest.ForwarderSpec = migrations.MigrateClusterLogForwarderSpec(forwarder.Spec, clusterLogging.Spec.LogStore)
 	clusterLoggingRequest.Cluster = clusterLogging
 
 	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {


### PR DESCRIPTION
### Description
This is the 5.5 fix.  Same general idea as the 5.6 fix: [LOG-3269](https://issues.redhat.com//browse/LOG-3269)
- Adds a name to custom inputs which will now prevent the invalid pipeline error.  
- Adds loki function for getting input type from name, in order for loki labels to work properly.

/cc @vimalk78 @syedriko 
/assign @jcantrill 

### Links
- https://issues.redhat.com/browse/LOG-3474
