### PR TITLE
LOG-3762: replace 'encoding' with 'content_type' parameter according to fluentd http plugin docs

### DIFF
--- a/internal/generator/fluentd/output/http/http.go
+++ b/internal/generator/fluentd/output/http/http.go
@@ -37,7 +37,7 @@ func (h Http) Template() string {
 @type http
 endpoint {{.URI}}
 http_method {{.Method}}
-encoding "application/x-ndjson"
+content_type "application/x-ndjson"
 {{kv  .Headers -}}
 {{compose .SecurityConfig}}
 {{compose .BufferConfig}}

--- a/internal/generator/fluentd/output/http/http_test.go
+++ b/internal/generator/fluentd/output/http/http_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Generate fluentd config", func() {
 	@type http
 	endpoint https://my-logstore.com/logs/app-logs
 	http_method post
-	encoding "application/x-ndjson"
+	content_type "application/x-ndjson"
 	username "#{File.read('/var/run/ocp-collector/secrets/http-receiver/username') rescue nil}"
 	password "#{File.read('/var/run/ocp-collector/secrets/http-receiver/password') rescue nil}"
 	<buffer>
@@ -102,7 +102,7 @@ var _ = Describe("Generate fluentd config", func() {
 	@type http
 	endpoint https://my-logstore.com/logs/app-logs
 	http_method post
-	encoding "application/x-ndjson"
+	content_type "application/x-ndjson"
 	bearer_token_file '/var/run/ocp-collector/secrets/http-receiver/token'
 	<buffer>
 	  @type file
@@ -157,7 +157,7 @@ var _ = Describe("Generate fluentd config", func() {
 	@type http
 	endpoint https://my-logstore.com/logs/app-logs
 	http_method post
-	encoding "application/x-ndjson"
+	content_type "application/x-ndjson"
 	headers {"k1":"v1","k2":"v2"}
 	bearer_token_file '/var/run/ocp-collector/secrets/http-receiver/token'
 	<buffer>
@@ -213,7 +213,7 @@ var _ = Describe("Generate fluentd config", func() {
 	@type http
 	endpoint https://my-logstore.com/logs/app-logs
 	http_method post
-	encoding "application/x-ndjson"
+	content_type "application/x-ndjson"
 	headers {"k1":"v1","k2":"v2"}
 	bearer_token_file '/var/run/ocp-collector/secrets/http-receiver/token'
 	<buffer>
@@ -275,7 +275,7 @@ var _ = Describe("Generate fluentd config", func() {
 	@type http
 	endpoint https://my-logstore.com/logs/app-logs
 	http_method post
-	encoding "application/x-ndjson"
+	content_type "application/x-ndjson"
 	headers {"k1":"v1","k2":"v2"}
 	key '/var/run/ocp-collector/secrets/http-receiver/tls.key'
 	cert '/var/run/ocp-collector/secrets/http-receiver/tls.crt'


### PR DESCRIPTION
### Description
This PR: 
- fix generated an invalid parameter `encoding "application/x-ndjson"` -> `content_type  "application/x-ndjson"`. Refer to https://docs.fluentd.org/output/http
- 
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3762
- Enhancement proposal:
