### PR TITLE
LOG-3769: fix enablement of console alerts

### DIFF
--- a/internal/visualization/console/feature_map.go
+++ b/internal/visualization/console/feature_map.go
@@ -7,12 +7,13 @@ import (
 
 const (
 	featureDevConsole = "dev-console"
+	featureAlerts     = "alerts"
 )
 
 var (
 
 	// featuresIfUnmatched represents the default features to enable
-	featuresIfUnmatched = []string{featureDevConsole}
+	featuresIfUnmatched = []string{featureAlerts, featureDevConsole}
 )
 
 // FeaturesForOCP will return the list of features to enable for the console plugin given the OCP version
@@ -23,6 +24,9 @@ func FeaturesForOCP(version string) []string {
 
 	if semver.Compare(version, "v4.11") < 0 {
 		return []string{}
+	}
+	if semver.Compare(version, "v4.11") >= 0 && semver.Compare(version, "v4.13") < 0 {
+		return []string{featureDevConsole}
 	}
 	return featuresIfUnmatched
 }

--- a/internal/visualization/console/feature_map_test.go
+++ b/internal/visualization/console/feature_map_test.go
@@ -9,12 +9,15 @@ var _ = Describe("#FeaturesForOCP", func() {
 	It("should return an empty set when there is an empty version ", func() {
 		Expect(FeaturesForOCP("")).To(Equal([]string{}))
 	})
-	It("should return the default set when there is no version match ", func() {
-		Expect(FeaturesForOCP("4.12.0-rc.3")).To(Equal(featuresIfUnmatched))
+	It("should enable the the dev console and alerts when <= 4.13", func() {
+		features := []string{featureAlerts, featureDevConsole}
+		Expect(FeaturesForOCP("4.13.0")).To(Equal(features))
+		Expect(FeaturesForOCP("4.14.0")).To(Equal(features))
 	})
-
-	It("should return the default set when greater than or equal 4.11", func() {
-		Expect(FeaturesForOCP("4.11.12")).To(Equal(featuresIfUnmatched))
+	It("should enable the dev console when <= 4.11 but < 4.13", func() {
+		features := []string{featureDevConsole}
+		Expect(FeaturesForOCP("4.11.12")).To(Equal(features))
+		Expect(FeaturesForOCP("4.12.0-rc.3")).To(Equal(features))
 	})
 
 	It("should not enable the dev console for OCP 4.10", func() {


### PR DESCRIPTION
### Description
This PR:
* fixes the console plugin to enable alerts for OCP v4.13 or greater

### Links
* https://issues.redhat.com/browse/LOG-3769

cc @periklis 