### PR TITLE
LOG-4242: remove 'enabled = true' from TLS config for Cloudwatch and GCL outputs

### DIFF
--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -117,6 +117,7 @@ func SecurityConfig(secret *corev1.Secret) Element {
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
 		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
+			tlsConf.NeedsEnabled = false
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
@@ -136,7 +136,6 @@ encoding.codec = "json"
 request.concurrency = 2
 healthcheck.enabled = false
 [sinks.cw.tls]
-enabled = true
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
 key_file = "/var/run/ocp-collector/secrets/vector-cw-secret-tls/tls.key"
@@ -158,7 +157,6 @@ encoding.codec = "json"
 request.concurrency = 2
 healthcheck.enabled = false
 [sinks.cw.tls]
-enabled = true
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
 `
@@ -178,7 +176,6 @@ encoding.codec = "json"
 request.concurrency = 2
 healthcheck.enabled = false
 [sinks.cw.tls]
-enabled = true
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
 verify_certificate = false
@@ -201,7 +198,6 @@ encoding.codec = "json"
 request.concurrency = 2
 healthcheck.enabled = false
 [sinks.cw.tls]
-enabled = true
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
 key_file = "/var/run/ocp-collector/secrets/vector-cw-secret-tls/tls.key"
@@ -222,7 +218,6 @@ encoding.codec = "json"
 request.concurrency = 2
 healthcheck.enabled = false
 [sinks.cw.tls]
-enabled = true
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
 verify_certificate = false
@@ -245,7 +240,6 @@ encoding.codec = "json"
 request.concurrency = 2
 healthcheck.enabled = false
 [sinks.cw.tls]
-enabled = true
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
 key_file = "/var/run/ocp-collector/secrets/vector-tls-credentials/tls.key"
@@ -266,7 +260,6 @@ encoding.codec = "json"
 request.concurrency = 2
 healthcheck.enabled = false
 [sinks.cw.tls]
-enabled = true
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
 verify_certificate = false

--- a/internal/generator/vector/output/gcl/gcl.go
+++ b/internal/generator/vector/output/gcl/gcl.go
@@ -92,6 +92,7 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
 	if o.Secret != nil {
 		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
+			tlsConf.NeedsEnabled = false
 			return []Element{tlsConf}
 		}
 	}

--- a/internal/generator/vector/output/gcl/gcl_test.go
+++ b/internal/generator/vector/output/gcl/gcl_test.go
@@ -213,7 +213,6 @@ type = "k8s_node"
 node_name = "{{hostname}}"
 
 [sinks.gcl_tls.tls]
-enabled = true
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
 verify_certificate = false
@@ -318,7 +317,6 @@ type = "k8s_node"
 node_name = "{{hostname}}"
 
 [sinks.gcl_tls.tls]
-enabled = true
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
 verify_certificate = false


### PR DESCRIPTION
### Description
This PR fix TLS configuration for [AWS Cloudwatch logs](https://vector.dev/docs/reference/configuration/sinks/aws_cloudwatch_logs/#tls) and [GCP Stackdriver](https://vector.dev/docs/reference/configuration/sinks/gcp_stackdriver_logs/#tls), by removing `enabled = true` because this is lead to error after upgrading Vector to the new version
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @syedriko <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill  <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s): #1988 
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4242
- Enhancement proposal:
