### PR TITLE
[master] LOG-2544: Add support for Elasticsearch v8 for fluentd

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder.go
+++ b/apis/logging/v1/cluster_log_forwarder.go
@@ -18,10 +18,14 @@ var ReservedInputNames = sets.NewString(InputNameApplication, InputNameInfrastru
 
 func IsInputTypeName(s string) bool { return ReservedInputNames.Has(s) }
 
-// Default log store output name and version
+// OutputNameDefault is the Default log store output name and version
 const OutputNameDefault = "default"
+
+// DefaultESVersion is the version of ES deployed by default
 const DefaultESVersion = 6
-const LatestESVersion = 8
+
+// FirstESVersionWithoutType (e.g. v8) is the first version without types
+const FirstESVersionWithoutType = 8
 
 // IsReservedOutputName returns true if s is a reserved output name.
 func IsReservedOutputName(s string) bool { return s == OutputNameDefault }

--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -28,8 +28,8 @@ var _ = Describe("Testing Complete Config Generation", func() {
 		conf, err := g.GenerateConf(e...)
 		Expect(err).To(BeNil())
 		diff := cmp.Diff(
-			strings.Split(strings.TrimSpace(helpers.FormatFluentConf(testcase.ExpectedConf)), "\n"),
-			strings.Split(strings.TrimSpace(helpers.FormatFluentConf(conf)), "\n"))
+			strings.Split(strings.Replace(strings.TrimSpace(helpers.FormatFluentConf(testcase.ExpectedConf)), "\n\n", "\n", -1), "\n"),
+			strings.Split(strings.Replace(strings.TrimSpace(helpers.FormatFluentConf(conf)), "\n\n", "\n", -1), "\n"))
 		if diff != "" {
 			b, _ := json.MarshalIndent(e, "", " ")
 			fmt.Printf("elements:\n%s\n", string(b))
@@ -587,7 +587,6 @@ var _ = Describe("Testing Complete Config Generation", func() {
     @id retry_es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/es-1-secret/tls.key'
@@ -596,11 +595,10 @@ var _ = Describe("Testing Complete Config Generation", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -632,7 +630,6 @@ var _ = Describe("Testing Complete Config Generation", func() {
     @id es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/es-1-secret/tls.key'
@@ -641,12 +638,11 @@ var _ = Describe("Testing Complete Config Generation", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -632,7 +632,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id retry_apps_es_1
     host es.svc.messaging.cluster.local
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
@@ -641,11 +640,10 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -677,7 +675,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id apps_es_1
     host es.svc.messaging.cluster.local
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
@@ -686,12 +683,11 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -778,7 +774,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id retry_apps_es_2
     host es2.svc.messaging.cluster.local
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
@@ -787,11 +782,10 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -823,7 +817,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id apps_es_2
     host es2.svc.messaging.cluster.local
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
@@ -832,12 +825,11 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1367,7 +1359,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id retry_apps_es_1
     host es.svc.messaging.cluster.local
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
@@ -1376,11 +1367,10 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1412,7 +1402,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id apps_es_1
     host es.svc.messaging.cluster.local
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
@@ -1421,12 +1410,11 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1513,7 +1501,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id retry_apps_es_2
     host es.svc.messaging.cluster.local2
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
@@ -1522,11 +1509,10 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1558,7 +1544,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id apps_es_2
     host es.svc.messaging.cluster.local2
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
@@ -1567,12 +1552,11 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2106,7 +2090,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id retry_apps_es_1
     host es.svc.messaging.cluster.local
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
@@ -2115,11 +2098,10 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2151,7 +2133,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id apps_es_1
     host es.svc.messaging.cluster.local
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
@@ -2160,12 +2141,11 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2252,7 +2232,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id retry_apps_es_2
     host es.svc.messaging.cluster.local2
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
@@ -2261,11 +2240,10 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -2297,7 +2275,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id apps_es_2
     host es.svc.messaging.cluster.local2
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
@@ -2306,12 +2283,11 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3245,7 +3221,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id retry_infra_es
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
@@ -3254,11 +3229,10 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3290,7 +3264,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id infra_es
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
@@ -3299,12 +3272,11 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_infra_es
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3391,7 +3363,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id retry_apps_es_1
     host es.svc.messaging.cluster.local
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
@@ -3400,11 +3371,10 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3436,7 +3406,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id apps_es_1
     host es.svc.messaging.cluster.local
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
@@ -3445,12 +3414,11 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_apps_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3537,7 +3505,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id retry_apps_es_2
     host es.svc.messaging.cluster.local2
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
@@ -3546,11 +3513,10 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3582,7 +3548,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id apps_es_2
     host es.svc.messaging.cluster.local2
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
@@ -3591,12 +3556,11 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_apps_es_2
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3683,7 +3647,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id retry_audit_es
     host es.svc.audit.cluster
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
@@ -3692,11 +3655,10 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -3728,7 +3690,6 @@ var _ = Describe("Generating fluentd config", func() {
     @id audit_es
     host es.svc.audit.cluster
     port 9654
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
@@ -3737,12 +3698,11 @@ var _ = Describe("Generating fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_audit_es
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -102,7 +102,6 @@ var _ = Describe("Generate fluentd config", func() {
     @id retry_es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     user "#{File.exists?('/var/run/ocp-collector/secrets/es-1/username') ? open('/var/run/ocp-collector/secrets/es-1/username','r') do |f|f.read end : ''}"
@@ -110,11 +109,10 @@ var _ = Describe("Generate fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -146,7 +144,6 @@ var _ = Describe("Generate fluentd config", func() {
     @id es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     user "#{File.exists?('/var/run/ocp-collector/secrets/es-1/username') ? open('/var/run/ocp-collector/secrets/es-1/username','r') do |f|f.read end : ''}"
@@ -154,12 +151,11 @@ var _ = Describe("Generate fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -269,7 +265,6 @@ var _ = Describe("Generate fluentd config", func() {
     @id retry_es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/es-1/tls.key'
@@ -278,11 +273,10 @@ var _ = Describe("Generate fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -314,7 +308,6 @@ var _ = Describe("Generate fluentd config", func() {
     @id es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     client_key '/var/run/ocp-collector/secrets/es-1/tls.key'
@@ -323,12 +316,11 @@ var _ = Describe("Generate fluentd config", func() {
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -430,16 +422,14 @@ var _ = Describe("Generate fluentd config", func() {
     @id retry_es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme http
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -471,17 +461,15 @@ var _ = Describe("Generate fluentd config", func() {
     @id es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme http
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -580,17 +568,15 @@ var _ = Describe("Generate fluentd config", func() {
     @id retry_es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -622,18 +608,16 @@ var _ = Describe("Generate fluentd config", func() {
     @id es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -742,18 +726,16 @@ var _ = Describe("Generate fluentd config", func() {
     @id retry_es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme http
     user "#{File.exists?('/var/run/ocp-collector/secrets/es-1/username') ? open('/var/run/ocp-collector/secrets/es-1/username','r') do |f|f.read end : ''}"
     password "#{File.exists?('/var/run/ocp-collector/secrets/es-1/password') ? open('/var/run/ocp-collector/secrets/es-1/password','r') do |f|f.read end : ''}"
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -785,19 +767,17 @@ var _ = Describe("Generate fluentd config", func() {
     @id es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme http
     user "#{File.exists?('/var/run/ocp-collector/secrets/es-1/username') ? open('/var/run/ocp-collector/secrets/es-1/username','r') do |f|f.read end : ''}"
     password "#{File.exists?('/var/run/ocp-collector/secrets/es-1/password') ? open('/var/run/ocp-collector/secrets/es-1/password','r') do |f|f.read end : ''}"
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -899,17 +879,15 @@ var _ = Describe("Generate fluentd config", func() {
     @id retry_es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -941,18 +919,16 @@ var _ = Describe("Generate fluentd config", func() {
     @id es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1057,17 +1033,15 @@ var _ = Describe("Generate fluentd config", func() {
     @id retry_es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1099,18 +1073,16 @@ var _ = Describe("Generate fluentd config", func() {
     @id es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme https
     ssl_version TLSv1_2
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1214,16 +1186,14 @@ var _ = Describe("Generate fluentd config", func() {
     @id retry_es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme http
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'
@@ -1255,17 +1225,15 @@ var _ = Describe("Generate fluentd config", func() {
     @id es_1
     host es.svc.infra.cluster
     port 9999
-    verify_es_version_at_startup false
     scheme http
     target_index_key viaq_index_name
     id_key viaq_msg_id
     remove_keys viaq_index_name
+    verify_es_version_at_startup false
     type_name _doc
     retry_tag retry_es_1
     http_backend typhoeus
     write_operation create
-    # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-    suppress_type_name 'true'
     reload_connections 'true'
     # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
     reload_after '200'

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -142,17 +142,14 @@ var _ = Describe("Generating fluentd config", func() {
               @id retry_other_elasticsearch
               host es.svc.messaging.cluster.local
               port 9654
-              verify_es_version_at_startup false
               scheme http
               target_index_key viaq_index_name
               id_key viaq_msg_id
               remove_keys viaq_index_name
-
+              verify_es_version_at_startup false
               type_name _doc
               http_backend typhoeus
               write_operation create
-              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -183,18 +180,15 @@ var _ = Describe("Generating fluentd config", func() {
               @id other_elasticsearch
               host es.svc.messaging.cluster.local
               port 9654
-              verify_es_version_at_startup false
               scheme http
               target_index_key viaq_index_name
               id_key viaq_msg_id
               remove_keys viaq_index_name
-
+              verify_es_version_at_startup false
               type_name _doc
               retry_tag retry_other_elasticsearch
               http_backend typhoeus
               write_operation create
-			  # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-			  suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -302,17 +296,14 @@ var _ = Describe("Generating fluentd config", func() {
               @id retry_other_elasticsearch
               host es.svc.messaging.cluster.local
               port 9654
-              verify_es_version_at_startup false
               scheme http
               target_index_key viaq_index_name
               id_key viaq_msg_id
               remove_keys viaq_index_name
-
+              verify_es_version_at_startup false
               type_name _doc
               http_backend typhoeus
               write_operation create
-              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -343,18 +334,15 @@ var _ = Describe("Generating fluentd config", func() {
               @id other_elasticsearch
               host es.svc.messaging.cluster.local
               port 9654
-              verify_es_version_at_startup false
               scheme http
               target_index_key viaq_index_name
               id_key viaq_msg_id
               remove_keys viaq_index_name
-
+              verify_es_version_at_startup false
               type_name _doc
               retry_tag retry_other_elasticsearch
               http_backend typhoeus
               write_operation create
-              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-			  suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -448,17 +436,14 @@ var _ = Describe("Generating fluentd config", func() {
               @id retry_other_elasticsearch
               host es.svc.messaging.cluster.local
               port 9654
-              verify_es_version_at_startup false
               scheme http
               target_index_key viaq_index_name
               id_key viaq_msg_id
               remove_keys viaq_index_name
-
+              verify_es_version_at_startup false
               type_name _doc
               http_backend typhoeus
               write_operation create
-              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'
@@ -488,18 +473,15 @@ var _ = Describe("Generating fluentd config", func() {
               @id other_elasticsearch
               host es.svc.messaging.cluster.local
               port 9654
-              verify_es_version_at_startup false
               scheme http
               target_index_key viaq_index_name
               id_key viaq_msg_id
               remove_keys viaq_index_name
-
+              verify_es_version_at_startup false
               type_name _doc
               retry_tag retry_other_elasticsearch
               http_backend typhoeus
               write_operation create
-              # https://github.com/uken/fluent-plugin-elasticsearch#suppress_type_name
-              suppress_type_name 'true'
               reload_connections 'true'
               # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
               reload_after '200'

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -1031,7 +1031,7 @@ ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1
 						URL:  "https://es-2.svc.messaging.cluster.local:9200",
 						OutputTypeSpec: logging.OutputTypeSpec{
 							Elasticsearch: &logging.Elasticsearch{
-								Version: logging.LatestESVersion,
+								Version: logging.FirstESVersionWithoutType,
 							},
 						},
 						Secret: &logging.OutputSecretSpec{

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -244,7 +244,7 @@ func Output(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Opt
 		ComponentID:     helpers.FormatComponentID(o.Name),
 		Endpoint:        o.URL,
 		Inputs:          helpers.MakeInputs(inputs...),
-		SuppressVersion: logging.LatestESVersion,
+		SuppressVersion: logging.FirstESVersionWithoutType,
 	}
 	// If valid version is specified
 	if o.Elasticsearch != nil && o.Elasticsearch.Version > 0 {

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -1764,7 +1764,7 @@ id_key = "_id"
 						URL:  "http://es.svc.infra.cluster:9200",
 						OutputTypeSpec: logging.OutputTypeSpec{
 							Elasticsearch: &logging.Elasticsearch{
-								Version: logging.LatestESVersion + 1,
+								Version: logging.FirstESVersionWithoutType + 1,
 							},
 						},
 						Secret: nil,

--- a/test/client/test.go
+++ b/test/client/test.go
@@ -42,7 +42,9 @@ func NewTest(testOptions ...TestOption) *Test {
 		Client: Get(),
 		NS:     runtime.NewNamespace(ns),
 	}
-	test.Must(t.Create(t.NS))
+	if !TestOptions(testOptions).Include(DryRunTestOption) {
+		test.Must(t.Create(t.NS))
+	}
 	if _, ok := test.GinkgoCurrentTest(); ok {
 		fmt.Fprintf(ginkgo.GinkgoWriter, "test namespace: %v\n", t.NS.Name)
 	}
@@ -63,8 +65,13 @@ func (options TestOptions) Include(option TestOption) bool {
 	return false
 }
 
-// UseInfraNamespaceTestOption is the option to hint the test should be run in an infrastructure namespace
-const UseInfraNamespaceTestOption TestOption = "useInfraNamespace"
+const (
+	//UseInfraNamespaceTestOption is the option to hint the test should be run in an infrastructure namespace
+	UseInfraNamespaceTestOption TestOption = "useInfraNamespace"
+
+	//DryRunTestOption is a hint to use in testing to not actually create resources against cluster (e.g. unit tests)
+	DryRunTestOption TestOption = "dryRun"
+)
 
 // NamespaceClient wraps the singleton test client for use with hack testing
 type NamespaceClient struct {

--- a/test/framework/functional/builders.go
+++ b/test/framework/functional/builders.go
@@ -1,0 +1,68 @@
+package functional
+
+import (
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/test/client"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type CollectorFunctionalFrameworkBuilder struct {
+	builder     *ClusterLogForwarderBuilder
+	Framework   *CollectorFunctionalFramework
+	podVisitors []runtime.PodBuilderVisitor
+}
+
+type FrameworkPipelineBuilder struct {
+	frameworkBuilder *CollectorFunctionalFrameworkBuilder
+	pipelineBuilder  *PipelineBuilder
+}
+
+func NewCollectorFunctionalFrameworkUsingCollectorBuilder(logCollectorType logging.LogCollectionType, testOptions ...client.TestOption) *CollectorFunctionalFrameworkBuilder {
+	framework := NewCollectorFunctionalFrameworkUsingCollector(logCollectorType, testOptions...)
+
+	return &CollectorFunctionalFrameworkBuilder{
+		builder:     NewClusterLogForwarderBuilder(framework.Forwarder),
+		Framework:   framework,
+		podVisitors: []runtime.PodBuilderVisitor{},
+	}
+}
+
+func (b *CollectorFunctionalFrameworkBuilder) FromInput(inputName string) *FrameworkPipelineBuilder {
+	return &FrameworkPipelineBuilder{
+		frameworkBuilder: b,
+		pipelineBuilder:  b.builder.FromInput(inputName),
+	}
+}
+
+func (b *CollectorFunctionalFrameworkBuilder) Deploy() error {
+	return b.Framework.DeployWithVisitors(b.podVisitors)
+}
+
+type ElasticsearchVersion int
+
+const (
+	ElasticsearchVersion6 ElasticsearchVersion = 6
+	ElasticsearchVersion7 ElasticsearchVersion = 7
+	ElasticsearchVersion8 ElasticsearchVersion = 8
+)
+
+func (p *FrameworkPipelineBuilder) ToElasticSearchOutput(version ElasticsearchVersion, secret *corev1.Secret) *CollectorFunctionalFrameworkBuilder {
+	p.pipelineBuilder.ToOutputWithVisitor(func(output *logging.OutputSpec) {
+		if version > ElasticsearchVersion6 {
+			output.Elasticsearch.Version = int(version)
+		}
+		if secret != nil {
+			p.frameworkBuilder.Framework.Secrets = append(p.frameworkBuilder.Framework.Secrets, secret)
+			output.Secret = &logging.OutputSecretSpec{
+				Name: secret.Name,
+			}
+		}
+		deploy := func(b *runtime.PodBuilder) error {
+			return AddESOutput(version, b, *output)
+		}
+		p.frameworkBuilder.podVisitors = append(p.frameworkBuilder.podVisitors, deploy)
+	}, logging.OutputTypeElasticsearch)
+
+	return p.frameworkBuilder
+}

--- a/test/framework/functional/builders_test.go
+++ b/test/framework/functional/builders_test.go
@@ -1,0 +1,52 @@
+package functional
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/test"
+	"github.com/openshift/cluster-logging-operator/test/client"
+)
+
+var _ = Describe("CollectorFunctionalFrameworkUsingCollectorBuilder", func() {
+
+	var (
+		secret = runtime.NewSecret("", "mysecret", map[string][]byte{
+			constants.ClientUsername: []byte("admin"),
+			constants.ClientPassword: []byte("elasticadmin"),
+		},
+		)
+	)
+
+	BeforeEach(func() {
+	})
+
+	Context("#FromInput", func() {
+
+		It("should correctly build to Elasticsearch", func() {
+			builder := NewCollectorFunctionalFrameworkUsingCollectorBuilder("vector", client.DryRunTestOption)
+			builder.FromInput(logging.InputNameApplication).
+				ToElasticSearchOutput(ElasticsearchVersion7, secret)
+
+			Expect(test.YAMLString(builder.Framework.Forwarder.Spec)).To(MatchYAML(`inputs:
+- name: application
+outputs:
+- name: elasticsearch
+  secret:
+    name: mysecret
+  elasticsearch:
+    version: 7
+  type: elasticsearch
+  url: http://0.0.0.0:9200
+pipelines:
+- inputRefs:
+  - application
+  name: forward-pipeline
+  outputRefs:
+  - elasticsearch
+`))
+		})
+	})
+})

--- a/test/framework/functional/output_kafka.go
+++ b/test/framework/functional/output_kafka.go
@@ -7,7 +7,6 @@ import (
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
-	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/helpers/kafka"
 )
@@ -82,14 +81,6 @@ func (f *CollectorFunctionalFramework) AddKafkaOutput(b *runtime.PodBuilder, out
 	if err := f.Test.Client.Create(brokercm); err != nil {
 		return err
 	}
-
-	//Doing below at the time of creating spec for fluentd container now as tls.key, tls.crts need to be mounted on fluentd pod
-
-	//add broker secret containing keys,certs for secure connection in the below fluentd container
-
-	b.AddSecretVolume("kafka", kafka.DeploymentName).
-		GetContainer(constants.CollectorName).
-		AddVolumeMount("kafka", "/var/run/ocp-collector/secrets/kafka", "", true)
 
 	//standup pod with container running broker
 	b.AddInitContainer("init-config1", ImageRemoteKafkaInit).

--- a/test/framework/functional/write.go
+++ b/test/framework/functional/write.go
@@ -23,9 +23,9 @@ func (f *CollectorFunctionalFramework) WriteMessagesToApplicationLogForContainer
 	return f.WriteMessagesToLog(msg, numOfLogs, filename)
 }
 
-// WriteMessagesInfraContainerLog mocks writing infra container logs for the functional framework.  This may require
+// WriteMessagesInfraContainerLog mocks writing infra container logs for the functional Framework.  This may require
 // enabling the mock api adapter to get metadata for infrastructure logs since the path does not match a pod
-// running on the cluster (e.g framework.VisitConfig = functional.TestAPIAdapterConfigVisitor)
+// running on the cluster (e.g Framework.VisitConfig = functional.TestAPIAdapterConfigVisitor)
 func (f *CollectorFunctionalFramework) WriteMessagesToInfraContainerLog(msg string, numOfLogs int) error {
 	ns := "openshift-fake-infra"
 	if strings.HasPrefix(f.Namespace, "openshift-test") {

--- a/test/functional/normalization/flatten_labels_test.go
+++ b/test/functional/normalization/flatten_labels_test.go
@@ -130,8 +130,7 @@ var _ = Describe("[Functional][Normalization] flatten labels", func() {
 			}
 
 			pb.ToKafkaOutput()
-			secret := kafka.NewBrokerSecret(framework.Namespace)
-			Expect(framework.Test.Client.Create(secret)).To(Succeed())
+			framework.Secrets = append(framework.Secrets, kafka.NewBrokerSecret(framework.Namespace))
 			Expect(framework.Deploy()).To(BeNil())
 
 			Expect(framework.WritesApplicationLogs(1)).To(BeNil())

--- a/test/functional/outputs/elasticsearch/forward_to_elasticsearch_test.go
+++ b/test/functional/outputs/elasticsearch/forward_to_elasticsearch_test.go
@@ -1,18 +1,23 @@
 package elasticsearch
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	testfw "github.com/openshift/cluster-logging-operator/test/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"github.com/openshift/cluster-logging-operator/test/matchers"
+	core "k8s.io/api/core/v1"
 	"sort"
 	"time"
 )
 
-var _ = Describe("[Functional][Outputs][ElasticSearch] FluentdForward Output to ElasticSearch", func() {
+var _ = Describe(fmt.Sprintf("[Functional][Outputs][ElasticSearch] %s Logforwarding to ElasticSearch", testfw.LogCollectionType), func() {
 
 	var (
 		framework *functional.CollectorFunctionalFramework
@@ -21,33 +26,17 @@ var _ = Describe("[Functional][Outputs][ElasticSearch] FluentdForward Output to 
 		outputLogTemplate = functional.NewApplicationLogTemplate()
 	)
 
-	BeforeEach(func() {
-		outputLogTemplate.ViaqIndexName = "app-write"
-		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(testfw.LogCollectionType)
-		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
-			FromInput(logging.InputNameApplication).
-			ToElasticSearchOutput()
-		Expect(framework.Deploy()).To(BeNil())
-	})
-	AfterEach(func() {
-		framework.Cleanup()
-	})
-
-	Context("when sending to ElasticSearch "+functional.ElasticSearchTag+" protocol", func() {
-		It("should  be compatible", func() {
-			Expect(framework.WritesApplicationLogs(1)).To(BeNil())
-			raw, err := framework.GetLogsFromElasticSearch(logging.OutputTypeElasticsearch, logging.InputNameApplication)
-			Expect(err).To(BeNil(), "Expected no errors reading the logs")
-			Expect(raw).To(Not(BeEmpty()))
-
-			// Parse log line
-			var logs []types.ApplicationLog
-			err = types.StrictlyParseLogsFromSlice(raw, &logs)
-			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
-			// Compare to expected template
-			outputTestLog := logs[0]
-			outputLogTemplate.ViaqIndexName = ""
-			Expect(outputTestLog).To(matchers.FitLogFormatTemplate(outputLogTemplate))
+	Context("and writing log messages", func() {
+		BeforeEach(func() {
+			outputLogTemplate.ViaqIndexName = "app-write"
+			framework = functional.NewCollectorFunctionalFrameworkUsingCollector(testfw.LogCollectionType)
+			functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(logging.InputNameApplication).
+				ToElasticSearchOutput()
+			Expect(framework.Deploy()).To(BeNil())
+		})
+		AfterEach(func() {
+			framework.Cleanup()
 		})
 		It("should work well for valid utf-8 and replace not utf-8", func() {
 			timestamp := functional.CRIOTime(time.Now())
@@ -76,4 +65,41 @@ var _ = Describe("[Functional][Outputs][ElasticSearch] FluentdForward Output to 
 			Expect(logs[1].Message).To(Equal("������������"))
 		})
 	})
+
+	DescribeTable("should be compatible with version", func(version functional.ElasticsearchVersion) {
+		var secret *core.Secret
+		if version > functional.ElasticsearchVersion7 {
+			secret = runtime.NewSecret("", "mysecret", map[string][]byte{
+				constants.ClientUsername: []byte("admin"),
+				constants.ClientPassword: []byte("elasticadmin"),
+			})
+		}
+		outputLogTemplate.ViaqIndexName = "app-write"
+
+		builder := functional.NewCollectorFunctionalFrameworkUsingCollectorBuilder(testfw.LogCollectionType)
+		defer builder.Framework.Cleanup()
+		builder.FromInput(logging.InputNameApplication).
+			ToElasticSearchOutput(version, secret)
+		Expect(builder.Deploy()).To(BeNil())
+
+		framework = builder.Framework
+		Expect(framework.WritesApplicationLogs(1)).To(BeNil())
+		raw, err := framework.ReadLogsFrom(logging.OutputTypeElasticsearch, logging.InputNameApplication)
+		Expect(err).To(BeNil(), "Expected no errors reading the logs")
+		Expect(raw).To(Not(BeEmpty()))
+
+		// Parse log line
+		var logs []types.ApplicationLog
+		err = types.StrictlyParseLogsFromSlice(raw, &logs)
+		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+		// Compare to expected template
+		outputTestLog := logs[0]
+		outputLogTemplate.ViaqIndexName = ""
+		Expect(outputTestLog).To(matchers.FitLogFormatTemplate(outputLogTemplate))
+	},
+		Entry("Elasticsearch v6", functional.ElasticsearchVersion6),
+		Entry("Elasticsearch v7", functional.ElasticsearchVersion7),
+		Entry("Elasticsearch v8", functional.ElasticsearchVersion8),
+	)
+
 })

--- a/test/functional/outputs/kafka/forward_to_kafka_test.go
+++ b/test/functional/outputs/kafka/forward_to_kafka_test.go
@@ -18,12 +18,8 @@ var _ = Describe("[Functional][Outputs][Kafka] Functional tests", func() {
 
 	BeforeEach(func() {
 		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(testfw.LogCollectionType)
-
 		log.V(2).Info("Creating secret for broker credentials")
-		brokersecret := kafka.NewBrokerSecret(framework.Namespace)
-		if err := framework.Test.Client.Create(brokersecret); err != nil {
-			panic(err)
-		}
+		framework.Secrets = append(framework.Secrets, kafka.NewBrokerSecret(framework.Namespace))
 
 	})
 
@@ -31,32 +27,13 @@ var _ = Describe("[Functional][Outputs][Kafka] Functional tests", func() {
 		framework.Cleanup()
 	})
 
-	//What would be other Kafka specific values ?
-	setKafkaSpecValues := func(outspec *logging.OutputSpec) {
-		outspec.Kafka = &logging.Kafka{
-			Topic: kafka.AppLogsTopic,
-		}
-	}
-	join := func(
-		f1 func(spec *logging.OutputSpec),
-		f2 func(spec *logging.OutputSpec)) func(*logging.OutputSpec) {
-		return func(s *logging.OutputSpec) {
-			f1(s)
-			f2(s)
-		}
-	}
-
 	//	timestamp := "2013-03-28T14:36:03.243000+00:00"
 
 	Context("Application Logs", func() {
 		It("should send large message over Kafka", func() {
 			functional.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(logging.InputNameApplication).
-				ToOutputWithVisitor(join(setKafkaSpecValues, func(spec *logging.OutputSpec) {
-					//at this port fluent connects with kafka broker
-					spec.URL = "https://localhost:9093"
-					spec.Secret.Name = "kafka"
-				}), logging.OutputTypeKafka)
+				ToKafkaOutput()
 			Expect(framework.Deploy()).To(BeNil())
 
 			maxLen := 1000


### PR DESCRIPTION
#### Description
This PR:

Adds fluentd support for Elasticsearch 8
Add functionality to functional framework to utilize secrets
Allows fluentd to verify es version on startup which may lead to transient error messages

### Links
* forward port of https://github.com/openshift/cluster-logging-operator/pull/1858
