### PR TITLE
[release-5.4] LOG-3731: add volume mount for /var/log/oauth-server/

### DIFF
--- a/internal/k8shandler/fluentd.go
+++ b/internal/k8shandler/fluentd.go
@@ -36,6 +36,8 @@ const (
 	logOvnValue            = "/var/log/ovn"
 	logOauthapiserver      = "varlogoauthapiserver"
 	logOauthapiserverValue = "/var/log/oauth-apiserver"
+	logOauthserver         = "varlogoauthserver"
+	logOauthserverValue    = "/var/log/oauth-server"
 	logOpenshiftapiserver  = "varlogopenshiftapiserver"
 
 	logJournalTransientValue = "/run/log/journal"
@@ -149,6 +151,7 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *v1.Co
 		{Name: logOvn, ReadOnly: true, MountPath: logOvnValue},
 		{Name: logOauthapiserver, ReadOnly: true, MountPath: logOauthapiserverValue},
 		{Name: logOpenshiftapiserver, ReadOnly: true, MountPath: logOpenshiftapiserverValue},
+		{Name: logOauthserver, ReadOnly: true, MountPath: logOauthserverValue},
 		{Name: logKubeapiserver, ReadOnly: true, MountPath: logKubeapiserverValue},
 		{Name: config, ReadOnly: true, MountPath: configValue},
 		{Name: secureforwardconfig, ReadOnly: true, MountPath: secureforwardconfigValue},
@@ -238,6 +241,7 @@ func newFluentdPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *v1.Co
 			{Name: logAudit, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: logAuditValue}}},
 			{Name: logOvn, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: logOvnValue}}},
 			{Name: logOauthapiserver, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: logOauthapiserverValue}}},
+			{Name: logOauthserver, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: logOauthserverValue}}},
 			{Name: logOpenshiftapiserver, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: logOpenshiftapiserverValue}}},
 			{Name: logKubeapiserver, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: logKubeapiserverValue}}},
 			{Name: config, VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: constants.CollectorName}}}},
@@ -424,7 +428,7 @@ func (clusterRequest *ClusterLoggingRequest) RestartCollector() (err error) {
 	return clusterRequest.UpdateCollectorStatus(collectorType)
 }
 
-//updateEnvar adds the value to the list or replaces it if it already existing
+// updateEnvar adds the value to the list or replaces it if it already existing
 func updateEnvVar(value v1.EnvVar, values []v1.EnvVar) []v1.EnvVar {
 	found := false
 	for i, envvar := range values {

--- a/internal/k8shandler/vector.go
+++ b/internal/k8shandler/vector.go
@@ -2,7 +2,6 @@ package k8shandler
 
 import (
 	"fmt"
-
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
@@ -106,6 +105,7 @@ func newVectorPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *corev1
 		{Name: logAudit, ReadOnly: true, MountPath: logAuditValue},
 		{Name: logOvn, ReadOnly: true, MountPath: logOvnValue},
 		{Name: logOauthapiserver, ReadOnly: true, MountPath: logOauthapiserverValue},
+		{Name: logOauthserver, ReadOnly: true, MountPath: logOauthserverValue},
 		{Name: logOpenshiftapiserver, ReadOnly: true, MountPath: logOpenshiftapiserverValue},
 		{Name: logKubeapiserver, ReadOnly: true, MountPath: logKubeapiserverValue},
 		{Name: config, ReadOnly: true, MountPath: vectorConfigValue},
@@ -184,6 +184,7 @@ func newVectorPodSpec(cluster *logging.ClusterLogging, trustedCABundleCM *corev1
 			{Name: logAudit, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: logAuditValue}}},
 			{Name: logOvn, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: logOvnValue}}},
 			{Name: logOauthapiserver, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: logOauthapiserverValue}}},
+			{Name: logOauthserver, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: logOauthserverValue}}},
 			{Name: logOpenshiftapiserver, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: logOpenshiftapiserverValue}}},
 			{Name: logKubeapiserver, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: logKubeapiserverValue}}},
 			{Name: config, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: constants.CollectorConfigSecretName, Optional: utils.GetBool(true)}}},


### PR DESCRIPTION
### Description

This PR:

- add volume mount for OAuth Server logs (`/var/log/oauth-server/`), this is additional fix for #1865

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3731
- Enhancement proposal:
