### PR TITLE
[release-5.6] Fix namespace metadata in gen-olm-artifacts.py

### DIFF
--- a/hack/gen-olm-artifacts.py
+++ b/hack/gen-olm-artifacts.py
@@ -40,11 +40,11 @@ def generateNamespace(namespace):
       "name": namespace,
       "annotations": {
         "openshift.io/node-selector": ""
+      },
+      "labels": {
+        "openshift.io/cluster-logging": "true",
+        "openshift.io/cluster-monitoring": "true"
       }
-    },
-    "labels": {
-      "openshift.io/cluster-logging": "true",
-      "openshift.io/cluster-monitoring": "true"
     }
   }
   writeResource(ns)


### PR DESCRIPTION
Manual backport of https://github.com/openshift/cluster-logging-operator/pull/1900

/cc jcantrill
/assign vimalk78