### PR TITLE
[release-5.5] Remove --skip-headers oc flag from container_security_test.go

### DIFF
--- a/test/e2e/collection/fluentd/container_security_test.go
+++ b/test/e2e/collection/fluentd/container_security_test.go
@@ -2,13 +2,14 @@ package fluentd
 
 import (
 	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
 	"github.com/openshift/cluster-logging-operator/test/helpers"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"runtime"
-	"strconv"
-	"strings"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 
@@ -94,7 +95,7 @@ var _ = Describe("Tests of collector container security stance", func() {
 		}
 
 		nodes := 0
-		out, err := oc.Literal().From("oc get nodes --skip-headers -o name").Run()
+		out, err := oc.Literal().From("oc get nodes -o name").Run()
 		if err != nil {
 			Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", helpers.ComponentTypeCollector, err))
 		}


### PR DESCRIPTION
### Description
The use of the flag `--skip-headers` is deprecated in newer versions of `oc`. This PR removes this flag from `test/e2e/collection/fluentd/container_security_test.go` in the branch release-5.5, which will unblock PRs in openshift/release that run rehearsal e2e and smoke tests on release-5.5

Reference: https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components#removed-klog-flags
