### PR TITLE
LOG-4185: Always prefer collection.logs.* over collection.

### DIFF
--- a/internal/migrations/migrate_collection.go
+++ b/internal/migrations/migrate_collection.go
@@ -18,12 +18,6 @@ func MigrateCollectionSpec(spec logging.ClusterLoggingSpec) logging.ClusterLoggi
 		spec.Forwarder = nil
 	}
 
-	if spec.Collection.Type != "" && spec.Collection.Type.IsSupportedCollector() {
-		log.V(3).Info("collectionSpec already using latest. removing spec.Collection.Logs while reconciling")
-		spec.Collection.Logs = nil
-		return spec
-	}
-
 	logSpec := spec.Collection.Logs
 	if logSpec != nil {
 		spec.Collection.Type = logSpec.Type

--- a/internal/migrations/migrate_collection_test.go
+++ b/internal/migrations/migrate_collection_test.go
@@ -75,14 +75,33 @@ var _ = Describe("Migrating ClusterLogging instance", func() {
 			})
 		})
 
-		Context("when new collection fields are set", func() {
-			It("should ignore deprecated fields", func() {
+		Context("when new collection and deprecated fields are set", func() {
+			It("should prefer deprecated fields", func() {
 
 				cl.Collection.Type = LogCollectionTypeFluentd
+				cl.Collection.Resources = &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1000Gi"),
+						corev1.ResourceCPU:    resource.MustParse("4"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("15Gi"),
+						corev1.ResourceCPU:    resource.MustParse("18"),
+					},
+				}
+				cl.Collection.Tolerations = []corev1.Toleration{
+					{Key: "abc", Operator: corev1.TolerationOpExists, Value: "bar", Effect: corev1.TaintEffectNoExecute},
+				}
+				cl.Collection.NodeSelector = map[string]string{"ignorme": "yes"}
 
 				Expect(MigrateCollectionSpec(cl)).To(Equal(ClusterLoggingSpec{
 					Collection: &CollectionSpec{
-						Type:    LogCollectionTypeFluentd,
+						Type: LogCollectionTypeFluentd,
+						CollectorSpec: CollectorSpec{
+							Resources:    resources,
+							NodeSelector: nodeSelector,
+							Tolerations:  tolerations,
+						},
 						Fluentd: fluentTuning,
 					},
 				}))


### PR DESCRIPTION
### Description
This PR:
* modifies migration to always prefer the deprecated collection.logs.* over collection.*
* This breaks any users that have both collection.logs.* over collection.* defined

### Links
* https://issues.redhat.com/browse/LOG-4185
* forward port of https://github.com/openshift/cluster-logging-operator/pull/2037