### PR TITLE
LOG-3811: remove collector-config secret on deleting Vector Collector instance

### DIFF
--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -180,6 +180,12 @@ func (clusterRequest *ClusterLoggingRequest) removeCollector(name string) (err e
 			return
 		}
 
+		if logging.LogCollectionTypeVector == clusterRequest.Cluster.Spec.Collection.Type {
+			if err = clusterRequest.RemoveSecret(constants.CollectorConfigSecretName); err != nil {
+				return
+			}
+		}
+
 		if err = clusterRequest.RemoveDaemonset(name); err != nil {
 			return
 		}


### PR DESCRIPTION
### Description
This PR adds ability to remove `collector-config` secret on deleting Vector Collector instance
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3811
- Enhancement proposal:
