### PR TITLE
LOG-4163: [release-5.7] TLS configuration for multiple Kafka brokers is not created in Vector

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -171,9 +171,11 @@ type Kafka struct {
 	// +optional
 	Topic string `json:"topic,omitempty"`
 
-	// Brokers specifies the list of brokers
-	// to register in addition to the main output URL
-	// on initial connect to enhance reliability.
+	// Brokers specifies the list of broker endpoints of a Kafka cluster.
+	// The list represents only the initial set used by the collector's Kafka client for the
+	// first connection only. The collector's Kafka client fetches constantly an updated list
+	// from Kafka. These updates are not reconciled back to the collector configuration.
+	// If none provided the target URL from the OutputSpec is used as fallback.
 	//
 	// +optional
 	Brokers []string `json:"brokers,omitempty"`

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -248,9 +248,14 @@ spec:
                         kafka`'
                       properties:
                         brokers:
-                          description: Brokers specifies the list of brokers to register
-                            in addition to the main output URL on initial connect
-                            to enhance reliability.
+                          description: Brokers specifies the list of broker endpoints
+                            of a Kafka cluster. The list represents only the initial
+                            set used by the collector's Kafka client for the first
+                            connection only. The collector's Kafka client fetches
+                            constantly an updated list from Kafka. These updates are
+                            not reconciled back to the collector configuration. If
+                            none provided the target URL from the OutputSpec is used
+                            as fallback.
                           items:
                             type: string
                           type: array

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -244,9 +244,14 @@ spec:
                         kafka`'
                       properties:
                         brokers:
-                          description: Brokers specifies the list of brokers to register
-                            in addition to the main output URL on initial connect
-                            to enhance reliability.
+                          description: Brokers specifies the list of broker endpoints
+                            of a Kafka cluster. The list represents only the initial
+                            set used by the collector's Kafka client for the first
+                            connection only. The collector's Kafka client fetches
+                            constantly an updated list from Kafka. These updates are
+                            not reconciled back to the collector configuration. If
+                            none provided the target URL from the OutputSpec is used
+                            as fallback.
                           items:
                             type: string
                           type: array

--- a/docs/reference/operator/api.adoc
+++ b/docs/reference/operator/api.adoc
@@ -1036,7 +1036,9 @@ This is the struct that will contain information pertinent to Log visualization 
 |Property|Type|Description
 
 |kibana|object| **(DEPRECATED)** *(optional)* Specification of the Kibana Visualization component
+|nodeSelector|object|  Define which Nodes the Pods are scheduled on.
 |ocpConsole|object|  *(optional)* OCPConsole is the specification for the OCP console plugin
+|tolerations|array|  *(optional)* Define the tolerations the Pods will accept
 |type|string|  The type of Visualization to configure
 |======================
 
@@ -1050,11 +1052,11 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 |Property|Type|Description
 
-|nodeSelector|object|  Define which Nodes the Pods are scheduled on.
+|nodeSelector|object| **(DEPRECATED)** Define which Nodes the Pods are scheduled on.
 |proxy|object|  Specification of the Kibana Proxy component
 |replicas|int|  *(optional)* Number of instances to deploy for a Kibana deployment
 |resources|object|  *(optional)* The resource requirements for Kibana
-|tolerations|array|  
+|tolerations|array| **(DEPRECATED)** Define the tolerations the Pods will accept
 |======================
 
 === .spec.visualization.kibana.nodeSelector
@@ -1157,6 +1159,12 @@ This is the struct that will contain information pertinent to Log visualization 
 =====  Type
 * int
 
+=== .spec.visualization.nodeSelector
+===== Description
+
+=====  Type
+* object
+
 === .spec.visualization.ocpConsole
 ===== Description
 
@@ -1170,6 +1178,29 @@ This is the struct that will contain information pertinent to Log visualization 
 |logsLimit|int|  *(optional)* LogsLimit is the max number of entries returned for a query.
 |timeout|string|  *(optional)* Timeout is the max duration before a query timeout
 |======================
+
+=== .spec.visualization.tolerations[]
+===== Description
+
+=====  Type
+* array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|effect|string|  *(optional)* Effect indicates the taint effect to match. Empty means match all taint effects.
+|key|string|  *(optional)* Key is the taint key that the toleration applies to. Empty means match all taint keys.
+|operator|string|  *(optional)* Operator represents a key&#39;s relationship to the value.
+|tolerationSeconds|int|  *(optional)* TolerationSeconds represents the period of time the toleration (which must be
+|value|string|  *(optional)* Value is the taint value the toleration matches to.
+|======================
+
+=== .spec.visualization.tolerations[].tolerationSeconds
+===== Description
+
+=====  Type
+* int
 
 === .status
 ===== Description

--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -116,7 +116,7 @@ func SecurityConfig(secret *corev1.Secret) Element {
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -256,7 +256,7 @@ func Output(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Opt
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/gcl/gcl.go
+++ b/internal/generator/vector/output/gcl/gcl.go
@@ -90,7 +90,7 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/http/http.go
+++ b/internal/generator/vector/output/http/http.go
@@ -196,7 +196,7 @@ func Encoding(o logging.OutputSpec) Element {
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -191,7 +191,7 @@ func Tenant(l *logging.Loki) Element {
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 

--- a/internal/generator/vector/output/security/security.go
+++ b/internal/generator/vector/output/security/security.go
@@ -196,14 +196,19 @@ func GetFromSecret(secret *corev1.Secret, name string) string {
 	return ""
 }
 
-func GenerateTLSConf(o logging.OutputSpec, secret *corev1.Secret, op generator.Options) *TLSConf {
-	u, _ := url.Parse(o.URL)
-	if urlhelper.IsTLSScheme(u.Scheme) || o.URL == "" {
+func GenerateTLSConf(o logging.OutputSpec, secret *corev1.Secret, op generator.Options, genTLSConf bool) *TLSConf {
+	if !genTLSConf {
+		if o.URL == "" {
+			genTLSConf = true
+		} else if u, _ := url.Parse(o.URL); u != nil {
+			genTLSConf = urlhelper.IsTLSScheme(u.Scheme)
+		}
+	}
+	if genTLSConf {
 		tlsConf := NewTLSConf(o, op)
 		if addTLSSettings(o, secret, &tlsConf) {
 			return &tlsConf
 		}
 	}
-
 	return nil
 }

--- a/internal/generator/vector/output/splunk/splunk.go
+++ b/internal/generator/vector/output/splunk/splunk.go
@@ -93,7 +93,7 @@ func Encoding(o logging.OutputSpec) Element {
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -129,7 +129,7 @@ func Encoding(o logging.OutputSpec) Element {
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op); tlsConf != nil {
+		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}
 	}


### PR DESCRIPTION
### Description
- Kafka output validation now looks at both the URL and the brokers Kafka output fields
- Vector TLS config for the Kafka output is generated if there is a TLS/HTTPS URL among the specified Kafka endpoints

Cherrypick of https://github.com/openshift/cluster-logging-operator/pull/1981

/cc @Clee2691
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4163

