### PR TITLE
bump maxOCPVersion to 4.15

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.12
+    value: 4.15


### PR DESCRIPTION
### Description
This PR updates the max OCP version to 4.15


