### PR TITLE
LOG-4237: add validation rule that will drop configuration for Splunk output and Fluentd collector

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -213,6 +213,9 @@ func verifyOutputs(clusterlogging *loggingv1.ClusterLogging, clfClient client.Cl
 			status.Outputs.Set(output.Name,
 				CondInvalid("output %q: Exactly one of billingAccountId, folderId, organizationId, or projectId must be set.",
 					output.Name))
+		case output.Type == loggingv1.OutputTypeSplunk && constants.FluentdName == clusterlogging.Spec.Collection.Type:
+			log.V(3).Info("verifyOutputs failed", "reason", "Splunk output not supported by Fluentd collector", "output name", output.Name)
+			status.Outputs.Set(output.Name, CondInvalid("output %q: Splunk output not supported by Fluentd collector", output.Name))
 		default:
 			status.Outputs.Set(output.Name, condReady)
 		}

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
@@ -397,6 +397,36 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 			Expect(clfStatus.Outputs["aName"]).To(HaveCondition("Ready", false, "MissingResource", "secret.*not found"))
 		})
 
+		It("should drop Splunk for Fluent", func() {
+			forwarderSpec.Outputs = []loggingv1.OutputSpec{
+				{
+					Name: "splunk",
+					Type: loggingv1.OutputTypeSplunk,
+					URL:  "https://somewhere",
+				},
+			}
+			cluster.Spec.Collection = &loggingv1.CollectionSpec{
+				Type: loggingv1.LogCollectionTypeFluentd,
+			}
+			verifyOutputs(cluster, client, forwarderSpec, clfStatus, extras)
+			Expect(clfStatus.Outputs["splunk"]).To(HaveCondition("Ready", false, "Invalid", "Splunk output not supported by Fluentd collector"))
+		})
+
+		It("should pass Splunk for Vector", func() {
+			forwarderSpec.Outputs = []loggingv1.OutputSpec{
+				{
+					Name: "splunk",
+					Type: loggingv1.OutputTypeSplunk,
+					URL:  "https://somewhere",
+				},
+			}
+			cluster.Spec.Collection = &loggingv1.CollectionSpec{
+				Type: loggingv1.LogCollectionTypeVector,
+			}
+			verifyOutputs(cluster, client, forwarderSpec, clfStatus, extras)
+			Expect(clfStatus.Outputs["splunk"]).To(HaveCondition(loggingv1.ConditionReady, true, "", ""))
+		})
+
 		Context("when validating secrets", func() {
 			var secret *corev1.Secret
 			BeforeEach(func() {


### PR DESCRIPTION
### Description
This PR addresses the issue where the configuration for `Splunk` output and `Fluentd` collector, this can lead to unexpected behavior and errors in the system, it because we not support `Fluentd` and `Splunk` integration (see https://docs.openshift.com/container-platform/4.13/logging/v5_6/logging-5-6-reference.html). To resolve this, we have implemented a new validation rule that will drop the configuration for `Splunk` output and `Fluentd` collector.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
