### PR TITLE
LOG-4392 Remove duplicate clf watch from forwarding controller

### DIFF
--- a/controllers/forwarding/forwarding_controller.go
+++ b/controllers/forwarding/forwarding_controller.go
@@ -20,9 +20,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 var _ reconcile.Reconciler = &ReconcileForwarder{}
@@ -150,9 +148,6 @@ func (r *ReconcileForwarder) updateStatus(instance *logging.ClusterLogForwarder)
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReconcileForwarder) SetupWithManager(mgr ctrl.Manager) error {
-	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
-		Watches(&source.Kind{Type: &logging.ClusterLogForwarder{}}, &handler.EnqueueRequestForObject{})
-	return controllerBuilder.
-		For(&logging.ClusterLogForwarder{}).
+	return ctrl.NewControllerManagedBy(mgr).
 		Complete(r)
 }


### PR DESCRIPTION
### Description
We ended up with two watches for the clusterlogforwarder.  One in the clusterlogging controller, and one added to the forwarding controller.  

https://github.com/openshift/cluster-logging-operator/blob/release-5.7/controllers/clusterlogging/clusterlogging_controller.go

https://github.com/openshift/cluster-logging-operator/blob/release-5.7/controllers/forwarding/forwarding_controller.go

We are not aware of any issues or bugs related, but this can lead to race conditions and unintended side effects.    

/cc @Clee2691 @syedriko @vparfonov 
/assign @jcantrill 

/cherry-pick master

### Links
- https://issues.redhat.com/browse/LOG-4392
