### PR TITLE
[master] LOG-3645-default-output-migration-fix

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -137,6 +137,8 @@ const (
 	EventReasonGetObject            = "GetObject"
 	EventReasonRemoveObject         = "RemoveObject"
 	EventReasonUpdateObject         = "UpdateObject"
+
+	MigrateDefaultOutput = "default-replaced"
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -26,8 +26,8 @@ const (
 	AnnotationDebugOutput = "logging.openshift.io/debug-output"
 )
 
-// CreateOrUpdateCollection component of the cluster
-func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err error) {
+//CreateOrUpdateCollection component of the cluster
+func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection(extras map[string]bool) (err error) {
 	if !clusterRequest.isManaged() {
 		return nil
 	}
@@ -71,7 +71,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 			return
 		}
 
-		if collectorConfig, err = clusterRequest.generateCollectorConfig(); err != nil {
+		if collectorConfig, err = clusterRequest.generateCollectorConfig(extras); err != nil {
 			log.V(9).Error(err, "clusterRequest.generateCollectorConfig")
 			return
 		}

--- a/internal/logstore/lokistack/logstore_lokistack_test.go
+++ b/internal/logstore/lokistack/logstore_lokistack_test.go
@@ -10,16 +10,18 @@ import (
 func TestProcessPipelinesForLokiStack(t *testing.T) {
 	tests := []struct {
 		desc          string
-		in            []loggingv1.PipelineSpec
+		spec          loggingv1.ClusterLogForwarderSpec
 		wantOutputs   []loggingv1.OutputSpec
 		wantPipelines []loggingv1.PipelineSpec
 	}{
 		{
 			desc: "no default output",
-			in: []loggingv1.PipelineSpec{
-				{
-					OutputRefs: []string{"custom-output"},
-					InputRefs:  []string{loggingv1.InputNameApplication},
+			spec: loggingv1.ClusterLogForwarderSpec{
+				Pipelines: []loggingv1.PipelineSpec{
+					{
+						OutputRefs: []string{"custom-output"},
+						InputRefs:  []string{loggingv1.InputNameApplication},
+					},
 				},
 			},
 			wantOutputs: []loggingv1.OutputSpec{},
@@ -32,10 +34,12 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 		},
 		{
 			desc: "single tenant - single output",
-			in: []loggingv1.PipelineSpec{
-				{
-					OutputRefs: []string{loggingv1.OutputNameDefault},
-					InputRefs:  []string{loggingv1.InputNameApplication},
+			spec: loggingv1.ClusterLogForwarderSpec{
+				Pipelines: []loggingv1.PipelineSpec{
+					{
+						OutputRefs: []string{loggingv1.OutputNameDefault},
+						InputRefs:  []string{loggingv1.InputNameApplication},
+					},
 				},
 			},
 			wantOutputs: []loggingv1.OutputSpec{
@@ -54,12 +58,14 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 		},
 		{
 			desc: "multiple tenants - single output",
-			in: []loggingv1.PipelineSpec{
-				{
-					OutputRefs: []string{loggingv1.OutputNameDefault},
-					InputRefs: []string{
-						loggingv1.InputNameApplication,
-						loggingv1.InputNameInfrastructure,
+			spec: loggingv1.ClusterLogForwarderSpec{
+				Pipelines: []loggingv1.PipelineSpec{
+					{
+						OutputRefs: []string{loggingv1.OutputNameDefault},
+						InputRefs: []string{
+							loggingv1.InputNameApplication,
+							loggingv1.InputNameInfrastructure,
+						},
 					},
 				},
 			},
@@ -88,13 +94,15 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 		},
 		{
 			desc: "multiple tenants - single output - named pipeline",
-			in: []loggingv1.PipelineSpec{
-				{
-					Name:       "named-pipeline",
-					OutputRefs: []string{loggingv1.OutputNameDefault},
-					InputRefs: []string{
-						loggingv1.InputNameApplication,
-						loggingv1.InputNameInfrastructure,
+			spec: loggingv1.ClusterLogForwarderSpec{
+				Pipelines: []loggingv1.PipelineSpec{
+					{
+						Name:       "named-pipeline",
+						OutputRefs: []string{loggingv1.OutputNameDefault},
+						InputRefs: []string{
+							loggingv1.InputNameApplication,
+							loggingv1.InputNameInfrastructure,
+						},
 					},
 				},
 			},
@@ -125,14 +133,16 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 		},
 		{
 			desc: "single tenant - multiple outputs",
-			in: []loggingv1.PipelineSpec{
-				{
-					OutputRefs: []string{
-						"custom-output",
-						loggingv1.OutputNameDefault,
-					},
-					InputRefs: []string{
-						loggingv1.InputNameInfrastructure,
+			spec: loggingv1.ClusterLogForwarderSpec{
+				Pipelines: []loggingv1.PipelineSpec{
+					{
+						OutputRefs: []string{
+							"custom-output",
+							loggingv1.OutputNameDefault,
+						},
+						InputRefs: []string{
+							loggingv1.InputNameInfrastructure,
+						},
 					},
 				},
 			},
@@ -155,15 +165,17 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 		},
 		{
 			desc: "multiple tenants - multiple outputs",
-			in: []loggingv1.PipelineSpec{
-				{
-					OutputRefs: []string{
-						"custom-output",
-						loggingv1.OutputNameDefault,
-					},
-					InputRefs: []string{
-						loggingv1.InputNameInfrastructure,
-						loggingv1.InputNameAudit,
+			spec: loggingv1.ClusterLogForwarderSpec{
+				Pipelines: []loggingv1.PipelineSpec{
+					{
+						OutputRefs: []string{
+							"custom-output",
+							loggingv1.OutputNameDefault,
+						},
+						InputRefs: []string{
+							loggingv1.InputNameInfrastructure,
+							loggingv1.InputNameAudit,
+						},
 					},
 				},
 			},
@@ -208,7 +220,9 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 					Name: "lokistack-testing",
 				},
 			}
-			outputs, pipelines := ProcessForwarderPipelines(logStore, "aNamespace", tc.in)
+			var outputs []loggingv1.OutputSpec
+			var pipelines []loggingv1.PipelineSpec
+			outputs, pipelines, _ = ProcessForwarderPipelines(logStore, "aNamespace", tc.spec, map[string]bool{})
 
 			if diff := cmp.Diff(outputs, tc.wantOutputs); diff != "" {
 				t.Errorf("outputs differ: -got+want\n%s", diff)

--- a/internal/migrations/migrate_clusterlogforwarder_test.go
+++ b/internal/migrations/migrate_clusterlogforwarder_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 )
 
 var _ = Describe("MigrateDefaultOutput", func() {
@@ -15,6 +16,7 @@ var _ = Describe("MigrateDefaultOutput", func() {
 		spec      logging.ClusterLogForwarderSpec
 		esSpec    *logging.Elasticsearch
 		logstore  *logging.LogStoreSpec
+		extras    map[string]bool
 	)
 
 	BeforeEach(func() {
@@ -43,15 +45,20 @@ var _ = Describe("MigrateDefaultOutput", func() {
 			Outputs:   outputs,
 			Pipelines: pipelines,
 		}
+		extras = map[string]bool{}
 	})
 
 	It("should not add the default OutputSpec when it is not referenced by a pipeline", func() {
-		Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(spec))
+		// This is equal to returning (spec, nil) and will only pass if 2nd param is nil
+		forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+		Expect(forwarderSpec).To(Equal(spec))
+		Expect(extras).To(Equal(map[string]bool{}))
 	})
 
 	It("should add the default OutputSpec when default logstore exists and spec is empty ", func() {
 		logstore = &logging.LogStoreSpec{Type: logging.OutputTypeElasticsearch}
-		Expect(MigrateDefaultOutput(logging.ClusterLogForwarderSpec{}, logstore)).To(Equal(
+		forwarderSpec, extras := MigrateClusterLogForwarderSpec(logging.ClusterLogForwarderSpec{}, logstore, extras)
+		Expect(forwarderSpec).To(Equal(
 			logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -62,6 +69,7 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				Outputs: []logging.OutputSpec{NewDefaultOutput(nil)},
 			},
 		))
+		Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 	})
 
 	It("generates default configuration for empty spec with LokiStack log store", func() {
@@ -71,7 +79,10 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				Name: "lokistack-testing",
 			},
 		}
-		Expect(MigrateDefaultOutput(logging.ClusterLogForwarderSpec{}, logstore)).To(Equal(
+
+		spec, extras = MigrateClusterLogForwarderSpec(logging.ClusterLogForwarderSpec{}, logstore, extras)
+
+		Expect(spec).To(Equal(
 			logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -97,7 +108,9 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				},
 			},
 		))
+		Expect(extras).To(Equal(map[string]bool{}))
 	})
+
 	It("processes custom pipelines to default LokiStack log store", func() {
 		logstore = &logging.LogStoreSpec{
 			Type: logging.LogStoreTypeLokiStack,
@@ -113,7 +126,10 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				},
 			},
 		}
-		Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(
+
+		spec, extras = MigrateClusterLogForwarderSpec(spec, logstore, extras)
+
+		Expect(spec).To(Equal(
 			logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
@@ -130,6 +146,7 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				},
 			},
 		))
+		Expect(extras).To(Equal(map[string]bool{}))
 	})
 
 	Context("when a pipeline references 'default'", func() {
@@ -151,8 +168,11 @@ var _ = Describe("MigrateDefaultOutput", func() {
 			})
 
 			It("should add the default OutputSpec", func() {
-				Expect((MigrateDefaultOutput(spec, logstore))).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 			})
+
 			It("should add the default OutputSpec and OutputDefaults when OutputDefaults are spec'd", func() {
 				spec.OutputDefaults = &logging.OutputDefaults{
 					Elasticsearch: &logging.ElasticsearchStructuredSpec{
@@ -161,7 +181,11 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				}
 				exp.Outputs[1].Elasticsearch = &logging.Elasticsearch{ElasticsearchStructuredSpec: *spec.OutputDefaults.Elasticsearch}
 				exp.OutputDefaults = spec.OutputDefaults
-				Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 			})
 		})
 
@@ -184,7 +208,10 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				}
 				exp = *spec.DeepCopy()
 				exp.Outputs = append(outputs, NewDefaultOutput(nil))
-				Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 			})
 
 			It("should replace the OutputSpec with the default OutputSpec and use the config (e.g. structureTypeKey) defined in the original OutputSpec", func() {
@@ -196,10 +223,93 @@ var _ = Describe("MigrateDefaultOutput", func() {
 				}
 				exp = *spec.DeepCopy()
 				exp.Outputs = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: &esSpec.ElasticsearchStructuredSpec}))
-				Expect(MigrateDefaultOutput(spec, logstore)).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 			})
 		})
 
+	})
+	Context("when a pipeline references 'default'", func() {
+
+		var exp logging.ClusterLogForwarderSpec
+		BeforeEach(func() {
+			logstore = &logging.LogStoreSpec{Type: logging.OutputTypeElasticsearch}
+			pipelines[0].OutputRefs = append(spec.Pipelines[0].OutputRefs, logging.OutputNameDefault)
+			spec = logging.ClusterLogForwarderSpec{
+				Outputs:   outputs,
+				Pipelines: pipelines,
+			}
+		})
+
+		Context("and outputs does not explicitly spec 'default'", func() {
+			BeforeEach(func() {
+				exp = *spec.DeepCopy()
+				exp.Outputs = append(outputs, NewDefaultOutput(nil))
+			})
+
+			It("should add the default OutputSpec", func() {
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
+			})
+			It("should add the default OutputSpec and OutputDefaults when OutputDefaults are spec'd", func() {
+				spec.OutputDefaults = &logging.OutputDefaults{
+					Elasticsearch: &logging.ElasticsearchStructuredSpec{
+						StructuredTypeKey: "foo.bar",
+					},
+				}
+				exp.Outputs[1].Elasticsearch = &logging.Elasticsearch{ElasticsearchStructuredSpec: *spec.OutputDefaults.Elasticsearch}
+				exp.OutputDefaults = spec.OutputDefaults
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
+			})
+		})
+
+		Context("and outputs includes an OutputSpec named 'default'", func() {
+			var tobereplaced logging.OutputSpec
+			BeforeEach(func() {
+				tobereplaced = logging.OutputSpec{
+					Name:   logging.OutputNameDefault,
+					Type:   logging.OutputTypeElasticsearch,
+					URL:    "thiswillgetreplaced",
+					Secret: &logging.OutputSecretSpec{Name: "replacem"},
+				}
+
+			})
+
+			It("should replace the OutputSpec with the default OutputSpec", func() {
+				spec = logging.ClusterLogForwarderSpec{
+					Outputs:   append(outputs, tobereplaced),
+					Pipelines: pipelines,
+				}
+				exp = *spec.DeepCopy()
+				exp.Outputs = append(outputs, NewDefaultOutput(nil))
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
+			})
+
+			It("should replace the OutputSpec with the default OutputSpec and use the config (e.g. structureTypeKey) defined in the original OutputSpec", func() {
+				tobereplaced.Elasticsearch = esSpec
+				spec = logging.ClusterLogForwarderSpec{
+					Outputs:        append(outputs, tobereplaced),
+					Pipelines:      pipelines,
+					OutputDefaults: &logging.OutputDefaults{Elasticsearch: &logging.ElasticsearchStructuredSpec{StructuredTypeKey: "abc"}},
+				}
+				exp = *spec.DeepCopy()
+				exp.Outputs = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: &esSpec.ElasticsearchStructuredSpec}))
+
+				forwarderSpec, extras := MigrateClusterLogForwarderSpec(spec, logstore, extras)
+				Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
+				Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
+			})
+		})
 	})
 
 })

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -60,7 +60,7 @@ func Generate(collectionType logging.LogCollectionType, clfYaml string, includeD
 		}
 	}
 
-	spec, status := clRequest.NormalizeForwarder()
+	spec, status := clRequest.NormalizeForwarder(map[string]bool{})
 	log.V(2).Info("Normalization", "spec", spec)
 	log.V(2).Info("Normalization", "status", status)
 

--- a/internal/visualization/console/plugin.go
+++ b/internal/visualization/console/plugin.go
@@ -2,15 +2,15 @@ package console
 
 import (
 	"context"
-	"fmt"
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ReconcilePlugin reconciles the console plugin to expose log querying of storage
 func ReconcilePlugin(k8sClient client.Client, logStore *logging.LogStoreSpec, owner client.Object, clusterVersion string) error {
-	lokiService := LokiStackGatewayService(logStore)
+	lokiService := lokistack.LokiStackGatewayService(logStore)
 	r := NewReconciler(k8sClient, NewConfig(owner, lokiService, FeaturesForOCP(clusterVersion)))
 	if logStore != nil && logStore.Type == logging.LogStoreTypeLokiStack {
 		log.V(3).Info("Enabling logging console plugin", "created-by", r.CreatedBy(), "loki-service", lokiService)
@@ -19,14 +19,4 @@ func ReconcilePlugin(k8sClient client.Client, logStore *logging.LogStoreSpec, ow
 		log.V(3).Info("Removing logging console plugin", "created-by", r.CreatedBy(), "loki-service", lokiService)
 		return r.Delete(context.TODO())
 	}
-}
-
-// LokiStackGatewayService returns the name of LokiStack gateway service.
-// Returns an empty string if ClusterLogging is not configured for a LokiStack log store.
-func LokiStackGatewayService(logStore *logging.LogStoreSpec) string {
-	if logStore == nil || logStore.LokiStack.Name == "" {
-		return ""
-	}
-
-	return fmt.Sprintf("%s-gateway-http", logStore.LokiStack.Name)
 }

--- a/test/functional/normalization/flatten_labels_test.go
+++ b/test/functional/normalization/flatten_labels_test.go
@@ -61,8 +61,10 @@ var _ = Describe("[Functional][Normalization] flatten labels", func() {
 				return false, nil
 			}
 			namespaceLabels := map[string]string{
-				"foo":     "bar",
-				"foo.bar": "foobar",
+				"foo":                                "bar",
+				"foo.bar":                            "foobar",
+				"pod-security.kubernetes.io/enforce": "privileged",
+				"security.openshift.io/scc.podSecurityLabelSync": "false",
 			}
 			ns.Labels = namespaceLabels
 			if err := framework.Test.Client.Update(ns); err != nil {


### PR DESCRIPTION
### Description
This is the 5.7 version of the fix below, which was implemented in 5.6.2

The fix was created in migration and with minor updates to the logic surrounding 'default' outputRef for both ES and Loki. Mainly adding a map to the migration and subsequent normalization (validate), indicating if the ES output was created by our default migration. This allows us to handle verify with the context of migration. This is the initial and least impactful change to a refactor of the migration and validation logic to come in: [LOG-3247](https://issues.redhat.com/browse/LOG-3247) when we remove degraded status.

Expected:
If you use 'default' as an output, it will either correct the ES output, or if its Loki, it will inform the user the name is reserved. Any other output named 'default' should now invalidate as expected.
This should also fix the issue in [LOG-3559](https://issues.redhat.com//browse/LOG-3559) where collector restarts due to invalid pipelines when using default along with another outputRef (in same or separate pipeline)

/cc @jcantrill
/assign @vimalk78 @syedriko

Links
- https://issues.redhat.com/browse/LOG-3437
- https://issues.redhat.com/browse/LOG-3559
- https://issues.redhat.com/browse/LOG-3247
