### PR TITLE
LOG-2854: Update go version to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### This is a generated file from Dockerfile.in ###
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.17)
-FROM registry.redhat.io/ubi8/go-toolset:1.17.12 AS builder
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.18)
+FROM registry.redhat.io/ubi8/go-toolset:1.18.9 AS builder
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}
 ENV OS_GIT_MAJOR=${CI_X_VERSION}
@@ -31,10 +31,10 @@ USER 0
 RUN make build
 
 #@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.9)
-FROM quay.io/openshift/origin-cli:4.11 AS origincli
+FROM quay.io/openshift/origin-cli:4.12 AS origincli
 
 #@follow_tag(registry.redhat.io/ubi8:latest)
-FROM registry.redhat.io/ubi8:8.6
+FROM registry.redhat.io/ubi8:8.7
 
 ENV APP_DIR=/opt/apt-root/src
 ENV SRC_DIR=./

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,4 +1,4 @@
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.17)
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.18)
 FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.17.12-202207291741.el8.g01211db AS builder
 
 ENV BUILD_VERSION=${CI_CONTAINER_VERSION}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/cluster-logging-operator
 
-go 1.17
+go 1.18
 
 // Pinned to kubernetes-1.18.3
 require (

--- a/origin-meta.yaml
+++ b/origin-meta.yaml
@@ -1,7 +1,7 @@
 from:
   - source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder\:v(?:[\.0-9\-]*).*
-    target: registry.redhat.io/ubi8/go-toolset:1.17.12 AS builder
+    target:  registry.redhat.io/ubi8/go-toolset:1.18.9 AS builder
   - source: registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli:v4.9.0-([0-9]*).*
-    target: quay.io/openshift/origin-cli:4.11 AS origincli
+    target: quay.io/openshift/origin-cli:4.12 AS origincli
   - source: registry.redhat.io/ubi8:8.(\d)-([\.0-9])*
-    target: registry.redhat.io/ubi8:8.6
+    target: registry.redhat.io/ubi8:8.7


### PR DESCRIPTION
### Description
This PR:
* Updates to project to use golang 1.18

### Links
* https://issues.redhat.com/browse/LOG-2854