### PR TITLE
LOG-2575: Added documentation for fluent forward workaround

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -21,8 +21,9 @@ If you have questions, connect to the coreos.slack.com workspace on slack and ch
 * link:administration/unmanaged_configuration.md[Unmanaged Configurations for Cluster Logging]
 * link:administration/output_url_field.md[Using the clusterlogforwarder.output.url field]
 * link:contributing/how-to-add-new-output.md[How-to add a new output type]
-* link:docs/logforwarding/outputs/google-cloud-forwarding.md[Forward logs to Google Cloud Logging]
-* link:docs/logforwarding/outputs/splunk-forwarding.adoc[Forward logs to Splunk]
+* link:features/logforwarding/outputs/google-cloud-forwarding.adoc[Forward logs to Google Cloud Logging]
+* link:features/logforwarding/outputs/splunk-forwarding.adoc[Forward logs to Splunk]
+* link:features/logforwarding/outputs/send-logs-to-fluentd-http.adoc[Send logs to Fluentd over Http]
 
 == Relevant links
 

--- a/docs/features/logforwarding/outputs/google-cloud-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/google-cloud-forwarding.adoc
@@ -1,13 +1,15 @@
 
-### Steps to send logs to Google Cloud Logging
+=== Steps to send logs to Google Cloud Logging
 
- 1. Create a secret which contains google application credentials (the credentials which will be used to send logs to Google Cloud Logging)
-    ```
+. Create a secret which contains google application credentials (the credentials which will be used to send logs to Google Cloud Logging)
++
+----
     oc -n openshift-logging create secret generic gcp-secret --from-file=google-application-credentials.json
-    ```
-
-    Where `google-application-credentials.json` has following format
-    ```json
+----
++
+.Where `google-application-credentials.json` has following format
+[source,json]
+----
     {
       "type": "service_account",
       "project_id": "<gcp-project-id>",
@@ -20,16 +22,19 @@
       "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
       "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/aos-serviceaccount%40openshift-gce-devel.iam.gserviceaccount.com"
     }
+----
++
+Replace `project_id` and `private_key` with real values.
 
-    ```
-    Replace `project_id` and `private_key` with real values.
-
-2. Create a `Cluster Logging` instance with vector collector with following yaml.
-  ```
+. Create a `Cluster Logging` instance with vector collector with following yaml.
++
+----
   oc apply -f cluster-logging.yaml
-  ```
-cluster-logging.yaml:
-  ```yaml
+----
++
+.cluster-logging.yaml:
+[source,yaml]
+----
 apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
 metadata:
@@ -41,16 +46,19 @@ spec:
     type: vector
   managementState: Managed
 
-  ```
+----
 
 
-3. Create a Cluster Log Forwarder instance with following yaml.
-
-  ```
+. Create a Cluster Log Forwarder instance with following yaml.
++
+----
   oc apply -f cluster-log-forwarder.yaml
-  ```
-cluster-log-forwarder.yaml
-  ```yaml
+----
++
+.cluster-log-forwarder.yaml
++
+[source,yaml]
+----
 apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogForwarder"
 metadata:
@@ -73,14 +81,17 @@ spec:
         - audit
       outputRefs:
         - gcp-1
-  ```
+----
 
-4. Login to google console and check logs
-
+. Login to google console and check logs
++
 set query as:
-```
++
+----
 logName="projects/openshift-gce-devel/logs/app-gcp"
-```
+----
++
 the log name should match `logId` set in Cluster Log Forwarder.
++
+image::logs-in-gcp.png[Logs in Google Cloud Logging]
 
-![Logs in Google Cloud Logging](./logs-in-gcp.png "logs in google cloud logging")

--- a/docs/features/logforwarding/outputs/send-logs-to-fluentd-http.adoc
+++ b/docs/features/logforwarding/outputs/send-logs-to-fluentd-http.adoc
@@ -1,0 +1,161 @@
+
+=== Steps to send logs using vector to fluentd over http
+
+. Create a Pod which runs http endpoint on fluentd using following fluentd configuration
++
+.fluent.conf
+[source,xml]
+----
+<system>
+  log_level info
+</system>
+<source>
+  # http source plugins uses http path to create fluentd tags
+  @type http
+  port 24224
+  bind 0.0.0.0
+  body_size_limit 32m
+  keepalive_timeout 10s
+  # Headers are capitalized, and added with prefix "HTTP_"
+  add_http_headers true
+  add_remote_addr true
+  <parse>
+    @type json
+  </parse>
+  <transport tls>
+	  ca_path /etc/fluentd/secrets/ca-bundle.crt
+	  cert_path /etc/fluentd/secrets/tls.crt
+	  private_key_path /etc/fluentd/secrets/tls.key
+  </transport>
+</source>
+
+<match logs.app>
+  @type file
+  append true
+  path /tmp/app.logs
+  symlink_path /tmp/app-logs
+</match>
+<match logs.infra>
+  @type file
+  append true
+  path /tmp/infra.logs
+  symlink_path /tmp/infra-logs
+</match>
+<match logs.audit>
+  @type file
+  append true
+  path /tmp/audit.logs
+  symlink_path /tmp/audit-logs
+</match>
+<match **>
+	@type stdout
+</match>
+----
+
+
+. Create a Cluster Log Forwarder instance with following yaml.
++
+----
+  oc apply -f cluster-log-forwarder.yaml
+----
++
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+  name: instance
+  namespace: openshift-logging
+spec:
+  outputs:
+  - http:
+      headers:
+        h1: v1
+        h2: v2
+      method: POST
+    name: httpout-app
+    secret:
+      name: fluent-receiver
+    tls:
+      insecureSkipVerify: true
+    type: http
+    url: https://fluent-receiver.openshift-logging.svc:24224/logs/app
+  - http:
+      headers:
+        h1: v1
+        h2: v2
+      method: POST
+    name: httpout-infra
+    secret:
+      name: fluent-receiver
+    tls:
+      insecureSkipVerify: true
+    type: http
+    url: https://fluent-receiver.openshift-logging.svc:24224/logs/infra
+  - http:
+      headers:
+        h1: v1
+        h2: v2
+      method: POST
+    name: httpout-audit
+    secret:
+      name: fluent-receiver
+    tls:
+      insecureSkipVerify: true
+    type: http
+    url: https://fluent-receiver.openshift-logging.svc:24224/logs/audit
+  pipelines:
+  - inputRefs:
+    - application
+    name: app-logs
+    outputRefs:
+    - httpout-app
+  - inputRefs:
+    - infrastructure
+    name: infra-logs
+    outputRefs:
+    - httpout-infra
+  - inputRefs:
+    - audit
+    name: audit-logs
+    outputRefs:
+    - httpout-audit
+
+----
+
+
+. Create a `Cluster Logging` instance with vector collector with following yaml.
++
+----
+  oc apply -f cluster-logging.yaml
+----
++
+.cluster-logging.yaml
+[source,yaml]
+----
+apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  name: "instance"
+  namespace: "openshift-logging"
+  annotations:
+spec:
+  collection:
+    type: vector
+  managementState: Managed
+----
+
+
+
+. Check logs in destination http endpoint
++
+----
+ Since the CLF spec sends each log type using a different http path, the receiving fluentd
+ can use fluentd tags to differentiate each log type.
+ In the receiving fluentd, Application logs are dispatched over `logs.app`, similarly infrastructure and
+ audit logs are dispatched over `logs.infra` and `logs.audit` respectively.
+----


### PR DESCRIPTION
### Description
 Fluent Forward protocol sends fluentd tags along with logs, and receiving fluentd can
 use this tag information to dispatch the logs to labels as per fluentd conf.

 With vector not supporting fluent forward, and vector having no concept of dispatching using
 tags, an alternative is to use http paths to function as tags. Fluentd http sink can convert
 http endpoint path information to create fluentd tags. This example uses different http path
 for each log type and the same is used in receiving fluentd to dispatch each log type separately.


/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-2575

