### PR TITLE
LOG-1413: `http_proxy`, `https_proxy` and `no_proxy` variables keys in lowercase

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -469,7 +469,7 @@ func GetProxyEnvVars() []v1.EnvVar {
 				}
 			}
 			envVars = append(envVars, v1.EnvVar{
-				Name:  envvar,
+				Name:  strings.ToLower(envvar),
 				Value: value,
 			})
 		}


### PR DESCRIPTION
Modified the `GetProxyEnvVars()` function to return an array of `v1.EnvVar` where `http_proxy`, `https_proxy` and `no_proxy` environment variables key are in lowercase.

### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-1413
- Enhancement proposal:
