### PR TITLE
LOG-3447: Pass the version to the consumer

### DIFF
--- a/controllers/clusterlogging/clusterlogging_controller.go
+++ b/controllers/clusterlogging/clusterlogging_controller.go
@@ -85,7 +85,7 @@ func (r *ReconcileClusterLogging) Reconcile(ctx context.Context, request ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	if _, err = k8shandler.Reconcile(instance, r.Client, r.Reader, r.Recorder, r.ClusterID); err != nil {
+	if _, err = k8shandler.Reconcile(instance, r.Client, r.Reader, r.Recorder, r.ClusterVersion, r.ClusterID); err != nil {
 		telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 		log.Error(err, "Error reconciling clusterlogging instance")
 	}

--- a/internal/consoleplugin/feature_map.go
+++ b/internal/consoleplugin/feature_map.go
@@ -13,10 +13,6 @@ var (
 
 	// featuresIfUnmatched represents the default features to enable
 	featuresIfUnmatched = []string{featureDevConsole}
-
-	versionMap = map[string][]string{
-		"v4.10": {},
-	}
 )
 
 // FeaturesForOCP will return the list of features to enable for the console plugin given the OCP version
@@ -24,8 +20,9 @@ func FeaturesForOCP(version string) []string {
 	if !strings.HasPrefix(version, "v") {
 		version = "v" + version
 	}
-	if features, found := versionMap[semver.MajorMinor(version)]; found {
-		return features
+
+	if semver.Compare(version, "v4.11") < 0 {
+		return []string{}
 	}
 	return featuresIfUnmatched
 }

--- a/internal/consoleplugin/feature_map_test.go
+++ b/internal/consoleplugin/feature_map_test.go
@@ -6,11 +6,22 @@ import (
 )
 
 var _ = Describe("#FeaturesForOCP", func() {
+	It("should return an empty set when there is an empty version ", func() {
+		Expect(FeaturesForOCP("")).To(Equal([]string{}))
+	})
 	It("should return the default set when there is no version match ", func() {
 		Expect(FeaturesForOCP("4.12.0-rc.3")).To(Equal(featuresIfUnmatched))
 	})
 
+	It("should return the default set when greater than or equal 4.11", func() {
+		Expect(FeaturesForOCP("4.11.12")).To(Equal(featuresIfUnmatched))
+	})
+
 	It("should not enable the dev console for OCP 4.10", func() {
 		Expect(FeaturesForOCP("4.10.4+abc")).To(Equal([]string{}))
+	})
+
+	It("should not enable the dev console for OCP 4.10.51", func() {
+		Expect(FeaturesForOCP("4.10.51")).To(Equal([]string{}))
 	})
 })

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -26,13 +26,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func Reconcile(cl *logging.ClusterLogging, requestClient client.Client, reader client.Reader, r record.EventRecorder, clusterID string) (instance *logging.ClusterLogging, err error) {
+func Reconcile(cl *logging.ClusterLogging, requestClient client.Client, reader client.Reader, r record.EventRecorder, clusterVersion, clusterID string) (instance *logging.ClusterLogging, err error) {
 	clusterLoggingRequest := ClusterLoggingRequest{
-		Cluster:       cl,
-		Client:        requestClient,
-		Reader:        reader,
-		EventRecorder: r,
-		ClusterID:     clusterID,
+		Cluster:        cl,
+		Client:         requestClient,
+		Reader:         reader,
+		EventRecorder:  r,
+		ClusterVersion: clusterVersion,
+		ClusterID:      clusterID,
 	}
 
 	// Cancel previous info metrics

--- a/internal/k8shandler/visualization_test.go
+++ b/internal/k8shandler/visualization_test.go
@@ -52,8 +52,9 @@ func TestRemoveKibanaCR(t *testing.T) {
 func TestConsolePluginIsCreatedAndDeleted(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
 	cr := &ClusterLoggingRequest{
-		Cluster: runtime.NewClusterLogging(),
-		Client:  c,
+		Cluster:        runtime.NewClusterLogging(),
+		Client:         c,
+		ClusterVersion: "4.10.0",
 	}
 	cl := cr.Cluster
 


### PR DESCRIPTION
### Description
This PR fixes the issue where we were not passing the version to the consumer to properly deploy the log view plugin


### Links
* https://issues.redhat.com/browse/LOG-3447
