### PR TITLE
LOG-3497: Generate vector config for Detect Multiline Exceptions

### DIFF
--- a/docs/features/collection.adoc
+++ b/docs/features/collection.adoc
@@ -69,7 +69,7 @@ logstash 7.10.1|✓|
 |Loglevel||✓|✓
 |https://github.com/openshift/enhancements/blob/196445c9d19b2159c9e8639e4428fa5a4c1b3577/enhancements/cluster-logging/forwarding-json-structured-logs.md[JSON Parsing]||✓|✓
 |Structured Index for Elasticsearch JSON parsing||✓|✓
-|Multiline error detection||✓|
+|Multiline error detection||✓|✓
 |https://github.com/openshift/enhancements/blob/196445c9d19b2159c9e8639e4428fa5a4c1b3577/enhancements/cluster-logging/multi-container-structured-logging.md[Split indices for multi-container pods]||✓|✓
 |https://github.com/openshift/enhancements/blob/196445c9d19b2159c9e8639e4428fa5a4c1b3577/enhancements/cluster-logging/forwarder-tagging.md[Static labels for forwarding pipelines] ||✓|✓
 

--- a/internal/generator/vector/elements/elements.go
+++ b/internal/generator/vector/elements/elements.go
@@ -80,6 +80,27 @@ source = '''
 `
 }
 
+type DetectExceptions struct {
+	ComponentID string
+	Inputs      string
+}
+
+func (d DetectExceptions) Name() string{
+  return "detectExceptions"
+}
+
+func (d DetectExceptions) Template() string{
+  return `{{define "detectExceptions" -}}
+[transforms.{{.ComponentID}}]
+type = "detect_exceptions"
+inputs = {{.Inputs}}
+languages = ["All"]
+group_by = ["kubernetes.namespace_name","kubernetes.pod_name","kubernetes.container_name", "kubernetes.pod_id"]
+expire_after_ms = 2000
+multiline_flush_interval_ms = 1000
+{{end}}`
+}
+
 func Debug(id string, inputs string) generator.Element {
 	return generator.ConfLiteral{
 		Desc:         "Sending records to stdout for debug purposes",


### PR DESCRIPTION
### Description
This PR adds support for generating vector config for detecting and handling multiline exceptions. This requires a new transform for detecting and handling multiline exceptions., which is added in PR https://github.com/ViaQ/vector/pull/132

 - Enabled Multiline Exception functional test for vector
  
/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- JIRA: https://issues.redhat.com/browse/LOG-3497

