### PR TITLE
Add common labels for Log Files Metric Exporter

### DIFF
--- a/internal/metrics/logfilemetricexporter/daemonset.go
+++ b/internal/metrics/logfilemetricexporter/daemonset.go
@@ -4,6 +4,7 @@ import (
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/apis/logging/v1alpha1"
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/tls"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,10 +19,10 @@ func ReconcileDaemonset(exporter loggingv1alpha1.LogFileMetricExporter,
 	namespace,
 	name string,
 	collectionType loggingv1.LogCollectionType,
-	owner metav1.OwnerReference) error {
+	owner metav1.OwnerReference, visitors ...func(o runtime.Object)) error {
 
 	tlsProfile, _ := tls.FetchAPIServerTlsProfile(k8sClient)
-	desired := NewDaemonSet(exporter, namespace, name, collectionType, tls.GetClusterTLSProfileSpec(tlsProfile))
+	desired := NewDaemonSet(exporter, namespace, name, collectionType, tls.GetClusterTLSProfileSpec(tlsProfile), visitors...)
 	utils.AddOwnerRefToObject(desired, owner)
 	return reconcile.DaemonSet(er, k8sClient, desired)
 }

--- a/internal/metrics/logfilemetricexporter/factory.go
+++ b/internal/metrics/logfilemetricexporter/factory.go
@@ -1,6 +1,7 @@
 package logfilemetricexporter
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/tls"
@@ -63,9 +64,9 @@ func Tolerations(exporter loggingv1a1.LogFileMetricExporter) []v1.Toleration {
 	return append(defaultTolerations, exporter.Spec.Tolerations...)
 }
 
-func NewDaemonSet(exporter loggingv1a1.LogFileMetricExporter, namespace, name string, collectionType loggingv1.LogCollectionType, tlsProfileSpec configv1.TLSProfileSpec) *apps.DaemonSet {
+func NewDaemonSet(exporter loggingv1a1.LogFileMetricExporter, namespace, name string, collectionType loggingv1.LogCollectionType, tlsProfileSpec configv1.TLSProfileSpec, visitors ...func(o runtime.Object)) *apps.DaemonSet {
 	podSpec := NewPodSpec(exporter, tlsProfileSpec)
-	ds := coreFactory.NewDaemonSet(name, namespace, constants.LogfilesmetricexporterName, constants.LogfilesmetricexporterName, string(collectionType), *podSpec)
+	ds := coreFactory.NewDaemonSet(name, namespace, constants.LogfilesmetricexporterName, constants.LogfilesmetricexporterName, string(collectionType), *podSpec, visitors...)
 	return ds
 }
 

--- a/internal/metrics/logfilemetricexporter/metric_exporter.go
+++ b/internal/metrics/logfilemetricexporter/metric_exporter.go
@@ -46,7 +46,8 @@ func Reconcile(lfmeInstance *loggingv1alpha1.LogFileMetricExporter,
 		lfmeInstance.Namespace,
 		constants.LogfilesmetricexporterName,
 		clInstance.Spec.Collection.Type,
-		owner); err != nil {
+		owner,
+		commonLabels); err != nil {
 		msg := fmt.Sprintf("Unable to reconcile LogFileMetricExporter: %v", err)
 		telemetry.Data.LFMEInfo.Set(telemetry.HealthStatus, constants.UnHealthyStatus)
 		log.Error(err, msg)


### PR DESCRIPTION
### Description

This PR adds Kubernetes common labels to the Log Files Metric Exporter pods and daemonset. These labels will help with grouping and filtering resources in Kubernetes.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
