### PR TITLE
Fix for a race condition in fluentd/receiver_test

### DIFF
--- a/internal/cmd/functional-benchmarker/runners/cluster/cluster_runner.go
+++ b/internal/cmd/functional-benchmarker/runners/cluster/cluster_runner.go
@@ -3,12 +3,13 @@ package cluster
 import (
 	"fmt"
 	"io/ioutil"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"path"
 	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
@@ -50,7 +51,7 @@ func (r *ClusterRunner) Pod() string {
 }
 
 func (r *ClusterRunner) Deploy() {
-	testclient := client.NewNamesapceClient()
+	testclient := client.NewNamespaceClient()
 	r.framework = functional.NewCollectorFunctionalFrameworkUsing(&testclient.Test, testclient.Close, r.Verbosity, logging.LogCollectionTypeFluentd)
 	r.framework.Conf = r.CollectorConfig
 

--- a/test/client/test.go
+++ b/test/client/test.go
@@ -78,7 +78,7 @@ type NamespaceClient struct {
 	Test
 }
 
-func NewNamesapceClient() *NamespaceClient {
+func NewNamespaceClient() *NamespaceClient {
 	namespace := test.UniqueName("testhack")
 	t := &NamespaceClient{
 		Test{


### PR DESCRIPTION
### Description

This PR makes sure the ConfigMap, Service and Pod for the fluentd receiver are created before the test invokes on it.
There are also corrections for the curl command line and for an unrelated typo.

The test failure looks as follows:
```
  [oc exec -i -n test-syrcw7it Pod/receiver -- curl -fsS -X POST -key cakey.pem --cacert cacert.pem -d json={"hello":"world"} https://receiver.test-syrcw7it.svc:24225/test.tag]
  curl: (6) Could not resolve host: cakey.pem
  curl: (7) Failed to connect to receiver.test-syrcw7it.svc port 24225: Connection refused
  command terminated with exit code 7
```

 `curl: (6) Could not resolve host: cakey.pem` was due to `-key` missing another dash. It was not clear to me where cakey.pem and cacert.pem were expected to come from, so I reworked the certs.

 `curl: (7) Failed to connect to receiver.test-syrcw7it.svc port 24225: Connection refused` was due to the service not being completely up when curl tried to connect to it.

/cc @Clee2691 
/assign @jcantrill 
