### PR TITLE
[release-5.6 cherrypick] Addressed race condition during cert generation, fixed loki uid for vector CI

### DIFF
--- a/internal/certificates/certificates.go
+++ b/internal/certificates/certificates.go
@@ -2,13 +2,24 @@ package certificates
 
 import (
 	"fmt"
+	"math/rand"
+	"os"
 	"os/exec"
 
 	"sigs.k8s.io/yaml"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/test"
 )
+
+func GenerateTestCertificates(logStoreName string) (err error, certsDir string) {
+	certsDir = fmt.Sprintf("/tmp/clo-test-%d-%d", os.Getpid(), rand.Intn(10000)) //nolint:gosec
+	log.V(3).Info("Generating Pipeline certificates for Log Store to certs dir", "logStoreName", logStoreName, "certsDir", certsDir)
+	err, _, _ = GenerateCertificates(constants.WatchNamespace, test.GitRoot("scripts"), logStoreName, certsDir)
+	return
+}
 
 func GenerateCertificates(namespace, scriptsDir, logStoreName, workDir string) (err error, updated bool, output []interface{}) {
 	script := fmt.Sprintf("%s/cert_generation.sh", scriptsDir)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -227,6 +227,10 @@ func GetScriptsDir() string {
 	return scriptsDir
 }
 
+func GetDirFileContents(dirPath, filePath string) []byte {
+	return GetFileContents(path.Join(dirPath, filePath))
+}
+
 func GetWorkingDirFileContents(filePath string) []byte {
 	return GetFileContents(GetWorkingDirFilePath(filePath))
 }

--- a/test/framework/e2e/elasticsearch.go
+++ b/test/framework/e2e/elasticsearch.go
@@ -174,9 +174,9 @@ func (es *ElasticLogStore) Indices() (Indices, error) {
 	return indices, nil
 }
 
-func (tc *E2ETestFramework) DeployAnElasticsearchCluster(pwd string) (cr *elasticsearch.Elasticsearch, pipelineSecret *corev1.Secret, err error) {
+func (tc *E2ETestFramework) DeployAnElasticsearchCluster() (cr *elasticsearch.Elasticsearch, pipelineSecret *corev1.Secret, err error) {
 	logStoreName := "test-elastic-cluster"
-	if pipelineSecret, err = tc.CreatePipelineSecret(pwd, logStoreName, "test-pipeline-to-elastic", map[string][]byte{}); err != nil {
+	if pipelineSecret, err = tc.CreatePipelineSecret(logStoreName, "test-pipeline-to-elastic", map[string][]byte{}); err != nil {
 		return nil, nil, err
 	}
 

--- a/test/framework/e2e/fluentd.go
+++ b/test/framework/e2e/fluentd.go
@@ -318,7 +318,7 @@ func (tc *E2ETestFramework) DeployFluentdReceiver(rootDir string, secure bool) (
 		otherConf := map[string][]byte{
 			"shared_key": []byte("my_shared_key"),
 		}
-		if logStore.pipelineSecret, err = tc.CreatePipelineSecret(rootDir, receiverName, receiverName, otherConf); err != nil {
+		if logStore.pipelineSecret, err = tc.CreatePipelineSecret(receiverName, receiverName, otherConf); err != nil {
 			return nil, err
 		}
 		tc.AddCleanup(func() error {

--- a/test/framework/e2e/framework.go
+++ b/test/framework/e2e/framework.go
@@ -637,26 +637,17 @@ func (tc *E2ETestFramework) PodExec(namespace, name, container string, command [
 	return oc.Exec().WithNamespace(namespace).Pod(name).Container(container).WithCmd(command[0], command[1:]...).Run()
 }
 
-func (tc *E2ETestFramework) CreatePipelineSecret(pwd, logStoreName, secretName string, otherData map[string][]byte) (*corev1.Secret, error) {
-	workingDir := fmt.Sprintf("/tmp/clo-test-%d", rand.Intn(10000)) //nolint:gosec
-	clolog.V(3).Info("Generating Pipeline certificates for Log Store to working dir", "logStoreName", logStoreName, "workingDir", workingDir)
-	if _, err := os.Stat(workingDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(workingDir, 0766); err != nil {
-			return nil, err
-		}
-	}
-	if err := os.Setenv("WORKING_DIR", workingDir); err != nil {
-		return nil, err
-	}
-	scriptsDir := fmt.Sprintf("%s/scripts", pwd)
-	if err, _, _ := certificates.GenerateCertificates(constants.WatchNamespace, scriptsDir, logStoreName, workingDir); err != nil {
+func (tc *E2ETestFramework) CreatePipelineSecret(logStoreName, secretName string, otherData map[string][]byte) (*corev1.Secret, error) {
+	err, certsDir := certificates.GenerateTestCertificates(logStoreName)
+	defer os.RemoveAll(certsDir)
+	if err != nil {
 		return nil, err
 	}
 	data := map[string][]byte{
-		"tls.key":       utils.GetWorkingDirFileContents("system.logging.fluentd.key"),
-		"tls.crt":       utils.GetWorkingDirFileContents("system.logging.fluentd.crt"),
-		"ca-bundle.crt": utils.GetWorkingDirFileContents("ca.crt"),
-		"ca.key":        utils.GetWorkingDirFileContents("ca.key"),
+		"tls.key":       utils.GetDirFileContents(certsDir, "system.logging.fluentd.key"),
+		"tls.crt":       utils.GetDirFileContents(certsDir, "system.logging.fluentd.crt"),
+		"ca-bundle.crt": utils.GetDirFileContents(certsDir, "ca.crt"),
+		"ca.key":        utils.GetDirFileContents(certsDir, "ca.key"),
 	}
 	for key, value := range otherData {
 		data[key] = value

--- a/test/helpers/loki/receiver.go
+++ b/test/helpers/loki/receiver.go
@@ -68,6 +68,7 @@ func NewReceiver(ns, name string) *Receiver {
 	}}
 	r.Pod.Spec.SecurityContext = &corev1.PodSecurityContext{
 		RunAsNonRoot: utils.GetBool(true),
+		RunAsUser:    utils.GetInt64(10001), // uid of user loki in the loki image
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},


### PR DESCRIPTION
### Description
A cherry-pick of https://github.com/openshift/cluster-logging-operator/pull/1831 (and another commit it depends on) onto release-5.6 so the fix is seen in vector CI, which runs on top of release-5.6

/cc @jcantrill
/assign @vimalk78