### PR TITLE
Fixed LogFileMetricExporter UI information & tolerations

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -26,4 +26,13 @@ resources:
   kind: ClusterLogging
   path: github.com/openshift/cluster-logging-operator/apis/logging/v1
   version: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: openshift.io
+  group: logging
+  kind: LogFileMetricExporter
+  path: github.com/openshift/cluster-logging-operator/apis/logging/v1alpha1
+  version: v1alpha1
 version: "3"

--- a/apis/logging/v1alpha1/groupversion_info.go
+++ b/apis/logging/v1alpha1/groupversion_info.go
@@ -11,6 +11,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package v1alpha1 contains API Schema definitions for the logging v1alpha1 API group
+// +kubebuilder:object:generate=true
+// +groupName=logging.openshift.io
 package v1alpha1
 
 import (

--- a/apis/logging/v1alpha1/log_file_metrics_exporter_types.go
+++ b/apis/logging/v1alpha1/log_file_metrics_exporter_types.go
@@ -37,10 +37,9 @@ type LogFileMetricExporterStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories=logging,shortName=lfme
-// +kubebuilder:printcolumn:name="Management State",JSONPath=".spec.managementState",type=string
 // +kubebuilder:object:root=true
-// +operator-sdk:csv:customresourcedefinitions:displayName="Log File Metric Exporter",resources={{Pod,v1},{Deployment,v1},{ReplicaSet,v1},{ConfigMap,v1},{Service,v1},{Route,v1},{CronJob,v1},{Role,v1},{RoleBinding,v1},{ServiceAccount,v1},{ServiceMonitor,v1},{persistentvolumeclaims,v1}}
 // A Log File Metric Exporter instance. LogFileMetricExporter is the Schema for the logFileMetricExporters API
+// +operator-sdk:csv:customresourcedefinitions:displayName="Log File Metric Exporter",resources={{Pod,v1}, {Service,v1}, {ServiceMonitor,v1}, {DaemonSet, v1}}
 type LogFileMetricExporter struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -330,8 +330,46 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v1
-    - kind: LogFileMetricExporter
+    - description: A Log File Metric Exporter instance. LogFileMetricExporter is the
+        Schema for the logFileMetricExporters API
+      displayName: Log File Metric Exporter
+      kind: LogFileMetricExporter
       name: logfilemetricexporters.logging.openshift.io
+      resources:
+      - kind: DaemonSet
+        name: ""
+        version: v1
+      - kind: Pod
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
+      - kind: ServiceMonitor
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: Define which Nodes the Pods are scheduled on.
+        displayName: LogFileMetricExporter Node Selector
+        path: nodeSelector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap
+      - description: The resource requirements for the LogFileMetricExporter
+        displayName: LogFileMetricExporter Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Define the tolerations the Pods will accept
+        displayName: LogFileMetricExporter Pod Tolerations
+        path: tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Toleration
+      statusDescriptors:
+      - description: Conditions of the Log File Metrics Exporter.
+        displayName: Log File Metrics Exporter Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:logFileMetricsExporterConditions
       version: v1alpha1
   description: |-
     # Red Hat OpenShift Logging

--- a/bundle/manifests/logging.openshift.io_logfilemetricexporters.yaml
+++ b/bundle/manifests/logging.openshift.io_logfilemetricexporters.yaml
@@ -18,11 +18,7 @@ spec:
     singular: logfilemetricexporter
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.managementState
-      name: Management State
-      type: string
-    name: v1alpha1
+  - name: v1alpha1
     schema:
       openAPIV3Schema:
         description: A Log File Metric Exporter instance. LogFileMetricExporter is

--- a/config/crd/bases/logging.openshift.io_logfilemetricexporters.yaml
+++ b/config/crd/bases/logging.openshift.io_logfilemetricexporters.yaml
@@ -19,11 +19,7 @@ spec:
     singular: logfilemetricexporter
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.managementState
-      name: Management State
-      type: string
-    name: v1alpha1
+  - name: v1alpha1
     schema:
       openAPIV3Schema:
         description: A Log File Metric Exporter instance. LogFileMetricExporter is

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -219,6 +219,47 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v1
+    - description: A Log File Metric Exporter instance. LogFileMetricExporter is the
+        Schema for the logFileMetricExporters API
+      displayName: Log File Metric Exporter
+      kind: LogFileMetricExporter
+      name: logfilemetricexporters.logging.openshift.io
+      resources:
+      - kind: DaemonSet
+        name: ""
+        version: v1
+      - kind: Pod
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
+      - kind: ServiceMonitor
+        name: ""
+        version: v1
+      specDescriptors:
+      - description: Define which Nodes the Pods are scheduled on.
+        displayName: LogFileMetricExporter Node Selector
+        path: nodeSelector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:ConfigMap
+      - description: The resource requirements for the LogFileMetricExporter
+        displayName: LogFileMetricExporter Resource Requirements
+        path: resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Define the tolerations the Pods will accept
+        displayName: LogFileMetricExporter Pod Tolerations
+        path: tolerations
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Toleration
+      statusDescriptors:
+      - description: Conditions of the Log File Metrics Exporter.
+        displayName: Log File Metrics Exporter Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:logFileMetricsExporterConditions
+      version: v1alpha1
   description: |-
     # Red Hat OpenShift Logging
     The Red Hat OpenShift Logging Operator orchestrates and manages the aggregated logging stack as a cluster-wide service.


### PR DESCRIPTION
### Description
This PR fixes Openshift's UI console to display information about the `LogFileMetricExporter` custom resource as well as allowing users to set the resource requirements and tolerations through the form view [LOG-4252](https://issues.redhat.com/browse/LOG-4252).

[LOG-4253](https://issues.redhat.com/browse/LOG-4253): This PR also fixes duplicate tolerations.

/cc @vparfonov @cahartma 
/assign @jcantrill 

### Links
#### Jira
- https://issues.redhat.com/browse/LOG-4252
- https://issues.redhat.com/browse/LOG-4253
- https://issues.redhat.com/browse/LOG-3819