### PR TITLE
LOG-4185: Always prefer collection.logs.* over collection.

### DIFF
--- a/internal/migrations/migrate_clusterlogging.go
+++ b/internal/migrations/migrate_clusterlogging.go
@@ -27,12 +27,6 @@ func MigrateCollectionSpec(spec loggingv1.ClusterLoggingSpec) loggingv1.ClusterL
 		spec.Forwarder = nil
 	}
 
-	if spec.Collection.Type != "" && spec.Collection.Type.IsSupportedCollector() {
-		log.V(3).Info("collectionSpec already using latest. removing spec.Collection.Logs while reconciling")
-		spec.Collection.Logs = nil
-		return spec
-	}
-
 	logSpec := spec.Collection.Logs
 	if logSpec != nil {
 		spec.Collection.Type = logSpec.Type


### PR DESCRIPTION
### Description
This PR:
* modifies migration to always prefer the deprecated collection.logs.* over collection.*
* This breaks any users that have both collection.logs.* over collection.* defined

### Links
* https://issues.redhat.com/browse/LOG-4185

cc @alanconway @libander @anpingli 
