### PR TITLE
LOG-3314: fix config generation for Kafka output

### DIFF
--- a/internal/generator/fluentd/output/kafka/kafka_test.go
+++ b/internal/generator/fluentd/output/kafka/kafka_test.go
@@ -366,6 +366,82 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
+		Entry("with username,password, sasl_over_ssl, passphrase and sasl.mechanisms (scram_mechanism in kafka plugin conf)", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeKafka,
+						Name: "kafka-receiver",
+						URL:  "tls://broker1-kafka.svc.messaging.cluster.local:9092/topic",
+						Secret: &logging.OutputSecretSpec{
+							Name: "kafka-receiver-1",
+						},
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Kafka: &logging.Kafka{
+								Topic: "build_complete",
+							},
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"kafka-receiver": {
+					Data: map[string][]byte{
+						"username":               []byte("junk"),
+						"password":               []byte("junk"),
+						constants.SASLMechanisms: []byte("PLAIN"),
+						"sasl_over_ssl":          []byte("true"),
+						"passphrase":             []byte("-- passphrase --"),
+					},
+				},
+			},
+			ExpectedConf: `
+<label @KAFKA_RECEIVER>
+  #dedot namespace_labels and rebuild message field if present
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_, _dummy3_
+  </filter>
+
+  <match **>
+    @type kafka2
+    @id kafka_receiver
+    brokers broker1-kafka.svc.messaging.cluster.local:9092
+    default_topic build_complete
+    use_event_time true
+    username "#{File.exists?('/var/run/ocp-collector/secrets/kafka-receiver-1/username') ? open('/var/run/ocp-collector/secrets/kafka-receiver-1/username','r') do |f|f.read end : ''}"
+    password "#{File.exists?('/var/run/ocp-collector/secrets/kafka-receiver-1/password') ? open('/var/run/ocp-collector/secrets/kafka-receiver-1/password','r') do |f|f.read end : ''}"
+    sasl_over_ssl true
+    ssl_client_cert_key_password "#{File.exists?('/var/run/ocp-collector/secrets/kafka-receiver-1/passphrase') ? open('/var/run/ocp-collector/secrets/kafka-receiver-1/passphrase','r') do |f|f.read end : ''}"
+    scram_mechanism "PLAIN"
+    <format>
+      @type json
+    </format>
+    <buffer _build_complete>
+      @type file
+      path '/var/lib/fluentd/kafka_receiver'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+</label>
+`,
+		}),
 	)
 })
 

--- a/internal/generator/fluentd/output/kafka/sasl.go
+++ b/internal/generator/fluentd/output/kafka/sasl.go
@@ -20,7 +20,7 @@ func (s SASL) Template() string {
 sasl_over_ssl %t
 `, s.SaslOverSSL)
 	if s.SaslKeyPassword != "" {
-		conf += `ssl_client_cert_key_password "#{File.exists?({{.SaslKeyPassword}}) ? open({{.SaslKeyPassword}},'r') do |f|f.read end : ''}"`
+		conf += "ssl_client_cert_key_password \"#{File.exists?({{.SaslKeyPassword}}) ? open({{.SaslKeyPassword}},'r') do |f|f.read end : ''}\"\n"
 	}
 	if s.ScramMechanism != "" {
 		conf += fmt.Sprintf(`scram_mechanism "%s"`, s.ScramMechanism)


### PR DESCRIPTION
### Description
This PR fix configuration for Kafka output plugin adding new line after `ssl_client_cert_key_password` config parameter to prevent such behavior:

```
sasl_over_ssl true
ssl_client_cert_key_password "#{File.exists?('/var/run/ocp-collector/secrets/kafka-fluentd/passphrase') ? open('/var/run/ocp-collector/secrets/kafka-fluentd/passphrase','r') do |f|f.read end : ''}"scram_mechanism "PLAIN"
```
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-3314
- Enhancement proposal:
