### PR TITLE
LOG-3880: Hide deprecated fields in UI form view

### DIFF
--- a/apis/logging/v1/clusterlogging_types.go
+++ b/apis/logging/v1/clusterlogging_types.go
@@ -59,6 +59,7 @@ type ClusterLoggingSpec struct {
 	// +nullable
 	// +optional
 	// +deprecated
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Curation *CurationSpec `json:"curation,omitempty"`
 
 	// Deprecated. Specification for Forwarder component for the cluster
@@ -67,6 +68,7 @@ type ClusterLoggingSpec struct {
 	// +nullable
 	// +optional
 	// +deprecated
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
 	Forwarder *ForwarderSpec `json:"forwarder,omitempty"`
 }
 

--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -258,6 +258,19 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:fluentd
         - urn:alm:descriptor:com.tectonic.ui:select:vector
+      - description: Deprecated. Specification of the Curation component for the cluster
+          This component was specifically for use with Elasticsearch and was replaced
+          by index management spec
+        displayName: Curation
+        path: curation
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deprecated. Specification for Forwarder component for the cluster
+          See spec.collection.fluentd
+        displayName: Forwarder
+        path: forwarder
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Number of nodes to deploy for Elasticsearch
         displayName: Elasticsearch Size
         path: logStore.elasticsearch.nodeCount

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -173,6 +173,19 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:fluentd
         - urn:alm:descriptor:com.tectonic.ui:select:vector
+      - description: Deprecated. Specification of the Curation component for the cluster
+          This component was specifically for use with Elasticsearch and was replaced
+          by index management spec
+        displayName: Curation
+        path: curation
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: Deprecated. Specification for Forwarder component for the cluster
+          See spec.collection.fluentd
+        displayName: Forwarder
+        path: forwarder
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - description: Number of nodes to deploy for Elasticsearch
         displayName: Elasticsearch Size
         path: logStore.elasticsearch.nodeCount


### PR DESCRIPTION
### Description
Hide ClusterLogging deprecated fields in UI form view

### Links
* https://issues.redhat.com/browse/LOG-3880
