### PR TITLE
LOG-4302: skip checking URL on is secure if URL not provided in config

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_url_to_output_tls_config.go
+++ b/internal/validations/clusterlogforwarder/validate_url_to_output_tls_config.go
@@ -13,12 +13,14 @@ import (
 func validateUrlAccordingToTls(clf v1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *v1.ClusterLogForwarderStatus) {
 	for i, output := range clf.Spec.Outputs {
 		_, output := i, output // Don't bind range variable.
-		u, _ := url.Parse(output.URL)
-		scheme := strings.ToLower(u.Scheme)
-		if !url.IsTLSScheme(scheme) && (output.TLS != nil && (output.TLS.InsecureSkipVerify || output.TLS.TLSSecurityProfile != nil)) {
-			log.V(3).Info("validateUrlAccordingToTls failed", "reason", "URL not secure but output has TLS configuration parameters",
-				"output URL", output.URL, "output Name", output.Name)
-			return fmt.Errorf("URL not secure: %v, but output %s has TLS configuration parameters", u, output.Name), nil
+		if output.URL != "" {  // some outputs not require to have output URL (e.g. Amazon CloudWatch or Google Cloud Logging) see verifyOutputURL()
+			u, _ := url.Parse(output.URL)
+			scheme := strings.ToLower(u.Scheme)
+			if !url.IsTLSScheme(scheme) && (output.TLS != nil && (output.TLS.InsecureSkipVerify || output.TLS.TLSSecurityProfile != nil)) {
+				log.V(3).Info("validateUrlAccordingToTls failed", "reason", "URL not secure but output has TLS configuration parameters",
+					"output URL", output.URL, "output Name", output.Name)
+				return fmt.Errorf("URL not secure: %v, but output %s has TLS configuration parameters", u, output.Name), nil
+			}
 		}
 	}
 	return nil, nil

--- a/internal/validations/clusterlogforwarder/validate_url_to_output_tls_test.go
+++ b/internal/validations/clusterlogforwarder/validate_url_to_output_tls_test.go
@@ -54,15 +54,27 @@ var _ = Describe("[internal][validations] ClusterLogForwarder: Output URL vs Out
 			}
 			Expect(validateUrlAccordingToTls(*clf, nil, nil)).To(Succeed())
 		})
-		It("should pass pass validation when secure URL and exist TLS config: tls.InsecureSkipVerify=false", func() {
+		It("should pass validation when secure URL and exist TLS config: tls.InsecureSkipVerify=false", func() {
 			clf.Spec.Outputs[0].URL = "https://local.svc:514"
 			clf.Spec.Outputs[0].TLS = &v1.OutputTLSSpec{
 				InsecureSkipVerify: false,
 			}
 			Expect(validateUrlAccordingToTls(*clf, nil, nil)).To(Succeed())
 		})
-		It("should pass pass validation when secure URL and exist TLS config: tls.TLSSecurityProfile", func() {
+		It("should pass validation when secure URL and exist TLS config: tls.TLSSecurityProfile", func() {
 			clf.Spec.Outputs[0].URL = "https://local.svc:514"
+			clf.Spec.Outputs[0].TLS = &v1.OutputTLSSpec{
+				TLSSecurityProfile: &configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileOldType,
+				},
+			}
+			Expect(validateUrlAccordingToTls(*clf, nil, nil)).To(Succeed())
+		})
+		It("should pass validation when URL not provided for specific Output type", func() {
+			clf.Spec.Outputs[0].GoogleCloudLogging = &v1.GoogleCloudLogging{
+				BillingAccountID: "billing-1",
+				LogID:            "vector-1",
+			}
 			clf.Spec.Outputs[0].TLS = &v1.OutputTLSSpec{
 				TLSSecurityProfile: &configv1.TLSSecurityProfile{
 					Type: configv1.TLSProfileOldType,


### PR DESCRIPTION
### Description
This PR introduces a modification to the URL security check logic by skipping the check if a URL is not provided in the configuration, it because output URL is not necessary for certain output types, such as Amazon CloudWatch or Google Cloud Logging.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill  <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
