### PR TITLE
LOG-4240: initialize spec.visualization with ocp-console plugin, if spec.LogStore was defined as lokistack and the visualization not defined

### DIFF
--- a/internal/k8s/loader/load.go
+++ b/internal/k8s/loader/load.go
@@ -31,6 +31,7 @@ func FetchClusterLogging(k8sClient client.Client, namespace, name string, skipMi
 	}
 	// TODO Drop migration upon introduction of v2
 	clusterLogging.Spec = migrations.MigrateCollectionSpec(clusterLogging.Spec)
+	clusterLogging.Spec = migrations.MigrateVisualizationSpec(clusterLogging.Spec)
 	if err = clusterlogging.Validate(clusterLogging, k8sClient, map[string]bool{}); err != nil {
 		return clusterLogging, err
 	}

--- a/internal/migrations/migrate_visualization.go
+++ b/internal/migrations/migrate_visualization.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"fmt"
+	log "github.com/ViaQ/logerr/v2/log/static"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+)
+
+// MigrateVisualizationSpec initialize spec.visualization with ocp-console plugin,
+// if spec.LogStore was defined as 'lokistack' and the spec.visualization not defined
+func MigrateVisualizationSpec(spec logging.ClusterLoggingSpec) logging.ClusterLoggingSpec {
+	log.V(3).Info("Migrating visualizationSpec for reconciliation call", "spec", spec)
+	if spec.Visualization == nil && spec.LogStore != nil && spec.LogStore.Type == logging.LogStoreTypeLokiStack {
+		log.V(3).Info(fmt.Sprintf("Migrating: visualisation spec not set but LogStore is %s, going to set %s as default visualisation spec", spec.LogStore.Type, logging.VisualizationTypeOCPConsole))
+		spec.Visualization = &logging.VisualizationSpec{
+			Type:       logging.VisualizationTypeOCPConsole,
+			OCPConsole: &logging.OCPConsoleSpec{},
+		}
+	}
+
+	log.V(3).Info("Migrated visualizationSpec for reconciliation", "spec", spec)
+	return spec
+}

--- a/internal/migrations/migrate_visualization_test.go
+++ b/internal/migrations/migrate_visualization_test.go
@@ -1,0 +1,78 @@
+package migrations
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+)
+
+var _ = Describe("Migrating ClusterLogging instance", func() {
+
+	Context("when migrating visualization", func() {
+		It("should return clusterlogging as-is when visualization and LogStore are not defined", func() {
+			spec := ClusterLoggingSpec{}
+			Expect(MigrateVisualizationSpec(spec)).To(Equal(ClusterLoggingSpec{}))
+		})
+
+		It("should return clusterlogging as-is when visualization defined with empty value and LogStore is not defined", func() {
+			spec := ClusterLoggingSpec{}
+			spec.Visualization = &VisualizationSpec{}
+			Expect(MigrateVisualizationSpec(spec)).To(Equal(ClusterLoggingSpec{Visualization: &VisualizationSpec{}}))
+		})
+
+		It("should return clusterlogging with visualization as ocp-console when LogStore defined with lokistack and visualisation with nil", func() {
+			spec := ClusterLoggingSpec{}
+			spec.LogStore = &LogStoreSpec{
+				Type:      LogStoreTypeLokiStack,
+				LokiStack: LokiStackStoreSpec{},
+			}
+			Expect(MigrateVisualizationSpec(spec)).To(Equal(ClusterLoggingSpec{
+				LogStore: &LogStoreSpec{
+					Type:      LogStoreTypeLokiStack,
+					LokiStack: LokiStackStoreSpec{},
+				},
+				Visualization: &VisualizationSpec{
+					Type:       VisualizationTypeOCPConsole,
+					OCPConsole: &OCPConsoleSpec{},
+				}}))
+		})
+
+		It("should return clusterlogging as is when LogStore defined with Elasticsearch", func() {
+			spec := ClusterLoggingSpec{}
+			spec.LogStore = &LogStoreSpec{
+				Type:          LogStoreTypeElasticsearch,
+				Elasticsearch: &ElasticsearchSpec{},
+			}
+			Expect(MigrateVisualizationSpec(spec)).To(Equal(ClusterLoggingSpec{
+				LogStore: &LogStoreSpec{
+					Type:          LogStoreTypeElasticsearch,
+					Elasticsearch: &ElasticsearchSpec{},
+				},
+			}))
+		})
+
+		It("should return clusterlogging as is when visualization is defined with not empty value", func() {
+			spec := ClusterLoggingSpec{}
+			spec.LogStore = &LogStoreSpec{
+				Type:      LogStoreTypeLokiStack,
+				LokiStack: LokiStackStoreSpec{},
+			}
+			spec.Visualization = &VisualizationSpec{
+				Type:   VisualizationTypeKibana,
+				Kibana: &KibanaSpec{},
+			}
+			Expect(MigrateVisualizationSpec(spec)).To(Equal(ClusterLoggingSpec{
+				LogStore: &LogStoreSpec{
+					Type:      LogStoreTypeLokiStack,
+					LokiStack: LokiStackStoreSpec{},
+				},
+				Visualization: &VisualizationSpec{
+					Type:   VisualizationTypeKibana,
+					Kibana: &KibanaSpec{},
+				},
+			}))
+		})
+
+	})
+
+})


### PR DESCRIPTION
### Description
This PR introduce ability to initialize `spec.visualization` with ocp-console plugin, if `LogStore` was defined as `lokistack` and the visualization not defined

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4240
- Enhancement proposal:
