### PR TITLE
LOG-3445: Apply 'tls.insecureSkipVerify=true' configuration even if certificate not added to the secret for Loki

### DIFF
--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -190,7 +190,7 @@ func Tenant(l *logging.Loki) Element {
 }
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
+	if o.Secret != nil || (o.TLS != nil && o.TLS.InsecureSkipVerify) {
 		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -564,6 +564,98 @@ verify_hostname = false
 ca_file = "/var/run/ocp-collector/secrets/custom-loki-secret/ca-bundle.crt"
 `,
 		}),
+		Entry("with TLS insecureSkipVerify=true, no certificate in secret", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeLoki,
+						Name: "loki-receiver",
+						URL:  "https://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application",
+						TLS: &logging.OutputTLSSpec{
+							InsecureSkipVerify: true,
+						},
+					},
+				},
+			},
+			ExpectedConf: `
+[transforms.loki_receiver_remap]
+type = "remap"
+inputs = ["application"]
+source = '''
+  del(.tag)
+'''
+
+[transforms.loki_receiver_dedot]
+type = "lua"
+inputs = ["loki_receiver_remap"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+    function init()
+        count = 0
+    end
+    function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+		dedot(event.log.kubernetes.namespace_labels)
+        dedot(event.log.kubernetes.labels)
+        emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "[./]", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+'''
+
+[sinks.loki_receiver]
+type = "loki"
+inputs = ["loki_receiver_dedot"]
+endpoint = "https://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application"
+out_of_order_action = "accept"
+healthcheck.enabled = false
+
+[sinks.loki_receiver.encoding]
+codec = "json"
+
+[sinks.loki_receiver.labels]
+kubernetes_container_name = "{{kubernetes.container_name}}"
+kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
+kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
+kubernetes_pod_name = "{{kubernetes.pod_name}}"
+log_type = "{{log_type}}"
+
+[sinks.loki_receiver.tls]
+enabled = true
+verify_certificate = false
+verify_hostname = false
+`,
+		}),
 		Entry("with TLS config with default minTLSVersion & ciphers", helpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{


### PR DESCRIPTION
### Description
This PR:
- It introduces the ability to apply the `tls.insecureSkipVerify=true` configuration even if the certificate is not added to the secret for Loki output. When using a TLS connection, our API will no longer require a certificate to be provided through K8s Secret if the `tls.insecureSkipVerify` option is set to `true`. The following configuration will be added to the Vector config:
```
tls.verify_certificate = false
tls.verify_hostname = false
```
- adds a unit test to verify the correct configuration when 'tls.insecureSkipVerify=true' is set for the Loki output

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
