### PR TITLE
LOG-3716:Remove console plugin command from deployment

### DIFF
--- a/internal/visualization/console/reconciler.go
+++ b/internal/visualization/console/reconciler.go
@@ -230,7 +230,6 @@ func (r *Reconciler) mutateDeployment() error {
 								Protocol:      "TCP",
 							},
 						},
-						Command: []string{"./plugin-backend"},
 						Args: []string{
 							"-port", "9443",
 							"-features", strings.Join(r.Config.Features, ","),


### PR DESCRIPTION
### Description
This PR:
- removes the command from the console plugin deployment to rely upon the entrypoint in the image

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3716
- Enhancement proposal:
