### PR TITLE
LOG-4173 & LOG-4174: manual forward ports of telemetry

### DIFF
--- a/internal/metrics/telemetry/cloteleminfo.go
+++ b/internal/metrics/telemetry/cloteleminfo.go
@@ -16,13 +16,16 @@ const (
 	InputNameAudit          = v1.InputNameAudit
 	InputNameInfrastructure = v1.InputNameInfrastructure
 
-	OutputTypeDefault        = "default"
-	OutputTypeElasticsearch  = v1.OutputTypeElasticsearch
-	OutputTypeFluentdForward = v1.OutputTypeFluentdForward
-	OutputTypeSyslog         = v1.OutputTypeSyslog
-	OutputTypeKafka          = v1.OutputTypeKafka
-	OutputTypeLoki           = v1.OutputTypeLoki
-	OutputTypeCloudwatch     = v1.OutputTypeCloudwatch
+	OutputTypeDefault            = "default"
+	OutputTypeElasticsearch      = v1.OutputTypeElasticsearch
+	OutputTypeFluentdForward     = v1.OutputTypeFluentdForward
+	OutputTypeSyslog             = v1.OutputTypeSyslog
+	OutputTypeKafka              = v1.OutputTypeKafka
+	OutputTypeLoki               = v1.OutputTypeLoki
+	OutputTypeCloudwatch         = v1.OutputTypeCloudwatch
+	OutputTypeHttp               = v1.OutputTypeHttp
+	OutputTypeGoogleCloudLogging = v1.OutputTypeGoogleCloudLogging
+	OutputTypeSplunk             = v1.OutputTypeSplunk
 
 	ManagedStatus = "managedStatus"
 	HealthStatus  = "healthStatus"
@@ -48,7 +51,17 @@ func NewTD() *TData {
 		CollectorErrorCount: utils.Float64Map{M: map[string]float64{"CollectorErrorCount": 0}},
 		CLFInfo:             utils.StringMap{M: map[string]string{HealthStatus: IsNotPresent, PipelineNo: IsNotPresent}},
 		CLFInputType:        utils.StringMap{M: map[string]string{InputNameApplication: IsNotPresent, InputNameAudit: IsNotPresent, InputNameInfrastructure: IsNotPresent}},
-		CLFOutputType:       utils.StringMap{M: map[string]string{OutputTypeDefault: IsNotPresent, OutputTypeElasticsearch: IsNotPresent, OutputTypeFluentdForward: IsNotPresent, OutputTypeSyslog: IsNotPresent, OutputTypeKafka: IsNotPresent, OutputTypeLoki: IsNotPresent, OutputTypeCloudwatch: IsNotPresent}},
+		CLFOutputType: utils.StringMap{M: map[string]string{
+			OutputTypeDefault:            IsNotPresent,
+			OutputTypeElasticsearch:      IsNotPresent,
+			OutputTypeFluentdForward:     IsNotPresent,
+			OutputTypeSyslog:             IsNotPresent,
+			OutputTypeKafka:              IsNotPresent,
+			OutputTypeLoki:               IsNotPresent,
+			OutputTypeCloudwatch:         IsNotPresent,
+			OutputTypeHttp:               IsNotPresent,
+			OutputTypeSplunk:             IsNotPresent,
+			OutputTypeGoogleCloudLogging: IsNotPresent}},
 	}
 }
 
@@ -80,7 +93,17 @@ var (
 	mCLFOutputType = NewInfoVec(
 		"log_forwarder_output_info",
 		"Clf output type specific metric",
-		[]string{OutputTypeDefault, OutputTypeElasticsearch, OutputTypeFluentdForward, OutputTypeSyslog, OutputTypeKafka, OutputTypeLoki, OutputTypeCloudwatch},
+		[]string{
+			OutputTypeDefault,
+			OutputTypeElasticsearch,
+			OutputTypeFluentdForward,
+			OutputTypeSyslog,
+			OutputTypeKafka,
+			OutputTypeLoki,
+			OutputTypeCloudwatch,
+			OutputTypeHttp,
+			OutputTypeSplunk,
+			OutputTypeGoogleCloudLogging},
 	)
 
 	MetricCLList = []prometheus.Collector{
@@ -136,13 +159,16 @@ func SetCLFMetrics(value float64) {
 		InputNameInfrastructure: CLFInputType[InputNameInfrastructure]}).Set(value)
 
 	mCLFOutputType.With(prometheus.Labels{
-		OutputTypeDefault:        CLFOutputType[OutputTypeDefault],
-		OutputTypeElasticsearch:  CLFOutputType[OutputTypeElasticsearch],
-		OutputTypeFluentdForward: CLFOutputType[OutputTypeFluentdForward],
-		OutputTypeSyslog:         CLFOutputType[OutputTypeSyslog],
-		OutputTypeKafka:          CLFOutputType[OutputTypeKafka],
-		OutputTypeLoki:           CLFOutputType[OutputTypeLoki],
-		OutputTypeCloudwatch:     CLFOutputType[OutputTypeCloudwatch]}).Set(value)
+		OutputTypeDefault:            CLFOutputType[OutputTypeDefault],
+		OutputTypeElasticsearch:      CLFOutputType[OutputTypeElasticsearch],
+		OutputTypeFluentdForward:     CLFOutputType[OutputTypeFluentdForward],
+		OutputTypeSyslog:             CLFOutputType[OutputTypeSyslog],
+		OutputTypeKafka:              CLFOutputType[OutputTypeKafka],
+		OutputTypeLoki:               CLFOutputType[OutputTypeLoki],
+		OutputTypeCloudwatch:         CLFOutputType[OutputTypeCloudwatch],
+		OutputTypeHttp:               CLFOutputType[OutputTypeHttp],
+		OutputTypeSplunk:             CLFOutputType[OutputTypeSplunk],
+		OutputTypeGoogleCloudLogging: CLFOutputType[OutputTypeGoogleCloudLogging]}).Set(value)
 }
 
 func NewInfoVec(metricname string, metrichelp string, labelNames []string) *prometheus.GaugeVec {


### PR DESCRIPTION
### Description
This is a forward port of [LOG-3932](https://github.com/openshift/cluster-logging-operator/pull/1957) & [LOG-3997](https://github.com/openshift/cluster-logging-operator/pull/1964)
- Adds `log_forwarder_output_info` for `http`, `splunk`, and `googleCloudLogging`

/cc @syedriko @cahartma 
/assign @jcantrill 

### Links

- JIRA:
  - https://issues.redhat.com/browse/LOG-4173
  - https://issues.redhat.com/browse/LOG-4174

