### PR TITLE
LOG-3447: Remove console plugin command from deployment

### DIFF
--- a/internal/consoleplugin/reconciler.go
+++ b/internal/consoleplugin/reconciler.go
@@ -230,7 +230,6 @@ func (r *Reconciler) mutateDeployment() error {
 								Protocol:      "TCP",
 							},
 						},
-						Command: []string{"./plugin-backend"},
 						Args: []string{
 							"-port", "9443",
 							"-features", strings.Join(r.Config.Features, ","),


### PR DESCRIPTION
### Description
This PR:
* removes the command from the console plugin deployment to rely upon the entrypoint in the image
### Links
* https://issues.redhat.com/browse/LOG-3447
