### PR TITLE
LOG-4239: Add ClusterLogging validation for multi clusterlogforwarder

### DIFF
--- a/internal/validations/clusterlogging/suite_test.go
+++ b/internal/validations/clusterlogging/suite_test.go
@@ -1,0 +1,13 @@
+package clusterlogging
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][validations][clusterlogging] Suite")
+}

--- a/internal/validations/clusterlogging/validate_clusterlogging_spec.go
+++ b/internal/validations/clusterlogging/validate_clusterlogging_spec.go
@@ -1,0 +1,25 @@
+package clusterlogging
+
+import (
+	v1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/validations/errors"
+)
+
+func validateClusterLoggingSpec(cl v1.ClusterLogging) error {
+
+	if cl.Namespace == constants.OpenshiftNS && cl.Name == constants.SingletonName {
+		return nil
+	}
+	spec := cl.Spec
+	if spec.Forwarder != nil || spec.LogStore != nil || spec.Curation != nil || spec.Visualization != nil {
+		return errors.NewValidationError("Only spec.collection is allowed when using multiple instances of ClusterLogForwarder: %s/%s", cl.Namespace, cl.Name)
+	}
+	if spec.Collection.Logs != nil {
+		return errors.NewValidationError("The use of spec.collection.logs is deprecated in favor of spec.collection fields of ClusterLogForwarder: %s/%s", cl.Namespace, cl.Name)
+	}
+	if spec.Collection.Type != v1.LogCollectionTypeVector {
+		return errors.NewValidationError("Only vector collector impl is supported when using multiple instances of ClusterLogForwarder: %s/%s", cl.Namespace, cl.Name)
+	}
+	return nil
+}

--- a/internal/validations/clusterlogging/validate_clusterlogging_spec_test.go
+++ b/internal/validations/clusterlogging/validate_clusterlogging_spec_test.go
@@ -1,0 +1,82 @@
+package clusterlogging
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/test/runtime"
+)
+
+var _ = Describe("[internal][validations] ClusterLogging", func() {
+
+	Context("#validateClusterLoggingSpec", func() {
+		var (
+			cl *logging.ClusterLogging
+		)
+		BeforeEach(func() {
+			cl = runtime.NewClusterLogging()
+			cl.Spec.LogStore = &logging.LogStoreSpec{
+				Type: logging.LogStoreTypeElasticsearch,
+			}
+			cl.Spec.Visualization = &logging.VisualizationSpec{}
+			cl.Spec.Curation = &logging.CurationSpec{}
+			cl.Spec.Forwarder = &logging.ForwarderSpec{}
+		})
+
+		Context("for resource in openshift-logging named 'instance'", func() {
+			It("should pass validation with no regressions since this is the legacy mode", func() {
+				Expect(validateClusterLoggingSpec(*cl)).To(Succeed())
+			})
+		})
+
+		Context("for resource not in openshift-logging or not named 'instance' in openshift-logging", func() {
+
+			BeforeEach(func() {
+				cl = runtime.NewClusterLogging()
+				cl.Namespace = "a test namespace"
+				cl.Name = "mycollector"
+				cl.Spec.Collection = &logging.CollectionSpec{
+					Type: logging.LogCollectionTypeVector,
+					CollectorSpec: logging.CollectorSpec{
+						NodeSelector: map[string]string{
+							"foo": "bar",
+						},
+					},
+				}
+			})
+
+			It("should fail when anything but collection is spec'd", func() {
+				cl.Spec.LogStore = &logging.LogStoreSpec{
+					Type: logging.LogStoreTypeElasticsearch,
+				}
+				cl.Spec.Visualization = &logging.VisualizationSpec{}
+				cl.Spec.Curation = &logging.CurationSpec{}
+				cl.Spec.Forwarder = &logging.ForwarderSpec{}
+				err := validateClusterLoggingSpec(*cl)
+				Expect(err).To(Not(Succeed()))
+			})
+			It("should fail when collection.logs is spec'd", func() {
+				cl.Spec.Collection.Logs = &logging.LogCollectionSpec{}
+				err := validateClusterLoggingSpec(*cl)
+				Expect(err).To(Not(Succeed()))
+			})
+			It("should fail when collection.type of fluentd is spec'd", func() {
+				cl.Spec.Collection.Type = logging.LogCollectionTypeFluentd
+				err := validateClusterLoggingSpec(*cl)
+				Expect(err).To(Not(Succeed()))
+			})
+			It("should fail when collection.type is empty", func() {
+				cl.Spec.Collection.Type = ""
+				err := validateClusterLoggingSpec(*cl)
+				Expect(err).To(Not(Succeed()))
+			})
+			It("should pass when collection.type is spec'd", func() {
+				err := validateClusterLoggingSpec(*cl)
+				Expect(err).To(Succeed())
+			})
+
+		})
+
+	})
+
+})

--- a/internal/validations/clusterlogging/validations.go
+++ b/internal/validations/clusterlogging/validations.go
@@ -1,0 +1,21 @@
+package clusterlogging
+
+import (
+	v1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Validate(cl v1.ClusterLogging, k8sClient client.Client, extras map[string]bool) error {
+	for _, validate := range validations {
+		if err := validate(cl); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validations are the set of admission rules for validating
+// a ClusterLogging
+var validations = []func(cl v1.ClusterLogging) error{
+	validateClusterLoggingSpec,
+}

--- a/internal/validations/errors/errors.go
+++ b/internal/validations/errors/errors.go
@@ -15,7 +15,7 @@ func (e *ValidationError) Error() string {
 
 func NewValidationError(msg string, args ...interface{}) *ValidationError {
 	if len(args) > 0 {
-		msg = fmt.Sprintf(msg, args)
+		msg = fmt.Sprintf(msg, args...)
 	}
 	return &ValidationError{msg: msg}
 }


### PR DESCRIPTION
### Description
This PR:
* adds ClusterLogging validation in support of multi-clusterlogforwarder

### Links
* https://issues.redhat.com/browse/LOG-4239
