### PR TITLE
LOG-4258: Fluentd able to send logs to an Elasticsearch when using passphrase for the private key provided

### DIFF
--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
@@ -166,6 +166,12 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 			}
 			conf = append(conf, ca)
 		}
+		if security.HasPassphrase(secret) {
+			p := Passphrase{
+				PassphrasePath: security.SecretPath(o.Secret.Name, constants.Passphrase),
+			}
+			conf = append(conf, p)
+		}
 	}
 	return conf
 }

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch_test.go
@@ -369,6 +369,184 @@ var _ = Describe("Generate fluentd config", func() {
 </label>
 `,
 		}),
+		Entry("with tls key,cert,ca-bundle and passphrase", testhelpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeElasticsearch,
+						Name: "es-1",
+						URL:  "https://es.svc.infra.cluster:9999",
+						Secret: &logging.OutputSecretSpec{
+							Name: "es-1",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"es-1": {
+					Data: map[string][]byte{
+						"tls.key":       []byte("junk"),
+						"tls.crt":       []byte("junk"),
+						"ca-bundle.crt": []byte("junk"),
+						"passphrase":    []byte("-- passphrase --"),
+					},
+				},
+			},
+			ExpectedConf: `
+<label @ES_1>
+  #dedot namespace_labels
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_, _dummy3_
+  </filter>
+
+  # Viaq Data Model
+  <filter **>
+    @type viaq_data_model
+    enable_openshift_model false
+    enable_prune_empty_fields false
+    rename_time false
+    undefined_dot_replace_char UNUSED
+    elasticsearch_index_prefix_field 'viaq_index_name'
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
+      name_type static
+      static_index_name infra-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+      name_type static
+      static_index_name audit-write
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      enabled 'true'
+      tag "**"
+      name_type structured
+      static_index_name app-write
+    </elasticsearch_index_name>
+  </filter>
+  <filter **>
+    @type viaq_data_model
+    enable_prune_labels true
+    enable_openshift_model false
+    rename_time false
+    undefined_dot_replace_char UNUSED
+    prune_labels_exclusions app_kubernetes_io_name,app_kubernetes_io_instance,app_kubernetes_io_version,app_kubernetes_io_component,app_kubernetes_io_part-of,app_kubernetes_io_managed-by,app_kubernetes_io_created-by
+  </filter>
+
+  #rebuild message field if present
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured'])) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    </record>
+    remove_keys _dummy_
+  </filter>
+
+  #remove structured field if present
+  <filter **>
+    @type record_modifier
+    remove_keys structured
+  </filter>
+  
+  <match retry_es_1>
+    @type elasticsearch
+    @id retry_es_1
+    host es.svc.infra.cluster
+    port 9999
+    scheme https
+    ssl_version TLSv1_2
+    client_key '/var/run/ocp-collector/secrets/es-1/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/es-1/tls.crt'
+    ca_file '/var/run/ocp-collector/secrets/es-1/ca-bundle.crt'
+    client_key_pass "#{File.exists?('/var/run/ocp-collector/secrets/es-1/passphrase') ? open('/var/run/ocp-collector/secrets/es-1/passphrase','r') do |f|f.read end : ''}"
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    verify_es_version_at_startup false
+    type_name _doc
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/retry_es_1'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+  
+  <match **>
+    @type elasticsearch
+    @id es_1
+    host es.svc.infra.cluster
+    port 9999
+    scheme https
+    ssl_version TLSv1_2
+    client_key '/var/run/ocp-collector/secrets/es-1/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/es-1/tls.crt'
+    ca_file '/var/run/ocp-collector/secrets/es-1/ca-bundle.crt'
+    client_key_pass "#{File.exists?('/var/run/ocp-collector/secrets/es-1/passphrase') ? open('/var/run/ocp-collector/secrets/es-1/passphrase','r') do |f|f.read end : ''}"
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    verify_es_version_at_startup false
+    type_name _doc
+    retry_tag retry_es_1
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/es_1'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+</label>
+`,
+		}),
 		Entry("with tls key,cert,ca-bundle tls insecureSkipVerify=true", testhelpers.ConfGenerateTest{
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Outputs: []logging.OutputSpec{

--- a/internal/generator/fluentd/output/elasticsearch/passphrase.go
+++ b/internal/generator/fluentd/output/elasticsearch/passphrase.go
@@ -1,0 +1,16 @@
+package elasticsearch
+
+import "github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
+
+type Passphrase security.Passphrase
+
+func (p Passphrase) Name() string {
+	return "passphraseTemplate"
+}
+
+func (p Passphrase) Template() string {
+	return `{{define "` + p.Name() + `" -}}
+client_key_pass "#{File.exists?({{.PassphrasePath}}) ? open({{.PassphrasePath}},'r') do |f|f.read end : ''}" 
+{{- end}}
+`
+}


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>
### Description
This PR addresses the issue where `Fluentd` is unable to send logs to an `Elasticsearch` cluster when a passphrase is applied to the private key provided. 
The issue was resolved by adding the necessary configuration to the `Fluentd` Elasticsearch plugin, `Fluentd` now properly handles passphrase-protected private keys when establishing a connection with Elasticsearch.

E.g.:
`client_key_pass "#{File.exists?('/var/run/ocp-collector/secrets/es-secret/passphrase') ? open('/var/run/ocp-collector/secrets/es-secret/passphrase','r') do |f|f.read end : ''}"
`
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
