### PR TITLE
LOG-4324: Clarify GCL CLF API verification

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -250,17 +250,9 @@ type Loki struct {
 	LabelKeys []string `json:"labelKeys,omitempty"`
 }
 
-// GoogleCloudLogging provides configuration for sending logs to Google Cloud Logging
+// GoogleCloudLogging provides configuration for sending logs to Google Cloud Logging.
+// Exactly one of billingAccountID, organizationID, folderID, or projectID must be set.
 type GoogleCloudLogging struct {
-	// Only one of BillingAccountID, OrganizationID, FolderID, or ProjectID can be used to send logs.
-	// If more than one are configured, the priority is as follows
-	// 1. BillingAccountID
-	// 2. OrganizationID
-	// 3. FolderID
-	// 4. ProjectID
-	//
-	// Reference: https://cloud.google.com/billing/docs/concepts
-
 	// +optional
 	BillingAccountID string `json:"billingAccountId,omitempty"`
 

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -217,7 +217,8 @@ spec:
                       type: object
                     googleCloudLogging:
                       description: GoogleCloudLogging provides configuration for sending
-                        logs to Google Cloud Logging
+                        logs to Google Cloud Logging. Exactly one of billingAccountID,
+                        organizationID, folderID, or projectID must be set.
                       properties:
                         billingAccountId:
                           type: string

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -218,7 +218,8 @@ spec:
                       type: object
                     googleCloudLogging:
                       description: GoogleCloudLogging provides configuration for sending
-                        logs to Google Cloud Logging
+                        logs to Google Cloud Logging. Exactly one of billingAccountID,
+                        organizationID, folderID, or projectID must be set.
                       properties:
                         billingAccountId:
                           type: string

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -257,10 +257,7 @@ func verifyGoogleCloudLogging(gcl *loggingv1.GoogleCloudLogging) bool {
 	if gcl.OrganizationID != "" {
 		i += 1
 	}
-	if i > 1 {
-		return false
-	}
-	return true
+	return i == 1
 }
 
 func verifyOutputURL(output *loggingv1.OutputSpec, conds loggingv1.NamedConditions) bool {


### PR DESCRIPTION
### Description
For Google Cloud Logging CLF API,  implement the "Exactly one of billing_account_id, folder_id, organization_id, or project_id must be set" rule.

/cc @vimalk78
/cc @Clee2691 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4324
