### PR TITLE
LOG-3314: add Passphrase Settings and SCRAM Mechanism for SSL to Kafka Fluentd Plugin

### DIFF
--- a/internal/generator/fluentd/output/kafka/kafka.go
+++ b/internal/generator/fluentd/output/kafka/kafka.go
@@ -165,7 +165,16 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 		}
 		// Try the preferred and deprecated names.
 		_, ok := security.TryKeys(secret, constants.SASLEnable, constants.DeprecatedSaslOverSSL)
-		conf = append(conf, SaslOverSSL(ok))
+		sasl := SASL{
+			SaslOverSSL: ok,
+		}
+		if security.HasPassphrase(secret) {
+			sasl.SaslKeyPassword = security.SecretPath(o.Secret.Name, constants.Passphrase)
+		}
+		if scramMechanism := security.GetFromSecret(secret, constants.SASLMechanisms); scramMechanism != "" {
+			sasl.ScramMechanism = scramMechanism
+		}
+		conf = append(conf, sasl)
 	}
 	return conf
 }

--- a/internal/generator/fluentd/output/kafka/kafka_test.go
+++ b/internal/generator/fluentd/output/kafka/kafka_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/test/helpers"
@@ -217,10 +218,158 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
+		Entry("with username,password, sasl_over_ssl and passphrase (ssl_client_cert_key_password in kafka plugin conf) ", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeKafka,
+						Name: "kafka-receiver",
+						URL:  "tls://broker1-kafka.svc.messaging.cluster.local:9092/topic",
+						Secret: &logging.OutputSecretSpec{
+							Name: "kafka-receiver-1",
+						},
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Kafka: &logging.Kafka{
+								Topic: "build_complete",
+							},
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"kafka-receiver": {
+					Data: map[string][]byte{
+						"username":      []byte("junk"),
+						"password":      []byte("junk"),
+						"passphrase":    []byte("-- passphrase --"),
+						"sasl_over_ssl": []byte("true"),
+					},
+				},
+			},
+			ExpectedConf: `
+<label @KAFKA_RECEIVER>
+  #dedot namespace_labels and rebuild message field if present
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_, _dummy3_
+  </filter>
+
+  <match **>
+    @type kafka2
+    @id kafka_receiver
+    brokers broker1-kafka.svc.messaging.cluster.local:9092
+    default_topic build_complete
+    use_event_time true
+    username "#{File.exists?('/var/run/ocp-collector/secrets/kafka-receiver-1/username') ? open('/var/run/ocp-collector/secrets/kafka-receiver-1/username','r') do |f|f.read end : ''}"
+    password "#{File.exists?('/var/run/ocp-collector/secrets/kafka-receiver-1/password') ? open('/var/run/ocp-collector/secrets/kafka-receiver-1/password','r') do |f|f.read end : ''}"
+    sasl_over_ssl true
+    ssl_client_cert_key_password "#{File.exists?('/var/run/ocp-collector/secrets/kafka-receiver-1/passphrase') ? open('/var/run/ocp-collector/secrets/kafka-receiver-1/passphrase','r') do |f|f.read end : ''}"
+    <format>
+      @type json
+    </format>
+    <buffer build_complete>
+      @type file
+      path '/var/lib/fluentd/kafka_receiver'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+</label>
+`,
+		}),
+		Entry("with username,password, sasl_over_ssl and sasl.mechanisms (scram_mechanism in kafka plugin conf)", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeKafka,
+						Name: "kafka-receiver",
+						URL:  "tls://broker1-kafka.svc.messaging.cluster.local:9092/topic",
+						Secret: &logging.OutputSecretSpec{
+							Name: "kafka-receiver-1",
+						},
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Kafka: &logging.Kafka{
+								Topic: "build_complete",
+							},
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"kafka-receiver": {
+					Data: map[string][]byte{
+						"username":               []byte("junk"),
+						"password":               []byte("junk"),
+						constants.SASLMechanisms: []byte("PLAIN"),
+						"sasl_over_ssl":          []byte("true"),
+					},
+				},
+			},
+			ExpectedConf: `
+<label @KAFKA_RECEIVER>
+  #dedot namespace_labels and rebuild message field if present
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_, _dummy3_
+  </filter>
+
+  <match **>
+    @type kafka2
+    @id kafka_receiver
+    brokers broker1-kafka.svc.messaging.cluster.local:9092
+    default_topic build_complete
+    use_event_time true
+    username "#{File.exists?('/var/run/ocp-collector/secrets/kafka-receiver-1/username') ? open('/var/run/ocp-collector/secrets/kafka-receiver-1/username','r') do |f|f.read end : ''}"
+    password "#{File.exists?('/var/run/ocp-collector/secrets/kafka-receiver-1/password') ? open('/var/run/ocp-collector/secrets/kafka-receiver-1/password','r') do |f|f.read end : ''}"
+    sasl_over_ssl true
+    scram_mechanism "PLAIN"
+    <format>
+      @type json
+    </format>
+    <buffer build_complete>
+      @type file
+      path '/var/lib/fluentd/kafka_receiver'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+</label>
+`,
+		}),
 	)
 })
 
 func TestFluendConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/kafka/sasl.go
+++ b/internal/generator/fluentd/output/kafka/sasl.go
@@ -1,16 +1,30 @@
 package kafka
 
-import "fmt"
+import (
+	"fmt"
+)
 
-type SaslOverSSL bool
+type SASL struct {
+	Desc            string
+	SaslOverSSL     bool
+	SaslKeyPassword string
+	ScramMechanism  string
+}
 
-func (s SaslOverSSL) Name() string {
+func (s SASL) Name() string {
 	return "kafkaSaslOverSSLTemplate"
 }
 
-func (s SaslOverSSL) Template() string {
-	return fmt.Sprintf(`{{define "kafkaSaslOverSSLTemplate" -}}
+func (s SASL) Template() string {
+	conf := fmt.Sprintf(`{{define "kafkaSaslOverSSLTemplate" -}} 
 sasl_over_ssl %t
-{{- end}}
-`, s)
+`, s.SaslOverSSL)
+	if s.SaslKeyPassword != "" {
+		conf += `ssl_client_cert_key_password "#{File.exists?({{.SaslKeyPassword}}) ? open({{.SaslKeyPassword}},'r') do |f|f.read end : ''}"`
+	}
+	if s.ScramMechanism != "" {
+		conf += fmt.Sprintf(`scram_mechanism "%s"`, s.ScramMechanism)
+	}
+	conf += `{{- end}}`
+	return conf
 }

--- a/internal/generator/vector/output/kafka/sasl.go
+++ b/internal/generator/vector/output/kafka/sasl.go
@@ -2,7 +2,7 @@ package kafka
 
 const (
 	SASLMechanismPlain = "PLAIN"
-	SASLMechamisnSSL   = "SCRAM-SHA-256"
+	SASLMechanismSSL   = "SCRAM-SHA-256"
 )
 
 type SASL struct {


### PR DESCRIPTION
### Description
This PR:
 - fix the ability to enable passphrase settings for Kafka Fluentd Plugin
 - add the ability to set the SCRAM mechanism for SSL for Kafka Fluentd Plugin
 - a few typos in the codebase.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3314
- Enhancement proposal:
