### PR TITLE
LOG-3784: value provided in HTTP header 'Content-Type' for Fluentd HTTP plugin is automatically assigned to the 'content_type' parameter

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_http_content_type_headers.go
+++ b/internal/validations/clusterlogforwarder/validate_http_content_type_headers.go
@@ -1,0 +1,34 @@
+package clusterlogforwarder
+
+import (
+	"fmt"
+	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"reflect"
+	"strings"
+)
+
+var validContentTypes = map[string]string{
+	"application/json":     "json",
+	"application/x-ndjson": "ndjson",
+}
+
+// validateHttpContentTypeHeaders will validate Content-Type header in Http Output
+// valid content-type are: "application/json" and "application/x-ndjson"
+// was introduced in https://github.com/openshift/cluster-logging-operator/pull/1924
+// for https://issues.redhat.com/browse/LOG-3784
+func validateHttpContentTypeHeaders(clf v1.ClusterLogForwarder) error {
+	for i, output := range clf.Spec.Outputs {
+		_, output := i, output // Don't bind range variable.
+		if output.Type == v1.OutputTypeHttp && output.Http != nil {
+			if contentType, found := output.Http.Headers["Content-Type"]; found && validContentTypes[strings.ToLower(contentType)] == "" {
+				validKeys := reflect.ValueOf(validContentTypes).MapKeys()
+				log.V(3).Info("validateHttpContentTypeHeaders failed", "reason", "not valid content type set in headers",
+					"content type", contentType, "supported types: ", validKeys)
+				return fmt.Errorf("not valid content type set in headers: %s , supported types: %s",
+					contentType, validKeys)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/validations/clusterlogforwarder/validate_http_content_type_headers_test.go
+++ b/internal/validations/clusterlogforwarder/validate_http_content_type_headers_test.go
@@ -1,0 +1,80 @@
+package clusterlogforwarder
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/apis/logging/v1"
+)
+
+var _ = Describe("[internal][validations] ClusterLogForwarder will validate Content-Type header in Http Output", func() {
+	var (
+		clf  *v1.ClusterLogForwarder
+		http *v1.Http
+	)
+	BeforeEach(func() {
+		http = &v1.Http{}
+		clf = &v1.ClusterLogForwarder{
+			Spec: v1.ClusterLogForwarderSpec{
+				Outputs: []v1.OutputSpec{
+					{
+						Name: "httpOutput",
+						Type: v1.OutputTypeHttp,
+						OutputTypeSpec: v1.OutputTypeSpec{
+							Http: http,
+						},
+					},
+				},
+			},
+		}
+	})
+
+	Context("#validateHttpContentTypeHeaders", func() {
+
+		It("should pass validation with empty headers", func() {
+			Expect(validateHttpContentTypeHeaders(*clf)).To(Succeed())
+		})
+		It("should pass validation when not Content Type header", func() {
+			clf.Spec.Outputs[0].Http.Headers = map[string]string{
+				"Accept": "application/json",
+			}
+			Expect(validateHttpContentTypeHeaders(*clf)).To(Succeed())
+		})
+		It("should pass validation when the Content Type header is application/json", func() {
+			clf.Spec.Outputs[0].Http.Headers = map[string]string{
+				"Content-Type": "application/json",
+			}
+			Expect(validateHttpContentTypeHeaders(*clf)).To(Succeed())
+		})
+		It("should pass validation when the Content Type header is application/x-ndjson", func() {
+			clf.Spec.Outputs[0].Http.Headers = map[string]string{
+				"Content-Type": "application/x-ndjson",
+			}
+			Expect(validateHttpContentTypeHeaders(*clf)).To(Succeed())
+		})
+		It("should fail validation when not valid content types", func() {
+			clf.Spec.Outputs[0].Http.Headers = map[string]string{
+				"Content-Type": "application/x-www-form-urlencoded",
+			}
+			Expect(validateHttpContentTypeHeaders(*clf)).To(Not(Succeed()))
+		})
+		It("should pass validation when not Http Output", func() {
+			notHttpClf := &v1.ClusterLogForwarder{
+				Spec: v1.ClusterLogForwarderSpec{
+					Outputs: []v1.OutputSpec{
+						{
+							Name: "esOutput",
+							Type: v1.OutputTypeElasticsearch,
+							OutputTypeSpec: v1.OutputTypeSpec{
+								Elasticsearch: &v1.Elasticsearch{},
+							},
+						},
+					},
+				},
+			}
+			clf.Spec.Outputs[0].Http.Headers = map[string]string{
+				"Content-Type": "application/x-www-form-urlencoded",
+			}
+			Expect(validateHttpContentTypeHeaders(*notHttpClf)).To(Succeed())
+		})
+	})
+})

--- a/internal/validations/clusterlogforwarder/validations.go
+++ b/internal/validations/clusterlogforwarder/validations.go
@@ -17,4 +17,5 @@ var validations = []func(clf v1.ClusterLogForwarder) error{
 	validateSingleton,
 	validateJsonParsingToElasticsearch,
 	validateUrlAccordingToTls,
+	validateHttpContentTypeHeaders,
 }


### PR DESCRIPTION
### Description

This PR allows users to overcome limitations in CLO API's to provide various content type for logs data output.
For the Fluentd HTTP plugin, users can now assign the content type for log forwarding seamlessly, by configuring the [HTTP header](https://docs.fluentd.org/output/http#headers) "Content-Type," the value provided is automatically assigned to the [`content_type`](https://docs.fluentd.org/output/http#content_type) parameter within the plugin.
For example:
```
apiVersion: logging.openshift.io/v1
kind: ClusterLogForwarder
metadata:
  name: instance
  namespace: openshift-logging
spec:
  outputs:
  - http:
      headers:
        k1: v1
        Content-Type: application/json
      method: POST
    name: my-http-storage
    type: http
    url: https://my-logstore.com/logs/app-logs
  pipelines:
  - inputRefs:
    - application
    name:  to-http
    outputRefs:
    - my-http-storage
```
will be:
```
<match **>
	@type http
	endpoint https://my-logstore.com/logs/app-logs
	http_method post
	content_type application/json
	headers {"Content-Type":"application/json","k1":"v1"}
	.......
  </match>
```
Also adds validation for Content-Type header in Http Output, valid types are: `application/json` and `application/x-ndjson`
other types will be rejected.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3784
- Enhancement proposal:
