### PR TITLE
LOG-4009: TLS configuration for multiple Kafka brokers is not created in Vector

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -171,9 +171,11 @@ type Kafka struct {
 	// +optional
 	Topic string `json:"topic,omitempty"`
 
-	// Brokers specifies the list of brokers
-	// to register in addition to the main output URL
-	// on initial connect to enhance reliability.
+	// Brokers specifies the list of broker endpoints of a Kafka cluster.
+	// The list represents only the initial set used by the collector's Kafka client for the
+	// first connection only. The collector's Kafka client fetches constantly an updated list
+	// from Kafka. These updates are not reconciled back to the collector configuration.
+	// If none provided the target URL from the OutputSpec is used as fallback.
 	//
 	// +optional
 	Brokers []string `json:"brokers,omitempty"`

--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -116,7 +116,7 @@ func SecurityConfig(secret *corev1.Secret) Element {
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -256,7 +256,7 @@ func Output(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Opt
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/gcl/gcl.go
+++ b/internal/generator/vector/output/gcl/gcl.go
@@ -91,7 +91,7 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/http/http.go
+++ b/internal/generator/vector/output/http/http.go
@@ -197,7 +197,7 @@ func Encoding(o logging.OutputSpec) Element {
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -191,7 +191,7 @@ func Tenant(l *logging.Loki) Element {
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 

--- a/internal/generator/vector/output/security/security.go
+++ b/internal/generator/vector/output/security/security.go
@@ -199,14 +199,19 @@ func GetFromSecret(secret *corev1.Secret, name string) string {
 	return ""
 }
 
-func GenerateTLSConf(o logging.OutputSpec, secret *corev1.Secret, op generator.Options) *TLSConf {
-	u, _ := url.Parse(o.URL)
-	if urlhelper.IsTLSScheme(u.Scheme) || o.URL == "" {
+func GenerateTLSConf(o logging.OutputSpec, secret *corev1.Secret, op generator.Options, genTLSConf bool) *TLSConf {
+	if !genTLSConf {
+		if o.URL == "" {
+			genTLSConf = true
+		} else if u, _ := url.Parse(o.URL); u != nil {
+			genTLSConf = urlhelper.IsTLSScheme(u.Scheme)
+		}
+	}
+	if genTLSConf {
 		tlsConf := NewTLSConf(o, op)
 		if addTLSSettings(o, secret, &tlsConf) {
 			return &tlsConf
 		}
 	}
-
 	return nil
 }

--- a/internal/generator/vector/output/splunk/splunk.go
+++ b/internal/generator/vector/output/splunk/splunk.go
@@ -93,7 +93,7 @@ func Encoding(o logging.OutputSpec) Element {
 }
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+	if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 		return []Element{tlsConf}
 	}
 

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -129,7 +129,7 @@ func Encoding(o logging.OutputSpec) Element {
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}


### PR DESCRIPTION
### Description
Made the URL field mandatory for Kafka output, as per original design

/cc @Clee2691 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4009
