### PR TITLE
LOG-4283: fix 'component' label value

### DIFF
--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -95,7 +95,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 
 	factory := collector.New(collectorConfHash, clusterRequest.ClusterID, *collectionSpec, clusterRequest.OutputSecrets, clusterRequest.Forwarder.Spec, clusterRequest.Forwarder.Name, clusterRequest.ResourceNames)
 
-	if err := network.ReconcileService(clusterRequest.EventRecorder, clusterRequest.Client, clusterRequest.Forwarder.Namespace, clusterRequest.ResourceNames.CommonName, collector.MetricsPortName, clusterRequest.ResourceNames.SecretMetrics, collector.MetricsPort, clusterRequest.ResourceOwner, factory.CommonLabelInitializer); err != nil {
+	if err := network.ReconcileService(clusterRequest.EventRecorder, clusterRequest.Client, clusterRequest.Forwarder.Namespace, clusterRequest.ResourceNames.CommonName, constants.CollectorName, collector.MetricsPortName, clusterRequest.ResourceNames.SecretMetrics, collector.MetricsPort, clusterRequest.ResourceOwner, factory.CommonLabelInitializer); err != nil {
 		log.Error(err, "collector.ReconcileService")
 		return err
 	}

--- a/internal/metrics/logfilemetricexporter/metric_exporter.go
+++ b/internal/metrics/logfilemetricexporter/metric_exporter.go
@@ -30,7 +30,7 @@ func Reconcile(lfmeInstance *loggingv1alpha1.LogFileMetricExporter,
 		runtime.SetCommonLabels(o, "lfme-service", lfmeInstance.Name, constants.LogfilesmetricexporterName)
 	}
 
-	if err := network.ReconcileService(er, requestClient, lfmeInstance.Namespace, constants.LogfilesmetricexporterName, ExporterPortName, ExporterMetricsSecretName, ExporterPort, owner, commonLabels); err != nil {
+	if err := network.ReconcileService(er, requestClient, lfmeInstance.Namespace, constants.LogfilesmetricexporterName, constants.LogfilesmetricexporterName, ExporterPortName, ExporterMetricsSecretName, ExporterPort, owner, commonLabels); err != nil {
 		log.Error(err, "logfilemetricexporter.ReconcileService")
 		return err
 	}

--- a/internal/network/service.go
+++ b/internal/network/service.go
@@ -14,11 +14,11 @@ import (
 )
 
 // ReconcileService reconciles the service that exposes metrics
-func ReconcileService(er record.EventRecorder, k8sClient client.Client, namespace, name, portName, certSecretName string, portNum int32, owner metav1.OwnerReference, visitors func(o runtime.Object)) error {
+func ReconcileService(er record.EventRecorder, k8sClient client.Client, namespace, name, selectorComponent, portName, certSecretName string, portNum int32, owner metav1.OwnerReference, visitors func(o runtime.Object)) error {
 	desired := factory.NewService(
 		name,
 		namespace,
-		name,
+		selectorComponent,
 		[]v1.ServicePort{
 			{
 				Port:       portNum,

--- a/internal/network/service_test.go
+++ b/internal/network/service_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Reconcile LogFileMetricExporter Service", func() {
 			reqClient,
 			constants.WatchNamespace,
 			constants.LogfilesmetricexporterName,
+			constants.LogfilesmetricexporterName,
 			portName,
 			certSecret,
 			port,


### PR DESCRIPTION
### Description
The PR, adds the ability to set the value of the "component" label in k8s service selector. 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4283
- Enhancement proposal:
