### PR TITLE
LOG-4371: Fix for fluentd sts cloudwatch using multiple roles

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -148,7 +148,7 @@ func (f *Factory) NewPodSpec(trustedCABundle *v1.ConfigMap, forwarderSpec loggin
 
 	f.Visit(collector, podSpec, f.ResourceNames)
 
-	addWebIdentityForCloudwatch(collector, podSpec, forwarderSpec, f.Secrets)
+	addWebIdentityForCloudwatch(collector, podSpec, forwarderSpec, f.Secrets, f.CollectorType)
 
 	podSpec.Containers = []v1.Container{
 		*collector,

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -302,7 +302,7 @@ var _ = Describe("Factory#CollectorResourceRequirements", func() {
 	})
 })
 
-var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
+var _ = Describe("Factory#NewPodSpec Add Cloudwatch STS Resources", func() {
 	var (
 		factory   *Factory
 		pipelines = []logging.PipelineSpec{
@@ -336,16 +336,6 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				},
 			},
 		}
-
-		verifyEnvVar = func(container v1.Container, name, value string) {
-			for _, elem := range container.Env {
-				if elem.Name == name {
-					Expect(elem.Value).To(Equal(value))
-					return
-				}
-			}
-			Fail(fmt.Sprintf("Expected collector to include env var '%s' with a value of '%s'", name, value))
-		}
 	)
 	Context("when collectorType is fluentd", func() {
 		BeforeEach(func() {
@@ -359,17 +349,26 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 		})
 		Context("when collector has a secret containing a credentials key", func() {
 
-			It("should find the AWS web identity env vars in the container", func() {
+			It("should NO LONGER be setting AWS ENV vars in the container", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
 				}, "1234", "", tls.GetClusterTLSProfileSpec(nil))
 				collector := podSpec.Containers[0]
 
-				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
-				verifyEnvVar(collector, constants.AWSRoleArnEnvVarKey, roleArn)
-				verifyEnvVar(collector, constants.AWSRoleSessionEnvVarKey, constants.AWSRoleSessionName)
-				verifyEnvVar(collector, constants.AWSWebIdentityTokenEnvVarKey, path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath))
+				// LOG-4084 fluentd no longer setting env vars
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRegionEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRoleArnEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRoleSessionEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSWebIdentityTokenEnvVarKey,
+				})))
 			})
 		})
 		Context("when collector has a secret containing a role_arn key", func() {
@@ -382,20 +381,28 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 					},
 				}
 			})
-			It("should find the AWS web identity env vars in the container", func() {
+			It("should NO LONGER be setting AWS ENV vars in the container", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
 				}, "1234", "", tls.GetClusterTLSProfileSpec(nil))
 				collector := podSpec.Containers[0]
 
-				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
-				verifyEnvVar(collector, constants.AWSRoleArnEnvVarKey, roleArn)
-				verifyEnvVar(collector, constants.AWSRoleSessionEnvVarKey, constants.AWSRoleSessionName)
-				verifyEnvVar(collector, constants.AWSWebIdentityTokenEnvVarKey, path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath))
+				// LOG-4084 fluentd no longer setting env vars
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRegionEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRoleArnEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSRoleSessionEnvVarKey,
+				})))
+				Expect(collector.Env).To(Not(IncludeEnvVar(v1.EnvVar{
+					Name: constants.AWSWebIdentityTokenEnvVarKey,
+				})))
 			})
 		})
-
 	})
 	Context("when collectorType is vector", func() {
 		BeforeEach(func() {
@@ -416,10 +423,22 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				}, "1234", "", tls.GetClusterTLSProfileSpec(nil))
 				collector := podSpec.Containers[0]
 
-				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
-				verifyEnvVar(collector, constants.AWSRoleArnEnvVarKey, roleArn)
-				verifyEnvVar(collector, constants.AWSRoleSessionEnvVarKey, constants.AWSRoleSessionName)
-				verifyEnvVar(collector, constants.AWSWebIdentityTokenEnvVarKey, path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRegionEnvVarKey,
+					Value: outputs[0].OutputTypeSpec.Cloudwatch.Region,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRoleArnEnvVarKey,
+					Value: roleArn,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRoleSessionEnvVarKey,
+					Value: constants.AWSRoleSessionName,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSWebIdentityTokenEnvVarKey,
+					Value: path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath),
+				}))
 			})
 		})
 		Context("when collector has a secret containing a role_arn key", func() {
@@ -439,10 +458,23 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch Resources", func() {
 				}, "1234", "", tls.GetClusterTLSProfileSpec(nil))
 				collector := podSpec.Containers[0]
 
-				verifyEnvVar(collector, constants.AWSRegionEnvVarKey, outputs[0].OutputTypeSpec.Cloudwatch.Region)
-				verifyEnvVar(collector, constants.AWSRoleArnEnvVarKey, roleArn)
-				verifyEnvVar(collector, constants.AWSRoleSessionEnvVarKey, constants.AWSRoleSessionName)
-				verifyEnvVar(collector, constants.AWSWebIdentityTokenEnvVarKey, path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRegionEnvVarKey,
+					Value: outputs[0].OutputTypeSpec.Cloudwatch.Region,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRoleArnEnvVarKey,
+					Value: roleArn,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSRoleSessionEnvVarKey,
+					Value: constants.AWSRoleSessionName,
+				}))
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
+					Name:  constants.AWSWebIdentityTokenEnvVarKey,
+					Value: path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath),
+				}))
+
 			})
 		})
 	})

--- a/internal/generator/fluentd/output/cloudwatch/aws.go
+++ b/internal/generator/fluentd/output/cloudwatch/aws.go
@@ -1,9 +1,11 @@
 package cloudwatch
 
 type AWSKey struct {
-	KeyIDPath     string
-	KeySecretPath string
-	KeyRoleArn    string
+	KeyIDPath           string
+	KeySecretPath       string
+	KeyRoleArn          string
+	KeyRoleSessionName  string
+	KeyWebIdentityToken string
 }
 
 func (a AWSKey) Name() string {
@@ -15,9 +17,9 @@ func (a AWSKey) Template() string {
 	if len(a.KeyRoleArn) > 0 {
 		return `{{define "` + a.Name() + `" -}}
 <web_identity_credentials>
-  role_arn "#{ENV['AWS_ROLE_ARN']}"
-  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+  role_arn "{{ .KeyRoleArn }}"
+  web_identity_token_file "{{ .KeyWebIdentityToken }}"
+  role_session_name "{{ .KeyRoleSessionName }}"
 </web_identity_credentials>
 {{end}}`
 	}

--- a/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/fluentd/output/cloudwatch/cloudwatch.go
@@ -2,6 +2,7 @@ package cloudwatch
 
 import (
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 
@@ -106,7 +107,9 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) Element {
 	// First check for credentials or role_arn key, indicating a sts-enabled authentication
 	if security.HasAwsRoleArnKey(secret) || security.HasAwsCredentialsKey(secret) {
 		return AWSKey{
-			KeyRoleArn: ParseRoleArn(secret),
+			KeyRoleArn:          ParseRoleArn(secret),
+			KeyRoleSessionName:  constants.AWSRoleSessionName,
+			KeyWebIdentityToken: path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath),
 		}
 	}
 	// Use ID and Secret

--- a/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/fluentd/output/cloudwatch/output_cloudwatch_test.go
@@ -1,6 +1,8 @@
 package cloudwatch
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"path"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
@@ -341,8 +343,10 @@ var _ = Describe("Generating fluentd config for sts", func() {
 				Name: "my-secret",
 			},
 		}
-		roleArn = "arn:aws:iam::123456789012:role/my-role-to-assume"
-		secrets = map[string]*corev1.Secret{
+		roleArn              = "arn:aws:iam::123456789012:role/my-role-to-assume"
+		roleSessionName      = constants.AWSRoleSessionName
+		webIdentityTokenFile = path.Join(constants.AWSWebIdentityTokenMount, constants.AWSWebIdentityTokenFilePath)
+		secrets              = map[string]*corev1.Secret{
 			output.Secret.Name: {
 				Data: map[string][]byte{
 					"role_arn": []byte(roleArn),
@@ -408,9 +412,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>    
     include_time_key true
     log_rejected_request true
@@ -484,9 +488,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>    
     include_time_key true
     log_rejected_request true
@@ -554,9 +558,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>      
     include_time_key true
     log_rejected_request true
@@ -627,9 +631,9 @@ var _ = Describe("Generating fluentd config for sts", func() {
     remove_log_group_name_key true
     concurrency 2
     <web_identity_credentials>
-	  role_arn "#{ENV['AWS_ROLE_ARN']}"
-	  web_identity_token_file "#{ENV['AWS_WEB_IDENTITY_TOKEN_FILE']}"
-	  role_session_name "#{ENV['AWS_ROLE_SESSION_NAME']}"
+	  role_arn "` + roleArn + `"
+	  web_identity_token_file "` + webIdentityTokenFile + `"
+	  role_session_name "` + roleSessionName + `"
     </web_identity_credentials>     
     include_time_key true
     log_rejected_request true
@@ -649,7 +653,7 @@ var _ = Describe("Generating fluentd config for sts", func() {
 	})
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
@@ -230,7 +230,7 @@ var _ = Describe("fluentd conf generation", func() {
 	)
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/kafka/kafka_test.go
+++ b/internal/generator/fluentd/output/kafka/kafka_test.go
@@ -445,7 +445,7 @@ var _ = Describe("Generate fluentd config", func() {
 	)
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/loki/loki_conf_test.go
+++ b/internal/generator/fluentd/output/loki/loki_conf_test.go
@@ -314,7 +314,7 @@ var _ = Describe("[internal][generator][fluentd][output][loki] #Conf", func() {
 	)
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/security/security_test.go
+++ b/internal/generator/fluentd/output/security/security_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Helpers for outputLabelConf", func() {
 	})
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
+++ b/internal/generator/fluentd/output/syslog/output_conf_syslog_test.go
@@ -969,7 +969,7 @@ var _ = Describe("Generating external syslog server output store config blocks",
 	})
 })
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }

--- a/internal/generator/fluentd/suite_test.go
+++ b/internal/generator/fluentd/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestFluendConfGenerator(t *testing.T) {
+func TestFluentdConfGenerator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Fluend Conf Generation")
+	RunSpecs(t, "Fluentd Conf Generation")
 }


### PR DESCRIPTION
### Description
Fix forward from 5.6,5.7
Fix fluentd so it no longer uses ENV vars for sts credentials.

#### Notes:
A change to the fluentd code resulted in regression of multiple role_arn authentication, when forwarding to cloudwatch. The change was introduced in logging 5.6, while implementing vector sts for cloudwatch. A similar change will need to be made for vector, once we figure out an authentication workaround.

/cc @Clee2691 @syedriko @vparfonov
/assign @jcantrill

### Links
- v5.8:  https://issues.redhat.com/browse/LOG-4371
- v5.7:  https://issues.redhat.com/browse/LOG-4368
- v5.6:  https://issues.redhat.com/browse/LOG-4084


