### PR TITLE
LOG-3935: fix how TLSProfile evaluates default loki names

### DIFF
--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -197,11 +197,13 @@ func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element 
 
 	} else if secret != nil {
 		// Set CA from logcollector ServiceAccount for internal Loki
+		tlsConf := security.TLSConf{
+			ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
+			CAFilePath:  `"/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"`,
+		}
+		tlsConf.SetTLSProfileFromOptions(op)
 		return []Element{
-			security.TLSConf{
-				ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
-				CAFilePath:  `"/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"`,
-			},
+			tlsConf,
 		}
 	}
 	return []Element{}

--- a/internal/generator/vector/output/security/security.go
+++ b/internal/generator/vector/output/security/security.go
@@ -50,13 +50,17 @@ func NewTLSConf(o logging.OutputSpec, op generator.Options) TLSConf {
 		ComponentID:        helpers.FormatComponentID(o.Name),
 		InsecureSkipVerify: o.TLS != nil && o.TLS.InsecureSkipVerify,
 	}
+	conf.SetTLSProfileFromOptions(op)
+	return conf
+}
+
+func (conf *TLSConf) SetTLSProfileFromOptions(op generator.Options) {
 	if version, found := op[generator.MinTLSVersion]; found {
 		conf.TlsMinVersion = version.(string)
 	}
 	if ciphers, found := op[generator.Ciphers]; found {
 		conf.CipherSuites = ciphers.(string)
 	}
-	return conf
 }
 
 func addTLSSettings(o logging.OutputSpec, secret *corev1.Secret, conf *TLSConf) bool {

--- a/internal/generator/vector/outputs.go
+++ b/internal/generator/vector/outputs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/loki"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/splunk"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/syslog"
+	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -45,7 +46,7 @@ func Outputs(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, 
 			}
 		}
 
-		if op.Has(constants.PreviewTLSSecurityProfile) || o.Name == logging.OutputNameDefault && o.Type == logging.OutputTypeLoki {
+		if op.Has(constants.PreviewTLSSecurityProfile) || lokistack.DefaultLokiOuputNames.Has(o.Name) {
 			if o.Name == logging.OutputNameDefault && o.Type == logging.OutputTypeElasticsearch {
 				op[generator.MinTLSVersion] = ""
 				op[generator.Ciphers] = ""


### PR DESCRIPTION
### Description
This PR:
* fixes applying a TLSProfile to the default loki store by properly evaluating the output names we create

### Links
* https://issues.redhat.com/browse/LOG-3935
