### PR TITLE
LOG-3948: [Vector] No error message shown on collector pods when the syslog output url is wrong in CLF

### DIFF
--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -18,7 +18,7 @@ import (
 const (
 	SyslogComponentType = `syslog`
 	TCP                 = `tcp`
-	UDP                 = `udp`
+	TLS                 = `tls`
 	RFC3164             = `rfc3164`
 	RFC5424             = `rfc5424`
 )
@@ -100,9 +100,9 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 }
 
 func Output(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options, urlScheme string, host string) Element {
-	var mode = TCP
-	if urlScheme == UDP {
-		mode = UDP
+	var mode = strings.ToLower(urlScheme)
+	if urlScheme == TLS {
+		mode = TCP
 	}
 	return Syslog{
 		ComponentID: vectorhelpers.FormatComponentID(o.Name),

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -274,6 +274,12 @@ func verifyOutputURL(output *loggingv1.OutputSpec, conds loggingv1.NamedConditio
 	if err := url.CheckAbsolute(u); err != nil {
 		return fail(CondInvalid("invalid URL: %v", err))
 	}
+	if output.Type == loggingv1.OutputTypeSyslog {
+		scheme := strings.ToLower(u.Scheme)
+		if !(scheme == `tcp` || scheme == `tls` || scheme == `udp`) {
+			return fail(CondInvalid("invalid URL scheme: %v", u.Scheme))
+		}
+	}
 	return true
 }
 

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
@@ -1074,24 +1074,60 @@ func Test_verifyOutputURL(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "With syslog",
-			args: args{
-				output: &loggingv1.OutputSpec{
-					Name: "test-output",
-					Type: "syslog",
-					URL:  "https://local.svc",
-				},
-				conds: loggingv1.NamedConditions{},
-			},
-			want: true,
-		},
-		{
 			name: "With syslog without url",
 			args: args{
 				output: &loggingv1.OutputSpec{
 					Name: "test-output",
 					Type: "syslog",
 					URL:  "",
+				},
+				conds: loggingv1.NamedConditions{},
+			},
+			want: false,
+		},
+		{
+			name: "With syslog with tcp",
+			args: args{
+				output: &loggingv1.OutputSpec{
+					Name: "test-output",
+					Type: "syslog",
+					URL:  "tcp://local.svc:514",
+				},
+				conds: loggingv1.NamedConditions{},
+			},
+			want: true,
+		},
+		{
+			name: "With syslog with tls",
+			args: args{
+				output: &loggingv1.OutputSpec{
+					Name: "test-output",
+					Type: "syslog",
+					URL:  "tls://local.svc:514",
+				},
+				conds: loggingv1.NamedConditions{},
+			},
+			want: true,
+		},
+		{
+			name: "With syslog with udp",
+			args: args{
+				output: &loggingv1.OutputSpec{
+					Name: "test-output",
+					Type: "syslog",
+					URL:  "udp://local.svc:514",
+				},
+				conds: loggingv1.NamedConditions{},
+			},
+			want: true,
+		},
+		{
+			name: "With syslog with xyz",
+			args: args{
+				output: &loggingv1.OutputSpec{
+					Name: "test-output",
+					Type: "syslog",
+					URL:  "xyz://local.svc:514",
 				},
 				conds: loggingv1.NamedConditions{},
 			},


### PR DESCRIPTION
### Description
Before this PR, when vector forwarded logs to a syslog endpoint, the scheme of the endpoint URL defaulted to 'tcp' (including 'tls') unless it was 'udp'. No error was produced for an invalid URL scheme.
With this PR, a URL scheme that is not 'tcp', 'tls' or 'udp', results in the status of the corresponding ClusterLogForwarder output set to False with an error message:

```
apiVersion: logging.openshift.io/v1
kind: ClusterLogForwarder
metadata:
  name: instance
  namespace: openshift-logging
spec:
  outputs:
  - name: rsyslog
    syslog:
      facility: local0
      rfc: RFC5424
      severity: informational
    type: syslog
    url: xyz://rsyslogd.syslog.svc.cluster.local:24224
...
status:
  outputs:
    rsyslog:
    - lastTransitionTime: "2023-04-14T21:27:26Z"
      message: 'invalid URL scheme: xyz'
      reason: Invalid
      status: "False"
      type: Ready
```

/cc @cahartma
/assign @jcantrill

### Links
- JIRA: https://issues.redhat.com/browse/LOG-3948
