### PR TITLE
Fix JSON parser of different log types

### DIFF
--- a/internal/generator/vector/pipelines.go
+++ b/internal/generator/vector/pipelines.go
@@ -30,13 +30,11 @@ func Pipelines(spec *logging.ClusterLogForwarderSpec, op generator.Options) []ge
 		}
 		if p.Parse == ParseJson {
 			parse := `
-if .log_type == "application" {
   parsed, err = parse_json(.message)
   if err == null {
     .structured = parsed
     del(.message)
   }
-}
 `
 			vrls = append(vrls, parse)
 		}


### PR DESCRIPTION
### Description

I am running the EventRouter application inside the `openshift-logging` namespace, which has the "**log_type**" set to infrastructure.
By doing so, the JSON parser will ignore any messages coming from the infrastructure log type. This happens because the parser has a hardcoded condition to match only application logs.

#### How to reproduce this problem?

1. At first, make sure the JSON parser is enabled for the infrastructure:

```yaml
# ClusterLogForwarder.. minimized output
pipelines:
  - inputRefs:
    - infrastructure
    labels:
      logSource: ClusterLogForwarder
      logType: infrastructure
    name: infra-pipeline
    outputRefs:
    - etc
    parse: json # enabled <---
  
  - inputRefs:
    - application
    labels:
      logSource: ClusterLogForwarder
      logType: application
    name: app-pipeline
    outputRefs:
    - etc
    parse: json  # enabled <---
```

2. Then deploy the Eventrouter in the `openshift-logging` namespace, according to the documentation:

> You should always deploy the Event Router to the openshift-logging project to ensure it collects events from across the cluster

3. After running the Cluster Logging Operator, the auto-generated `vector.toml` will look like:

```toml
[transforms.infra-pipeline]
type = "remap"
inputs = ["infrastructure"]
source = '''
  .openshift.labels = {"logSource":"ClusterLogForwarder","logType":"infrastructure"}
 
  # <--- THE following condition will NEVER match
  if .log_type == "application" {
    parsed, err = parse_json(.message)
    if err == null {
      .structured = parsed
      del(.message)
    }
  }
'''

[transforms.app-pipeline]
type = "remap"
inputs = ["application"]
source = '''
  .openshift.labels = {"logSource":"ClusterLogForwarder","logType":"application"}

  if .log_type == "application" {
    parsed, err = parse_json(.message)
    if err == null {
      .structured = parsed
      del(.message)
    }
  }
'''
```

#### Code Changes

The easiest fix would be to remove the if condition, since the "transforms" applies only to specific "inputs".

/cc @cahartma
/assign @jcantrill

I am using Vector 5.6.2, but this problem should affect all versions.

/cherry-pick release-5.6

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Support Case: 03458554
