### PR TITLE
LOG-3609: Fix collector restart after creation

### DIFF
--- a/internal/collector/service_account.go
+++ b/internal/collector/service_account.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"fmt"
+
 	security "github.com/openshift/api/security/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
@@ -27,6 +28,8 @@ var (
 		"NET_BIND_SERVICE",
 		"KILL",
 	}
+
+	DesiredSCCVolumes = []security.FSType{"configMap", "secret", "emptyDir", "projected"}
 )
 
 // ReconcileServiceAccount reconciles the serviceaccount specifically for a collector deployment
@@ -82,7 +85,7 @@ func NewSCC() *security.SecurityContextConstraints {
 	scc.AllowPrivilegedContainer = false
 	scc.RequiredDropCapabilities = RequiredDropCapabilities
 	scc.AllowHostDirVolumePlugin = true
-	scc.Volumes = []security.FSType{"configMap", "secret", "emptyDir", "projected"}
+	scc.Volumes = DesiredSCCVolumes
 	scc.DefaultAllowPrivilegeEscalation = utils.GetBool(false)
 	scc.AllowPrivilegeEscalation = utils.GetBool(false)
 	scc.RunAsUser = security.RunAsUserStrategyOptions{

--- a/internal/utils/comparators/scc/comparator_test.go
+++ b/internal/utils/comparators/scc/comparator_test.go
@@ -2,6 +2,7 @@ package scc_test
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -39,7 +40,7 @@ var _ = Describe("scc#AreSame", func() {
 			right.RequiredDropCapabilities = append(right.RequiredDropCapabilities, "foo")
 		}),
 		Entry("AllowHostDirVolumePlugin", func(right *security.SecurityContextConstraints) { right.AllowHostDirVolumePlugin = false }),
-		Entry("Volumes", func(right *security.SecurityContextConstraints) { right.Volumes = right.Volumes[1:] }),
+		Entry("Volumes", func(none *security.SecurityContextConstraints) {}, func(left *security.SecurityContextConstraints) { left.Volumes = left.Volumes[1:] }),
 		Entry("DefaultAllowPrivilegeEscalation", func(right *security.SecurityContextConstraints) {
 			right.DefaultAllowPrivilegeEscalation = utils.GetBool(true)
 		}),


### PR DESCRIPTION
### Description
  Collector gets restarted if collector is started without waiting for waiting for trusted ca-bundle config map to get created.
  Modified the reconcile logic to wait for trusted ca-bundle to get created.

  Log Collector SCC desires 4 volumes `"configMap"`,`"emptyDir"`,`"projected"`,`"secret"`, but CRC container adds another volume for `"hostpath"`.
  The SCC comparator does a reflect comparison, which fails because there is one extra Volume.
  Fixed the SCC comparator to check for desired volumes only.


/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA:  https://issues.redhat.com/browse/LOG-3609

