### PR TITLE
LOG-4105: fix api documentation and validation where pipeline.name is required

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder_types.go
+++ b/apis/logging/v1/cluster_log_forwarder_types.go
@@ -280,9 +280,10 @@ type PipelineSpec struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 
-	// Name is optional, but must be unique in the `pipelines` list if provided.
+	// Name must be unique in the `pipelines` list
 	//
-	// +optional
+	// 	+kubebuilder:validation:minLength:=1
+	//	+required
 	Name string `json:"name,omitempty"`
 
 	// Parse enables parsing of log entries into structured logs

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -570,8 +570,7 @@ spec:
                         in the log record.
                       type: object
                     name:
-                      description: Name is optional, but must be unique in the `pipelines`
-                        list if provided.
+                      description: Name must be unique in the `pipelines` list
                       type: string
                     outputRefs:
                       description: "OutputRefs lists the names (`output.name`) of

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -566,8 +566,7 @@ spec:
                         in the log record.
                       type: object
                     name:
-                      description: Name is optional, but must be unique in the `pipelines`
-                        list if provided.
+                      description: Name must be unique in the `pipelines` list
                       type: string
                     outputRefs:
                       description: "OutputRefs lists the names (`output.name`) of

--- a/docs/reference/operator/api.adoc
+++ b/docs/reference/operator/api.adoc
@@ -248,7 +248,7 @@ PipelinesSpec link a set of inputs to a set of outputs.
 |detectMultilineErrors|bool|  *(optional)* DetectMultilineErrors enables multiline error detection of container logs
 |inputRefs|array|  InputRefs lists the names (`input.name`) of inputs to this pipeline.
 |labels|object|  *(optional)* Labels applied to log records passing through this pipeline.
-|name|string|  *(optional)* Name is optional, but must be unique in the `pipelines` list if provided.
+|name|string|  Name must be unique in the `pipelines` list
 |outputRefs|array|  OutputRefs lists the names (`output.name`) of outputs from this pipeline.
 |parse|string|  *(optional)* Parse enables parsing of log entries into structured logs
 |======================


### PR DESCRIPTION
… required

### Description
This PR:
* corrects API documentation and validation so pipeline.name is required as it has been since the introduction of CLF

### Links
* https://issues.redhat.com/browse/LOG-4105
