### PR TITLE
LOG-3985: make spec.visualization.kibana.replicas optional on Kibana spec type

### DIFF
--- a/apis/logging/v1/clusterlogging_types.go
+++ b/apis/logging/v1/clusterlogging_types.go
@@ -131,8 +131,9 @@ type KibanaSpec struct {
 	Tolerations  []v1.Toleration   `json:"tolerations,omitempty"`
 
 	// Number of instances to deploy for a Kibana deployment
+	// +optional
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Kibana Size",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}
-	Replicas *int32 `json:"replicas"`
+	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Specification of the Kibana Proxy component
 	ProxySpec `json:"proxy,omitempty"`

--- a/bundle/manifests/logging.openshift.io_clusterloggings.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterloggings.yaml
@@ -951,8 +951,6 @@ spec:
                               type: string
                           type: object
                         type: array
-                    required:
-                    - replicas
                     type: object
                   ocpConsole:
                     description: OCPConsole is the specification for the OCP console

--- a/config/crd/bases/logging.openshift.io_clusterloggings.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterloggings.yaml
@@ -947,8 +947,6 @@ spec:
                               type: string
                           type: object
                         type: array
-                    required:
-                    - replicas
                     type: object
                   ocpConsole:
                     description: OCPConsole is the specification for the OCP console


### PR DESCRIPTION
### Description

Currently, the `spec.visualization.kibana.replicas` field in the Kibana spec is mandatory, which means that if Kibana is not available, it can cause errors. 
With this PR,  `spec.visualization.kibana.replicas` field can be set to null or omit it entirely when Kibana is not needed. This will prevent the Kubernetes API server from raising errors when trying to validate the Kibana spec.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com//browse/LOG-3985
- Enhancement proposal:
