### PR TITLE
LOG-4012: use TSL profile for fluent to loki

### DIFF
--- a/internal/generator/fluentd/helpers/tls.go
+++ b/internal/generator/fluentd/helpers/tls.go
@@ -1,0 +1,23 @@
+package helpers
+
+import (
+	"strings"
+)
+
+func TLSMinVersion(tlsProfileSpecVersion string) string {
+	switch tlsProfileSpecVersion {
+	case "VersionTLS10":
+		return "TLS1_1" // no TLS1_0 in fluentd conf
+	case "VersionTLS11":
+		return "TLS1_1"
+	case "VersionTLS12":
+		return "TLS1_2"
+	case "VersionTLS13":
+		return "TLS1_3"
+	}
+	return ""
+}
+
+func TLSCiphers(ciphers []string) string {
+	return strings.Join(ciphers, ":")
+}

--- a/internal/generator/fluentd/output/loki/loki_conf_test.go
+++ b/internal/generator/fluentd/output/loki/loki_conf_test.go
@@ -31,6 +31,7 @@ var _ = Describe("outputLabelConf", func() {
 			})
 		})
 		Context("are spec'd", func() {
+
 			It("should use the ones provided and add the required ones", func() {
 				loki.LabelKeys = []string{"foo"}
 				exp := append(loki.LabelKeys, requiredLabelKeys...)
@@ -39,18 +40,121 @@ var _ = Describe("outputLabelConf", func() {
 		})
 
 	})
+	Context("#setTLSProfileFromOptions", func() {
+		var (
+			op           generator.Options
+			lokiTemplate Loki
+		)
+		BeforeEach(func() {
+			lokiTemplate = Loki{}
+			op = generator.Options{}
+		})
+		It("should set the ciphers", func() {
+			ciphers := "abc,123"
+			op[generator.Ciphers] = ciphers
+			lokiTemplate.setTLSProfileFromOptions(op)
+			Expect(lokiTemplate.CipherSuites).To(Equal(ciphers))
+		})
+		DescribeTable("should convert the TLS min_version", func(version, exp string) {
+			op[generator.MinTLSVersion] = version
+			lokiTemplate.setTLSProfileFromOptions(op)
+			Expect(lokiTemplate.TLSMinVersion).To(Equal(exp))
+		},
+			Entry(" for VersionTLS10 it should upgrade to 1.1", "VersionTLS10", "TLS1_1"),
+			Entry(" for VersionTLS11", "VersionTLS11", "TLS1_1"),
+			Entry(" for VersionTLS12", "VersionTLS12", "TLS1_2"),
+			Entry(" for VersionTLS13", "VersionTLS13", "TLS1_3"),
+		)
+	})
 })
 
-var _ = Describe("Generate fluentd config", func() {
+var _ = Describe("[internal][generator][fluentd][output][loki] #Conf", func() {
+	defaultTLS := "VersionTLS12"
+	defaultCiphers := "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
 	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
 		var bufspec *logging.FluentdBufferSpec = nil
 		if clspec.Fluentd != nil &&
 			clspec.Fluentd.Buffer != nil {
 			bufspec = clspec.Fluentd.Buffer
 		}
-		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], generator.NoOptions)
+		return Conf(bufspec, secrets[clfspec.Outputs[0].Name], clfspec.Outputs[0], op)
 	}
 	DescribeTable("for Loki output", helpers.TestGenerateConfWith(f),
+		Entry("with TLS Profile", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeLoki,
+						Name: "loki-receiver",
+						URL:  "https://logs-us-west1.grafana.net",
+						Secret: &logging.OutputSecretSpec{
+							Name: "es-1",
+						},
+					},
+				},
+			},
+			Options: generator.Options{
+				generator.MinTLSVersion: defaultTLS,
+				generator.Ciphers:       defaultCiphers,
+			},
+			ExpectedConf: `
+<label @LOKI_RECEIVER>
+  #dedot namespace_labels and rebuild message field if present
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_, _dummy3_
+  </filter>
+  
+  <filter **>
+    @type record_modifier
+    <record>
+      _kubernetes_container_name ${record.dig("kubernetes","container_name")}
+      _kubernetes_host "#{ENV['NODE_NAME']}"
+      _kubernetes_namespace_name ${record.dig("kubernetes","namespace_name")}
+      _kubernetes_pod_name ${record.dig("kubernetes","pod_name")}
+      _log_type ${record.dig("log_type")}
+    </record>
+  </filter>
+  
+  <match **>
+    @type loki
+    @id loki_receiver
+    line_format json
+    url https://logs-us-west1.grafana.net
+    min_version TLS1_2
+	ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+    <label>
+      kubernetes_container_name _kubernetes_container_name
+      kubernetes_host _kubernetes_host
+      kubernetes_namespace_name _kubernetes_namespace_name
+      kubernetes_pod_name _kubernetes_pod_name
+      log_type _log_type
+    </label>
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/loki_receiver'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+</label>
+`,
+		}),
 		Entry("with default labels", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{

--- a/internal/generator/fluentd/outputs.go
+++ b/internal/generator/fluentd/outputs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/kafka"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/loki"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/syslog"
+	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -39,7 +40,11 @@ func Outputs(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, 
 				log.V(9).Info("No Secret found in " + constants.LogCollectorToken)
 			}
 		}
-
+		if lokistack.DefaultLokiOuputNames.Has(o.Name) {
+			outMinTlsVersion, outCiphers := op.TLSProfileInfo(clfspec.TLSSecurityProfile, o, ":")
+			op[MinTLSVersion] = outMinTlsVersion
+			op[Ciphers] = outCiphers
+		}
 		switch o.Type {
 		case logging.OutputTypeElasticsearch:
 			if _, ok := op[elements.CharEncoding]; !ok {

--- a/internal/generator/fluentd/outputs_test.go
+++ b/internal/generator/fluentd/outputs_test.go
@@ -1,0 +1,103 @@
+package fluentd
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("[internal][generator][fluentd] Generating outputs", func() {
+	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
+		return Outputs(nil, secrets, &clfspec, op)
+	}
+	DescribeTable("using #Outputs", helpers.TestGenerateConfWith(f),
+		Entry("should honor global minTLSVersion & ciphers with loki as the default logstore regardless of the feature gate setting", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Pipelines: []logging.PipelineSpec{
+					{Name: logging.InputNameApplication, OutputRefs: []string{lokistack.FormatOutputNameFromInput(logging.InputNameApplication)}},
+				},
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeLoki,
+						Name: lokistack.FormatOutputNameFromInput(logging.InputNameApplication),
+						URL:  "https://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application",
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				constants.LogCollectorToken: {
+					Data: map[string][]byte{
+						"token": []byte("token-for-loki"),
+					},
+				},
+			},
+			Options: generator.Options{},
+			ExpectedConf: `
+    # Ship logs to specific outputs
+    <label @DEFAULT_LOKI_APPS>
+      #dedot namespace_labels and rebuild message field if present
+      <filter **>
+        @type record_modifier
+        <record>
+          _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+          _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+          _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+        </record>
+        remove_keys _dummy_, _dummy2_, _dummy3_
+      </filter>
+      
+      <filter **>
+        @type record_modifier
+        <record>
+          _kubernetes_container_name ${record.dig("kubernetes","container_name")}
+          _kubernetes_host "#{ENV['NODE_NAME']}"
+          _kubernetes_namespace_name ${record.dig("kubernetes","namespace_name")}
+          _kubernetes_pod_name ${record.dig("kubernetes","pod_name")}
+          _log_type ${record.dig("log_type")}
+        </record>
+      </filter>
+      
+      <match **>
+        @type loki
+        @id default_loki_apps
+        line_format json
+        url https://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application
+        min_version TLS1_2
+        ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+        ca_cert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        bearer_token_file /var/run/secrets/kubernetes.io/serviceaccount/token
+        <label>
+          kubernetes_container_name _kubernetes_container_name
+          kubernetes_host _kubernetes_host
+          kubernetes_namespace_name _kubernetes_namespace_name
+          kubernetes_pod_name _kubernetes_pod_name
+          log_type _log_type
+        </label>
+        <buffer>
+          @type file
+          path '/var/lib/fluentd/default_loki_apps'
+          flush_mode interval
+          flush_interval 1s
+          flush_thread_count 2
+          retry_type exponential_backoff
+          retry_wait 1s
+          retry_max_interval 60s
+          retry_timeout 60m
+          queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+          total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+          chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+          overflow_action block
+          disable_chunk_backup true
+        </buffer>
+      </match>
+    </label>
+`,
+		}),
+	)
+})

--- a/internal/generator/fluentd/sources.go
+++ b/internal/generator/fluentd/sources.go
@@ -2,6 +2,7 @@ package fluentd
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/helpers"
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -25,22 +26,10 @@ func Sources(clspec *logging.CollectionSpec, spec *logging.ClusterLogForwarderSp
 
 func MetricSources(spec *logging.ClusterLogForwarderSpec, o generator.Options) []generator.Element {
 	tlsProfileSpec := o[generator.ClusterTLSProfileSpec].(configv1.TLSProfileSpec)
-	var minTlsVersion string
-	switch tls.MinTLSVersion(tlsProfileSpec) {
-	case "VersionTLS10":
-		minTlsVersion = "TLS1_1" // no TLS1_0 in fluentd conf
-	case "VersionTLS11":
-		minTlsVersion = "TLS1_1"
-	case "VersionTLS12":
-		minTlsVersion = "TLS1_2"
-	case "VersionTLS13":
-		minTlsVersion = "TLS1_3"
-	}
-	cipherSuites := strings.Join(tls.TLSCiphers(tlsProfileSpec), ":")
 	return []generator.Element{
 		PrometheusMonitor{
-			TlsMinVersion: minTlsVersion,
-			CipherSuites:  cipherSuites,
+			TlsMinVersion: helpers.TLSMinVersion(tls.MinTLSVersion(tlsProfileSpec)),
+			CipherSuites:  helpers.TLSCiphers(tls.TLSCiphers(tlsProfileSpec)),
 		},
 	}
 }

--- a/internal/generator/tls.go
+++ b/internal/generator/tls.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TLSProfileInfo returns the minTLSVersion, ciphers as a comma-separated list given the available TLSSecurityProfile
-func (op Options) TLSProfileInfo(clfProfile *configv1.TLSSecurityProfile, outputSpec logging.OutputSpec) (string, string) {
+func (op Options) TLSProfileInfo(clfProfile *configv1.TLSSecurityProfile, outputSpec logging.OutputSpec, separator string) (string, string) {
 	var tlsProfileSpec configv1.TLSProfileSpec
 	if outputSpec.TLS != nil && outputSpec.TLS.TLSSecurityProfile != nil {
 		tlsProfileSpec = tls.GetClusterTLSProfileSpec(outputSpec.TLS.TLSSecurityProfile)
@@ -20,6 +20,6 @@ func (op Options) TLSProfileInfo(clfProfile *configv1.TLSSecurityProfile, output
 	}
 
 	minTlsVersion := tls.MinTLSVersion(tlsProfileSpec)
-	cipherSuites := strings.Join(tls.TLSCiphers(tlsProfileSpec), ",")
+	cipherSuites := strings.Join(tls.TLSCiphers(tlsProfileSpec), separator)
 	return minTlsVersion, cipherSuites
 }

--- a/internal/generator/tls_test.go
+++ b/internal/generator/tls_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Options#TLSProfileInfo", func() {
 	Context("when a cluster profile is absent", func() {
 
 		It("should use the defaults when clf profile is nil and output.TLS is nil", func() {
-			minTLS, ciphers := options.TLSProfileInfo(nil, logging.OutputSpec{})
+			minTLS, ciphers := options.TLSProfileInfo(nil, logging.OutputSpec{}, ",")
 			Expect(minTLS).To(BeEquivalentTo(tls.DefaultMinTLSVersion))
 			Expect(ciphers).To(Equal(strings.Join(tls.DefaultTLSCiphers, ",")))
 		})
@@ -60,25 +60,25 @@ var _ = Describe("Options#TLSProfileInfo", func() {
 		})
 
 		It("should prefer the output profile over the cluster profile", func() {
-			minTLS, ciphers := options.TLSProfileInfo(nil, outputSpec)
+			minTLS, ciphers := options.TLSProfileInfo(nil, outputSpec, ",")
 			spec := configv1.TLSProfiles[outputProfile.Type]
 			Expect(minTLS).To(BeEquivalentTo(spec.MinTLSVersion))
 			Expect(ciphers).To(Equal(strings.Join(spec.Ciphers, ",")))
 		})
 
 		It("should prefer the output profile over the forwarder profile", func() {
-			minTLS, ciphers := options.TLSProfileInfo(clfProfile, outputSpec)
+			minTLS, ciphers := options.TLSProfileInfo(clfProfile, outputSpec, ",")
 			spec := configv1.TLSProfiles[outputProfile.Type]
 			Expect(minTLS).To(BeEquivalentTo(spec.MinTLSVersion))
 			Expect(ciphers).To(Equal(strings.Join(spec.Ciphers, ",")))
 		})
 		It("should prefer the forwarder profile over the cluster profile", func() {
-			minTLS, ciphers := options.TLSProfileInfo(clfProfile, logging.OutputSpec{})
+			minTLS, ciphers := options.TLSProfileInfo(clfProfile, logging.OutputSpec{}, ",")
 			Expect(minTLS).To(BeEquivalentTo(clfProfile.Custom.MinTLSVersion))
 			Expect(ciphers).To(Equal(strings.Join(clfProfile.Custom.Ciphers, ",")))
 		})
 		It("should prefer the cluster profile when the forwarder and output.TLS are nil", func() {
-			minTLS, ciphers := options.TLSProfileInfo(nil, logging.OutputSpec{})
+			minTLS, ciphers := options.TLSProfileInfo(nil, logging.OutputSpec{}, ",")
 			Expect(minTLS).To(BeEquivalentTo(clusterMinTLSVersion))
 			Expect(ciphers).To(Equal(strings.Join(clusterCiphers, ",")))
 		})

--- a/internal/generator/vector/outputs.go
+++ b/internal/generator/vector/outputs.go
@@ -51,7 +51,7 @@ func Outputs(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, 
 				op[generator.MinTLSVersion] = ""
 				op[generator.Ciphers] = ""
 			} else {
-				outMinTlsVersion, outCiphers := op.TLSProfileInfo(clfspec.TLSSecurityProfile, o)
+				outMinTlsVersion, outCiphers := op.TLSProfileInfo(clfspec.TLSSecurityProfile, o, ",")
 				op[generator.MinTLSVersion] = outMinTlsVersion
 				op[generator.Ciphers] = outCiphers
 			}
@@ -78,7 +78,7 @@ func Outputs(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, 
 		}
 	}
 
-	minTlsVersion, cipherSuites := op.TLSProfileInfo(nil, logging.OutputSpec{})
+	minTlsVersion, cipherSuites := op.TLSProfileInfo(nil, logging.OutputSpec{}, ",")
 	outputs = append(outputs,
 		AddNodeNameToMetric(AddNodenameToMetricTransformName, []string{InternalMetricsSourceName}),
 		PrometheusOutput(PrometheusOutputSinkName, []string{AddNodenameToMetricTransformName}, minTlsVersion, cipherSuites))


### PR DESCRIPTION
### Description
This PR:
* sets the TLS profile for fluent to default loki regardless of feature gate

### Links
* https://issues.redhat.com/browse/LOG-4012
* blocked by #1969 
* blocked by https://github.com/ViaQ/logging-fluentd/pull/80

cc @IshwarKanse 

/hold
