### PR TITLE
LOG-3754: Update manifest annotations to hide deprecated fields

### DIFF
--- a/apis/logging/v1/clusterlogging_types.go
+++ b/apis/logging/v1/clusterlogging_types.go
@@ -100,6 +100,7 @@ type VisualizationSpec struct {
 	Type VisualizationType `json:"type"`
 
 	// Specification of the Kibana Visualization component
+	// +deprecated
 	KibanaSpec `json:"kibana,omitempty"`
 }
 
@@ -143,9 +144,11 @@ type LogStoreSpec struct {
 	// managing the LokiStack himself.
 	//
 	// +kubebuilder:validation:Enum=elasticsearch;lokistack
+	// +kubebuilder:default:=lokistack
 	Type LogStoreType `json:"type"`
 
 	// Specification of the Elasticsearch Log Store component
+	// +deprecated
 	Elasticsearch *ElasticsearchSpec `json:"elasticsearch,omitempty"`
 
 	// LokiStack contains information about which LokiStack to use for log storage if Type is set to LogStoreTypeLokiStack.
@@ -153,10 +156,11 @@ type LogStoreSpec struct {
 	// The cluster-logging-operator does not create or manage the referenced LokiStack.
 	LokiStack LokiStackStoreSpec `json:"lokistack,omitempty"`
 
-	// Retention policy defines the maximum age for an index after which it should be deleted
+	// Retention policy defines the maximum age for an Elasticsearch index after which it should be deleted
 	//
 	// +nullable
 	// +optional
+	// +deprecated
 	RetentionPolicy *RetentionPoliciesSpec `json:"retentionPolicy,omitempty"`
 }
 
@@ -232,12 +236,11 @@ type LokiStackStoreSpec struct {
 // This is the struct that will contain information pertinent to Log and event collection
 type CollectionSpec struct {
 
-	// TODO make type required in v2 once Logs is removed. For now assume default which is fluentd
+	// TODO make type required in v2 once Logs is removed. For now assume default which is vector
 
 	// The type of Log Collection to configure
-	// +nullable
-	// +optional
-	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Collector Implementation",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:fluentd","urn:alm:descriptor:com.tectonic.ui:select:vector"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Collector Implementation",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:fluentd","urn:alm:descriptor:com.tectonic.ui:select:vector"}
+	// +kubebuilder:default:=vector
 	Type LogCollectionType `json:"type"`
 
 	// Deprecated. Specification of Log Collection for the cluster
@@ -245,6 +248,7 @@ type CollectionSpec struct {
 	// +nullable
 	// +optional
 	// +deprecated
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Logs *LogCollectionSpec `json:"logs,omitempty"`
 
 	// CollectorSpec is the common specification that applies to any collector

--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -55,7 +55,7 @@ metadata:
           },
           "spec": {
             "collection": {
-              "type": "fluentd"
+              "type": "vector"
             },
             "logStore": {
               "elasticsearch": {
@@ -67,8 +67,7 @@ metadata:
                   }
                 },
                 "storage": {
-                  "size": "200G",
-                  "storageClassName": "gp2"
+                  "size": "200G"
                 }
               },
               "retentionPolicy": {
@@ -217,6 +216,12 @@ spec:
         name: ""
         version: v1
       specDescriptors:
+      - description: Deprecated. Specification of Log Collection for the cluster See
+          spec.collection
+        displayName: Logs
+        path: collection.logs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Define which Nodes the Pods are scheduled on.
         displayName: Collector Node Selector
         path: collection.logs.nodeSelector

--- a/bundle/manifests/logging.openshift.io_clusterloggings.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterloggings.yaml
@@ -322,9 +322,11 @@ spec:
                     nullable: true
                     type: array
                   type:
+                    default: vector
                     description: The type of Log Collection to configure
-                    nullable: true
                     type: string
+                required:
+                - type
                 type: object
               curation:
                 description: Deprecated. Specification of the Curation component for
@@ -687,8 +689,8 @@ spec:
                     - name
                     type: object
                   retentionPolicy:
-                    description: Retention policy defines the maximum age for an index
-                      after which it should be deleted
+                    description: Retention policy defines the maximum age for an Elasticsearch
+                      index after which it should be deleted
                     nullable: true
                     properties:
                       application:
@@ -807,6 +809,7 @@ spec:
                         type: object
                     type: object
                   type:
+                    default: lokistack
                     description: "The Type of Log Storage to configure. The operator
                       currently supports either using ElasticSearch managed by elasticsearch-operator
                       or Loki managed by loki-operator (LokiStack) as a default log

--- a/config/crd/bases/logging.openshift.io_clusterloggings.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterloggings.yaml
@@ -318,9 +318,11 @@ spec:
                     nullable: true
                     type: array
                   type:
+                    default: vector
                     description: The type of Log Collection to configure
-                    nullable: true
                     type: string
+                required:
+                - type
                 type: object
               curation:
                 description: Deprecated. Specification of the Curation component for
@@ -683,8 +685,8 @@ spec:
                     - name
                     type: object
                   retentionPolicy:
-                    description: Retention policy defines the maximum age for an index
-                      after which it should be deleted
+                    description: Retention policy defines the maximum age for an Elasticsearch
+                      index after which it should be deleted
                     nullable: true
                     properties:
                       application:
@@ -803,6 +805,7 @@ spec:
                         type: object
                     type: object
                   type:
+                    default: lokistack
                     description: "The Type of Log Storage to configure. The operator
                       currently supports either using ElasticSearch managed by elasticsearch-operator
                       or Loki managed by loki-operator (LokiStack) as a default log

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -131,6 +131,12 @@ spec:
         name: ""
         version: v1
       specDescriptors:
+      - description: Deprecated. Specification of Log Collection for the cluster See
+          spec.collection
+        displayName: Logs
+        path: collection.logs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Define which Nodes the Pods are scheduled on.
         displayName: Collector Node Selector
         path: collection.logs.nodeSelector

--- a/config/samples/logging_v1_clusterlogging.yaml
+++ b/config/samples/logging_v1_clusterlogging.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-logging
 spec:
   collection:
-    type: fluentd
+    type: vector
   logStore:
     type: elasticsearch
     elasticsearch:
@@ -15,7 +15,6 @@ spec:
           memory: 2Gi
       redundancyPolicy: SingleRedundancy
       storage:
-        storageClassName: gp2
         size: 200G
     retentionPolicy:
       application:


### PR DESCRIPTION
### Description
This PR:
* updates the manifest annotations to hide deprecated fields
* sets vector as the default collector
* removes storage class from the CR sample

### Links
* https://issues.redhat.com/browse/LOG-3754