### PR TITLE
De-raced test/e2e/logforwarding/elasticsearchmanaged

### DIFF
--- a/test/framework/e2e/framework.go
+++ b/test/framework/e2e/framework.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/test/helpers/certificate"
 	"math/rand"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers/certificate"
 
 	"github.com/openshift/cluster-logging-operator/test/runtime"
 
@@ -104,6 +105,9 @@ func (tc *E2ETestFramework) DeployLogGenerator() (string, error) {
 }
 
 func (tc *E2ETestFramework) DeployLogGeneratorWithNamespace(namespace string) error {
+	if err := tc.WaitForResourceCondition(namespace, "serviceaccount", "default", "", "{}", 10, func(string) (bool, error) { return true, nil }); err != nil {
+		return err
+	}
 	pod := runtime.NewLogGenerator(namespace, "log-generator", 1000, 0, "My life is my message")
 	clolog.Info("Deploying LogGenerator to namespace", "deployment name", pod.Name, "namespace", namespace)
 	opts := metav1.CreateOptions{}


### PR DESCRIPTION
### Description
Yet another race condition fix, this time with a log generator pod getting created in a newly created namespace which does not yet have its `sa/default` set up:
```
[ClusterLogForwarder] Forwards logs
/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go:19
  when the output is a CLO managed elasticsearch and no explicit forwarder is configured should default to forwarding logs to the spec'd logstore [BeforeEach]
  /go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go:43
    using vector collector
    /go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/elasticsearchmanaged/clo_managed_logstore_test.go:70

    Timed out waiting for the log generator to deploy: pods "log-generator" is forbidden: error looking up service account clo-test-2831/default: serviceaccount "default" not found
```

/cc @cahartma 
/assign @jcantrill 
