### PR TITLE
[release-5.6] LOG-4030: Remove collector daemonset when no logStore or forwarder

### DIFF
--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -227,6 +227,9 @@ func (clusterRequest *ClusterLoggingRequest) getLogForwarder() (*logging.Cluster
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "Encountered unexpected error getting", "forwarder", nsname)
 		}
+		if !clusterRequest.IncludesManagedStorage() {
+			return nil, map[string]bool{}
+		}
 		forwarder.Spec = logging.ClusterLogForwarderSpec{}
 	}
 	extras := map[string]bool{}


### PR DESCRIPTION
### Description
Regression fix to remove daemonset when no default logStore and no forwarder

/cc @Clee2691 @syedriko
/assign @jcantrill

### Links
- this is the 5.6 version of the fix for:  https://issues.redhat.com/browse/LOG-4030
