### PR TITLE
[release-5.6] LOG-3437: fix for invalidate or migrate default output

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -138,6 +138,8 @@ const (
 	EventReasonGetObject            = "GetObject"
 	EventReasonRemoveObject         = "RemoveObject"
 	EventReasonUpdateObject         = "UpdateObject"
+
+	MigrateDefaultOutput = "default-replaced"
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -27,7 +27,7 @@ const (
 )
 
 //CreateOrUpdateCollection component of the cluster
-func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err error) {
+func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection(extras map[string]bool) (err error) {
 	if !clusterRequest.isManaged() {
 		return nil
 	}
@@ -71,7 +71,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 			return
 		}
 
-		if collectorConfig, err = clusterRequest.generateCollectorConfig(); err != nil {
+		if collectorConfig, err = clusterRequest.generateCollectorConfig(extras); err != nil {
 			log.V(9).Error(err, "clusterRequest.generateCollectorConfig")
 			return
 		}

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -64,7 +64,7 @@ func Reconcile(cl *logging.ClusterLogging, requestClient client.Client, reader c
 	// CL is managed by default set it as 1
 	telemetry.Data.CLInfo.Set("managedStatus", constants.ManagedStatus)
 	updateInfofromCL(&clusterLoggingRequest)
-	forwarder := clusterLoggingRequest.getLogForwarder()
+	forwarder, extras := clusterLoggingRequest.getLogForwarder()
 	if forwarder != nil {
 		if err := clusterlogforwarder.Validate(*forwarder); err != nil {
 			return nil, err
@@ -106,7 +106,7 @@ func Reconcile(cl *logging.ClusterLogging, requestClient client.Client, reader c
 	})
 
 	// Reconcile Collection
-	if err = clusterLoggingRequest.CreateOrUpdateCollection(); err != nil {
+	if err = clusterLoggingRequest.CreateOrUpdateCollection(extras); err != nil {
 		telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 		telemetry.Data.CollectorErrorCount.Inc("CollectorErrorCount")
 		return clusterLoggingRequest.Cluster, fmt.Errorf("unable to create or update collection for %q: %v", clusterLoggingRequest.Cluster.Name, err)
@@ -170,7 +170,8 @@ func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, req
 		return nil
 	}
 
-	clusterLoggingRequest.ForwarderSpec = migrations.MigrateClusterLogForwarderSpec(forwarder.Spec, clusterLogging.Spec.LogStore)
+	extras := map[string]bool{}
+	clusterLoggingRequest.ForwarderSpec, extras = migrations.MigrateClusterLogForwarderSpec(forwarder.Spec, clusterLogging.Spec.LogStore, extras)
 	clusterLoggingRequest.Cluster = clusterLogging
 
 	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {
@@ -179,7 +180,7 @@ func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, req
 	}
 
 	// Reconcile Collection
-	err = clusterLoggingRequest.CreateOrUpdateCollection()
+	err = clusterLoggingRequest.CreateOrUpdateCollection(extras)
 	forwarder.Status = clusterLoggingRequest.ForwarderRequest.Status
 
 	if err != nil {
@@ -219,7 +220,7 @@ func (clusterRequest *ClusterLoggingRequest) getClusterLogging(skipMigrations bo
 	return clusterLogging, nil
 }
 
-func (clusterRequest *ClusterLoggingRequest) getLogForwarder() *logging.ClusterLogForwarder {
+func (clusterRequest *ClusterLoggingRequest) getLogForwarder() (*logging.ClusterLogForwarder, map[string]bool) {
 	nsname := types.NamespacedName{Name: constants.SingletonName, Namespace: clusterRequest.Cluster.Namespace}
 	forwarder := runtime.NewClusterLogForwarder(clusterRequest.Cluster.Namespace, clusterRequest.Cluster.Name)
 	if err := clusterRequest.Client.Get(context.TODO(), nsname, forwarder); err != nil {
@@ -228,8 +229,9 @@ func (clusterRequest *ClusterLoggingRequest) getLogForwarder() *logging.ClusterL
 		}
 		forwarder.Spec = logging.ClusterLogForwarderSpec{}
 	}
-	forwarder.Spec = migrations.MigrateClusterLogForwarderSpec(forwarder.Spec, clusterRequest.Cluster.Spec.LogStore)
-	return forwarder
+	extras := map[string]bool{}
+	forwarder.Spec, extras = migrations.MigrateClusterLogForwarderSpec(forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras)
+	return forwarder, extras
 }
 
 func updateInfofromCL(request *ClusterLoggingRequest) {

--- a/internal/migrations/logstore_lokistack_test.go
+++ b/internal/migrations/logstore_lokistack_test.go
@@ -251,7 +251,9 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 					Name: "lokistack-testing",
 				},
 			}
-			outputs, pipelines := processPipelinesForLokiStack(logStore, "aNamespace", tc.spec)
+			var outputs []loggingv1.OutputSpec
+			var pipelines []loggingv1.PipelineSpec
+			outputs, pipelines, _ = processPipelinesForLokiStack(logStore, "aNamespace", tc.spec, map[string]bool{})
 
 			if diff := cmp.Diff(outputs, tc.wantOutputs); diff != "" {
 				t.Errorf("outputs differ: -got+want\n%s", diff)

--- a/internal/migrations/migrate_clusterlogforwarder_test.go
+++ b/internal/migrations/migrate_clusterlogforwarder_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 )
 
 var _ = Describe("MigrateDefaultOutput", func() {
@@ -15,6 +16,7 @@ var _ = Describe("MigrateDefaultOutput", func() {
 		spec      logging.ClusterLogForwarderSpec
 		esSpec    *logging.Elasticsearch
 		logstore  *logging.LogStoreSpec
+		extras    map[string]bool
 	)
 
 	BeforeEach(func() {
@@ -43,15 +45,20 @@ var _ = Describe("MigrateDefaultOutput", func() {
 			Outputs:   outputs,
 			Pipelines: pipelines,
 		}
+		extras = map[string]bool{}
 	})
 
 	It("should not add the default OutputSpec when it is not referenced by a pipeline", func() {
-		Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(spec))
+		// This is equal to returning (spec, nil) and will only pass if 2nd param is nil
+		forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+		Expect(forwarderSpec).To(Equal(spec))
+		Expect(extras).To(Equal(map[string]bool{}))
 	})
 
 	It("should add the default OutputSpec when default logstore exists and spec is empty ", func() {
 		logstore = &logging.LogStoreSpec{Type: logging.OutputTypeElasticsearch}
-		Expect(MigrateDefaultOutput(logging.ClusterLogForwarderSpec{}, logstore)).To(Equal(
+		forwarderSpec, extras := MigrateClusterLogForwarderSpec(logging.ClusterLogForwarderSpec{}, logstore, extras)
+		Expect(forwarderSpec).To(Equal(
 			logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -62,6 +69,7 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				Outputs: []logging.OutputSpec{NewDefaultOutput(nil)},
 			},
 		))
+		Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 	})
 
 	It("generates default configuration for empty spec with LokiStack log store", func() {
@@ -71,7 +79,10 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				Name: "lokistack-testing",
 			},
 		}
-		Expect(MigrateDefaultOutput(logging.ClusterLogForwarderSpec{}, logstore)).To(Equal(
+
+		spec, extras = MigrateClusterLogForwarderSpec(logging.ClusterLogForwarderSpec{}, logstore, extras)
+
+		Expect(spec).To(Equal(
 			logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -97,7 +108,9 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				},
 			},
 		))
+		Expect(extras).To(Equal(map[string]bool{}))
 	})
+
 	It("processes custom pipelines to default LokiStack log store", func() {
 		logstore = &logging.LogStoreSpec{
 			Type: logging.LogStoreTypeLokiStack,
@@ -113,7 +126,10 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				},
 			},
 		}
-		Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(
+
+		spec, extras = MigrateClusterLogForwarderSpec(spec, logstore, extras)
+
+		Expect(spec).To(Equal(
 			logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -130,6 +146,7 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				},
 			},
 		))
+		Expect(extras).To(Equal(map[string]bool{}))
 	})
 
 	Context("when a pipeline references 'default'", func() {
@@ -151,8 +168,11 @@ var _ = Describe("MigrateDefaultOutput", func() {
 			})
 
 			It("should add the default OutputSpec", func() {
-				Expect((MigrateDefaultOutput(spec, logstore))).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 			})
+
 			It("should add the default OutputSpec and OutputDefaults when OutputDefaults are spec'd", func() {
 				spec.OutputDefaults = &logging.OutputDefaults{
 					Elasticsearch: &logging.ElasticsearchStructuredSpec{
@@ -161,7 +181,11 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				}
 				exp.Outputs[1].Elasticsearch = &logging.Elasticsearch{ElasticsearchStructuredSpec: *spec.OutputDefaults.Elasticsearch}
 				exp.OutputDefaults = spec.OutputDefaults
-				Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 			})
 		})
 
@@ -184,7 +208,10 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				}
 				exp = *spec.DeepCopy()
 				exp.Outputs = append(outputs, NewDefaultOutput(nil))
-				Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 			})
 
 			It("should replace the OutputSpec with the default OutputSpec and use the config (e.g. structureTypeKey) defined in the original OutputSpec", func() {
@@ -196,10 +223,93 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				}
 				exp = *spec.DeepCopy()
 				exp.Outputs = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: &esSpec.ElasticsearchStructuredSpec}))
-				Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 			})
 		})
 
+	})
+	Context("when a pipeline references 'default'", func() {
+
+		var exp logging.ClusterLogForwarderSpec
+		BeforeEach(func() {
+			logstore = &logging.LogStoreSpec{Type: logging.OutputTypeElasticsearch}
+			pipelines[0].OutputRefs = append(spec.Pipelines[0].OutputRefs, logging.OutputNameDefault)
+			spec = logging.ClusterLogForwarderSpec{
+				Outputs:   outputs,
+				Pipelines: pipelines,
+			}
+		})
+
+		Context("and outputs does not explicitly spec 'default'", func() {
+			BeforeEach(func() {
+				exp = *spec.DeepCopy()
+				exp.Outputs = append(outputs, NewDefaultOutput(nil))
+			})
+
+			It("should add the default OutputSpec", func() {
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
+			})
+			It("should add the default OutputSpec and OutputDefaults when OutputDefaults are spec'd", func() {
+				spec.OutputDefaults = &logging.OutputDefaults{
+					Elasticsearch: &logging.ElasticsearchStructuredSpec{
+						StructuredTypeKey: "foo.bar",
+					},
+				}
+				exp.Outputs[1].Elasticsearch = &logging.Elasticsearch{ElasticsearchStructuredSpec: *spec.OutputDefaults.Elasticsearch}
+				exp.OutputDefaults = spec.OutputDefaults
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
+			})
+		})
+
+		Context("and outputs includes an OutputSpec named 'default'", func() {
+			var tobereplaced logging.OutputSpec
+			BeforeEach(func() {
+				tobereplaced = logging.OutputSpec{
+					Name:   logging.OutputNameDefault,
+					Type:   logging.OutputTypeElasticsearch,
+					URL:    "thiswillgetreplaced",
+					Secret: &logging.OutputSecretSpec{Name: "replacem"},
+				}
+
+			})
+
+			It("should replace the OutputSpec with the default OutputSpec", func() {
+				spec = logging.ClusterLogForwarderSpec{
+					Outputs:   append(outputs, tobereplaced),
+					Pipelines: pipelines,
+				}
+				exp = *spec.DeepCopy()
+				exp.Outputs = append(outputs, NewDefaultOutput(nil))
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
+			})
+
+			It("should replace the OutputSpec with the default OutputSpec and use the config (e.g. structureTypeKey) defined in the original OutputSpec", func() {
+				tobereplaced.Elasticsearch = esSpec
+				spec = logging.ClusterLogForwarderSpec{
+					Outputs:        append(outputs, tobereplaced),
+					Pipelines:      pipelines,
+					OutputDefaults: &logging.OutputDefaults{Elasticsearch: &logging.ElasticsearchStructuredSpec{StructuredTypeKey: "abc"}},
+				}
+				exp = *spec.DeepCopy()
+				exp.Outputs = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: &esSpec.ElasticsearchStructuredSpec}))
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
+			})
+		})
 	})
 
 })

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -60,7 +60,7 @@ func Generate(collectionType logging.LogCollectionType, clfYaml string, includeD
 		}
 	}
 
-	spec, status := clRequest.NormalizeForwarder()
+	spec, status := clRequest.NormalizeForwarder(map[string]bool{})
 	log.V(2).Info("Normalization", "spec", spec)
 	log.V(2).Info("Normalization", "status", status)
 


### PR DESCRIPTION
### Description
The fix was created in migration and with minor updates to the logic surrounding 'default' outputRef for both ES and Loki.   Mainly adding a map to the migration and subsequent normalization (validate), indicating if the ES output was created by our default migration.  This allows us to handle verify with the context of migration.  This is the initial and least impactful change to a refactor of the migration and validation logic to come in: [LOG-3247](https://issues.redhat.com/browse/LOG-3247) when we remove degraded status.

Expected:  
If you use 'default' as an output, it will either correct the ES output, or if its Loki, it will inform the user the name is reserved.  Any other output named 'default' should now invalidate as expected. 
This should also fix the issue in [LOG-3559](https://issues.redhat.com//browse/LOG-3559) where collector restarts due to invalid pipelines when using default along with another outputRef (in same or separate pipeline) 

/cc @jcantrill
/assign @vimalk78 @syedriko

### Links
- https://issues.redhat.com/browse/LOG-3437
- https://issues.redhat.com/browse/LOG-3559
- (in progress) https://issues.redhat.com/browse/LOG-3247
