### PR TITLE
LOG-4121: Vector fails to run when configuring syslog forwarding for audit log

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -378,7 +378,7 @@ type = "route"
 inputs = ["application"]
 route.mytestapp = '.kubernetes.namespace_name == "test-ns"'
 
-[transforms.pipeline]
+[transforms.pipeline_user_defined]
 type = "remap"
 inputs = ["route_application_logs.mytestapp","infrastructure","audit"]
 source = '''
@@ -387,7 +387,7 @@ source = '''
 
 [transforms.kafka_receiver_dedot]
 type = "lua"
-inputs = ["pipeline"]
+inputs = ["pipeline_user_defined"]
 version = "2"
 hooks.init = "init"
 hooks.process = "process"
@@ -803,7 +803,7 @@ source = '''
   ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
-[transforms.pipeline]
+[transforms.pipeline_user_defined]
 type = "remap"
 inputs = ["application","infrastructure","audit"]
 source = '''
@@ -813,7 +813,7 @@ source = '''
 # Set Elasticsearch index
 [transforms.es_1_add_es_index]
 type = "remap"
-inputs = ["pipeline"]
+inputs = ["pipeline_user_defined"]
 source = '''
   index = "default"
   if (.log_type == "application"){
@@ -925,7 +925,7 @@ ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 # Set Elasticsearch index
 [transforms.es_2_add_es_index]
 type = "remap"
-inputs = ["pipeline"]
+inputs = ["pipeline_user_defined"]
 source = '''
   index = "default"
   if (.log_type == "application"){
@@ -1410,7 +1410,7 @@ source = '''
   ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
-[transforms.pipeline]
+[transforms.pipeline_user_defined]
 type = "remap"
 inputs = ["application","infrastructure","audit"]
 source = '''
@@ -1420,7 +1420,7 @@ source = '''
 # Set Elasticsearch index
 [transforms.default_add_es_index]
 type = "remap"
-inputs = ["pipeline"]
+inputs = ["pipeline_user_defined"]
 source = '''
   index = "default"
   if (.log_type == "application"){
@@ -1533,7 +1533,7 @@ ca_file = "/var/run/ocp-collector/secrets/collector/ca-bundle.crt"
 # Set Elasticsearch index
 [transforms.es_1_add_es_index]
 type = "remap"
-inputs = ["pipeline"]
+inputs = ["pipeline_user_defined"]
 source = '''
   index = "default"
   if (.log_type == "application"){
@@ -1651,7 +1651,7 @@ ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"
 # Set Elasticsearch index
 [transforms.es_2_add_es_index]
 type = "remap"
-inputs = ["pipeline"]
+inputs = ["pipeline_user_defined"]
 source = '''
   index = "default"
   if (.log_type == "application"){
@@ -2104,7 +2104,7 @@ source = '''
   ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
-[transforms.pipeline_with_space]
+[transforms.pipeline_with_space_user_defined]
 type = "remap"
 inputs = ["application","infrastructure","audit"]
 source = '''
@@ -2114,7 +2114,7 @@ source = '''
 # Set Elasticsearch index
 [transforms.es_1_add_es_index]
 type = "remap"
-inputs = ["pipeline_with_space"]
+inputs = ["pipeline_with_space_user_defined"]
 source = '''
   index = "default"
   if (.log_type == "application"){

--- a/internal/generator/vector/pipelines.go
+++ b/internal/generator/vector/pipelines.go
@@ -24,8 +24,7 @@ func Pipelines(spec *logging.ClusterLogForwarderSpec, op generator.Options) []ge
 	userDefined := spec.InputMap()
 	for i, p := range spec.Pipelines {
 		inputs := []string{}
-		// Sanitize pipeline name and persist it for config generation
-		p.Name = helpers.FormatComponentID(p.Name)
+		p.Name = helpers.FormatComponentID(p.Name) + "_user_defined"
 		spec.Pipelines[i].Name = p.Name
 
 		for _, inputName := range p.InputRefs {

--- a/internal/generator/vector/sources_to_pipelines_test.go
+++ b/internal/generator/vector/sources_to_pipelines_test.go
@@ -65,7 +65,7 @@ source = '''
   ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
-[transforms.pipeline]
+[transforms.pipeline_user_defined]
 type = "remap"
 inputs = ["application","infrastructure","audit"]
 source = '''
@@ -127,14 +127,14 @@ source = '''
   ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
-[transforms.pipeline1]
+[transforms.pipeline1_user_defined]
 type = "remap"
 inputs = ["application","infrastructure","audit"]
 source = '''
   .
 '''
 
-[transforms.pipeline2]
+[transforms.pipeline2_user_defined]
 type = "remap"
 inputs = ["application"]
 source = '''
@@ -179,7 +179,7 @@ type = "route"
 inputs = ["application"]
 route.myapplogs = '(.kubernetes.namespace_name == "test-ns1") || (.kubernetes.namespace_name == "test-ns2")'
 
-[transforms.pipeline]
+[transforms.pipeline_user_defined]
 type = "remap"
 inputs = ["route_application_logs.myapplogs"]
 source = '''
@@ -230,7 +230,7 @@ type = "route"
 inputs = ["application"]
 route.myapplogs = '((.kubernetes.namespace_name == "myapp1") || (.kubernetes.namespace_name == "myapp2")) && ((.kubernetes.labels.key1 == "value1") && (.kubernetes.labels.key2 == "value2"))'
 
-[transforms.pipeline]
+[transforms.pipeline_user_defined]
 type = "remap"
 inputs = ["route_application_logs.myapplogs"]
 source = '''
@@ -274,7 +274,7 @@ source = '''
   .log_type = "infrastructure"
 '''
 
-[transforms.pipeline]
+[transforms.pipeline_user_defined]
 type = "remap"
 inputs = ["application","infrastructure"]
 source = '''
@@ -316,7 +316,7 @@ source = '''
   .log_type = "infrastructure"
 '''
 
-[transforms.pipeline]
+[transforms.pipeline_user_defined]
 type = "remap"
 inputs = ["application","infrastructure"]
 source = '''
@@ -364,7 +364,7 @@ source = '''
   .log_type = "infrastructure"
 '''
 
-[transforms.detect_exceptions_pipeline]
+[transforms.detect_exceptions_pipeline_user_defined]
 type = "detect_exceptions"
 inputs = ["application","infrastructure"]
 languages = ["All"]
@@ -372,9 +372,9 @@ group_by = ["kubernetes.namespace_name","kubernetes.pod_name","kubernetes.contai
 expire_after_ms = 2000
 multiline_flush_interval_ms = 1000
 
-[transforms.pipeline]
+[transforms.pipeline_user_defined]
 type = "remap"
-inputs = ["detect_exceptions_pipeline"]
+inputs = ["detect_exceptions_pipeline_user_defined"]
 source = '''
   .
 '''
@@ -427,7 +427,7 @@ source = '''
   ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
 '''
 
-[transforms.pipeline_with_space]
+[transforms.pipeline_with_space_user_defined]
 type = "remap"
 inputs = ["application","infrastructure","audit"]
 source = '''


### PR DESCRIPTION
### Description
Add a namespace for the transforms generated for the CLF pipelines to avoid user-specified pipeline names clashing with names of "reserved" transforms, such as "infrastructure", "application", "audit", "drop_journal_logs", etc.

/cc @Clee2691 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4121

