### PR TITLE
Refactored default tolerations to have a single and immutable definition

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -48,21 +48,6 @@ const (
 	tmpPath                         = "/tmp"
 )
 
-var (
-	defaultTolerations = []v1.Toleration{
-		{
-			Key:      "node-role.kubernetes.io/master",
-			Operator: v1.TolerationOpExists,
-			Effect:   v1.TaintEffectNoSchedule,
-		},
-		{
-			Key:      "node.kubernetes.io/disk-pressure",
-			Operator: v1.TolerationOpExists,
-			Effect:   v1.TaintEffectNoSchedule,
-		},
-	}
-)
-
 type Visitor func(collector *v1.Container, podSpec *v1.PodSpec)
 type CommonLabelVisitor func(o runtime.Object)
 
@@ -138,7 +123,7 @@ func (f *Factory) NewPodSpec(trustedCABundle *v1.ConfigMap, forwarderSpec loggin
 		PriorityClassName:             clusterLoggingPriorityClassName,
 		ServiceAccountName:            constants.CollectorServiceAccountName,
 		TerminationGracePeriodSeconds: utils.GetInt64(10),
-		Tolerations:                   defaultTolerations,
+		Tolerations:                   constants.DefaultTolerations(),
 		Volumes: []v1.Volume{
 			{Name: logContainers, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: logContainersValue}}},
 			{Name: logPods, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: logPodsValue}}},

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 
 		Context("and evaluating tolerations", func() {
 			It("should add only defaults when none are defined", func() {
-				Expect(podSpec.Tolerations).To(Equal(defaultTolerations))
+				Expect(podSpec.Tolerations).To(Equal(constants.DefaultTolerations()))
 			})
 
 			It("should add the default and additional ones that are defined", func() {
@@ -84,7 +84,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 					},
 				}
 				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil))
-				expTolerations := append(defaultTolerations, providedToleration)
+				expTolerations := append(constants.DefaultTolerations(), providedToleration)
 				Expect(podSpec.Tolerations).To(Equal(expTolerations))
 			})
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,5 +1,7 @@
 package constants
 
+import v1 "k8s.io/api/core/v1"
+
 var WatchNamespace string
 
 func init() {
@@ -147,3 +149,18 @@ const (
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}
 var ExtraNoProxyList = []string{ElasticsearchFQDN}
+
+func DefaultTolerations() []v1.Toleration {
+	return []v1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "node.kubernetes.io/disk-pressure",
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+	}
+}

--- a/internal/metrics/logfilemetricexporter/factory.go
+++ b/internal/metrics/logfilemetricexporter/factory.go
@@ -31,21 +31,6 @@ const (
 	metricsVolumePath               = "/etc/logfilemetricexporter/metrics"
 )
 
-var (
-	defaultTolerations = []v1.Toleration{
-		{
-			Key:      "node-role.kubernetes.io/master",
-			Operator: v1.TolerationOpExists,
-			Effect:   v1.TaintEffectNoSchedule,
-		},
-		{
-			Key:      "node.kubernetes.io/disk-pressure",
-			Operator: v1.TolerationOpExists,
-			Effect:   v1.TaintEffectNoSchedule,
-		},
-	}
-)
-
 // resourceRequirements returns the resource requirements for a given metric-exporter implementation
 // or it's default if none are specified
 func resourceRequirements(exporter loggingv1a1.LogFileMetricExporter) v1.ResourceRequirements {
@@ -61,7 +46,7 @@ func nodeSelector(exporter loggingv1a1.LogFileMetricExporter) map[string]string 
 
 func tolerations(exporter loggingv1a1.LogFileMetricExporter) []v1.Toleration {
 	if exporter.Spec.Tolerations == nil {
-		return defaultTolerations
+		return constants.DefaultTolerations()
 	}
 
 	// Add default tolerations if tolerations spec'd
@@ -74,7 +59,7 @@ func tolerations(exporter loggingv1a1.LogFileMetricExporter) []v1.Toleration {
 		tolerationMap[tol.Key] = true
 	}
 
-	for _, defaultTol := range defaultTolerations {
+	for _, defaultTol := range constants.DefaultTolerations() {
 		if exists := tolerationMap[defaultTol.Key]; !exists {
 			finalTolerations = append(finalTolerations, defaultTol)
 		}

--- a/internal/metrics/logfilemetricexporter/factory_test.go
+++ b/internal/metrics/logfilemetricexporter/factory_test.go
@@ -119,27 +119,13 @@ var _ = Describe("LogFileMetricExporter functions", func() {
 
 	Context("new exporter podspec", func() {
 		It("should spec a new default pod with default tolerations and NodeSelector", func() {
-
-			defaultTolerations := []corev1.Toleration{
-				{
-					Key:      "node-role.kubernetes.io/master",
-					Operator: corev1.TolerationOpExists,
-					Effect:   corev1.TaintEffectNoSchedule,
-				},
-				{
-					Key:      "node.kubernetes.io/disk-pressure",
-					Operator: corev1.TolerationOpExists,
-					Effect:   corev1.TaintEffectNoSchedule,
-				},
-			}
-
 			podSpec := NewPodSpec(*logFileMetricExporter, tlsProfileSpec)
 			Expect(podSpec.NodeSelector).ToNot(BeEmpty())
 			Expect(podSpec.NodeSelector).To(HaveLen(1))
 			Expect(podSpec.NodeSelector).To(HaveKeyWithValue("kubernetes.io/os", "linux"))
 
 			// Tolerations
-			Expect(podSpec.Tolerations).To(Equal(defaultTolerations))
+			Expect(podSpec.Tolerations).To(Equal(constants.DefaultTolerations()))
 		})
 
 		It("should spec a new pod with defined tolerations and NodeSelector", func() {
@@ -153,19 +139,10 @@ var _ = Describe("LogFileMetricExporter functions", func() {
 				testTol1,
 			}
 
-			finalTolerations := []corev1.Toleration{
+			expectedTolerations := []corev1.Toleration{
 				testTol1,
-				{
-					Key:      "node-role.kubernetes.io/master",
-					Operator: corev1.TolerationOpExists,
-					Effect:   corev1.TaintEffectNoSchedule,
-				},
-				{
-					Key:      "node.kubernetes.io/disk-pressure",
-					Operator: corev1.TolerationOpExists,
-					Effect:   corev1.TaintEffectNoSchedule,
-				},
 			}
+			expectedTolerations = append(expectedTolerations, constants.DefaultTolerations()...)
 
 			testNodeSelect := map[string]string{
 				"testNode": "testval",
@@ -185,7 +162,7 @@ var _ = Describe("LogFileMetricExporter functions", func() {
 
 			// Tolerations
 			Expect(podSpec.Tolerations).To(ContainElement(testTol1))
-			Expect(podSpec.Tolerations).To(Equal(finalTolerations))
+			Expect(podSpec.Tolerations).To(Equal(expectedTolerations))
 		})
 
 		It("should not have duplicate tolerations in the pod spec", func() {
@@ -199,7 +176,7 @@ var _ = Describe("LogFileMetricExporter functions", func() {
 				testTol1,
 			}
 
-			finalTolerations := []corev1.Toleration{
+			expectedTolerations := []corev1.Toleration{
 				testTol1,
 				{
 					Key:      "node.kubernetes.io/disk-pressure",
@@ -213,7 +190,7 @@ var _ = Describe("LogFileMetricExporter functions", func() {
 
 			// Tolerations
 			Expect(podSpec.Tolerations).To(ContainElement(testTol1))
-			Expect(podSpec.Tolerations).To(Equal(finalTolerations))
+			Expect(podSpec.Tolerations).To(Equal(expectedTolerations))
 		})
 	})
 })


### PR DESCRIPTION
### Description
Refactored default tolerations to have a single and immutable definition

/cc @Clee2691 
/assign @alanconway 

### Links
This is a follow-up to https://github.com/openshift/cluster-logging-operator/pull/2063
