### PR TITLE
LOG-3838: add ability to skip certificates verification for ES output

### DIFF
--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
@@ -136,9 +136,15 @@ func RetryOutput(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o lo
 }
 
 func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
-	// URL is parasable, checked at input sanitization
+	// URL is passable, checked at input sanitization
 	u, _ := url.Parse(o.URL)
-	conf := append([]Element{}, TLS(url.IsTLSScheme(u.Scheme)))
+	isHttps := url.IsTLSScheme(u.Scheme)
+	isSSLVerify := !(o.TLS != nil && o.TLS.InsecureSkipVerify)
+	esTls := EsTLS{
+		security.TLS(isHttps),
+		isSSLVerify,
+	}
+	conf := append([]Element{}, esTls)
 	if o.Secret != nil {
 		if security.HasUsernamePassword(secret) {
 			up := UserNamePass{

--- a/internal/generator/fluentd/output/elasticsearch/tls.go
+++ b/internal/generator/fluentd/output/elasticsearch/tls.go
@@ -1,26 +1,30 @@
 package elasticsearch
 
-import (
-	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
-)
+import "github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
 
-type TLS security.TLS
+type EsTLS struct {
+	security.TLS
+	SSLVerify bool
+}
 
-func (t TLS) Name() string {
+func (t EsTLS) Name() string {
 	return "elasticsearchTLSTemplate"
 }
 
-func (t TLS) Template() string {
+func (t EsTLS) Template() string {
 	https := `{{define "elasticsearchTLSTemplate" -}}
 scheme https
 ssl_version TLSv1_2
+{{- if not .SSLVerify }}
+ssl_verify false
+{{- end }}
 {{- end}}
 `
 	http := `{{define "elasticsearchTLSTemplate" -}}
 scheme http
 {{- end}}
 `
-	if t {
+	if t.TLS {
 		return https
 	}
 	return http


### PR DESCRIPTION
### Description

This PR adds the ability to skip SSL certificate verification for the Elasticsearch output plugin in Fluentd. This feature can be useful in cases where you need to connect to an Elasticsearch cluster with a self-signed SSL certificate or with an invalid certificate due to an expired or mismatched domain.

To enable this feature, need to set option `insecureSkipVerify=true`.
E.g.
```
spec:
  outputs:
  - name: elasticsearch
    tls:
      insecureSkipVerify: true
    type: elasticsearch
    url: https://localhost:9200
```
In `fluentd.conf` file should appear:
`ssl_verify false`
  
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3838
- Enhancement proposal:
