### PR TITLE
[release-5.7] LOG-4368: Fix fluentd sts cloudwatch multiple roles

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -161,7 +161,7 @@ func (f *Factory) NewPodSpec(trustedCABundle *v1.ConfigMap, forwarderSpec loggin
 
 	f.Visit(collector, podSpec)
 
-	addWebIdentityForCloudwatch(collector, podSpec, forwarderSpec, f.Secrets)
+	addWebIdentityForCloudwatch(collector, podSpec, forwarderSpec, f.Secrets, f.CollectorType)
 
 	podSpec.Containers = []v1.Container{
 		*collector,

--- a/internal/generator/fluentd/output/cloudwatch/aws.go
+++ b/internal/generator/fluentd/output/cloudwatch/aws.go
@@ -1,9 +1,11 @@
 package cloudwatch
 
 type AWSKey struct {
-	KeyIDPath     string
-	KeySecretPath string
-	KeyRoleArn    string
+	KeyIDPath           string
+	KeySecretPath       string
+	KeyRoleArn          string
+	KeyRoleSessionName  string
+	KeyWebIdentityToken string
 }
 
 func (a AWSKey) Name() string {
@@ -15,9 +17,9 @@ func (a AWSKey) Template() string {
 	if len(a.KeyRoleArn) > 0 {
 		return `{{define "` + a.Name() + `" -}}
 <web_identity_credentials>
-  role_arn "#{ENV['AWS_ROLE_ARN']}"
-  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+  role_arn "{{ .KeyRoleArn }}"
+  web_identity_token_file "{{ .KeyWebIdentityToken }}"
+  role_session_name "{{ .KeyRoleSessionName }}"
 </web_identity_credentials>
 {{end}}`
 	}

--- a/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
@@ -2,6 +2,7 @@ package cloudwatch
 
 import (
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 
@@ -106,7 +107,9 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) Element {
 	// First check for credentials or role_arn key, indicating a sts-enabled authentication
 	if security.HasAwsRoleArnKey(secret) || security.HasAwsCredentialsKey(secret) {
 		return AWSKey{
-			KeyRoleArn: ParseRoleArn(secret),
+			KeyRoleArn:          ParseRoleArn(secret),
+			KeyRoleSessionName:  constants.AWSRoleSessionName,
+			KeyWebIdentityToken: path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath),
 		}
 	}
 	// Use ID and Secret

--- a/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
@@ -1,6 +1,8 @@
 package cloudwatch
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"path"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
@@ -341,8 +343,10 @@ var _ = Describe("Generating fluentd config for sts", func() {
 				Name: "my-secret",
 			},
 		}
-		roleArn = "arn:aws:iam::123456789012:role/my-role-to-assume"
-		secrets = map[string]*corev1.Secret{
+		roleArn              = "arn:aws:iam::123456789012:role/my-role-to-assume"
+		roleSessionName      = constants.AWSRoleSessionName
+		webIdentityTokenFile = path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath)
+		secrets              = map[string]*corev1.Secret{
 			output.Secret.Name: {
 				Data: map[string][]byte{
 					"role_arn": []byte(roleArn),
@@ -408,9 +412,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>    
     include_time_key true
     log_rejected_request true
@@ -484,9 +488,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>    
     include_time_key true
     log_rejected_request true
@@ -554,9 +558,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>      
     include_time_key true
     log_rejected_request true
@@ -627,9 +631,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>     
     include_time_key true
     log_rejected_request true
@@ -649,7 +653,7 @@ var _ = Describe("Generating fluentd config for sts", func() {
 	})
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
@@ -230,7 +230,7 @@ var _ = Describe("fluentd conf generation", func() {
 	)
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/kafka/kafka_test.go
+++ b/internal/generator/fluentd/output/kafka/kafka_test.go
@@ -445,7 +445,7 @@ var _ = Describe("Generate fluentd config", func() {
 	)
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/loki/loki_conf_test.go
+++ b/internal/generator/fluentd/output/loki/loki_conf_test.go
@@ -314,7 +314,7 @@ var _ = Describe("[internal][generator][fluentd][output][loki] #Conf", func() {
 	)
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/security/security_test.go
+++ b/internal/generator/fluentd/output/security/security_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Helpers for outputLabelConf", func() {
 	})
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
+++ b/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
@@ -969,7 +969,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 	})
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/suite_test.go
+++ b/internal/generator/fluentd/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }


### PR DESCRIPTION
### Description
Fix fluentd so it no longer uses ENV vars for sts credentials.

#### Notes:
A change to the fluentd code resulted in regression of multiple role_arn authentication, when forwarding to cloudwatch. The change was introduced in logging 5.6, while implementing vector sts for cloudwatch. A similar change will need to be made for vector, once we figure out an authentication workaround.

/cc @Clee2691 @syedriko @vparfonov
/assign @jcantrill

### Links
- v5.7:  https://issues.redhat.com/browse/LOG-4368
- v5.6   https://issues.redhat.com/browse/LOG-4084
