### PR TITLE
LOG-3827:Read TLS passphrase from file instead of K8s configmap for fluentd http output plugin

### DIFF
--- a/internal/generator/fluentd/output/http/http.go
+++ b/internal/generator/fluentd/output/http/http.go
@@ -130,7 +130,7 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 		}
 		if security.HasPassphrase(secret) {
 			p := Passphrase{
-				Passphrase: security.GetFromSecret(secret, constants.Passphrase),
+				PassphrasePath: security.SecretPath(o.Secret.Name, constants.Passphrase),
 			}
 			conf = append(conf, p)
 		}

--- a/internal/generator/fluentd/output/http/http_test.go
+++ b/internal/generator/fluentd/output/http/http_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Generate fluentd config", func() {
 	tls_private_key_path '/var/run/ocp-collector/secrets/http-receiver/tls.key'
 	tls_client_cert_path '/var/run/ocp-collector/secrets/http-receiver/tls.crt'
 	tls_ca_cert_path '/var/run/ocp-collector/secrets/http-receiver/ca-bundle.crt'
-  tls_client_private_key_passphrase "-- passphrase --" 
+  tls_private_key_passphrase "#{File.exists?('/var/run/ocp-collector/secrets/http-receiver/passphrase') ? open('/var/run/ocp-collector/secrets/http-receiver/passphrase','r') do |f|f.read end : ''}"
 	<buffer>
 	  @type file
 	  path '/var/lib/fluentd/http_receiver'
@@ -228,7 +228,7 @@ func TestHeaders(t *testing.T) {
 	}
 }
 
-func TestVectorConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Vector Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/http/passphrase.go
+++ b/internal/generator/fluentd/output/http/passphrase.go
@@ -1,8 +1,8 @@
 package http
 
-type Passphrase struct {
-	Passphrase string
-}
+import "github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+
+type Passphrase security.Passphrase
 
 func (p Passphrase) Name() string {
 	return "passphraseTemplate"
@@ -10,7 +10,7 @@ func (p Passphrase) Name() string {
 
 func (p Passphrase) Template() string {
 	return `{{define "` + p.Name() + `" -}}
-tls_client_private_key_passphrase "{{.Passphrase}}" 
+tls_private_key_passphrase "#{File.exists?({{.PassphrasePath}}) ? open({{.PassphrasePath}},'r') do |f|f.read end : ''}" 
 {{- end}}
 `
 }


### PR DESCRIPTION
### Description

This PR fixes the issue with reading the TLS passphrase directly from the K8s configmap, which was causing security concerns. The fix involves reading the passphrase from a file instead of the configmap. 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3827
- Enhancement proposal:
