### PR TITLE
LOG-3827: generate tls_private_key_passphrase for fluentd http output plugin

### DIFF
--- a/internal/generator/fluentd/output/http/http.go
+++ b/internal/generator/fluentd/output/http/http.go
@@ -128,6 +128,12 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 			}
 			conf = append(conf, ca)
 		}
+		if security.HasPassphrase(secret) {
+			p := Passphrase{
+				Passphrase: security.GetFromSecret(secret, constants.Passphrase),
+			}
+			conf = append(conf, p)
+		}
 	}
 	return conf
 }

--- a/internal/generator/fluentd/output/http/http_test.go
+++ b/internal/generator/fluentd/output/http/http_test.go
@@ -171,6 +171,7 @@ var _ = Describe("Generate fluentd config", func() {
 						"tls.crt":       []byte("-- crt-- "),
 						"tls.key":       []byte("-- key-- "),
 						"ca-bundle.crt": []byte("-- ca-bundle -- "),
+						"passphrase":    []byte("-- passphrase --"),
 					},
 				},
 			},
@@ -190,6 +191,7 @@ var _ = Describe("Generate fluentd config", func() {
 	tls_private_key_path '/var/run/ocp-collector/secrets/http-receiver/tls.key'
 	tls_client_cert_path '/var/run/ocp-collector/secrets/http-receiver/tls.crt'
 	tls_ca_cert_path '/var/run/ocp-collector/secrets/http-receiver/ca-bundle.crt'
+  tls_client_private_key_passphrase "-- passphrase --" 
 	<buffer>
 	  @type file
 	  path '/var/lib/fluentd/http_receiver'

--- a/internal/generator/fluentd/output/http/passphrase.go
+++ b/internal/generator/fluentd/output/http/passphrase.go
@@ -1,0 +1,16 @@
+package http
+
+type Passphrase struct {
+	Passphrase string
+}
+
+func (p Passphrase) Name() string {
+	return "passphraseTemplate"
+}
+
+func (p Passphrase) Template() string {
+	return `{{define "` + p.Name() + `" -}}
+tls_client_private_key_passphrase "{{.Passphrase}}" 
+{{- end}}
+`
+}


### PR DESCRIPTION
### Description
This PR adds ability to generate `tls_private_key_passphrase`  in the TLS section configuration for fluentd http output plugin.
https://docs.fluentd.org/output/http#tls_private_key_passphrase 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3827
- Enhancement proposal:
