### PR TITLE
LOG-4095: fix loki labelKeys that contain slash

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -233,19 +233,18 @@ type Loki struct {
 	// +optional
 	TenantKey string `json:"tenantKey,omitempty"`
 
-	// LabelKeys is a list of meta-data field keys to replace the default Loki labels.
-	//
-	// Loki label names must match the regular expression "[a-zA-Z_:][a-zA-Z0-9_:]*".
-	// Illegal characters in meta-data keys are replaced with "_" to form the label name.
-	// For example meta-data key "kubernetes.labels.foo" becomes Loki label "kubernetes_labels_foo".
+	// LabelKeys is a list of log record keys that will be used as Loki labels with the corresponding log record value.
 	//
 	// If LabelKeys is not set, the default keys are `[log_type, kubernetes.namespace_name, kubernetes.pod_name, kubernetes_host]`
-	// These keys are translated to Loki labels by replacing '.' with '_' as: `log_type`, `kubernetes_namespace_name`, `kubernetes_pod_name`, `kubernetes_host`
-	// Note that not all logs will include all of these keys: audit logs and infrastructure journal logs do not have namespace or pod name.
+	//
+	// Note: Loki label names must match the regular expression "[a-zA-Z_:][a-zA-Z0-9_:]*"
+	// Log record keys may contain characters like "." and "/" that are not allowed in Loki labels.
+	// Log record keys are translated to Loki labels by replacing any illegal characters with '_'.
+	// For example the default log record keys translate to these Loki labels: `log_type`, `kubernetes_namespace_name`, `kubernetes_pod_name`, `kubernetes_host`
 	//
 	// Note: the set of labels should be small, Loki imposes limits on the size and number of labels allowed.
 	// See https://grafana.com/docs/loki/latest/configuration/#limits_config for more.
-	// You can still query based on any log record field using query filters.
+	// Loki queries can also query based on any log record field (not just labels) using query filters.
 	//
 	// +optional
 	LabelKeys []string `json:"labelKeys,omitempty"`

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -269,24 +269,22 @@ spec:
                         loki`'
                       properties:
                         labelKeys:
-                          description: "LabelKeys is a list of meta-data field keys
-                            to replace the default Loki labels. \n Loki label names
-                            must match the regular expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\".
-                            Illegal characters in meta-data keys are replaced with
-                            \"_\" to form the label name. For example meta-data key
-                            \"kubernetes.labels.foo\" becomes Loki label \"kubernetes_labels_foo\".
-                            \n If LabelKeys is not set, the default keys are `[log_type,
-                            kubernetes.namespace_name, kubernetes.pod_name, kubernetes_host]`
-                            These keys are translated to Loki labels by replacing
-                            '.' with '_' as: `log_type`, `kubernetes_namespace_name`,
-                            `kubernetes_pod_name`, `kubernetes_host` Note that not
-                            all logs will include all of these keys: audit logs and
-                            infrastructure journal logs do not have namespace or pod
-                            name. \n Note: the set of labels should be small, Loki
-                            imposes limits on the size and number of labels allowed.
-                            See https://grafana.com/docs/loki/latest/configuration/#limits_config
-                            for more. You can still query based on any log record
-                            field using query filters."
+                          description: "LabelKeys is a list of log record keys that
+                            will be used as Loki labels with the corresponding log
+                            record value. \n If LabelKeys is not set, the default
+                            keys are `[log_type, kubernetes.namespace_name, kubernetes.pod_name,
+                            kubernetes_host]` \n Note: Loki label names must match
+                            the regular expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\" Log
+                            record keys may contain characters like \".\" and \"/\"
+                            that are not allowed in Loki labels. Log record keys are
+                            translated to Loki labels by replacing any illegal characters
+                            with '_'. For example the default log record keys translate
+                            to these Loki labels: `log_type`, `kubernetes_namespace_name`,
+                            `kubernetes_pod_name`, `kubernetes_host` \n Note: the
+                            set of labels should be small, Loki imposes limits on
+                            the size and number of labels allowed. See https://grafana.com/docs/loki/latest/configuration/#limits_config
+                            for more. Loki queries can also query based on any log
+                            record field (not just labels) using query filters."
                           items:
                             type: string
                           type: array

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -265,24 +265,22 @@ spec:
                         loki`'
                       properties:
                         labelKeys:
-                          description: "LabelKeys is a list of meta-data field keys
-                            to replace the default Loki labels. \n Loki label names
-                            must match the regular expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\".
-                            Illegal characters in meta-data keys are replaced with
-                            \"_\" to form the label name. For example meta-data key
-                            \"kubernetes.labels.foo\" becomes Loki label \"kubernetes_labels_foo\".
-                            \n If LabelKeys is not set, the default keys are `[log_type,
-                            kubernetes.namespace_name, kubernetes.pod_name, kubernetes_host]`
-                            These keys are translated to Loki labels by replacing
-                            '.' with '_' as: `log_type`, `kubernetes_namespace_name`,
-                            `kubernetes_pod_name`, `kubernetes_host` Note that not
-                            all logs will include all of these keys: audit logs and
-                            infrastructure journal logs do not have namespace or pod
-                            name. \n Note: the set of labels should be small, Loki
-                            imposes limits on the size and number of labels allowed.
-                            See https://grafana.com/docs/loki/latest/configuration/#limits_config
-                            for more. You can still query based on any log record
-                            field using query filters."
+                          description: "LabelKeys is a list of log record keys that
+                            will be used as Loki labels with the corresponding log
+                            record value. \n If LabelKeys is not set, the default
+                            keys are `[log_type, kubernetes.namespace_name, kubernetes.pod_name,
+                            kubernetes_host]` \n Note: Loki label names must match
+                            the regular expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\" Log
+                            record keys may contain characters like \".\" and \"/\"
+                            that are not allowed in Loki labels. Log record keys are
+                            translated to Loki labels by replacing any illegal characters
+                            with '_'. For example the default log record keys translate
+                            to these Loki labels: `log_type`, `kubernetes_namespace_name`,
+                            `kubernetes_pod_name`, `kubernetes_host` \n Note: the
+                            set of labels should be small, Loki imposes limits on
+                            the size and number of labels allowed. See https://grafana.com/docs/loki/latest/configuration/#limits_config
+                            for more. Loki queries can also query based on any log
+                            record field (not just labels) using query filters."
                           items:
                             type: string
                           type: array

--- a/docs/reference/operator/api.adoc
+++ b/docs/reference/operator/api.adoc
@@ -1036,7 +1036,9 @@ This is the struct that will contain information pertinent to Log visualization 
 |Property|Type|Description
 
 |kibana|object| **(DEPRECATED)** *(optional)* Specification of the Kibana Visualization component
+|nodeSelector|object|  Define which Nodes the Pods are scheduled on.
 |ocpConsole|object|  *(optional)* OCPConsole is the specification for the OCP console plugin
+|tolerations|array|  *(optional)* Define the tolerations the Pods will accept
 |type|string|  The type of Visualization to configure
 |======================
 
@@ -1050,11 +1052,11 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 |Property|Type|Description
 
-|nodeSelector|object|  Define which Nodes the Pods are scheduled on.
+|nodeSelector|object| **(DEPRECATED)** Define which Nodes the Pods are scheduled on.
 |proxy|object|  Specification of the Kibana Proxy component
 |replicas|int|  *(optional)* Number of instances to deploy for a Kibana deployment
 |resources|object|  *(optional)* The resource requirements for Kibana
-|tolerations|array|  
+|tolerations|array| **(DEPRECATED)** Define the tolerations the Pods will accept
 |======================
 
 === .spec.visualization.kibana.nodeSelector
@@ -1157,6 +1159,12 @@ This is the struct that will contain information pertinent to Log visualization 
 =====  Type
 * int
 
+=== .spec.visualization.nodeSelector
+===== Description
+
+=====  Type
+* object
+
 === .spec.visualization.ocpConsole
 ===== Description
 
@@ -1170,6 +1178,29 @@ This is the struct that will contain information pertinent to Log visualization 
 |logsLimit|int|  *(optional)* LogsLimit is the max number of entries returned for a query.
 |timeout|string|  *(optional)* Timeout is the max duration before a query timeout
 |======================
+
+=== .spec.visualization.tolerations[]
+===== Description
+
+=====  Type
+* array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|effect|string|  *(optional)* Effect indicates the taint effect to match. Empty means match all taint effects.
+|key|string|  *(optional)* Key is the taint key that the toleration applies to. Empty means match all taint keys.
+|operator|string|  *(optional)* Operator represents a key&#39;s relationship to the value.
+|tolerationSeconds|int|  *(optional)* TolerationSeconds represents the period of time the toleration (which must be
+|value|string|  *(optional)* Value is the taint value the toleration matches to.
+|======================
+
+=== .spec.visualization.tolerations[].tolerationSeconds
+===== Description
+
+=====  Type
+* int
 
 === .status
 ===== Description


### PR DESCRIPTION
### Description
This PR:
* fixes CLF loki label keys to replace slash with underscore

### Links
https://issues.redhat.com/browse/LOG-4095
forward port of https://github.com/openshift/cluster-logging-operator/pull/2023