### PR TITLE
LOG-4177: checking is ClusterLogging in Management state before perform reconcile

### DIFF
--- a/controllers/forwarding/forwarding_controller.go
+++ b/controllers/forwarding/forwarding_controller.go
@@ -75,6 +75,10 @@ func (r *ReconcileForwarder) Reconcile(ctx context.Context, request ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
+	if !k8shandler.IsManaged(r.Client, r.Recorder, r.ClusterID) {
+		return ctrl.Result{}, nil
+	}
+
 	if err := clusterlogforwarder.Validate(*instance); err != nil {
 		instance.Status.Conditions.SetCondition(condInvalid("validation failed: %v", err))
 		return r.updateStatus(instance)

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -162,6 +162,23 @@ func removeManagedStorage(clusterRequest ClusterLoggingRequest) {
 	}
 }
 
+func IsManaged(requestClient client.Client, er record.EventRecorder, clusterID string) bool {
+	clusterLoggingRequest := ClusterLoggingRequest{
+		Client:        requestClient,
+		EventRecorder: er,
+		ClusterID:     clusterID,
+	}
+	clusterLogging, _ := clusterLoggingRequest.getClusterLogging(false)
+	if clusterLogging == nil {
+		return false
+	}
+	if clusterLogging.Spec.ManagementState == logging.ManagementStateUnmanaged {
+		telemetry.Data.CLInfo.Set("managedStatus", constants.UnManagedStatus)
+		return false
+	}
+	return true
+}
+
 func ReconcileForClusterLogForwarder(forwarder *logging.ClusterLogForwarder, requestClient client.Client, er record.EventRecorder, clusterID string) (err error) {
 	clusterLoggingRequest := ClusterLoggingRequest{
 		Client:        requestClient,


### PR DESCRIPTION
### Description
This PR adds a check that ensures the `ClusterLogging` resource is in the appropriate `Management` state before proceeding with reconciliation `ClusterLoggingForwarder`.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4177
- Enhancement proposal:
