### PR TITLE
Added a mutex lock around the cert script or func tests can fail

### DIFF
--- a/internal/certificates/certificates.go
+++ b/internal/certificates/certificates.go
@@ -3,6 +3,7 @@ package certificates
 import (
 	"fmt"
 	"os/exec"
+	"sync"
 
 	"sigs.k8s.io/yaml"
 
@@ -10,7 +11,11 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 )
 
+var m sync.Mutex
+
 func GenerateCertificates(namespace, scriptsDir, logStoreName, workDir string) (err error, updated bool, output []interface{}) {
+	m.Lock()
+	defer m.Unlock()
 	script := fmt.Sprintf("%s/cert_generation.sh", scriptsDir)
 	return RunCertificatesScript(namespace, logStoreName, workDir, script)
 }


### PR DESCRIPTION
### Description
Added a mutex lock around the cert script to keep functional tests running in parallel from randomly failing.

/cc @jcantrill 
/assign @vimalk78 