### PR TITLE
Fix syntax error in gen-olm-artifacts.py

### DIFF
--- a/hack/gen-olm-artifacts.py
+++ b/hack/gen-olm-artifacts.py
@@ -40,7 +40,7 @@ def generateNamespace(namespace):
       "name": namespace,
       "annotations": {
         "openshift.io/node-selector": ""
-      }
+      },
       "labels": {
         "openshift.io/cluster-logging": "true",
         "openshift.io/cluster-monitoring": "true"


### PR DESCRIPTION
Missing semicolon introduced in https://github.com/openshift/cluster-logging-operator/pull/1900

/cc jcantrill
/assign vimalk78