### PR TITLE
LOG-3959: remove obsolete critical-pod annotation

### DIFF
--- a/internal/factory/daemonset.go
+++ b/internal/factory/daemonset.go
@@ -24,8 +24,7 @@ func NewDaemonSet(daemonsetName, namespace, loggingComponent, component, impl st
 	}
 
 	annotations := map[string]string{
-		"scheduler.alpha.kubernetes.io/critical-pod": "",
-		"target.workload.openshift.io/management":    `{"effect": "PreferredDuringScheduling"}`,
+		"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
 	}
 
 	strategy := apps.DaemonSetUpdateStrategy{

--- a/internal/factory/daemonset_test.go
+++ b/internal/factory/daemonset_test.go
@@ -42,8 +42,4 @@ var _ = Describe("#NewDaemonSet", func() {
 		Expect(daemonSet.Labels).To(Equal(expLabels))
 		Expect(daemonSet.Spec.Template.Labels).To(Equal(expLabels))
 	})
-	It("should include the critical pod annotation", func() {
-		Expect(daemonSet.Spec.Template.ObjectMeta.Annotations).To(HaveKey("scheduler.alpha.kubernetes.io/critical-pod"))
-	})
-
 })


### PR DESCRIPTION
### Description
This PR:
* removes the critical-pod annotation that causes a warning in the logs and is/was removed in kube v1.16+

### Links
* https://issues.redhat.com/browse/LOG-3959
