### PR TITLE
De-race e2e forward_to_loki and forward_to_splunk

### DIFF
--- a/test/e2e/logforwarding/loki/forward_to_loki_test.go
+++ b/test/e2e/logforwarding/loki/forward_to_loki_test.go
@@ -110,8 +110,7 @@ func testLogForwardingToLoki(t *testing.T, cl *loggingv1.ClusterLogging, clf *lo
 
 	// Start independent components in parallel to speed up the test.
 	var g errgroup.Group
-	g.Go(func() error { return c.Recreate(cl) })
-	g.Go(func() error { return c.Recreate(clf) })
+	e2e.RecreateClClfAsync(&g, c, cl, clf)
 	g.Go(func() error { return rcv.Create(c.Client) })
 	g.Go(func() error { return c.Create(gen) })
 

--- a/test/e2e/logforwarding/splunk/forward_to_splunk_test.go
+++ b/test/e2e/logforwarding/splunk/forward_to_splunk_test.go
@@ -103,9 +103,8 @@ func testLogForwardingToSplunk(t *testing.T, cl *loggingv1.ClusterLogging, clf *
 	clf.Spec.Outputs[0].URL = framework.SplunkEndpoint.String()
 
 	var g errgroup.Group
-	require.NoError(t, c.Recreate(cl))
+	framework.RecreateClClfAsync(&g, c, cl, clf)
 	defer func(r *loggingv1.ClusterLogging) { _ = c.Delete(r) }(cl)
-	g.Go(func() error { return c.Recreate(clf) })
 	defer func(r *loggingv1.ClusterLogForwarder) { _ = c.Delete(r) }(clf)
 	g.Go(func() error { return c.Create(gen) })
 	require.NoError(t, g.Wait())


### PR DESCRIPTION
### Description
Addressed the following race:
```
--- FAIL: TestLogForwardingToLokiWithFluentd (26.95s)
    test.go:107: test namespace: test-pmqwyblw
    test.go:107: test namespace: test-pm3cossz
    forward_to_loki_test.go:119: 
        	Error Trace:	/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/loki/forward_to_loki_test.go:119
        	            				/go/src/github.com/openshift/cluster-logging-operator/test/e2e/logforwarding/loki/forward_to_loki_test.go:82
        	Error:      	Received unexpected error:
        	            	ClusterLogForwarder unexpected condition: conditions:
        	            	- lastTransitionTime: "2023-07-14T20:45:42Z"
        	            	  message: 'validation failed: ClusterLogForwarder named "instance" depends on a missing
        	            	    ClusterLogging instance'
        	            	  reason: Invalid
        	            	  status: "False"
        	            	  type: Ready
        	Test:       	TestLogForwardingToLokiWithFluentd
```
, improved how a race in e2e forward_to_splunk_test was addressed in https://github.com/openshift/cluster-logging-operator/pull/2084

/cc @cahartma 
/assign @jcantrill 

### Links
- Depending on PR(s): https://github.com/openshift/cluster-logging-operator/pull/2084
