### PR TITLE
LOG-3330: fix run.sh script to displays correct chunk_limit_size value if it is changed

### DIFF
--- a/internal/collector/fluentd/run_script.go
+++ b/internal/collector/fluentd/run_script.go
@@ -115,8 +115,13 @@ else
     echo "Requested buffer size per output $TOTAL_LIMIT_SIZE_PER_BUFFER for $NUM_OUTPUTS buffers exceeds maximum available size  $TOTAL_LIMIT_SIZE_ALLOWED_PER_BUFFER bytes per output"
     TOTAL_LIMIT_SIZE_PER_BUFFER=$TOTAL_LIMIT_SIZE_ALLOWED_PER_BUFFER
 fi
-echo "Setting each total_size_limit for $NUM_OUTPUTS buffers to $TOTAL_LIMIT_SIZE_PER_BUFFER bytes"
 export TOTAL_LIMIT_SIZE_PER_BUFFER
+
+total_limit_size=$(awk '/total_limit_size/{print $2; exit}' $FLUENT_CONF)
+if [[ -z "$total_limit_size" ]] || [[ "$total_limit_size" == *TOTAL_LIMIT_SIZE_PER_BUFFER* ]]; then
+  total_limit_size="$TOTAL_LIMIT_SIZE_PER_BUFFER"
+fi
+echo "Setting each total_size_limit for $NUM_OUTPUTS buffers to $total_limit_size bytes"
 
 ##
 # Calculate the max number of queued chunks given the size of each chunk
@@ -126,8 +131,13 @@ BUFFER_SIZE_LIMIT=$(echo ${BUFFER_SIZE_LIMIT:-8388608})
 BUFFER_QUEUE_LIMIT=$(expr $TOTAL_LIMIT_SIZE_PER_BUFFER / $BUFFER_SIZE_LIMIT)
 echo "Setting queued_chunks_limit_size for each buffer to $BUFFER_QUEUE_LIMIT"
 export BUFFER_QUEUE_LIMIT
-echo "Setting chunk_limit_size for each buffer to $BUFFER_SIZE_LIMIT"
 export BUFFER_SIZE_LIMIT
+
+chunk_limit_size=$(awk '/chunk_limit_size/{print $2; exit}' $FLUENT_CONF)
+if [[ -z "$chunk_limit_size" ]] || [[ "$chunk_limit_size" == *BUFFER_SIZE_LIMIT* ]]; then
+  chunk_limit_size="$BUFFER_SIZE_LIMIT"
+fi
+echo "Setting chunk_limit_size for each buffer to $chunk_limit_size"
 
 issue_deprecation_warnings
 


### PR DESCRIPTION
### Description
This pull request addresses the issue where the `run.sh` script displays an incorrect `chunk_limit_size` value if it is changed. Script show correct value when setting the `chunk_limit_size` via the env variable `BUFFER_SIZE_LIMIT`, but shows wrong if do it, as described in the [OpenShift documentation](https://docs.openshift.com/container-platform/4.12/logging/config/cluster-logging-collector.html). 
The new code uses the `awk` command to search for the `chunk_limit_size` value in the `fluentd.conf` file, if the value is not found in the `fluentd.conf` file, the script shows the default value from the `$BUFFER_SIZE_LIMIT` environment variable.
```
chunk_limit_size=$(awk '/chunk_limit_size/{print $2; exit}' $FLUENT_CONF)
if [[ -z "$chunk_limit_size" ]] || [[ "$chunk_limit_size" == *BUFFER_SIZE_LIMIT* ]]; then
  chunk_limit_size="$BUFFER_SIZE_LIMIT"
fi
echo "Setting chunk_limit_size for each buffer to $chunk_limit_size"
```

Also add the same behavior for other variable: `total_limit_size`

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3330
- Enhancement proposal:
