### PR TITLE
LOG-3585: Bump bundle OCP max version property to 4.14

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.12
+    value: 4.14


### PR DESCRIPTION
### Description
This PR:
* updates the max OCP version to 4.14
### Links
* https://issues.redhat.com/browse/LOG-3584
