### PR TITLE
LOG-3811: Ensure collector-config secret is deleted with Cluster Logging instance

### DIFF
--- a/internal/collector/config.go
+++ b/internal/collector/config.go
@@ -35,6 +35,7 @@ func (f *Factory) ReconcileCollectorConfig(er record.EventRecorder, k8sClient cl
 			map[string][]byte{
 				"vector.toml": []byte(collectorConfig),
 			})
+		utils.AddOwnerRefToObject(secret, owner)
 		return reconcile.Secret(er, k8sClient, secret)
 	}
 

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -180,12 +180,6 @@ func (clusterRequest *ClusterLoggingRequest) removeCollector(name string) (err e
 			return
 		}
 
-		if logging.LogCollectionTypeVector == clusterRequest.Cluster.Spec.Collection.Type {
-			if err = clusterRequest.RemoveSecret(constants.CollectorConfigSecretName); err != nil {
-				return
-			}
-		}
-
 		if err = clusterRequest.RemoveDaemonset(name); err != nil {
 			return
 		}

--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -272,17 +272,6 @@ var _ = Describe("Reconciling", func() {
 				extras[constants.MigrateDefaultOutput] = true
 				clusterRequest.ForwarderSpec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.ForwarderSpec, clusterRequest.Cluster.Spec.LogStore, extras)
 			})
-
-			It("on removing vector collector should be removed collector-config secret", func() {
-				// Set collector to vector
-				cluster.Spec.Collection.Type = loggingv1.LogCollectionTypeVector
-				Expect(clusterRequest.CreateOrUpdateCollection(extras)).To(Succeed())
-				secretKey := types.NamespacedName{Name: constants.CollectorConfigSecretName, Namespace: cluster.GetNamespace()}
-				secret := &corev1.Secret{}
-				Expect(client.Get(context.TODO(), secretKey, secret)).Should(Succeed())
-				Expect(clusterRequest.removeCollector(constants.CollectorName))
-				Expect(client.Get(context.TODO(), secretKey, secret)).ShouldNot(Succeed())
-			})
 		})
 	})
 })


### PR DESCRIPTION
### Description

In this PR:
- It was discovered that this solution #1922 was not working as intended, as the `collector-config` secret was not being deleted when the `Cluster Logging instance` was deleted, so this changes was reverted 

- added a reference to the `Cluster Logging instance` in the `collector-config` secret. This ensures that when the Cluster Logging instance is deleted, the Kubernetes garbage collector will also delete the `collector-config` secret.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3811
- Enhancement proposal:
