### PR TITLE
[release-5.4] LOG-3499: add /var/log/oauth-server/audit.log to the log collection path

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
   @type tail
   @id openshift-audit-input
   @label @INGRESS
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   tag openshift-audit.log

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -2727,7 +2727,7 @@ var _ = Describe("Generating fluentd config", func() {
   @type tail
   @id openshift-audit-input
   @label @INGRESS
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   tag openshift-audit.log

--- a/internal/generator/fluentd/source/audit_logs.go
+++ b/internal/generator/fluentd/source/audit_logs.go
@@ -44,7 +44,7 @@ const OpenshiftAuditLogTemplate = `
   @type tail
   @id openshift-audit-input
   @label @{{.OutLabel}}
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   {{- .ReadLinesLimit }}

--- a/internal/generator/fluentd/sources_test.go
+++ b/internal/generator/fluentd/sources_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Testing Config Generation", func() {
   @type tail
   @id openshift-audit-input
   @label @INGRESS
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   tag openshift-audit.log
@@ -296,7 +296,7 @@ var _ = Describe("Testing Config Generation", func() {
   @type tail
   @id openshift-audit-input
   @label @INGRESS
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   read_lines_limit 1500
@@ -426,7 +426,7 @@ const AllSources = `
   @type tail
   @id openshift-audit-input
   @label @INGRESS
-  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
   pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
   follow_inodes true
   tag openshift-audit.log

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -107,7 +107,7 @@ include = ["/var/log/kube-apiserver/audit.log"]
 [sources.openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 
 [sources.internal_metrics]
 type = "internal_metrics"
@@ -315,7 +315,7 @@ include = ["/var/log/kube-apiserver/audit.log"]
 [sources.openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 
 [sources.internal_metrics]
 type = "internal_metrics"
@@ -673,7 +673,7 @@ include = ["/var/log/kube-apiserver/audit.log"]
 [sources.openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 
 [sources.internal_metrics]
 type = "internal_metrics"

--- a/internal/generator/vector/source/audit_logs.go
+++ b/internal/generator/vector/source/audit_logs.go
@@ -21,7 +21,7 @@ const OpenshiftAuditLogTemplate = `
 [sources.{{.ComponentID}}]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 {{end}}
 `
 

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -88,7 +88,7 @@ include = ["/var/log/kube-apiserver/audit.log"]
 [sources.openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 `,
 		}),
 		Entry("All Log Sources", unit.ConfGenerateTest{
@@ -131,7 +131,7 @@ include = ["/var/log/kube-apiserver/audit.log"]
 [sources.openshift_audit_logs]
 type = "file"
 ignore_older_secs = 600
-include = ["/var/log/oauth-apiserver.audit.log"]
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 `,
 		}))
 })


### PR DESCRIPTION

Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
This PR:

- fixes the path used by oauthapi audit logs (https://github.com/openshift/cluster-logging-operator/pull/1438)
- manual cherry-pick of https://github.com/openshift/cluster-logging-operator/pull/1857

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
