### PR TITLE
LOG-3830: Add common labels to CLF objects 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ generate: $(GEN_TIMESTAMP)
 $(GEN_TIMESTAMP): $(shell find apis -name '*.go')  $(OPERATOR_SDK) $(CONTROLLER_GEN) $(KUSTOMIZE) .target
 	@$(CONTROLLER_GEN) object paths="./apis/..."
 	@$(CONTROLLER_GEN) crd:crdVersions=v1 rbac:roleName=clusterlogging-operator paths="./..." output:crd:artifacts:config=config/crd/bases
-	echo -e "package version\n\nvar Version = \"$(or $(CI_CONTAINER_VERSION),$(LOGGING_VERSION))\"" > version/version.go
+	echo -e "package version\n\nvar Version = \"$(or $(CI_CONTAINER_VERSION),$(VERSION))\"" > version/version.go
 	@$(MAKE) fmt
 	@touch $@
 

--- a/internal/collector/config.go
+++ b/internal/collector/config.go
@@ -25,6 +25,7 @@ func (f *Factory) ReconcileCollectorConfig(er record.EventRecorder, k8sClient cl
 				"run.sh":              fluentd.RunScript,
 				"cleanInValidJson.rb": fluentd.CleanInValidJson,
 			},
+			f.CommonLabelInitializer,
 		)
 		utils.AddOwnerRefToObject(collectorConfigMap, owner)
 		return reconcile.Configmap(k8sClient, k8sClient, collectorConfigMap)
@@ -34,7 +35,9 @@ func (f *Factory) ReconcileCollectorConfig(er record.EventRecorder, k8sClient cl
 			constants.CollectorConfigSecretName,
 			map[string][]byte{
 				"vector.toml": []byte(collectorConfig),
-			})
+			},
+			f.CommonLabelInitializer)
+
 		utils.AddOwnerRefToObject(secret, owner)
 		return reconcile.Secret(er, k8sClient, secret)
 	}

--- a/internal/collector/service.go
+++ b/internal/collector/service.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ReconcileService reconciles the service specifically for the collector that exposes the collector metrics
-func ReconcileService(er record.EventRecorder, k8sClient client.Client, namespace, name string, owner metav1.OwnerReference) error {
+func (f *Factory) ReconcileService(er record.EventRecorder, k8sClient client.Client, namespace, name string, owner metav1.OwnerReference) error {
 	desired := factory.NewService(
 		constants.CollectorName,
 		namespace,
@@ -30,6 +30,7 @@ func ReconcileService(er record.EventRecorder, k8sClient client.Client, namespac
 				Name:       ExporterPortName,
 			},
 		},
+		f.CommonLabelInitializer,
 	)
 
 	desired.Annotations = map[string]string{

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -129,6 +129,8 @@ const (
 	LabelK8sManagedBy = "app.kubernetes.io/managed-by" // The tool being used to manage the operation of an application (string)
 	LabelK8sCreatedBy = "app.kubernetes.io/created-by" // The controller/user who created this resource (string)
 
+	ClusterLogging         = "cluster-logging"
+	ClusterLoggingOperator = "cluster-logging-operator"
 	// Commonly-used label names.
 	LabelApp = "app"
 

--- a/internal/factory/daemonset.go
+++ b/internal/factory/daemonset.go
@@ -1,14 +1,15 @@
 package factory
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // NewDaemonSet stubs an instance of a daemonset
-func NewDaemonSet(daemonsetName, namespace, loggingComponent, component, impl string, podSpec core.PodSpec) *apps.DaemonSet {
+func NewDaemonSet(daemonsetName, namespace, loggingComponent, component, impl string, podSpec core.PodSpec, visitors ...func(o runtime.Object)) *apps.DaemonSet {
 	selectors := map[string]string{
 		"provider":      "openshift",
 		"component":     component,
@@ -21,40 +22,27 @@ func NewDaemonSet(daemonsetName, namespace, loggingComponent, component, impl st
 	for k, v := range selectors {
 		labels[k] = v
 	}
-	return &apps.DaemonSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "DaemonSet",
-			APIVersion: apps.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      daemonsetName,
-			Namespace: namespace,
-			Labels:    labels,
-		},
-		Spec: apps.DaemonSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: selectors,
-			},
-			Template: core.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   daemonsetName,
-					Labels: labels,
-					Annotations: map[string]string{
-						"scheduler.alpha.kubernetes.io/critical-pod": "",
-						"target.workload.openshift.io/management":    `{"effect": "PreferredDuringScheduling"}`,
-					},
-				},
-				Spec: podSpec,
-			},
-			UpdateStrategy: apps.DaemonSetUpdateStrategy{
-				Type: apps.RollingUpdateDaemonSetStrategyType,
-				RollingUpdate: &apps.RollingUpdateDaemonSet{
-					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.String,
-						StrVal: "100%",
-					},
-				},
+
+	annotations := map[string]string{
+		"scheduler.alpha.kubernetes.io/critical-pod": "",
+		"target.workload.openshift.io/management":    `{"effect": "PreferredDuringScheduling"}`,
+	}
+
+	strategy := apps.DaemonSetUpdateStrategy{
+		Type: apps.RollingUpdateDaemonSetStrategyType,
+		RollingUpdate: &apps.RollingUpdateDaemonSet{
+			MaxUnavailable: &intstr.IntOrString{
+				Type:   intstr.String,
+				StrVal: "100%",
 			},
 		},
 	}
+	ds := runtime.NewDaemonSet(namespace, daemonsetName, visitors...)
+	utils.AddLabels(ds, labels) //todo
+	runtime.NewDaemonSetBuilder(ds).WithTemplateAnnotations(annotations).
+		WithTemplateLabels(ds.Labels).
+		WithSelector(selectors).
+		WithUpdateStrategy(strategy).
+		WithPodSpec(podSpec)
+	return ds
 }

--- a/internal/factory/daemonset_test.go
+++ b/internal/factory/daemonset_test.go
@@ -17,9 +17,11 @@ var _ = Describe("#NewDaemonSet", func() {
 			"logging-infra": "thecomponent",
 		}
 		expLabels = map[string]string{
-			"provider":       "openshift",
-			"component":      "thecomponent",
-			"logging-infra":  "thecomponent",
+			"provider":                           "openshift",
+			"component":                          "thecomponent",
+			"logging-infra":                      "thecomponent",
+			"pod-security.kubernetes.io/enforce": "privileged",
+			"security.openshift.io/scc.podSecurityLabelSync": "false",
 			"implementation": "collectorImpl",
 		}
 	)

--- a/internal/factory/service.go
+++ b/internal/factory/service.go
@@ -1,30 +1,17 @@
 package factory
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	core "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NewService stubs an instance of a Service
-func NewService(serviceName string, namespace string, selectorComponent string, servicePorts []core.ServicePort) *core.Service {
-	return &core.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: core.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"logging-infra": "support",
-			},
-		},
-		Spec: core.ServiceSpec{
-			Selector: map[string]string{
-				"component": selectorComponent,
-				"provider":  "openshift",
-			},
-			Ports: servicePorts,
-		},
+func NewService(serviceName string, namespace string, selectorComponent string, servicePorts []core.ServicePort, visitors ...func(o runtime.Object)) *core.Service {
+	service := runtime.NewService(namespace, serviceName, visitors...)
+	selector := map[string]string{
+		"component": selectorComponent,
+		"provider":  "openshift",
 	}
+	runtime.NewServiceBuilder(service).WithSelector(selector).WithServicePort(servicePorts).AddLabel("logging-infra", "support")
+	return service
 }

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -81,7 +81,10 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection(extras map
 			return
 		}
 
-		if err := collector.ReconcileService(clusterRequest.EventRecorder, clusterRequest.Client, cluster.Namespace, constants.CollectorName, utils.AsOwner(cluster)); err != nil {
+		instance := clusterRequest.Cluster
+		factory := collector.New(collectorConfHash, clusterRequest.ClusterID, *instance.Spec.Collection, clusterRequest.OutputSecrets, clusterRequest.ForwarderSpec, instance.Name)
+
+		if err := factory.ReconcileService(clusterRequest.EventRecorder, clusterRequest.Client, cluster.Namespace, constants.CollectorName, utils.AsOwner(cluster)); err != nil {
 			log.Error(err, "collector.ReconcileService")
 			return err
 		}
@@ -94,9 +97,6 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection(extras map
 		if err := collector.ReconcilePrometheusRule(clusterRequest.EventRecorder, clusterRequest.Client, collectorType, cluster.Namespace, constants.CollectorName, utils.AsOwner(cluster)); err != nil {
 			log.V(9).Error(err, "collector.ReconcilePrometheusRule")
 		}
-
-		instance := clusterRequest.Cluster
-		factory := collector.New(collectorConfHash, clusterRequest.ClusterID, *instance.Spec.Collection, clusterRequest.OutputSecrets, clusterRequest.ForwarderSpec)
 
 		if err = factory.ReconcileCollectorConfig(clusterRequest.EventRecorder, clusterRequest.Client, instance.Namespace, constants.CollectorName, collectorConfig, utils.AsOwner(instance)); err != nil {
 			log.Error(err, "collector.ReconcileCollectorConfig")

--- a/internal/runtime/core.go
+++ b/internal/runtime/core.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // NewNamespace returns a corev1.Namespace with name.
@@ -13,12 +14,12 @@ func NewNamespace(name string) *corev1.Namespace {
 }
 
 // NewConfigMap returns a corev1.ConfigMap with namespace, name and data.
-func NewConfigMap(namespace, name string, data map[string]string) *corev1.ConfigMap {
+func NewConfigMap(namespace, name string, data map[string]string, visitors ...func(o runtime.Object)) *corev1.ConfigMap {
 	if data == nil {
 		data = map[string]string{}
 	}
 	cm := &corev1.ConfigMap{Data: data}
-	Initialize(cm, namespace, name)
+	Initialize(cm, namespace, name, visitors...)
 	return cm
 }
 
@@ -30,9 +31,9 @@ func NewPod(namespace, name string, containers ...corev1.Container) *corev1.Pod 
 }
 
 // NewService returns a corev1.Service with namespace and name.
-func NewService(namespace, name string) *corev1.Service {
+func NewService(namespace, name string, visitors ...func(o runtime.Object)) *corev1.Service {
 	svc := &corev1.Service{}
-	Initialize(svc, namespace, name)
+	Initialize(svc, namespace, name, visitors...)
 	return svc
 }
 
@@ -44,18 +45,18 @@ func NewServiceAccount(namespace, name string) *corev1.ServiceAccount {
 }
 
 // NewSecret returns a corev1.Secret with namespace and name.
-func NewSecret(namespace, name string, data map[string][]byte) *corev1.Secret {
+func NewSecret(namespace, name string, data map[string][]byte, visitors ...func(o runtime.Object)) *corev1.Secret {
 	if data == nil {
 		data = map[string][]byte{}
 	}
 	s := &corev1.Secret{Data: data}
-	Initialize(s, namespace, name)
+	Initialize(s, namespace, name, visitors...)
 	return s
 }
 
 // NewDaemonSet returns a daemon set.
-func NewDaemonSet(namespace, name string) *appsv1.DaemonSet {
+func NewDaemonSet(namespace, name string, visitors ...func(o runtime.Object)) *appsv1.DaemonSet {
 	ds := &appsv1.DaemonSet{}
-	Initialize(ds, namespace, name)
+	Initialize(ds, namespace, name, visitors...)
 	return ds
 }

--- a/internal/runtime/daemonset.go
+++ b/internal/runtime/daemonset.go
@@ -1,0 +1,44 @@
+package runtime
+
+import (
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DaemonSetBuilder struct {
+	DaemonSet *apps.DaemonSet
+}
+
+func NewDaemonSetBuilder(ds *apps.DaemonSet) *DaemonSetBuilder {
+	return &DaemonSetBuilder{
+		DaemonSet: ds,
+	}
+}
+
+func (builder *DaemonSetBuilder) WithTemplateAnnotations(annotations map[string]string) *DaemonSetBuilder {
+	builder.DaemonSet.Spec.Template.Annotations = annotations
+	return builder
+}
+
+func (builder *DaemonSetBuilder) WithSelector(selector map[string]string) *DaemonSetBuilder {
+	builder.DaemonSet.Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: selector,
+	}
+	return builder
+}
+
+func (builder *DaemonSetBuilder) WithTemplateLabels(labels map[string]string) *DaemonSetBuilder {
+	builder.DaemonSet.Spec.Template.Labels = labels
+	return builder
+}
+
+func (builder *DaemonSetBuilder) WithUpdateStrategy(updateStrategy apps.DaemonSetUpdateStrategy) *DaemonSetBuilder {
+	builder.DaemonSet.Spec.UpdateStrategy = updateStrategy
+	return builder
+}
+
+func (builder *DaemonSetBuilder) WithPodSpec(podSpec core.PodSpec) *DaemonSetBuilder {
+	builder.DaemonSet.Spec.Template.Spec = podSpec
+	return builder
+}

--- a/internal/runtime/service.go
+++ b/internal/runtime/service.go
@@ -30,6 +30,16 @@ func (builder *ServiceBuilder) AddServicePort(port int32, targetPort int) *Servi
 	return builder
 }
 
+func (builder *ServiceBuilder) AddLabel(key, val string) *ServiceBuilder {
+	builder.Service.Labels[key] = val
+	return builder
+}
+
+func (builder *ServiceBuilder) WithServicePort(servicePorts []corev1.ServicePort) *ServiceBuilder {
+	builder.Service.Spec.Ports = servicePorts
+	return builder
+}
+
 // SvcClusterLocal returns the svc.cluster.local hostname for name and namespace.
 func SvcClusterLocal(namespace, name string) string {
 	return fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -499,3 +499,20 @@ func ToJsonLogs(logs []string) string {
 	}
 	return fmt.Sprintf("[%s]", strings.Join(logs, ","))
 }
+
+func AddLabels(object metav1.Object, labels map[string]string) {
+	existed := object.GetLabels()
+	for key, val := range existed {
+		labels[key] = val
+	}
+	object.SetLabels(labels)
+}
+
+func GetCollectorName(collectorType logging.LogCollectionType) string {
+	if collectorType == logging.LogCollectionTypeFluentd {
+		return constants.FluentdName
+	} else if collectorType == logging.LogCollectionTypeVector {
+		return constants.VectorName
+	}
+	return "unknown"
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "5.8"
+var Version = "5.8.0"


### PR DESCRIPTION
### Description
This PR adds Kubernetes common labels to the deployed objects in our application. These labels will help with grouping and filtering resources in Kubernetes.


<table>
<thead>
<tr>
<th>

```
K8s Object
```

</th>
<th>

```
Name
```

</th>
<th>

```
Before the changes
```

</th>
<th>

```
With this PR
```

</th>
</tr>
</thead>
<tbody>
<tr>
	<td>

```
DaemonSet
```

</td>
	<td>

```
collector
```

</td>
	<td>

```
{
  "component": "collector",
  "logging-infra": "collector",
  "provider": "openshift"
}
```

</td>
<td>

```
{
  "app.kubernetes.io/component": "collector",
  "app.kubernetes.io/instance": "instance",
  "app.kubernetes.io/managed-by": "cluster-logging-operator",
  "app.kubernetes.io/name": "fluentd | vector",
  "app.kubernetes.io/part-of": "cluster-logging",
  "app.kubernetes.io/version": "5.7.0",

  "component": "collector",
  "logging-infra": "collector",
  "provider": "openshift"
}


```

</td>
</tr>
<tr>
	<td>

Pod

</td>
	<td>

```
collector-***
```

</td>
	<td>

```
{
  "component": "collector",
  "controller-revision-hash": "df5c5d69",
  "logging-infra": "collector",
  "pod-template-generation": "2",
  "provider": "openshift"
}
```

</td>
	<td>

```
{
  "app.kubernetes.io/component": "collector",
  "app.kubernetes.io/instance": "instance",
  "app.kubernetes.io/managed-by": "cluster-logging-operator",
  "app.kubernetes.io/name": "fluentd | vector",
  "app.kubernetes.io/part-of": "cluster-logging",
  "app.kubernetes.io/version": "5.7.0",
  "component": "collector",
  "controller-revision-hash": "6b58bcb6c6",
  "logging-infra": "collector",
  "pod-template-generation": "1",
  "provider": "openshift"
}
```

</td>
</tr>
<tr>
<td>

```
Service
```

</td>
	<td>

```
collector
```

</td>
	<td>

```
{
  "logging-infra": "support"
}
```

</td>
	<td>

```
{
  "app.kubernetes.io/component": "support",
  "app.kubernetes.io/instance": "instance",
  "app.kubernetes.io/managed-by": "cluster-logging-operator",
  "app.kubernetes.io/name": "fluentd | vector",
  "app.kubernetes.io/part-of": "cluster-logging",
  "app.kubernetes.io/version": "5.7.0",

  "logging-infra": "support"
}
```

</td>
</tr>
<tr>
	<td>

`Secret`

</td>
	<td>

collector-config (for Vector)

</td>
	<td>

```
{
  "pod-security.kubernetes.io/enforce": "privileged",
  "security.openshift.io/scc.podSecurityLabelSync": "false"
}
```

</td>
	<td>

```
{
  "app.kubernetes.io/component": "collector",
  "app.kubernetes.io/instance": "instance",
  "app.kubernetes.io/managed-by": "cluster-logging-operator",
  "app.kubernetes.io/name": "vector",
  "app.kubernetes.io/part-of": "cluster-logging",
  "app.kubernetes.io/version": "5.7.0",

  "pod-security.kubernetes.io/enforce": "privileged",
  "security.openshift.io/scc.podSecurityLabelSync": "false"
}
```

</td>
</tr>
<tr>
	<td>

```
ConfigMap
```

</td>
	<td>

```
collector (for Fluentd)
```

</td>
	<td>

```
{
  "pod-security.kubernetes.io/enforce": "privileged",
  "security.openshift.io/scc.podSecurityLabelSync": "false"
}
```

</td>
	<td>

```
{
  "app.kubernetes.io/component": "collector",
  "app.kubernetes.io/instance": "instance",
  "app.kubernetes.io/managed-by": "cluster-logging-operator",
  "app.kubernetes.io/name": "fluentd",
  "app.kubernetes.io/part-of": "cluster-logging",
  "app.kubernetes.io/version": "5.7.0",

  "pod-security.kubernetes.io/enforce": "privileged",
  "security.openshift.io/scc.podSecurityLabelSync": "false"
}
```

</td>
</tr>
<tbody>
</table>


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
