### PR TITLE
[release-5.5] LOG-2843, take two. Added client key passphrase

### DIFF
--- a/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
+++ b/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
@@ -243,7 +243,10 @@ var _ = Describe("Generating external syslog server output store config blocks",
     packet_size 4096
     hostname "#{ENV['NODE_NAME']}"
     tls true
+    client_cert_key '/var/run/ocp-collector/secrets/some-secret/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/some-secret/tls.crt'
     ca_file '/var/run/ocp-collector/secrets/some-secret/ca-bundle.crt'
+    client_cert_key_password "#{File.exists?('/var/run/ocp-collector/secrets/some-secret/passphrase') ? open('/var/run/ocp-collector/secrets/some-secret/passphrase','r') do |f|f.read end : ''}"
     timeout 60
     timeout_exception true
     keep_alive true
@@ -350,7 +353,10 @@ var _ = Describe("Generating external syslog server output store config blocks",
 					}
 					secret = &corev1.Secret{
 						Data: map[string][]byte{
-							"ca-bundle.crt": []byte("junk"),
+							"tls.crt":       []byte("my-tls"),
+							"tls.key":       []byte("my-tls-key"),
+							"ca-bundle.crt": []byte("my-bundle"),
+							"passphrase":    []byte("my-tls-passphrase"),
 						},
 					}
 				})

--- a/internal/generator/fluentd/output/syslog/passphrase.go
+++ b/internal/generator/fluentd/output/syslog/passphrase.go
@@ -1,0 +1,18 @@
+package syslog
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+)
+
+type Passphrase security.Passphrase
+
+func (p Passphrase) Name() string {
+	return "passphraseTemplate"
+}
+
+func (p Passphrase) Template() string {
+	return `{{define "` + p.Name() + `" -}}
+client_cert_key_password "#{File.exists?({{.PassphrasePath}}) ? open({{.PassphrasePath}},'r') do |f|f.read end : ''}"
+{{- end}}
+`
+}

--- a/internal/generator/fluentd/output/syslog/syslog.go
+++ b/internal/generator/fluentd/output/syslog/syslog.go
@@ -398,6 +398,12 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 				}
 				conf = append(conf, ca)
 			}
+			if security.HasPassphrase(secret) {
+				p := Passphrase{
+					PassphrasePath: security.SecretPath(o.Secret.Name, constants.Passphrase),
+				}
+				conf = append(conf, p)
+			}
 		}
 		return conf
 	} else {


### PR DESCRIPTION
### Description
A fix for the fix for [LOG-2843](https://issues.redhat.com//browse/LOG-2843), added support for client key passphrase missed in the original fix.

/cc @jcantrill 
/assign @vimalk78 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-3533

