### PR TITLE
Addressed race condition during cert generation, fixed loki uid for vector CI

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -227,6 +227,10 @@ func GetScriptsDir() string {
 	return scriptsDir
 }
 
+func GetDirFileContents(dirPath, filePath string) []byte {
+	return GetFileContents(path.Join(dirPath, filePath))
+}
+
 func GetWorkingDirFileContents(filePath string) []byte {
 	return GetFileContents(GetWorkingDirFilePath(filePath))
 }

--- a/test/framework/e2e/certificates/certificates.go
+++ b/test/framework/e2e/certificates/certificates.go
@@ -2,13 +2,24 @@ package certificates
 
 import (
 	"fmt"
+	"math/rand"
+	"os"
 	"os/exec"
 
 	"sigs.k8s.io/yaml"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/test"
 )
+
+func GenerateTestCertificates(logStoreName string) (err error, certsDir string) {
+	certsDir = fmt.Sprintf("/tmp/clo-test-%d-%d", os.Getpid(), rand.Intn(10000)) //nolint:gosec
+	log.V(3).Info("Generating Pipeline certificates for Log Store to certs dir", "logStoreName", logStoreName, "certsDir", certsDir)
+	err, _, _ = GenerateCertificates(constants.WatchNamespace, test.GitRoot("scripts"), logStoreName, certsDir)
+	return
+}
 
 func GenerateCertificates(namespace, scriptsDir, logStoreName, workDir string) (err error, updated bool, output []interface{}) {
 	script := fmt.Sprintf("%s/cert_generation.sh", scriptsDir)

--- a/test/framework/e2e/elasticsearch.go
+++ b/test/framework/e2e/elasticsearch.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/logstore/elasticsearch/indexmanagement"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/internal/logstore/elasticsearch/indexmanagement"
 
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
@@ -148,7 +149,7 @@ func (es *ElasticLogStore) ClusterLocalEndpoint() string {
 	panic("Not implemented")
 }
 
-//Indices fetches the list of indices stored by Elasticsearch
+// Indices fetches the list of indices stored by Elasticsearch
 func (es *ElasticLogStore) Indices() (Indices, error) {
 	options := metav1.ListOptions{
 		LabelSelector: "component=elasticsearch",
@@ -174,9 +175,9 @@ func (es *ElasticLogStore) Indices() (Indices, error) {
 	return indices, nil
 }
 
-func (tc *E2ETestFramework) DeployAnElasticsearchCluster(pwd string) (cr *elasticsearch.Elasticsearch, pipelineSecret *corev1.Secret, err error) {
+func (tc *E2ETestFramework) DeployAnElasticsearchCluster() (cr *elasticsearch.Elasticsearch, pipelineSecret *corev1.Secret, err error) {
 	logStoreName := "test-elastic-cluster"
-	if pipelineSecret, err = tc.CreatePipelineSecret(pwd, logStoreName, "test-pipeline-to-elastic", map[string][]byte{}); err != nil {
+	if pipelineSecret, err = tc.CreatePipelineSecret(logStoreName, "test-pipeline-to-elastic", map[string][]byte{}); err != nil {
 		return nil, nil, err
 	}
 

--- a/test/framework/e2e/fluentd.go
+++ b/test/framework/e2e/fluentd.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"strconv"
 	"strings"
 	"time"
+
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/factory"
@@ -318,7 +319,7 @@ func (tc *E2ETestFramework) DeployFluentdReceiver(rootDir string, secure bool) (
 		otherConf := map[string][]byte{
 			"shared_key": []byte("my_shared_key"),
 		}
-		if logStore.pipelineSecret, err = tc.CreatePipelineSecret(rootDir, receiverName, receiverName, otherConf); err != nil {
+		if logStore.pipelineSecret, err = tc.CreatePipelineSecret(receiverName, receiverName, otherConf); err != nil {
 			return nil, err
 		}
 		tc.AddCleanup(func() error {

--- a/test/helpers/loki/receiver.go
+++ b/test/helpers/loki/receiver.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 
@@ -68,6 +69,7 @@ func NewReceiver(ns, name string) *Receiver {
 	}}
 	r.Pod.Spec.SecurityContext = &corev1.PodSecurityContext{
 		RunAsNonRoot: utils.GetBool(true),
+		RunAsUser:    utils.GetInt64(10001), // uid of user loki in the loki image
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},


### PR DESCRIPTION
### Description
Two corrections for the functional and e2e tests:
- fixed a race condition during generation of certificates due to multiple instances of the certificate generation script running against the same directory
- Added a uid for the loki user to the security context of the loki receiver, this fixes the "container has runAsNonRoot and image has non-numeric user (loki), cannot verify user is non-root" issue happening in vector CI.

/cc @jcantrill 
/assign @cahartma 
