### PR TITLE
LOG-3445: Apply 'tls.insecureSkipVerify=true' configuration even if certificate not added to the secret

### DIFF
--- a/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
@@ -781,6 +781,9 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
 			BeforeEach(func() {
 				output.Cloudwatch.GroupBy = loggingv1.LogGroupByLogType
 				output.Secret.Name = "my-secret"
+				output.TLS = &loggingv1.OutputTLSSpec{
+					InsecureSkipVerify: false,
+				}
 			})
 
 			It("should provide a valid config", func() {

--- a/internal/generator/vector/output/security/security.go
+++ b/internal/generator/vector/output/security/security.go
@@ -83,6 +83,9 @@ func addTLSSettings(o logging.OutputSpec, secret *corev1.Secret, conf *TLSConf) 
 	if conf.TlsMinVersion != "" || conf.CipherSuites != "" {
 		addTLS = true
 	}
+	if conf.InsecureSkipVerify {
+		addTLS = true
+	}
 
 	return addTLS
 }
@@ -116,7 +119,7 @@ ca_file = {{ .CAFilePath }}
 {{- if .PassPhrase }}
 key_pass = "{{ .PassPhrase }}"
 {{- end }}
-{{- end}}`
+{{ end }}`
 }
 
 var NoSecrets = map[string]*corev1.Secret{}

--- a/internal/generator/vector/output/splunk/splunk.go
+++ b/internal/generator/vector/output/splunk/splunk.go
@@ -93,10 +93,8 @@ func Encoding(o logging.OutputSpec) Element {
 }
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
-			return []Element{tlsConf}
-		}
+	if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		return []Element{tlsConf}
 	}
 
 	return []Element{}

--- a/internal/validations/clusterlogforwarder/validate_url_to_output_tls_config.go
+++ b/internal/validations/clusterlogforwarder/validate_url_to_output_tls_config.go
@@ -1,0 +1,24 @@
+package clusterlogforwarder
+
+import (
+  "fmt"
+  log "github.com/ViaQ/logerr/v2/log/static"
+  "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+  "github.com/openshift/cluster-logging-operator/internal/url"
+  "strings"
+)
+
+// validateUrlAccordingToTls validate that if Output has TLS configuration Output URL scheme must be secure e.g. https, tls etc
+func validateUrlAccordingToTls(clf v1.ClusterLogForwarder) error {
+  for i, output := range clf.Spec.Outputs {
+    _, output := i, output // Don't bind range variable.
+    u, _ := url.Parse(output.URL)
+    scheme := strings.ToLower(u.Scheme)
+    if !url.IsTLSScheme(scheme) && (output.TLS != nil && (output.TLS.InsecureSkipVerify || output.TLS.TLSSecurityProfile != nil)) {
+      log.V(3).Info("validateUrlAccordingToTls failed", "reason", "URL not secure but output has TLS configuration parameters",
+        "output URL", output.URL, "output Name", output.Name)
+      return fmt.Errorf("URL not secure: %v, but output %s has TLS configuration parameters", u, output.Name)
+    }
+  }
+  return nil
+}

--- a/internal/validations/clusterlogforwarder/validate_url_to_output_tls_test.go
+++ b/internal/validations/clusterlogforwarder/validate_url_to_output_tls_test.go
@@ -1,0 +1,74 @@
+package clusterlogforwarder
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-logging-operator/apis/logging/v1"
+)
+
+var _ = Describe("[internal][validations] ClusterLogForwarder: Output URL vs Output TLS", func() {
+	var clf = &v1.ClusterLogForwarder{
+		Spec: v1.ClusterLogForwarderSpec{
+			Outputs: []v1.OutputSpec{
+				{
+					Name: "myOutput",
+				},
+			},
+		},
+	}
+
+	Context("#validateUrlAccordingToTls", func() {
+		It("should fail validation when not secure URL and tls.InsecureSkipVerify=true", func() {
+			clf.Spec.Outputs[0].URL = "http://local.svc:514"
+			clf.Spec.Outputs[0].TLS = &v1.OutputTLSSpec{
+				InsecureSkipVerify: true,
+			}
+			Expect(validateUrlAccordingToTls(*clf)).To(Not(Succeed()))
+		})
+		It("should pass validation when not secure URL and no TLS config", func() {
+			clf.Spec.Outputs[0].URL = "http://local.svc:514"
+			clf.Spec.Outputs[0].TLS = nil
+			Expect(validateUrlAccordingToTls(*clf)).To(Succeed())
+		})
+		It("should pass validation when when not secure URL and tls.InsecureSkipVerify=false", func() {
+			clf.Spec.Outputs[0].URL = "http://local.svc:514"
+			clf.Spec.Outputs[0].TLS = &v1.OutputTLSSpec{
+				InsecureSkipVerify: false,
+			}
+			Expect(validateUrlAccordingToTls(*clf)).To(Succeed())
+		})
+		It("should fail validation when not secure URL and exist TLS config: tls.TLSSecurityProfile", func() {
+			clf.Spec.Outputs[0].URL = "http://local.svc:514"
+			clf.Spec.Outputs[0].TLS = &v1.OutputTLSSpec{
+				TLSSecurityProfile: &configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileOldType,
+				},
+			}
+			Expect(validateUrlAccordingToTls(*clf)).To(Not(Succeed()))
+		})
+		It("should pass validation when secure URL and exist TLS config: tls.InsecureSkipVerify=true", func() {
+			clf.Spec.Outputs[0].URL = "https://local.svc:514"
+			clf.Spec.Outputs[0].TLS = &v1.OutputTLSSpec{
+				InsecureSkipVerify: true,
+			}
+			Expect(validateUrlAccordingToTls(*clf)).To(Succeed())
+		})
+		It("should pass pass validation when secure URL and exist TLS config: tls.InsecureSkipVerify=false", func() {
+			clf.Spec.Outputs[0].URL = "https://local.svc:514"
+			clf.Spec.Outputs[0].TLS = &v1.OutputTLSSpec{
+				InsecureSkipVerify: false,
+			}
+			Expect(validateUrlAccordingToTls(*clf)).To(Succeed())
+		})
+		It("should pass pass validation when secure URL and exist TLS config: tls.TLSSecurityProfile", func() {
+			clf.Spec.Outputs[0].URL = "https://local.svc:514"
+			clf.Spec.Outputs[0].TLS = &v1.OutputTLSSpec{
+				TLSSecurityProfile: &configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileOldType,
+				},
+			}
+			Expect(validateUrlAccordingToTls(*clf)).To(Succeed())
+		})
+	})
+})

--- a/internal/validations/clusterlogforwarder/validations.go
+++ b/internal/validations/clusterlogforwarder/validations.go
@@ -16,4 +16,5 @@ func Validate(clf v1.ClusterLogForwarder) error {
 var validations = []func(clf v1.ClusterLogForwarder) error{
 	validateSingleton,
 	validateJsonParsingToElasticsearch,
+	validateUrlAccordingToTls,
 }


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>
### Description
This PR:
- It introduces the ability to apply the `tls.insecureSkipVerify=true` configuration even if the certificate is not added to the secret. When using a TLS connection, our API will no longer require a certificate to be provided through K8s Secret if the `tls.insecureSkipVerify` option is set to `true`. The following configuration will be added to the Vector config:
```
tls.verify_certificate = false
tls.verify_hostname = false
```
- adds a unit test to verify the correct configuration when 'tls.insecureSkipVerify=true' is set for the Splunk output
- adds validation to check for cases where a non-empty TLS config is provided, but the URL is not secure. The validation will fail if the given URL has a non-secure scheme (e.g., `http` instead of `https`) while `tls.insecureSkipVerify=true` is set.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3445
- Enhancement proposal:
