### PR TITLE
LOG-3935: always enable TLS Security for default loki

### DIFF
--- a/docs/features/tls_security_profile.adoc
+++ b/docs/features/tls_security_profile.adoc
@@ -12,7 +12,7 @@ are applied according to the following order of precedence:
 . Cluster Log Forwarder Spec
 . Cluster-wide Config
 
-IMPORTANT: This is a tech-preview feature for output configurations. It is enabled by the feature gate annotation.
+IMPORTANT: This is a tech-preview feature for output configurations. It is enabled by the feature gate annotation.  The feature gate is ignored for the default log storage of type loki.
 
 .Enable TLS Security Profile feature
 [source]

--- a/internal/generator/vector/elements/elements.go
+++ b/internal/generator/vector/elements/elements.go
@@ -85,12 +85,12 @@ type DetectExceptions struct {
 	Inputs      string
 }
 
-func (d DetectExceptions) Name() string{
-  return "detectExceptions"
+func (d DetectExceptions) Name() string {
+	return "detectExceptions"
 }
 
-func (d DetectExceptions) Template() string{
-  return `{{define "detectExceptions" -}}
+func (d DetectExceptions) Template() string {
+	return `{{define "detectExceptions" -}}
 [transforms.{{.ComponentID}}]
 type = "detect_exceptions"
 inputs = {{.Inputs}}

--- a/internal/generator/vector/outputs.go
+++ b/internal/generator/vector/outputs.go
@@ -45,7 +45,7 @@ func Outputs(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, 
 			}
 		}
 
-		if op.Has(constants.PreviewTLSSecurityProfile) {
+		if op.Has(constants.PreviewTLSSecurityProfile) || o.Name == logging.OutputNameDefault && o.Type == logging.OutputTypeLoki {
 			if o.Name == logging.OutputNameDefault && o.Type == logging.OutputTypeElasticsearch {
 				op[generator.MinTLSVersion] = ""
 				op[generator.Ciphers] = ""

--- a/internal/generator/vector/outputs_test.go
+++ b/internal/generator/vector/outputs_test.go
@@ -1,0 +1,149 @@
+package vector
+
+import (
+	"github.com/openshift/cluster-logging-operator/test/helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Generating outputs", func() {
+	defaultTLS := "VersionTLS12"
+	defaultCiphers := "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
+	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
+		return Outputs(nil, secrets, &clfspec, op)
+	}
+	DescribeTable("using #Outputs", helpers.TestGenerateConfWith(f),
+		Entry("should honor global minTLSVersion & ciphers with loki as the default logstore regardless of the feature gate setting", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Pipelines: []logging.PipelineSpec{
+					{Name: logging.InputNameApplication, OutputRefs: []string{logging.OutputNameDefault}},
+				},
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeLoki,
+						Name: "default",
+						URL:  "https://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application",
+						Secret: &logging.OutputSecretSpec{
+							Name: "custom-loki-secret",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"default": {
+					Data: map[string][]byte{
+						"token": []byte("token-for-custom-loki"),
+					},
+				},
+			},
+			Options: generator.Options{},
+			ExpectedConf: `
+[transforms.default_remap]
+type = "remap"
+inputs = ["application"]
+source = '''
+  del(.tag)
+'''
+
+[transforms.default_dedot]
+type = "lua"
+inputs = ["default_remap"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+    function init()
+        count = 0
+    end
+    function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+		dedot(event.log.kubernetes.namespace_labels)
+        dedot(event.log.kubernetes.labels)
+        emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "[./]", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+'''
+
+[sinks.default]
+type = "loki"
+inputs = ["default_dedot"]
+endpoint = "https://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application"
+out_of_order_action = "accept"
+healthcheck.enabled = false
+[sinks.default.encoding]
+codec = "json"
+[sinks.default.labels]
+kubernetes_container_name = "{{kubernetes.container_name}}"
+kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
+kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
+kubernetes_pod_name = "{{kubernetes.pod_name}}"
+log_type = "{{log_type}}"
+[sinks.default.tls]
+enabled = true
+min_tls_version = "` + defaultTLS + `"
+ciphersuites = "` + defaultCiphers + `"
+key_file = "/var/run/ocp-collector/secrets/custom-loki-secret/tls.key"
+crt_file = "/var/run/ocp-collector/secrets/custom-loki-secret/tls.crt"
+ca_file = "/var/run/ocp-collector/secrets/custom-loki-secret/ca-bundle.crt"
+
+# Bearer Auth Config
+[sinks.default.auth]
+strategy = "bearer"
+token = "token-for-custom-loki"
+
+[transforms.add_nodename_to_metric]
+type = "remap"
+inputs = ["internal_metrics"]
+source = '''
+.tags.hostname = get_env_var!("VECTOR_SELF_NODE_NAME")
+'''
+
+[sinks.prometheus_output]
+type = "prometheus_exporter"
+inputs = ["add_nodename_to_metric"]
+address = "[::]:24231"
+default_namespace = "collector"
+
+[sinks.prometheus_output.tls]
+enabled = true
+key_file = "/etc/collector/metrics/tls.key"
+crt_file = "/etc/collector/metrics/tls.crt"
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
+`,
+		}),
+	)
+})

--- a/internal/generator/vector/sources_to_pipelines_test.go
+++ b/internal/generator/vector/sources_to_pipelines_test.go
@@ -334,9 +334,9 @@ source = '''
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Pipelines: []logging.PipelineSpec{
 					{
-						InputRefs:  []string{logging.InputNameApplication, logging.InputNameInfrastructure},
-						OutputRefs: []string{logging.OutputNameDefault},
-						Name:       "pipeline",
+						InputRefs:             []string{logging.InputNameApplication, logging.InputNameInfrastructure},
+						OutputRefs:            []string{logging.OutputNameDefault},
+						Name:                  "pipeline",
 						DetectMultilineErrors: true,
 					},
 				},


### PR DESCRIPTION
### Description
This PR:
* fixes TLS Security Profile to always be applied to the default loki logstore regardless of the feature gate

### Links
* https://issues.redhat.com/browse/LOG-3935
