### PR TITLE
Removed race conditions from the test/helpers/fluentd test

### DIFF
--- a/test/helpers/fluentd/receiver_test.go
+++ b/test/helpers/fluentd/receiver_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Receiver", func() {
 		By("sending to a forward source")
 		g.Go(func() {
 			s := r.Sources["foo"]
+			ExpectOK(r.WaitForOpenPort(s.Port, 10), "WaitForOpenPort/foo")
 			cmd := runtime.Exec(r.Pod, "fluent-cat", "-p", strconv.Itoa(s.Port), "-h", s.Host(), "test.tag")
 			cmd.Stdin = strings.NewReader(msg)
 			out, err := cmd.CombinedOutput()
@@ -47,6 +48,7 @@ var _ = Describe("Receiver", func() {
 		By("sending to a http+TLS source")
 		g.Go(func() {
 			s := r.Sources["bar"]
+			ExpectOK(r.WaitForOpenPort(s.Port, 10), "WaitForOpenPort/bar")
 			url := fmt.Sprintf("https://%v:%v/test.tag", s.Host(), s.Port)
 			cmd := runtime.Exec(r.Pod, "curl", "-kv", "--key", r.ConfigPath("bar-key.pem"), "--cert", r.ConfigPath("bar-cert.pem"), "--cacert", r.ConfigPath("bar-ca.pem"), "-d", "json="+msg, url)
 			out, err := cmd.CombinedOutput()
@@ -61,7 +63,6 @@ var _ = Describe("Receiver", func() {
 				line, err := tr.ReadLine()
 				ExpectOK(err)
 				Expect(strings.TrimSpace(line)).To(Equal(msg))
-				Expect(r.Sources["foo"].HasOutput()).To(BeTrue())
 			})
 		}
 	})


### PR DESCRIPTION
### Description

Removed two race conditions from the test/helpers/fluentd test:

1. Listeners on the fluentd receiver not listening yet when the test tries to talk to them:
```
   [91m[oc exec -i -n test-niyk3w4d Pod/receiver -- curl -kv --key /opt/app-root/etc/bar-key.pem --cert /opt/app-root/etc/bar-cert.pem --cacert /opt/app-root/etc/bar-ca.pem -d json={"hello":"world"} https://receiver.test-niyk3w4d.svc:24225/test.tag]
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
  
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 172.30.109.207:24225...
  * connect to 172.30.109.207 port 24225 failed: Connection refused
  * Failed to connect to receiver.test-niyk3w4d.svc port 24225: Connection refused
  ```

2. line 64: Expect(r.Sources["foo"].HasOutput()).To(BeTrue()) occasionally fails
```
~/go/src/github.com/openshift/cluster-logging-operator/test/helpers/fluentd/receiver_test.go:19
  receives and saves data [It]
  ~/go/src/github.com/openshift/cluster-logging-operator/test/helpers/fluentd/receiver_test.go:20

  Expected
      <bool>: false
  to be true

~/go/src/github.com/openshift/cluster-logging-operator/test/helpers/fluentd/receiver_test.go:66
```

/cc @alanconway 
/assign @jcantrill 
