### PR TITLE
LOG-4039: logging-view-plugin not deployed when visualization is nil

### DIFF
--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -255,6 +255,9 @@ func (clusterRequest *ClusterLoggingRequest) getLogForwarder() (*logging.Cluster
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Encountered unexpected error getting", "forwarder", nsname)
 		}
+		if !clusterRequest.IncludesManagedStorage() {
+			return nil, map[string]bool{}
+		}
 		forwarder.Spec = logging.ClusterLogForwarderSpec{}
 	}
 	extras := map[string]bool{}

--- a/internal/k8shandler/visualization.go
+++ b/internal/k8shandler/visualization.go
@@ -31,8 +31,11 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateVisualization() error
 	}
 
 	var consoleSpec *logging.OCPConsoleSpec
-	if spec.Visualization != nil && spec.Visualization.Type == logging.VisualizationTypeOCPConsole {
-		consoleSpec = spec.Visualization.OCPConsole
+	if spec.LogStore == nil || spec.LogStore.Type == logging.LogStoreTypeLokiStack {
+		if spec.Visualization != nil && spec.Visualization.Type == logging.VisualizationTypeOCPConsole {
+			consoleSpec = spec.Visualization.OCPConsole
+		}
+		// Will return not found if logStore is nil, as intended
 		errs = append(errs, console.ReconcilePlugin(clusterRequest.Client, clusterRequest.Cluster.Spec.LogStore, clusterRequest.Cluster, clusterRequest.ClusterVersion, consoleSpec))
 	}
 	return utilerrors.NewAggregate(errs)


### PR DESCRIPTION
### Description
Critical bug fix for 5.7
The logging-view-plugin will not be deployed unless visualization is added to clusterlogging CR

/cc @Clee2691 @syedriko
/assign @jcantrill

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4039
