### PR TITLE
LOG-3312: Support http output for fluentd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ test-functional: test-functional-benchmarker test-functional-fluentd test-functi
 .PHONY: test-functional-fluentd
 test-functional-fluentd:
 	RELATED_IMAGE_FLUENTD=$(IMAGE_LOGGING_FLUENTD) \
+	RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	go test --tags=fluentd -race ./test/functional/... -ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
 

--- a/docs/reference/operator/api.adoc
+++ b/docs/reference/operator/api.adoc
@@ -148,6 +148,7 @@ Output defines a destination for log messages.
 |loki|object|  *(optional)* 
 |googleCloudLogging|object|  *(optional)* 
 |splunk|object|  *(optional)* 
+|http|object|  *(optional)* 
 |name|string|  Name used to refer to the output from a `pipeline`.
 |secret|object|  *(optional)* Secret for authentication.
 |tls|object|  TLS contains settings for controlling options on TLS client connections.

--- a/internal/generator/fluentd/output/http/bearer-token-file.go
+++ b/internal/generator/fluentd/output/http/bearer-token-file.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+)
+
+type BearerTokenFile security.BearerTokenFile
+
+func (bt BearerTokenFile) Name() string {
+	return "lokiBearerTokenFileTemplate"
+}
+
+func (bt BearerTokenFile) Template() string {
+	return `{{define "` + bt.Name() + `" -}}
+bearer_token_file {{ .BearerTokenFilePath }}
+{{- end}}
+`
+}

--- a/internal/generator/fluentd/output/http/ca-file.go
+++ b/internal/generator/fluentd/output/http/ca-file.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+)
+
+type CAFile security.CAFile
+
+func (ca CAFile) Name() string {
+	return "httpCAFileTemplate"
+}
+
+func (ca CAFile) Template() string {
+	return `{{define "` + ca.Name() + `" -}}
+ca_cert {{.CAFilePath}}
+{{- end}}
+`
+}

--- a/internal/generator/fluentd/output/http/cert-key.go
+++ b/internal/generator/fluentd/output/http/cert-key.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+)
+
+type TLSKeyCert security.TLSCertKey
+
+func (kc TLSKeyCert) Name() string {
+	return "httpCertKeyTemplate"
+}
+
+func (kc TLSKeyCert) Template() string {
+	return `{{define "` + kc.Name() + `" -}}
+key {{.KeyPath}}
+cert {{.CertPath}}
+{{- end}}`
+}

--- a/internal/generator/fluentd/output/http/http.go
+++ b/internal/generator/fluentd/output/http/http.go
@@ -1,0 +1,139 @@
+package http
+
+import (
+	"strings"
+
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output"
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+	"github.com/openshift/cluster-logging-operator/internal/generator/utils"
+
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/openshift/cluster-logging-operator/internal/generator"
+	. "github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
+	genhelper "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
+)
+
+type Http struct {
+	StoreID        string
+	URI            string
+	Method         string
+	Headers        Element
+	SecurityConfig []Element
+	BufferConfig   []Element
+
+	// Encoding is set by plugin according to
+}
+
+func (h Http) Name() string {
+	return "fluentdHttpTemplate"
+}
+
+func (h Http) Template() string {
+	return `{{define "` + h.Name() + `" -}}
+@type http
+endpoint {{.URI}}
+http_method {{.Method}}
+encoding "application/x-ndjson"
+{{kv  .Headers -}}
+{{compose .SecurityConfig}}
+{{compose .BufferConfig}}
+{{end}}`
+}
+
+func Conf(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o logging.OutputSpec, op Options) []Element {
+	return []Element{
+		FromLabel{
+			InLabel: helpers.LabelName(o.Name),
+			SubElements: []Element{
+				Output(bufspec, secret, o, op),
+			},
+		},
+	}
+}
+
+func Output(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o logging.OutputSpec, op Options) Element {
+	if genhelper.IsDebugOutput(op) {
+		return genhelper.DebugOutput
+	}
+	storeID := helpers.StoreID("", o.Name, "")
+	return Match{
+		MatchTags: "**",
+		MatchElement: Http{
+			StoreID:        strings.ToLower(helpers.Replacer.Replace(o.Name)),
+			URI:            o.URL,
+			Method:         Method(o.Http),
+			Headers:        Headers(o),
+			SecurityConfig: SecurityConfig(o, secret),
+			BufferConfig:   output.Buffer(output.NOKEYS, bufspec, storeID, &o),
+		},
+	}
+}
+
+func Headers(o logging.OutputSpec) Element {
+	if o.Http == nil || len(o.Http.Headers) == 0 {
+		return Nil
+	}
+	return KV("headers", utils.ToHeaderStr(o.Http.Headers, "%q:%q"))
+}
+
+func Method(h *logging.Http) string {
+	if h == nil {
+		return "post"
+	}
+	switch h.Method {
+	case "GET":
+		return "get"
+	case "HEAD":
+		return "head"
+	case "POST":
+		return "post"
+	case "PUT":
+		return "put"
+	case "DELETE":
+		return "delete"
+	case "OPTIONS":
+		return "options"
+	case "TRACE":
+		return "trace"
+	case "PATCH":
+		return "patch"
+	}
+	return "post"
+}
+
+func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
+	conf := []Element{}
+	if o.Secret != nil {
+		if security.HasUsernamePassword(secret) {
+			up := UserNamePass{
+				UsernamePath: security.SecretPath(o.Secret.Name, constants.ClientUsername),
+				PasswordPath: security.SecretPath(o.Secret.Name, constants.ClientPassword),
+			}
+			conf = append(conf, up)
+		}
+		if security.HasTLSCertAndKey(secret) {
+			kc := TLSKeyCert{
+				CertPath: security.SecretPath(o.Secret.Name, constants.ClientCertKey),
+				KeyPath:  security.SecretPath(o.Secret.Name, constants.ClientPrivateKey),
+			}
+			conf = append(conf, kc)
+		}
+		if security.HasCABundle(secret) {
+			ca := CAFile{
+				CAFilePath: security.SecretPath(o.Secret.Name, constants.TrustedCABundleKey),
+			}
+			conf = append(conf, ca)
+		}
+		if security.HasBearerTokenFileKey(secret) {
+			bt := BearerTokenFile{
+				BearerTokenFilePath: security.SecretPath(o.Secret.Name, constants.BearerTokenFileKey),
+			}
+			conf = append(conf, bt)
+		}
+	}
+	return conf
+}

--- a/internal/generator/fluentd/output/http/http_test.go
+++ b/internal/generator/fluentd/output/http/http_test.go
@@ -1,0 +1,323 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	v1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/utils"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Generate fluentd config", func() {
+	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
+		var bufspec *logging.FluentdBufferSpec = nil
+		if clspec.Fluentd != nil &&
+			clspec.Fluentd.Buffer != nil {
+			bufspec = clspec.Fluentd.Buffer
+		}
+		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], op)
+	}
+	DescribeTable("for Http output", helpers.TestGenerateConfWith(f),
+		Entry("", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeHttp,
+						Name: "http-receiver",
+						URL:  "https://my-logstore.com/logs/app-logs",
+						Secret: &logging.OutputSecretSpec{
+							Name: "http-receiver",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"http-receiver": {
+					Data: map[string][]byte{
+						"username": []byte("username"),
+						"password": []byte("password"),
+					},
+				},
+			},
+			ExpectedConf: `
+<label @HTTP_RECEIVER>
+  <match **>
+	@type http
+	endpoint https://my-logstore.com/logs/app-logs
+	http_method post
+	encoding "application/x-ndjson"
+	username "#{File.read('/var/run/ocp-collector/secrets/http-receiver/username') rescue nil}"
+	password "#{File.read('/var/run/ocp-collector/secrets/http-receiver/password') rescue nil}"
+	<buffer>
+	  @type file
+	  path '/var/lib/fluentd/http_receiver'
+	  flush_mode interval
+	  flush_interval 1s
+	  flush_thread_count 2
+	  retry_type exponential_backoff
+	  retry_wait 1s
+	  retry_max_interval 60s
+	  retry_timeout 60m
+	  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+	  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+	  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+	  overflow_action block
+	  disable_chunk_backup true
+	</buffer>
+  </match>
+</label>
+`,
+		}),
+		Entry("with custom bearer token", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeHttp,
+						Name: "http-receiver",
+						URL:  "https://my-logstore.com/logs/app-logs",
+						Secret: &logging.OutputSecretSpec{
+							Name: "http-receiver",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"http-receiver": {
+					Data: map[string][]byte{
+						"token": []byte("token-for-custom-http"),
+					},
+				},
+			},
+			ExpectedConf: `
+<label @HTTP_RECEIVER>
+  <match **>
+	@type http
+	endpoint https://my-logstore.com/logs/app-logs
+	http_method post
+	encoding "application/x-ndjson"
+	bearer_token_file '/var/run/ocp-collector/secrets/http-receiver/token'
+	<buffer>
+	  @type file
+	  path '/var/lib/fluentd/http_receiver'
+	  flush_mode interval
+	  flush_interval 1s
+	  flush_thread_count 2
+	  retry_type exponential_backoff
+	  retry_wait 1s
+	  retry_max_interval 60s
+	  retry_timeout 60m
+	  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+	  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+	  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+	  overflow_action block
+	  disable_chunk_backup true
+	</buffer>
+  </match>
+</label>
+`,
+		}),
+		Entry("with Http config", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeHttp,
+						Name: "http-receiver",
+						URL:  "https://my-logstore.com/logs/app-logs",
+						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
+							Timeout: "50",
+							Headers: map[string]string{
+								"k1": "v1",
+								"k2": "v2",
+							},
+						}},
+						Secret: &logging.OutputSecretSpec{
+							Name: "http-receiver",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"http-receiver": {
+					Data: map[string][]byte{
+						"token": []byte("token-for-custom-http"),
+					},
+				},
+			},
+			ExpectedConf: `
+<label @HTTP_RECEIVER>
+  <match **>
+	@type http
+	endpoint https://my-logstore.com/logs/app-logs
+	http_method post
+	encoding "application/x-ndjson"
+	headers {"k1":"v1","k2":"v2"}
+	bearer_token_file '/var/run/ocp-collector/secrets/http-receiver/token'
+	<buffer>
+	  @type file
+	  path '/var/lib/fluentd/http_receiver'
+	  flush_mode interval
+	  flush_interval 1s
+	  flush_thread_count 2
+	  retry_type exponential_backoff
+	  retry_wait 1s
+	  retry_max_interval 60s
+	  retry_timeout 60m
+	  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+	  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+	  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+	  overflow_action block
+	  disable_chunk_backup true
+	</buffer>
+  </match>
+</label>
+`,
+		}),
+		Entry("with Http config", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeHttp,
+						Name: "http-receiver",
+						URL:  "https://my-logstore.com/logs/app-logs",
+						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
+							Timeout: "50",
+							Headers: map[string]string{
+								"k1": "v1",
+								"k2": "v2",
+							},
+						}},
+						Secret: &logging.OutputSecretSpec{
+							Name: "http-receiver",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"http-receiver": {
+					Data: map[string][]byte{
+						"token": []byte("token-for-custom-http"),
+					},
+				},
+			},
+			ExpectedConf: `
+<label @HTTP_RECEIVER>
+  <match **>
+	@type http
+	endpoint https://my-logstore.com/logs/app-logs
+	http_method post
+	encoding "application/x-ndjson"
+	headers {"k1":"v1","k2":"v2"}
+	bearer_token_file '/var/run/ocp-collector/secrets/http-receiver/token'
+	<buffer>
+	  @type file
+	  path '/var/lib/fluentd/http_receiver'
+	  flush_mode interval
+	  flush_interval 1s
+	  flush_thread_count 2
+	  retry_type exponential_backoff
+	  retry_wait 1s
+	  retry_max_interval 60s
+	  retry_timeout 60m
+	  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+	  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+	  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+	  overflow_action block
+	  disable_chunk_backup true
+	</buffer>
+  </match>
+</label>
+`,
+		}),
+		Entry("with TLS config", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeHttp,
+						Name: "http-receiver",
+						URL:  "https://my-logstore.com/logs/app-logs",
+						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
+							Timeout: "50",
+							Headers: map[string]string{
+								"k1": "v1",
+								"k2": "v2",
+							},
+						}},
+						TLS: &logging.OutputTLSSpec{
+							InsecureSkipVerify: true,
+						},
+						Secret: &logging.OutputSecretSpec{
+							Name: "http-receiver",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"http-receiver": {
+					Data: map[string][]byte{
+						"token":         []byte("token-for-custom-http"),
+						"tls.crt":       []byte("-- crt-- "),
+						"tls.key":       []byte("-- key-- "),
+						"ca-bundle.crt": []byte("-- ca-bundle -- "),
+					},
+				},
+			},
+			ExpectedConf: `
+<label @HTTP_RECEIVER>
+  <match **>
+	@type http
+	endpoint https://my-logstore.com/logs/app-logs
+	http_method post
+	encoding "application/x-ndjson"
+	headers {"k1":"v1","k2":"v2"}
+	key '/var/run/ocp-collector/secrets/http-receiver/tls.key'
+	cert '/var/run/ocp-collector/secrets/http-receiver/tls.crt'
+	ca_cert '/var/run/ocp-collector/secrets/http-receiver/ca-bundle.crt'
+	bearer_token_file '/var/run/ocp-collector/secrets/http-receiver/token'
+	<buffer>
+	  @type file
+	  path '/var/lib/fluentd/http_receiver'
+	  flush_mode interval
+	  flush_interval 1s
+	  flush_thread_count 2
+	  retry_type exponential_backoff
+	  retry_wait 1s
+	  retry_max_interval 60s
+	  retry_timeout 60m
+	  queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+	  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+	  chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+	  overflow_action block
+	  disable_chunk_backup true
+	</buffer>
+  </match>
+</label>
+`,
+		}),
+	)
+})
+
+func TestHeaders(t *testing.T) {
+	h := map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	}
+	expected := `{"k1":"v1","k2":"v2"}`
+	got := utils.ToHeaderStr(h, "%q:%q")
+	if got != expected {
+		t.Logf("got: %s, expected: %s", got, expected)
+		t.Fail()
+	}
+}
+
+func TestVectorConfGenerator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Vector Conf Generation")
+}

--- a/internal/generator/fluentd/output/http/userpass.go
+++ b/internal/generator/fluentd/output/http/userpass.go
@@ -1,0 +1,19 @@
+package http
+
+import (
+	security2 "github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+)
+
+type UserNamePass security2.UserNamePass
+
+func (up UserNamePass) Name() string {
+	return "httpUsernamePasswordTemplate"
+}
+
+func (up UserNamePass) Template() string {
+	return `{{define "` + up.Name() + `" -}}
+username "#{File.read({{ .UsernamePath }}) rescue nil}"
+password "#{File.read({{ .PasswordPath }}) rescue nil}"
+{{- end}}
+`
+}

--- a/internal/generator/fluentd/outputs.go
+++ b/internal/generator/fluentd/outputs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/cloudwatch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/elasticsearch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/fluentdforward"
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/http"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/kafka"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/loki"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/syslog"
@@ -58,6 +59,8 @@ func Outputs(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, 
 			outputs = MergeElements(outputs, syslog.Conf(bufspec, secret, o, op))
 		case logging.OutputTypeLoki:
 			outputs = MergeElements(outputs, loki.Conf(bufspec, secret, o, op))
+		case logging.OutputTypeHttp:
+			outputs = MergeElements(outputs, http.Conf(bufspec, secret, o, op))
 		}
 	}
 

--- a/internal/generator/utils/utils.go
+++ b/internal/generator/utils/utils.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func ToHeaderStr(h map[string]string, formatStr string) string {
+	sortedKeys := make([]string, len(h))
+	i := 0
+	for k := range h {
+		sortedKeys[i] = k
+		i += 1
+	}
+	sort.Strings(sortedKeys)
+	hv := make([]string, len(h))
+	for i, k := range sortedKeys {
+		hv[i] = fmt.Sprintf(formatStr, k, h[k])
+	}
+	return fmt.Sprintf("{%s}", strings.Join(hv, ","))
+}

--- a/internal/generator/vector/output/http/http.go
+++ b/internal/generator/vector/output/http/http.go
@@ -2,13 +2,13 @@ package http
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	. "github.com/openshift/cluster-logging-operator/internal/generator"
 	genhelper "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/utils"
 	. "github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	vectorhelpers "github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
@@ -181,22 +181,7 @@ func Headers(o logging.OutputSpec) Element {
 	if o.Http == nil || len(o.Http.Headers) == 0 {
 		return Nil
 	}
-	return KV("headers", ToHeaderStr(o.Http.Headers))
-}
-
-func ToHeaderStr(h map[string]string) string {
-	sortedKeys := make([]string, len(h))
-	i := 0
-	for k := range h {
-		sortedKeys[i] = k
-		i += 1
-	}
-	sort.Strings(sortedKeys)
-	hv := make([]string, len(h))
-	for i, k := range sortedKeys {
-		hv[i] = fmt.Sprintf("%q=%q", k, h[k])
-	}
-	return fmt.Sprintf("{%s}", strings.Join(hv, ","))
+	return KV("headers", utils.ToHeaderStr(o.Http.Headers, "%q=%q"))
 }
 
 func Encoding(o logging.OutputSpec) Element {

--- a/internal/generator/vector/output/http/http_test.go
+++ b/internal/generator/vector/output/http/http_test.go
@@ -11,6 +11,7 @@ import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	v1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/utils"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -313,19 +314,20 @@ token = "token-for-custom-http"
 	)
 })
 
-func TestVectorConfGenerator(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Vector Conf Generation")
-}
-
-func TestMap(t *testing.T) {
+func TestHeaders(t *testing.T) {
 	h := map[string]string{
 		"k1": "v1",
+		"k2": "v2",
 	}
-	expected := `{"k1"="v1"}`
-	got := ToHeaderStr(h)
+	expected := `{"k1"="v1","k2"="v2"}`
+	got := utils.ToHeaderStr(h, "%q=%q")
 	if got != expected {
 		t.Logf("got: %s, expected: %s", got, expected)
 		t.Fail()
 	}
+}
+
+func TestVectorConfGenerator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Vector Conf Generation")
 }

--- a/test/framework/functional/common/loglevel.go
+++ b/test/framework/functional/common/loglevel.go
@@ -1,9 +1,10 @@
 package common
 
 import (
-	log "github.com/ViaQ/logerr/v2/log/static"
 	"os"
 	"strconv"
+
+	log "github.com/ViaQ/logerr/v2/log/static"
 )
 
 func AdaptLogLevel() string {
@@ -17,7 +18,7 @@ func AdaptLogLevel() string {
 				logLevel = "info"
 			case 2:
 				logLevel = "debug"
-			case 3 - 8:
+			case 3 - 9:
 				logLevel = "trace"
 			default:
 			}

--- a/test/framework/functional/output_http.go
+++ b/test/framework/functional/output_http.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional/common"
 )
 
 const (
@@ -15,7 +16,7 @@ const (
 [sources.my_source]
 type = "http"
 address = "127.0.0.1:8090"
-encoding = "json"
+encoding = "ndjson"
 
 [sinks.my_sink]
 inputs = ["my_source"]
@@ -68,6 +69,8 @@ func (f *CollectorFunctionalFramework) AddVectorHttpOutput(b *runtime.PodBuilder
 	log.V(2).Info("Adding vector container", "name", name)
 	b.AddContainer(name, utils.GetComponentImage(constants.VectorName)).
 		AddVolumeMount(config.Name, "/tmp/config", "", false).
+		AddEnvVar("VECTOR_LOG", common.AdaptLogLevel()).
+		AddEnvVar("VECTOR_INTERNAL_LOG_RATE_LIMIT", "0").
 		WithCmd([]string{"vector", "--config-toml", "/tmp/config/vector.toml"}).
 		End().
 		AddConfigMapVolume(config.Name, config.Name)

--- a/test/framework/functional/vector/deploy.go
+++ b/test/framework/functional/vector/deploy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/test/client"
-	. "github.com/openshift/cluster-logging-operator/test/framework/functional/common"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional/common"
 )
 
 const entrypointScript = `#!/bin/bash
@@ -39,9 +39,10 @@ func (c *VectorCollector) DeployConfigMapForConfig(name, config, clfYaml string)
 }
 
 func (c *VectorCollector) BuildCollectorContainer(b *runtime.ContainerBuilder, nodeName string) *runtime.ContainerBuilder {
-	return b.AddEnvVar("VECTOR_LOG", AdaptLogLevel()).
+	return b.AddEnvVar("VECTOR_LOG", common.AdaptLogLevel()).
 		AddEnvVarFromFieldRef("POD_IP", "status.podIP").
 		AddEnvVar("NODE_NAME", nodeName).
+		AddEnvVar("VECTOR_INTERNAL_LOG_RATE_LIMIT", "0").
 		AddEnvVarFromFieldRef("VECTOR_SELF_NODE_NAME", "spec.nodeName").
 		AddVolumeMount("config", "/etc/vector", "", true).
 		AddVolumeMount("entrypoint", "/opt/app-root/src/run.sh", "run.sh", true).

--- a/test/functional/outputs/http/forward_to_http_test.go
+++ b/test/functional/outputs/http/forward_to_http_test.go
@@ -1,6 +1,3 @@
-//go:build vector
-// +build vector
-
 package http
 
 import (
@@ -14,6 +11,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	testfw "github.com/openshift/cluster-logging-operator/test/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 )
 
@@ -24,7 +22,7 @@ var _ = Describe("[Functional][Outputs][Http] Functional tests", func() {
 	)
 
 	BeforeEach(func() {
-		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
+		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(testfw.LogCollectionType)
 		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
 			FromInput(logging.InputNameApplication).
 			ToHttpOutput()
@@ -48,7 +46,6 @@ var _ = Describe("[Functional][Outputs][Http] Functional tests", func() {
 		Expect(err).To(BeNil(), "Expected no errors reading the logs")
 		Expect(result).ToNot(BeEmpty())
 		raw := strings.Split(strings.TrimSpace(result), "\n")
-		//err = types.ParseLogs(raw[0], &logs)
 		logs, err := types.ParseLogs(utils.ToJsonLogs(raw))
 		Expect(err).To(BeNil(), fmt.Sprintf("Expected no errors parsing the logs: %s", raw[0]))
 		// Compare to expected template


### PR DESCRIPTION
### Description
 *  Generate fluentd conf for http output
 *  Added unit tests
 * Added functional tests to send logs from fluentd to vector over http
 * Added functional tests to send logs from fluentd to fluentd over http


/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-3312
