### PR TITLE
[release-5.5] LOG-3499: add /var/log/oauth-server/audit.log to the log collection path

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
   @type tail
   @id openshift-audit-input
   @label @INGRESS
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   tag openshift-audit.log

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -2831,7 +2831,7 @@ var _ = Describe("Generating fluentd config", func() {
   @type tail
   @id openshift-audit-input
   @label @INGRESS
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   tag openshift-audit.log

--- a/internal/generator/fluentd/source/audit_logs.go
+++ b/internal/generator/fluentd/source/audit_logs.go
@@ -44,7 +44,7 @@ const OpenshiftAuditLogTemplate = `
   @type tail
   @id openshift-audit-input
   @label @{{.OutLabel}}
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   {{- .ReadLinesLimit }}

--- a/internal/generator/fluentd/sources_test.go
+++ b/internal/generator/fluentd/sources_test.go
@@ -202,7 +202,7 @@ var _ = Describe("Testing Config Generation", func() {
   @type tail
   @id openshift-audit-input
   @label @INGRESS
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   tag openshift-audit.log
@@ -292,7 +292,7 @@ var _ = Describe("Testing Config Generation", func() {
   @type tail
   @id openshift-audit-input
   @label @INGRESS
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   read_lines_limit 1500
@@ -422,7 +422,7 @@ const AllSources = `
   @type tail
   @id openshift-audit-input
   @label @INGRESS
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   tag openshift-audit.log

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -121,7 +121,7 @@ glob_minimum_cooldown_ms = 15000
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
-include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 
@@ -488,7 +488,7 @@ glob_minimum_cooldown_ms = 15000
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
-include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 

--- a/internal/generator/vector/source/audit_logs.go
+++ b/internal/generator/vector/source/audit_logs.go
@@ -21,7 +21,7 @@ const OpenshiftAuditLogTemplate = `
 # {{.Desc}}
 [sources.{{.ComponentID}}]
 type = "file"
-include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 {{end}}

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -102,7 +102,7 @@ glob_minimum_cooldown_ms = 15000
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
-include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 
@@ -162,7 +162,7 @@ glob_minimum_cooldown_ms = 15000
 # Logs from openshift audit
 [sources.raw_openshift_audit_logs]
 type = "file"
-include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 


### PR DESCRIPTION


Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
This is a manual cherry-pick of https://github.com/openshift/cluster-logging-operator/pull/1857

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
