### PR TITLE
LOG-3502: set provider name as 'redhat' in CatalogSource

### DIFF
--- a/olm_deploy/operatorregistry/catalog-source.yaml
+++ b/olm_deploy/operatorregistry/catalog-source.yaml
@@ -1,7 +1,11 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
+  labels:
+    opsrc-datastore: 'true'
+    opsrc-provider: redhat
   name: cluster-logging-catalog
 spec:
   sourceType: grpc
   address: ${CLUSTER_IP}:50051
+  publisher: Red Hat


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
This PR:
- set label with provider name 'redhat' to avoid alert message as "non official" operator during installation  
([console code](https://github.com/openshift/console/blob/1786b85b4a4201768bdbdfa5691e126ede2f921d/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx#L565))
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3502
- Enhancement proposal:
