### PR TITLE
Clarify CL-CLF dependency error message, fix race in e2e/logforwarding/splunk

### DIFF
--- a/internal/k8s/loader/load.go
+++ b/internal/k8s/loader/load.go
@@ -59,11 +59,7 @@ func FetchClusterLogForwarder(k8sClient client.Client, namespace, name, logstore
 	extras := map[string]bool{}
 	forwarder.Spec, extras = migrations.MigrateClusterLogForwarderSpec(forwarder.Namespace, forwarder.Name, forwarder.Spec, fetchClusterLogging().Spec.LogStore, extras, logstoreSecretName)
 
-	if fetchClusterLogging().Name == "" {
-		extras[constants.ClusterLoggingAvailable] = false
-	} else {
-		extras[constants.ClusterLoggingAvailable] = true
-	}
+	extras[constants.ClusterLoggingAvailable] = (fetchClusterLogging().Name != "")
 	if err, status = clusterlogforwarder.Validate(forwarder, k8sClient, extras); err != nil {
 		return forwarder, err, status
 	}

--- a/internal/validations/clusterlogforwarder/validate_clusterlogging_dependency.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogging_dependency.go
@@ -9,7 +9,7 @@ import (
 
 func ValidateClusterLoggingDependency(clf loggingv1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *loggingv1.ClusterLogForwarderStatus) {
 	if clf.Name == constants.SingletonName && !extras[constants.ClusterLoggingAvailable] {
-		return errors.NewValidationError("ClusterLogForwarder named %q is dependent on a ClusterLogging instance", constants.SingletonName), nil
+		return errors.NewValidationError("ClusterLogForwarder named %q depends on a missing ClusterLogging instance", constants.SingletonName), nil
 	}
 	return nil, nil
 }

--- a/test/e2e/logforwarding/splunk/forward_to_splunk_test.go
+++ b/test/e2e/logforwarding/splunk/forward_to_splunk_test.go
@@ -5,6 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"testing"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
@@ -19,9 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
-	"testing"
-	"time"
 )
 
 const (
@@ -102,7 +103,7 @@ func testLogForwardingToSplunk(t *testing.T, cl *loggingv1.ClusterLogging, clf *
 	clf.Spec.Outputs[0].URL = framework.SplunkEndpoint.String()
 
 	var g errgroup.Group
-	g.Go(func() error { return c.Recreate(cl) })
+	require.NoError(t, c.Recreate(cl))
 	defer func(r *loggingv1.ClusterLogging) { _ = c.Delete(r) }(cl)
 	g.Go(func() error { return c.Recreate(clf) })
 	defer func(r *loggingv1.ClusterLogForwarder) { _ = c.Delete(r) }(clf)


### PR DESCRIPTION
### Description
- Clarify CL-CLF dependency error message, it was not clear what the issue is.
- Fix race in e2e/logforwarding/splunk where CLF validation fails if CLF is created before CL:
```
{"_ts":"2023-07-13T19:59:19.412603726Z","_file:line":"test/helpers.go:122","_level":"3","_component":"e2e-framework_","_message":"begin: Recreate","object":"logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance"}
{"_ts":"2023-07-13T19:59:19.412596876Z","_file:line":"test/helpers.go:122","_level":"3","_component":"e2e-framework_","_message":"begin: Recreate","object":"logging.openshift.io/v1/namespaces/openshift-logging/clusterloggings/instance"}
{"_ts":"2023-07-13T19:59:19.55473952Z","_file:line":"test/helpers.go:129","_level":"3","_component":"e2e-framework_","_message":"end  : Recreate","elapsed":"142.042702ms","object":"logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance"}
{"_ts":"2023-07-13T19:59:19.555131469Z","_file:line":"test/helpers.go:129","_level":"3","_component":"e2e-framework_","_message":"end  : Recreate","elapsed":"142.429281ms","object":"logging.openshift.io/v1/namespaces/openshift-logging/clusterloggings/instance"}
{"_ts":"2023-07-13T19:59:19.627183443Z","_file:line":"test/helpers.go:122","_level":"3","_component":"e2e-framework_","_message":"begin: WaitFor(ClusterLogForwarderReady)","object":"logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance"}
{"_ts":"2023-07-13T19:59:19.638679204Z","_file:line":"client/watch.go:98","_level":"3","_component":"e2e-framework","_message":"event: WaitFor(ClusterLogForwarderReady)","elapsed":"11.403329ms","object":"logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance","type":"ADDED"}
{"_ts":"2023-07-13T19:59:19.638929099Z","_file:line":"logr@v1.2.3/logr.go:279","_level":"3","_component":"e2e-framework_","_message":"error: WaitFor(ClusterLogForwarderReady)","_error":{"msg":"ClusterLogForwarder unexpected condition: conditions:\n- lastTransitionTime: \"2023-07-13T19:59:19Z\"\n  message: 'validation failed: ClusterLogForwarder named \"instance\" is dependent on\n    a ClusterLogging instance'\n  reason: Invalid\n  status: \"False\"\n  type: Ready\n"},"elapsed":"11.669935ms","object":"logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance"}

```

/cc @Clee2691 
/assign @jcantrill 