### PR TITLE
LOG-3482: get rid of some senseless messages in log

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -139,6 +139,8 @@ const (
 	EventReasonUpdateObject         = "UpdateObject"
 
 	MigrateDefaultOutput = "default-replaced"
+
+	OptimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}


### PR DESCRIPTION
### Description
This PR get rid some not needed error messages in log: 
- `error deleting grafana configmap` in case config map not found;
- `Operation cannot be fulfilled on $something the object has been modified; please apply your changes to the latest version and try again`, to fix this adds some checking on message in error, more info here https://github.com/kubernetes/kubernetes/issues/28149 
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
