### PR TITLE
LOG-4188: Use sync.Map type from GoLang standard library

### DIFF
--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -264,21 +264,22 @@ func updateInfofromCLF(request *ClusterLoggingRequest) {
 		inref := pipeline.InputRefs
 		outref := pipeline.OutputRefs
 
-		for labelname := range telemetry.Data.CLFInputType.M {
+		telemetry.Data.CLFInputType.Range(func(labelname, value interface{}) bool {
 			log.V(1).Info("iter over labelnames", "labelname", labelname)
-			telemetry.Data.CLFInputType.Set(labelname, constants.IsNotPresent) //reset to zero
+			telemetry.Data.CLFInputType.Set(labelname.(string), constants.IsNotPresent) //reset to zero
 			for _, inputtype := range inref {
 				log.V(1).Info("iter over inputtype", "inputtype", inputtype)
 				if inputtype == labelname {
 					log.V(1).Info("labelname and inputtype", "labelname", labelname, "inputtype", inputtype) //when matched print matched labelname with input type stated in CLF spec
-					telemetry.Data.CLFInputType.Set(labelname, constants.IsPresent)                          //input type present in CLF spec
+					telemetry.Data.CLFInputType.Set(labelname.(string), constants.IsPresent)                 //input type present in CLF spec
 				}
 			}
-		}
+			return true // continue iterating
+		})
 
-		for labelname := range telemetry.Data.CLFOutputType.M {
+		telemetry.Data.CLFOutputType.Range(func(labelname, value interface{}) bool {
 			log.V(1).Info("iter over labelnames", "labelname", labelname)
-			telemetry.Data.CLFOutputType.Set(labelname, constants.IsNotPresent) //reset to zero
+			telemetry.Data.CLFOutputType.Set(labelname.(string), constants.IsNotPresent) //reset to zero
 			for _, outputname := range outref {
 				log.V(1).Info("iter over outref", "outputname", outputname)
 				if outputname == "default" {
@@ -290,11 +291,12 @@ func updateInfofromCLF(request *ClusterLoggingRequest) {
 					outputtype := output.Type
 					if outputtype == labelname {
 						log.V(1).Info("labelname and outputtype", "labelname", labelname, "outputtype", outputtype)
-						telemetry.Data.CLFOutputType.Set(labelname, constants.IsPresent) //when matched print matched labelname with output type stated in CLF spec
+						telemetry.Data.CLFOutputType.Set(labelname.(string), constants.IsPresent) //when matched print matched labelname with output type stated in CLF spec
 					}
 				}
 			}
-		}
+			return true // continue iterating
+		})
 		log.V(1).Info("post updating inputtype and outputtype")
 		telemetry.Data.CLFInfo.Set("pipelineInfo", strconv.Itoa(npipelines))
 	}

--- a/internal/telemetry/cloteleminfo.go
+++ b/internal/telemetry/cloteleminfo.go
@@ -34,23 +34,24 @@ const (
 
 // placeholder for keeping clo info which will be used for clo metrics update
 type TData struct {
-	CLInfo              utils.StringMap
-	CLLogStoreType      utils.StringMap
-	CollectorErrorCount utils.Float64Map
-	CLFInfo             utils.StringMap
-	CLFInputType        utils.StringMap
-	CLFOutputType       utils.StringMap
+	CLInfo              *utils.StringMap
+	CLLogStoreType      *utils.StringMap
+	CollectorErrorCount *utils.Float64Map
+	CLFInfo             *utils.StringMap
+	CLFInputType        *utils.StringMap
+	CLFOutputType       *utils.StringMap
 }
 
 // IsNotPresent stands for managedStatus and healthStatus true and healthy
 func NewTD() *TData {
+
 	return &TData{
-		CLInfo:              utils.StringMap{M: map[string]string{VersionNo: version.Version, ManagedStatus: IsNotPresent, HealthStatus: IsNotPresent}},
-		CLLogStoreType:      utils.StringMap{M: map[string]string{OutputTypeElasticsearch: IsNotPresent, OutputTypeLoki: IsNotPresent}},
-		CollectorErrorCount: utils.Float64Map{M: map[string]float64{"CollectorErrorCount": 0}},
-		CLFInfo:             utils.StringMap{M: map[string]string{HealthStatus: IsNotPresent, PipelineNo: IsNotPresent}},
-		CLFInputType:        utils.StringMap{M: map[string]string{InputNameApplication: IsNotPresent, InputNameAudit: IsNotPresent, InputNameInfrastructure: IsNotPresent}},
-		CLFOutputType: utils.StringMap{M: map[string]string{
+		CLInfo:              utils.InitStringMap(map[string]string{VersionNo: version.Version, ManagedStatus: IsNotPresent, HealthStatus: IsNotPresent}),
+		CLLogStoreType:      utils.InitStringMap(map[string]string{OutputTypeElasticsearch: IsNotPresent, OutputTypeLoki: IsNotPresent}),
+		CollectorErrorCount: utils.InitFloat64Map(map[string]float64{"CollectorErrorCount": 0}),
+		CLFInfo:             utils.InitStringMap(map[string]string{HealthStatus: IsNotPresent, PipelineNo: IsNotPresent}),
+		CLFInputType:        utils.InitStringMap(map[string]string{InputNameApplication: IsNotPresent, InputNameAudit: IsNotPresent, InputNameInfrastructure: IsNotPresent}),
+		CLFOutputType: utils.InitStringMap(map[string]string{
 			OutputTypeDefault:            IsNotPresent,
 			OutputTypeElasticsearch:      IsNotPresent,
 			OutputTypeFluentdForward:     IsNotPresent,
@@ -59,7 +60,7 @@ func NewTD() *TData {
 			OutputTypeLoki:               IsNotPresent,
 			OutputTypeCloudwatch:         IsNotPresent,
 			OutputTypeSplunk:             IsNotPresent,
-			OutputTypeGoogleCloudLogging: IsNotPresent}},
+			OutputTypeGoogleCloudLogging: IsNotPresent}),
 	}
 }
 
@@ -128,42 +129,42 @@ func RegisterMetrics() error {
 }
 
 func SetCLMetrics(value float64) {
-	CLInfo := Data.CLInfo.M
+	CLInfo := Data.CLInfo
 	mCLInfo.With(prometheus.Labels{
-		VersionNo:     CLInfo[VersionNo],
-		ManagedStatus: CLInfo[ManagedStatus],
-		HealthStatus:  CLInfo[HealthStatus]}).Set(value)
+		VersionNo:     CLInfo.Get(VersionNo),
+		ManagedStatus: CLInfo.Get(ManagedStatus),
+		HealthStatus:  CLInfo.Get(HealthStatus)}).Set(value)
 }
 
 func SetCLFMetrics(value float64) {
-	CLInfo := Data.CLInfo.M
-	CErrorCount := Data.CollectorErrorCount.M
-	CLFInfo := Data.CLFInfo.M
-	CLFInputType := Data.CLFInputType.M
-	CLFOutputType := Data.CLFOutputType.M
+	CLInfo := Data.CLInfo
+	CErrorCount := Data.CollectorErrorCount
+	CLFInfo := Data.CLFInfo
+	CLFInputType := Data.CLFInputType
+	CLFOutputType := Data.CLFOutputType
 
 	mCollectorErrorCount.With(prometheus.Labels{
-		VersionNo: CLInfo[VersionNo]}).Set(CErrorCount["CollectorErrorCount"])
+		VersionNo: CLInfo.Get(VersionNo)}).Set(CErrorCount.Get("CollectorErrorCount"))
 
 	mCLFInfo.With(prometheus.Labels{
-		HealthStatus: CLFInfo[HealthStatus],
-		PipelineNo:   CLFInfo[PipelineNo]}).Set(value)
+		HealthStatus: CLFInfo.Get(HealthStatus),
+		PipelineNo:   CLFInfo.Get(PipelineNo)}).Set(value)
 
 	mCLFInputType.With(prometheus.Labels{
-		InputNameApplication:    CLFInputType[InputNameApplication],
-		InputNameAudit:          CLFInputType[InputNameAudit],
-		InputNameInfrastructure: CLFInputType[InputNameInfrastructure]}).Set(value)
+		InputNameApplication:    CLFInputType.Get(InputNameApplication),
+		InputNameAudit:          CLFInputType.Get(InputNameAudit),
+		InputNameInfrastructure: CLFInputType.Get(InputNameInfrastructure)}).Set(value)
 
 	mCLFOutputType.With(prometheus.Labels{
-		OutputTypeDefault:            CLFOutputType[OutputTypeDefault],
-		OutputTypeElasticsearch:      CLFOutputType[OutputTypeElasticsearch],
-		OutputTypeFluentdForward:     CLFOutputType[OutputTypeFluentdForward],
-		OutputTypeSyslog:             CLFOutputType[OutputTypeSyslog],
-		OutputTypeKafka:              CLFOutputType[OutputTypeKafka],
-		OutputTypeLoki:               CLFOutputType[OutputTypeLoki],
-		OutputTypeCloudwatch:         CLFOutputType[OutputTypeCloudwatch],
-		OutputTypeSplunk:             CLFOutputType[OutputTypeSplunk],
-		OutputTypeGoogleCloudLogging: CLFOutputType[OutputTypeGoogleCloudLogging]}).Set(value)
+		OutputTypeDefault:            CLFOutputType.Get(OutputTypeDefault),
+		OutputTypeElasticsearch:      CLFOutputType.Get(OutputTypeElasticsearch),
+		OutputTypeFluentdForward:     CLFOutputType.Get(OutputTypeFluentdForward),
+		OutputTypeSyslog:             CLFOutputType.Get(OutputTypeSyslog),
+		OutputTypeKafka:              CLFOutputType.Get(OutputTypeKafka),
+		OutputTypeLoki:               CLFOutputType.Get(OutputTypeLoki),
+		OutputTypeCloudwatch:         CLFOutputType.Get(OutputTypeCloudwatch),
+		OutputTypeSplunk:             CLFOutputType.Get(OutputTypeSplunk),
+		OutputTypeGoogleCloudLogging: CLFOutputType.Get(OutputTypeGoogleCloudLogging)}).Set(value)
 }
 
 func NewInfoVec(metricname string, metrichelp string, labelNames []string) *prometheus.GaugeVec {

--- a/internal/telemetry/cloteleminfo_test.go
+++ b/internal/telemetry/cloteleminfo_test.go
@@ -17,16 +17,16 @@ func TestCart(t *testing.T) {
 	RunSpecs(t, "clo telemetry test")
 }
 
-//Test if ServiceMonitor spec is correct or not, also Prometheus Metrics get Registered, Updated, Retrieved properly or not
+// Test if ServiceMonitor spec is correct or not, also Prometheus Metrics get Registered, Updated, Retrieved properly or not
 var _ = Describe("telemetry", func() {
 
 	var (
 		data          = NewTD()
 		mdir          string
 		smYamlFile    string
-		CLinfo        = data.CLInfo.M
-		CLFinputType  = data.CLFInputType.M
-		CLFoutputType = data.CLFOutputType.M
+		CLinfo        = data.CLInfo
+		CLFinputType  = data.CLFInputType
+		CLFoutputType = data.CLFOutputType
 		manifestFile  string
 	)
 
@@ -51,9 +51,9 @@ var _ = Describe("telemetry", func() {
 				Expect(sm).To(MatchYAML(msm))
 			})
 			It("Info metric must have version, managedStatus, healthStatus as default values", func() {
-				Expect(CLinfo["version"]).To(Equal(version.Version))
-				Expect(CLFinputType["application"]).To(Equal("0"))
-				Expect(CLFoutputType["elasticsearch"]).To(Equal("0"))
+				Expect(CLinfo.Get("version")).To(Equal(version.Version))
+				Expect(CLFinputType.Get("application")).To(Equal("0"))
+				Expect(CLFoutputType.Get("elasticsearch")).To(Equal("0"))
 			})
 		})
 	})

--- a/internal/utils/safemap.go
+++ b/internal/utils/safemap.go
@@ -4,38 +4,61 @@ import "sync"
 
 // StringMap is a concurrent-safe map[string]string based on sync.Map
 type StringMap struct {
-	sync.RWMutex
-	M map[string]string
+	m sync.Map
 }
 type Float64Map struct {
-	sync.RWMutex
-	M map[string]float64
+	m sync.Map
+}
+
+func InitStringMap(m map[string]string) *StringMap {
+	sm := &StringMap{}
+	for key, val := range m {
+		sm.Set(key, val)
+	}
+	return sm
+}
+
+func InitFloat64Map(m map[string]float64) *Float64Map {
+	fm := &Float64Map{}
+	for key, val := range m {
+		fm.m.Store(key, val)
+	}
+	return fm
 }
 
 // Get is a wrapper for getting the value from the underlying map
-func (r *StringMap) Get(key string) string {
-	r.RLock()
-	defer r.RUnlock()
-	return r.M[key]
+func (sm *StringMap) Get(key string) string {
+	if val, ok := sm.m.Load(key); ok {
+		return val.(string)
+	}
+	return ""
 }
 
 // Set is a wrapper for setting the value of a key in the underlying map
-func (r *StringMap) Set(key string, val string) {
-	r.Lock()
-	defer r.Unlock()
-	r.M[key] = val
+func (sm *StringMap) Set(key string, val string) {
+	sm.m.Store(key, val)
 }
 
-//for prometheus gauge metric setting up a value of float64
-func (r *Float64Map) Inc(key string) {
-	r.Lock()
-	defer r.Unlock()
-	r.M[key]++
+// for prometheus gauge metric setting up a value of float64
+func (fm *Float64Map) Inc(key string) {
+	if val, ok := fm.m.Load(key); ok {
+		f := val.(float64) + 1
+		fm.m.Store(key, f)
+	}
 }
 
 // for prometheus gauge metric getting a value of float64
-func (f *Float64Map) Get(key string) float64 {
-	f.RLock()
-	defer f.RUnlock()
-	return f.M[key]
+func (fm *Float64Map) Get(key string) float64 {
+	if val, ok := fm.m.Load(key); ok {
+		return val.(float64)
+	}
+	return 0
+}
+
+func (sm *StringMap) Range(f func(key, value interface{}) bool) {
+	sm.m.Range(f)
+}
+
+func (fm *Float64Map) Range(f func(key, value interface{}) bool) {
+	fm.m.Range(f)
 }

--- a/internal/utils/safemap_test.go
+++ b/internal/utils/safemap_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStringMap(t *testing.T) {
+func TestSafeMap(t *testing.T) {
 	var y float64 = 0.04
-	m := StringMap{M: map[string]string{"x": "y"}}
+	m := InitStringMap(map[string]string{"x": "y"})
 	assert.Equal(t, "y", m.Get("x"))
 	m.Set("x", "z")
 	assert.Equal(t, "z", m.Get("x"))
-	f := Float64Map{M: map[string]float64{"x": y}}
+	f := InitFloat64Map(map[string]float64{"x": y})
 	f.Inc("x")
 	newy := f.Get("x")
 	assert.Equal(t, y+1, newy)

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func main() {
 		ClusterID:      clusterID,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterLogForwarder")
-		telemetry.Data.CLInfo.M["healthStatus"] = UnHealthyStatus
+		telemetry.Data.CLInfo.Set("healthStatus", UnHealthyStatus)
 		os.Exit(1)
 	}
 	if err = (&forwarding.ReconcileForwarder{
@@ -137,7 +137,7 @@ func main() {
 		ClusterID:      clusterID,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterLogging")
-		telemetry.Data.CLFInfo.M["healthStatus"] = UnHealthyStatus
+		telemetry.Data.CLFInfo.Set("healthStatus", UnHealthyStatus)
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder
@@ -157,7 +157,7 @@ func main() {
 		cloversion = version.Version
 		log.Info("Failed to get clo version from env variable OPERATOR_CONDITION_NAME so falling back to default version")
 	}
-	telemetry.Data.CLInfo.M["version"] = cloversion
+	telemetry.Data.CLInfo.Set("version", cloversion)
 
 	errr := telemetry.RegisterMetrics()
 	if errr != nil {


### PR DESCRIPTION
### Description
This PR introduces the usage of `sync.Map` to provide concurrent-safe access to a map instead of manually managing locks with a standard map in existed `StringMap` and `Float64Map` structs


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4188
- Enhancement proposal:
