### PR TITLE
LOG-4181: fix loki e2e flake by adding test cleanup

### DIFF
--- a/test/helpers/loki/receiver.go
+++ b/test/helpers/loki/receiver.go
@@ -112,6 +112,17 @@ func (r *Receiver) Create(c *client.Client) error {
 	})
 }
 
+// Delete the receiver's resources. Blocks till created.
+func (r *Receiver) Delete(c *client.Client) error {
+	r.timeout = c.Timeout()
+	for _, o := range []crclient.Object{r.Pod, r.service, r.route} {
+		if err := c.Delete(o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ExternalURL returns the URL of the external route. Only valid after Create()
 func (r *Receiver) ExternalURL(path string) *url.URL {
 	return &url.URL{Scheme: "http", Host: r.route.Spec.Host, Path: path}


### PR DESCRIPTION
### Description
This PR:
* adds cleanup of test resources to attempt to address:

```
        	Error Trace:	/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/loki/forward_to_loki_test.go:111
        	            				/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/loki/forward_to_loki_test.go:92
        	Error:      	Received unexpected error:
        	            	pods "loki-receiver" already exists
        	Test:       	TestLogForwardingToLokiWithVector
```

### Links
* https://issues.redhat.com/browse/LOG-4181