### PR TITLE
[release-5.7] LOG-3249: Fix log parsing and index logic in fluentd

### DIFF
--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -580,7 +580,7 @@ var _ = Describe("Testing Complete Config Generation", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -625,7 +625,7 @@ var _ = Describe("Generating fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -777,7 +777,7 @@ var _ = Describe("Generating fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -1372,7 +1372,7 @@ var _ = Describe("Generating fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -1524,7 +1524,7 @@ var _ = Describe("Generating fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -2123,7 +2123,7 @@ var _ = Describe("Generating fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -2275,7 +2275,7 @@ var _ = Describe("Generating fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -3285,7 +3285,7 @@ var _ = Describe("Generating fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -3437,7 +3437,7 @@ var _ = Describe("Generating fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -3589,7 +3589,7 @@ var _ = Describe("Generating fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -3741,7 +3741,7 @@ var _ = Describe("Generating fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -3903,6 +3903,7 @@ var _ = Describe("Generating fluentd config", func() {
     <parse>
       @type json
       json_parser oj
+      keep_time_key true
     </parse>
   </filter>
   

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Generate fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -269,7 +269,7 @@ var _ = Describe("Generate fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -447,7 +447,7 @@ var _ = Describe("Generate fluentd config", func() {
       <filter **>
         @type record_modifier
         <record>
-        _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+        _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
         </record>
         remove_keys _dummy_
       </filter>
@@ -616,7 +616,7 @@ var _ = Describe("Generate fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -772,7 +772,7 @@ var _ = Describe("Generate fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -940,7 +940,7 @@ var _ = Describe("Generate fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -1109,7 +1109,7 @@ var _ = Describe("Generate fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -1273,7 +1273,7 @@ var _ = Describe("Generate fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>
@@ -1429,7 +1429,7 @@ var _ = Describe("Generate fluentd config", func() {
   <filter **>
     @type record_modifier
     <record>
-    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
     </record>
     remove_keys _dummy_
   </filter>

--- a/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
+++ b/internal/generator/fluentd/output/elasticsearch/viaq_data_model.go
@@ -40,11 +40,13 @@ func ViaqDataModel(bufspec *logging.FluentdBufferSpec, secret *corev1.Secret, o 
 		RemoveKeys: []string{"_dummy_, _dummy2_, _dummy3_"},
 	}
 
+	// LOG-3249: If viaq_index_name is still 'app-write', it means we cant find the specified index key in the message
+	// and/or the structuredIndexName was not provided. Do not parse and instead re-assemble message and remove structured
 	modRecordRebuildMessage := RecordModifier{
 		Records: []Record{
 			{
 				Key:        "_dummy_",
-				Expression: `${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}`,
+				Expression: `${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}`,
 			},
 		},
 		RemoveKeys: []string{"_dummy_"},

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Generating fluentd config", func() {
 		<filter **>
 			@type record_modifier
 			<record>
-			_dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+			_dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
 			</record>
 			remove_keys _dummy_
 		</filter>
@@ -300,7 +300,7 @@ var _ = Describe("Generating fluentd config", func() {
 		<filter **>
 			@type record_modifier
 			<record>
-			_dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+			_dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
 			</record>
 			remove_keys _dummy_
 		</filter>
@@ -451,7 +451,7 @@ var _ = Describe("Generating fluentd config", func() {
 		<filter **>
 			@type record_modifier
 			<record>
-			_dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+			_dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
 			</record>
 			remove_keys _dummy_
 		</filter>

--- a/internal/generator/fluentd/pipeline_to_output.go
+++ b/internal/generator/fluentd/pipeline_to_output.go
@@ -44,6 +44,7 @@ const (
   <parse>
     @type json
     json_parser oj
+    keep_time_key true
   </parse>
 </filter>
 {{end}}`

--- a/internal/generator/fluentd/pipeline_to_output_test.go
+++ b/internal/generator/fluentd/pipeline_to_output_test.go
@@ -162,6 +162,7 @@ var _ = Describe("Testing Config Generation", func() {
     <parse>
       @type json
       json_parser oj
+      keep_time_key true
     </parse>
   </filter>
   

--- a/test/functional/normalization/json_parsing_test.go
+++ b/test/functional/normalization/json_parsing_test.go
@@ -166,7 +166,6 @@ var _ = Describe("[Functional][Normalization] Json log parsing", func() {
 		Expect(logs[0].Message).To(Equal(expectedMessage), "received message not matching")
 	})
 	It("should not parse invalid json message into structured", func() {
-		// This test case is disabled to fix the behavior of invalid json parsing
 		clfb.Forwarder.Spec.Pipelines[0].Parse = "json"
 		Expect(framework.Deploy()).To(BeNil())
 
@@ -229,8 +228,7 @@ var _ = Describe("[Functional][Normalization] Json log parsing", func() {
 		Expect(logs[0].Message).To(BeEmpty())
 	})
 
-	It("should not parse raise warn message in collector container : LOG-1806", func() {
-		// This test case is disabled to fix the behavior of invalid json parsing
+	It("should not raise parser error message in collector container : LOG-1806", func() {
 		clfb.Forwarder.Spec.Pipelines[0].Parse = "json"
 		Expect(framework.Deploy()).To(BeNil())
 

--- a/test/functional/normalization/loglevel/conainer_logs_test.go
+++ b/test/functional/normalization/loglevel/conainer_logs_test.go
@@ -45,7 +45,7 @@ var _ = Describe("[functional][normalization][loglevel] tests for message format
 
 		// Write log line as input to fluentd
 		applicationLogLine := functional.NewCRIOLogMessage(timestamp, message, false)
-		Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 10)).To(BeNil())
+		Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 2)).To(BeNil())
 		// Read line from Log Forward output
 		raw, err := framework.ReadRawApplicationLogsFrom(logging.OutputTypeFluentdForward)
 		Expect(err).To(BeNil(), "Expected no errors reading the logs")


### PR DESCRIPTION
### Description
Two quick fix issues found with fluentd json parsing feature: 
1. Currently when a `structuredTypeKey` is not found, and a `structuredTypeName` is not specified, the log message is still parsed into structured object, but the index is not created AND the original message is not deleted.    This fixes the issue so that the messages are not parsed in that scenario.
2.  When the key `time` is included in the json message, fluentd was dropping that element from the new `structured` field.  This change will ensure the element remains and is now included in the `structured` elements

/cc @Clee2691 @syedriko 
/assign @jcantrill 


### Links
- JIRA: https://issues.redhat.com/browse/LOG-3249
