### PR TITLE
LOG-3932: No log_forwarder_output_info for splunk and google logging

### DIFF
--- a/internal/telemetry/cloteleminfo.go
+++ b/internal/telemetry/cloteleminfo.go
@@ -16,13 +16,15 @@ const (
 	InputNameAudit          = v1.InputNameAudit
 	InputNameInfrastructure = v1.InputNameInfrastructure
 
-	OutputTypeDefault        = "default"
-	OutputTypeElasticsearch  = v1.OutputTypeElasticsearch
-	OutputTypeFluentdForward = v1.OutputTypeFluentdForward
-	OutputTypeSyslog         = v1.OutputTypeSyslog
-	OutputTypeKafka          = v1.OutputTypeKafka
-	OutputTypeLoki           = v1.OutputTypeLoki
-	OutputTypeCloudwatch     = v1.OutputTypeCloudwatch
+	OutputTypeDefault            = "default"
+	OutputTypeElasticsearch      = v1.OutputTypeElasticsearch
+	OutputTypeFluentdForward     = v1.OutputTypeFluentdForward
+	OutputTypeSyslog             = v1.OutputTypeSyslog
+	OutputTypeKafka              = v1.OutputTypeKafka
+	OutputTypeLoki               = v1.OutputTypeLoki
+	OutputTypeCloudwatch         = v1.OutputTypeCloudwatch
+	OutputTypeGoogleCloudLogging = v1.OutputTypeGoogleCloudLogging
+	OutputTypeSplunk             = v1.OutputTypeSplunk
 
 	ManagedStatus = "managedStatus"
 	HealthStatus  = "healthStatus"
@@ -48,7 +50,16 @@ func NewTD() *TData {
 		CollectorErrorCount: utils.Float64Map{M: map[string]float64{"CollectorErrorCount": 0}},
 		CLFInfo:             utils.StringMap{M: map[string]string{HealthStatus: IsNotPresent, PipelineNo: IsNotPresent}},
 		CLFInputType:        utils.StringMap{M: map[string]string{InputNameApplication: IsNotPresent, InputNameAudit: IsNotPresent, InputNameInfrastructure: IsNotPresent}},
-		CLFOutputType:       utils.StringMap{M: map[string]string{OutputTypeDefault: IsNotPresent, OutputTypeElasticsearch: IsNotPresent, OutputTypeFluentdForward: IsNotPresent, OutputTypeSyslog: IsNotPresent, OutputTypeKafka: IsNotPresent, OutputTypeLoki: IsNotPresent, OutputTypeCloudwatch: IsNotPresent}},
+		CLFOutputType: utils.StringMap{M: map[string]string{
+			OutputTypeDefault:            IsNotPresent,
+			OutputTypeElasticsearch:      IsNotPresent,
+			OutputTypeFluentdForward:     IsNotPresent,
+			OutputTypeSyslog:             IsNotPresent,
+			OutputTypeKafka:              IsNotPresent,
+			OutputTypeLoki:               IsNotPresent,
+			OutputTypeCloudwatch:         IsNotPresent,
+			OutputTypeSplunk:             IsNotPresent,
+			OutputTypeGoogleCloudLogging: IsNotPresent}},
 	}
 }
 
@@ -80,7 +91,15 @@ var (
 	mCLFOutputType = NewInfoVec(
 		"log_forwarder_output_info",
 		"Clf output type specific metric",
-		[]string{OutputTypeDefault, OutputTypeElasticsearch, OutputTypeFluentdForward, OutputTypeSyslog, OutputTypeKafka, OutputTypeLoki, OutputTypeCloudwatch},
+		[]string{OutputTypeDefault,
+			OutputTypeElasticsearch,
+			OutputTypeFluentdForward,
+			OutputTypeSyslog,
+			OutputTypeKafka,
+			OutputTypeLoki,
+			OutputTypeCloudwatch,
+			OutputTypeSplunk,
+			OutputTypeGoogleCloudLogging},
 	)
 
 	MetricCLList = []prometheus.Collector{
@@ -136,13 +155,15 @@ func SetCLFMetrics(value float64) {
 		InputNameInfrastructure: CLFInputType[InputNameInfrastructure]}).Set(value)
 
 	mCLFOutputType.With(prometheus.Labels{
-		OutputTypeDefault:        CLFOutputType[OutputTypeDefault],
-		OutputTypeElasticsearch:  CLFOutputType[OutputTypeElasticsearch],
-		OutputTypeFluentdForward: CLFOutputType[OutputTypeFluentdForward],
-		OutputTypeSyslog:         CLFOutputType[OutputTypeSyslog],
-		OutputTypeKafka:          CLFOutputType[OutputTypeKafka],
-		OutputTypeLoki:           CLFOutputType[OutputTypeLoki],
-		OutputTypeCloudwatch:     CLFOutputType[OutputTypeCloudwatch]}).Set(value)
+		OutputTypeDefault:            CLFOutputType[OutputTypeDefault],
+		OutputTypeElasticsearch:      CLFOutputType[OutputTypeElasticsearch],
+		OutputTypeFluentdForward:     CLFOutputType[OutputTypeFluentdForward],
+		OutputTypeSyslog:             CLFOutputType[OutputTypeSyslog],
+		OutputTypeKafka:              CLFOutputType[OutputTypeKafka],
+		OutputTypeLoki:               CLFOutputType[OutputTypeLoki],
+		OutputTypeCloudwatch:         CLFOutputType[OutputTypeCloudwatch],
+		OutputTypeSplunk:             CLFOutputType[OutputTypeSplunk],
+		OutputTypeGoogleCloudLogging: CLFOutputType[OutputTypeGoogleCloudLogging]}).Set(value)
 }
 
 func NewInfoVec(metricname string, metrichelp string, labelNames []string) *prometheus.GaugeVec {


### PR DESCRIPTION
### Description
This PR addresses the issue that the `prometheus` metrics output for the metric `log_forwarder_output_info` did not include the outputs of `splunk` and `google cloud logging`. With this change, the outputs are present in the metrics.

/cc @cahartma @syedriko 
/assign @jcantrill 

/cherry-pick release-5.7

### Links
- JIRA: https://issues.redhat.com/browse/LOG-3932

