### PR TITLE
LOG-4084: Fix fluentd sts cloudwatch auth using multiple roles

### DIFF
--- a/internal/collector/cloudwatch.go
+++ b/internal/collector/cloudwatch.go
@@ -4,26 +4,29 @@ import (
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/cloudwatch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/output/security"
-	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/cloudwatch"
 	v1 "k8s.io/api/core/v1"
 	"path"
 )
 
 // Add volumes and env vars if output type is cloudwatch and role is found in the secret
-func addWebIdentityForCloudwatch(collector *v1.Container, podSpec *v1.PodSpec, forwarderSpec logging.ClusterLogForwarderSpec, secrets map[string]*v1.Secret) {
+func addWebIdentityForCloudwatch(collector *v1.Container, podSpec *v1.PodSpec, forwarderSpec logging.ClusterLogForwarderSpec, secrets map[string]*v1.Secret, collectorType logging.LogCollectionType) {
 	if secrets == nil {
 		return
 	}
 	for _, o := range forwarderSpec.Outputs {
-		// output secrets are keyed by output name
-		secret := secrets[o.Name]
 		if o.Type == logging.OutputTypeCloudwatch {
+			secret := secrets[o.Name]
 			if security.HasAwsRoleArnKey(secret) || security.HasAwsCredentialsKey(secret) {
 				log.V(3).Info("Found sts key in secret")
-				// Originally for fluentd and now for vector to use as well
 				AddWebIdentityTokenVolumes(collector, podSpec)
-				AddWebIdentityTokenEnvVars(collector, o, secret)
+				// LOG-4084 fluentd no longer setting env vars
+				if collectorType == logging.LogCollectionTypeVector {
+					log.V(3).Info("Found vector collector")
+					AddWebIdentityTokenEnvVars(collector, o, secret)
+				}
+				return
 			}
 		}
 	}
@@ -60,8 +63,7 @@ func AddWebIdentityTokenVolumes(collector *v1.Container, podSpec *v1.PodSpec) {
 // AddWebIdentityTokenEnvVars Appends web identity env vars based on attributes of the secret and forwarder spec
 func AddWebIdentityTokenEnvVars(collector *v1.Container, output logging.OutputSpec, secret *v1.Secret) {
 	// Necessary for vector to use sts
-	// Also updated fluentd config to read from these as env vars
-	log.V(3).Info("Adding env vars for sts Cloudwatch")
+	log.V(3).Info("Adding env vars for vector sts Cloudwatch")
 	collector.Env = append(collector.Env,
 		v1.EnvVar{
 			Name:  constants.AWSRegionEnvVarKey,

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -158,7 +158,7 @@ func (f *Factory) NewPodSpec(trustedCABundle *v1.ConfigMap, forwarderSpec loggin
 
 	f.Visit(collector, podSpec)
 
-	addWebIdentityForCloudwatch(collector, podSpec, forwarderSpec, f.Secrets)
+	addWebIdentityForCloudwatch(collector, podSpec, forwarderSpec, f.Secrets, f.CollectorType)
 
 	podSpec.Containers = []v1.Container{
 		*collector,

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -253,7 +253,7 @@ var _ = Describe("Factory#CollectorResourceRequirements", func() {
 	})
 })
 
-var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
+var _ = Describe("Factory#NewPodSpec Add Cloudwatch STS Resources", func() {
 	var (
 		factory   *Factory
 		pipelines = []logging.PipelineSpec{
@@ -287,16 +287,6 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				},
 			},
 		}
-
-		verifyEnvVar = func(container v1.Container, name, value string) {
-			for _, elem := range container.Env {
-				if elem.Name == name {
-					Expect(elem.Value).To(Equal(value))
-					return
-				}
-			}
-			Fail(fmt.Sprintf("Expected collector to include env var '%s' with a value of '%s'", name, value))
-		}
 	)
 	Context("when collectorType is fluentd", func() {
 		BeforeEach(func() {
@@ -309,17 +299,26 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 		})
 		Context("when collector has a secret containing a credentials key", func() {
 
-			It("should find the AWS web identity env vars in the container", func() {
+			It("should NO LONGER be setting AWS ENV vars in the container", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
 				}, "1234", "")
 				collector := podSpec.Containers[0]
 
-				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
-				verifyEnvVar(collector, constants.AWSRoleArnEnvVarKey, roleArn)
-				verifyEnvVar(collector, constants.AWSRoleSessionEnvVarKey, constants.AWSRoleSessionName)
-				verifyEnvVar(collector, constants.AWSWebIdentityTokenEnvVarKey, path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath))
+				// LOG-4084 fluentd no longer setting env vars
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRegionEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRoleArnEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRoleSessionEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSWebIdentityTokenEnvVarKey,
+				})))
 			})
 		})
 		Context("when collector has a secret containing a role_arn key", func() {
@@ -332,20 +331,28 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 					},
 				}
 			})
-			It("should find the AWS web identity env vars in the container", func() {
+			It("should NO LONGER be setting AWS ENV vars in the container", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
 				}, "1234", "")
 				collector := podSpec.Containers[0]
 
-				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
-				verifyEnvVar(collector, constants.AWSRoleArnEnvVarKey, roleArn)
-				verifyEnvVar(collector, constants.AWSRoleSessionEnvVarKey, constants.AWSRoleSessionName)
-				verifyEnvVar(collector, constants.AWSWebIdentityTokenEnvVarKey, path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath))
+				// LOG-4084 fluentd no longer setting env vars
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRegionEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRoleArnEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRoleSessionEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSWebIdentityTokenEnvVarKey,
+				})))
 			})
 		})
-
 	})
 	Context("when collectorType is vector", func() {
 		BeforeEach(func() {
@@ -365,10 +372,22 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				}, "1234", "")
 				collector := podSpec.Containers[0]
 
-				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
-				verifyEnvVar(collector, constants.AWSRoleArnEnvVarKey, roleArn)
-				verifyEnvVar(collector, constants.AWSRoleSessionEnvVarKey, constants.AWSRoleSessionName)
-				verifyEnvVar(collector, constants.AWSWebIdentityTokenEnvVarKey, path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRegionEnvVarKey,
+					Value: outputs[0].OutputTypeSpec.Cloudwatch.Region,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRoleArnEnvVarKey,
+					Value: roleArn,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRoleSessionEnvVarKey,
+					Value: constants.AWSRoleSessionName,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSWebIdentityTokenEnvVarKey,
+					Value: path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath),
+				}))
 			})
 		})
 		Context("when collector has a secret containing a role_arn key", func() {
@@ -388,10 +407,22 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				}, "1234", "")
 				collector := podSpec.Containers[0]
 
-				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
-				verifyEnvVar(collector, constants.AWSRoleArnEnvVarKey, roleArn)
-				verifyEnvVar(collector, constants.AWSRoleSessionEnvVarKey, constants.AWSRoleSessionName)
-				verifyEnvVar(collector, constants.AWSWebIdentityTokenEnvVarKey, path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRegionEnvVarKey,
+					Value: outputs[0].OutputTypeSpec.Cloudwatch.Region,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRoleArnEnvVarKey,
+					Value: roleArn,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRoleSessionEnvVarKey,
+					Value: constants.AWSRoleSessionName,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSWebIdentityTokenEnvVarKey,
+					Value: path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath),
+				}))
 			})
 		})
 	})

--- a/internal/generator/fluentd/output/cloudwatch/aws.go
+++ b/internal/generator/fluentd/output/cloudwatch/aws.go
@@ -1,9 +1,11 @@
 package cloudwatch
 
 type AWSKey struct {
-	KeyIDPath     string
-	KeySecretPath string
-	KeyRoleArn    string
+	KeyIDPath           string
+	KeySecretPath       string
+	KeyRoleArn          string
+	KeyRoleSessionName  string
+	KeyWebIdentityToken string
 }
 
 func (a AWSKey) Name() string {
@@ -15,9 +17,9 @@ func (a AWSKey) Template() string {
 	if len(a.KeyRoleArn) > 0 {
 		return `{{define "` + a.Name() + `" -}}
 <web_identity_credentials>
-  role_arn "#{ENV['AWS_ROLE_ARN']}"
-  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+  role_arn "{{ .KeyRoleArn }}"
+  web_identity_token_file "{{ .KeyWebIdentityToken }}"
+  role_session_name "{{ .KeyRoleSessionName }}"
 </web_identity_credentials>
 {{end}}`
 	}

--- a/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
@@ -2,6 +2,7 @@ package cloudwatch
 
 import (
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 
@@ -106,7 +107,9 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) Element {
 	// First check for credentials or role_arn key, indicating a sts-enabled authentication
 	if security.HasAwsRoleArnKey(secret) || security.HasAwsCredentialsKey(secret) {
 		return AWSKey{
-			KeyRoleArn: ParseRoleArn(secret),
+			KeyRoleArn:          ParseRoleArn(secret),
+			KeyRoleSessionName:  constants.AWSRoleSessionName,
+			KeyWebIdentityToken: path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath),
 		}
 	}
 	// Use ID and Secret

--- a/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
@@ -1,6 +1,8 @@
 package cloudwatch
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"path"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
@@ -341,8 +343,10 @@ var _ = Describe("Generating fluentd config for sts", func() {
 				Name: "my-secret",
 			},
 		}
-		roleArn = "arn:aws:iam::123456789012:role/my-role-to-assume"
-		secrets = map[string]*corev1.Secret{
+		roleArn              = "arn:aws:iam::123456789012:role/my-role-to-assume"
+		roleSessionName      = constants.AWSRoleSessionName
+		webIdentityTokenFile = path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath)
+		secrets              = map[string]*corev1.Secret{
 			output.Secret.Name: {
 				Data: map[string][]byte{
 					"role_arn": []byte(roleArn),
@@ -408,9 +412,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>    
     include_time_key true
     log_rejected_request true
@@ -484,9 +488,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>    
     include_time_key true
     log_rejected_request true
@@ -554,9 +558,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>      
     include_time_key true
     log_rejected_request true
@@ -627,9 +631,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>     
     include_time_key true
     log_rejected_request true

--- a/internal/generator/vector/output/splunk/splunk_test.go
+++ b/internal/generator/vector/output/splunk/splunk_test.go
@@ -1,14 +1,14 @@
 package splunk
 
 import (
-  "testing"
+	"testing"
 
-  . "github.com/onsi/ginkgo"
-  . "github.com/onsi/gomega"
-  loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
-  "github.com/openshift/cluster-logging-operator/internal/generator"
-  . "github.com/openshift/cluster-logging-operator/test/matchers"
-  corev1 "k8s.io/api/core/v1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // #nosec G101
@@ -16,8 +16,8 @@ const hecToken = "VS0BNth3wCGF0eol0MuK07SHIrhYwCPHFWMG"
 
 var _ = Describe("Generating vector config for Splunk output", func() {
 
-  const (
-    splunkDedot = `
+	const (
+		splunkDedot = `
 [transforms.splunk_hec_dedot]
 type = "lua"
 inputs = ["pipelineName"]
@@ -66,7 +66,7 @@ source = '''
     end
 '''
 `
-    splunkSink = splunkDedot + `
+		splunkSink = splunkDedot + `
 [sinks.splunk_hec]
 type = "splunk_hec"
 inputs = ["splunk_hec_dedot"]
@@ -76,7 +76,7 @@ default_token = "` + hecToken + `"
 [sinks.splunk_hec.encoding]
 codec = "json"
 `
-    splunkSinkTls = splunkDedot + `
+		splunkSinkTls = splunkDedot + `
 [sinks.splunk_hec]
 type = "splunk_hec"
 inputs = ["splunk_hec_dedot"]
@@ -91,7 +91,7 @@ key_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/ca-bundle.crt"
 `
-    splunkSinkTlsSkipVerifyNoCert = splunkDedot + `
+		splunkSinkTlsSkipVerifyNoCert = splunkDedot + `
 [sinks.splunk_hec]
 type = "splunk_hec"
 inputs = ["splunk_hec_dedot"]
@@ -106,7 +106,7 @@ verify_certificate = false
 verify_hostname = false
 `
 
-    splunkSinkPassphrase = splunkDedot + `
+		splunkSinkPassphrase = splunkDedot + `
 [sinks.splunk_hec]
 type = "splunk_hec"
 inputs = ["splunk_hec_dedot"]
@@ -121,118 +121,118 @@ codec = "json"
 enabled = true
 key_pass = "junk"
 `
-  )
+	)
 
-  var (
-    g generator.Generator
+	var (
+		g generator.Generator
 
-    output = loggingv1.OutputSpec{
-      Type: loggingv1.OutputTypeSplunk,
-      Name: "splunk_hec",
-      URL:  "https://splunk-web:8088/endpoint",
-      OutputTypeSpec: loggingv1.OutputTypeSpec{
-        Splunk: &loggingv1.Splunk{},
-      },
-      Secret: &loggingv1.OutputSecretSpec{
-        Name: "vector-splunk-secret",
-      },
-    }
+		output = loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeSplunk,
+			Name: "splunk_hec",
+			URL:  "https://splunk-web:8088/endpoint",
+			OutputTypeSpec: loggingv1.OutputTypeSpec{
+				Splunk: &loggingv1.Splunk{},
+			},
+			Secret: &loggingv1.OutputSecretSpec{
+				Name: "vector-splunk-secret",
+			},
+		}
 
-    outputWithPassphrase = loggingv1.OutputSpec{
-      Type: loggingv1.OutputTypeSplunk,
-      Name: "splunk_hec",
-      URL:  "https://splunk-web:8088/endpoint",
-      OutputTypeSpec: loggingv1.OutputTypeSpec{
-        Splunk: &loggingv1.Splunk{},
-      },
-      Secret: &loggingv1.OutputSecretSpec{
-        Name: "vector-splunk-secret-passphrase",
-      },
-    }
-    outputWithTls = loggingv1.OutputSpec{
-      Type: loggingv1.OutputTypeSplunk,
-      Name: "splunk_hec",
-      URL:  "https://splunk-web:8088/endpoint",
-      OutputTypeSpec: loggingv1.OutputTypeSpec{
-        Splunk: &loggingv1.Splunk{},
-      },
-      Secret: &loggingv1.OutputSecretSpec{
-        Name: "vector-splunk-secret-tls",
-      },
-    }
+		outputWithPassphrase = loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeSplunk,
+			Name: "splunk_hec",
+			URL:  "https://splunk-web:8088/endpoint",
+			OutputTypeSpec: loggingv1.OutputTypeSpec{
+				Splunk: &loggingv1.Splunk{},
+			},
+			Secret: &loggingv1.OutputSecretSpec{
+				Name: "vector-splunk-secret-passphrase",
+			},
+		}
+		outputWithTls = loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeSplunk,
+			Name: "splunk_hec",
+			URL:  "https://splunk-web:8088/endpoint",
+			OutputTypeSpec: loggingv1.OutputTypeSpec{
+				Splunk: &loggingv1.Splunk{},
+			},
+			Secret: &loggingv1.OutputSecretSpec{
+				Name: "vector-splunk-secret-tls",
+			},
+		}
 
-    outputWithTlsSkipVerifyNoCert = loggingv1.OutputSpec{
-      Type: loggingv1.OutputTypeSplunk,
-      Name: "splunk_hec",
-      URL:  "https://splunk-web:8088/endpoint",
-      OutputTypeSpec: loggingv1.OutputTypeSpec{
-        Splunk: &loggingv1.Splunk{},
-      },
-      TLS: &loggingv1.OutputTLSSpec{
-        InsecureSkipVerify: true,
-      },
-    }
+		outputWithTlsSkipVerifyNoCert = loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeSplunk,
+			Name: "splunk_hec",
+			URL:  "https://splunk-web:8088/endpoint",
+			OutputTypeSpec: loggingv1.OutputTypeSpec{
+				Splunk: &loggingv1.Splunk{},
+			},
+			TLS: &loggingv1.OutputTLSSpec{
+				InsecureSkipVerify: true,
+			},
+		}
 
-    secrets = map[string]*corev1.Secret{
-      output.Secret.Name: {
-        Data: map[string][]byte{
-          "hecToken": []byte(hecToken),
-        },
-      },
-      outputWithTls.Secret.Name: {
-        Data: map[string][]byte{
-          "hecToken":      []byte(hecToken),
-          "tls.key":       []byte("junk"),
-          "tls.crt":       []byte("junk"),
-          "ca-bundle.crt": []byte("junk"),
-        },
-      },
-      outputWithPassphrase.Secret.Name: {
-        Data: map[string][]byte{
-          "hecToken":   []byte(hecToken),
-          "passphrase": []byte("junk"),
-        },
-      },
-    }
-  )
+		secrets = map[string]*corev1.Secret{
+			output.Secret.Name: {
+				Data: map[string][]byte{
+					"hecToken": []byte(hecToken),
+				},
+			},
+			outputWithTls.Secret.Name: {
+				Data: map[string][]byte{
+					"hecToken":      []byte(hecToken),
+					"tls.key":       []byte("junk"),
+					"tls.crt":       []byte("junk"),
+					"ca-bundle.crt": []byte("junk"),
+				},
+			},
+			outputWithPassphrase.Secret.Name: {
+				Data: map[string][]byte{
+					"hecToken":   []byte(hecToken),
+					"passphrase": []byte("junk"),
+				},
+			},
+		}
+	)
 
-  Context("splunk config", func() {
-    BeforeEach(func() {
-      g = generator.MakeGenerator()
-    })
+	Context("splunk config", func() {
+		BeforeEach(func() {
+			g = generator.MakeGenerator()
+		})
 
-    It("should provide a valid config", func() {
-      element := Conf(output, []string{"pipelineName"}, secrets[output.Secret.Name], nil)
-      results, err := g.GenerateConf(element...)
-      Expect(err).To(BeNil())
-      Expect(results).To(EqualTrimLines(splunkSink))
-    })
+		It("should provide a valid config", func() {
+			element := Conf(output, []string{"pipelineName"}, secrets[output.Secret.Name], nil)
+			results, err := g.GenerateConf(element...)
+			Expect(err).To(BeNil())
+			Expect(results).To(EqualTrimLines(splunkSink))
+		})
 
-    It("should provide a valid config with passphrase", func() {
-      element := Conf(outputWithPassphrase, []string{"pipelineName"}, secrets[outputWithPassphrase.Secret.Name], nil)
-      results, err := g.GenerateConf(element...)
-      Expect(err).To(BeNil())
-      Expect(results).To(EqualTrimLines(splunkSinkPassphrase))
-    })
+		It("should provide a valid config with passphrase", func() {
+			element := Conf(outputWithPassphrase, []string{"pipelineName"}, secrets[outputWithPassphrase.Secret.Name], nil)
+			results, err := g.GenerateConf(element...)
+			Expect(err).To(BeNil())
+			Expect(results).To(EqualTrimLines(splunkSinkPassphrase))
+		})
 
-    It("should provide a valid config with TLS", func() {
-      element := Conf(outputWithTls, []string{"pipelineName"}, secrets[outputWithTls.Secret.Name], nil)
-      results, err := g.GenerateConf(element...)
-      Expect(err).To(BeNil())
-      Expect(results).To(EqualTrimLines(splunkSinkTls))
-    })
+		It("should provide a valid config with TLS", func() {
+			element := Conf(outputWithTls, []string{"pipelineName"}, secrets[outputWithTls.Secret.Name], nil)
+			results, err := g.GenerateConf(element...)
+			Expect(err).To(BeNil())
+			Expect(results).To(EqualTrimLines(splunkSinkTls))
+		})
 
-    It("should provide a valid config with tls.insecureSkipVerify=true without secret", func() {
-      element := Conf(outputWithTlsSkipVerifyNoCert, []string{"pipelineName"}, nil, nil)
-      results, err := g.GenerateConf(element...)
-      Expect(err).To(BeNil())
-      Expect(results).To(EqualTrimLines(splunkSinkTlsSkipVerifyNoCert))
-    })
+		It("should provide a valid config with tls.insecureSkipVerify=true without secret", func() {
+			element := Conf(outputWithTlsSkipVerifyNoCert, []string{"pipelineName"}, nil, nil)
+			results, err := g.GenerateConf(element...)
+			Expect(err).To(BeNil())
+			Expect(results).To(EqualTrimLines(splunkSinkTlsSkipVerifyNoCert))
+		})
 
-  })
+	})
 })
 
 func TestVectorConfGenerator(t *testing.T) {
-  RegisterFailHandler(Fail)
-  RunSpecs(t, "Vector for Splunk Conf Generation")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Vector for Splunk Conf Generation")
 }


### PR DESCRIPTION
### Description
Fix fluentd so it no longer uses ENV vars for sts credentials.
#### Notes:
A change to the fluentd code resulted in regression of multiple role_arn authentication, when forwarding to cloudwatch.    The change was made in logging 5.6, while implementing vector sts for cloudwatch.   This will need to be fixed forward in 5.7 and 5.8 as well.       A similar change will need to be made for vector, once we figure out an authentication workaround.

/cc @Clee2691 @syedriko @vparfonov 
/assign @jcantrill 

### Links
- https://issues.redhat.com/browse/LOG-4084
