### PR TITLE
LOG-4310: Creating CL with 'name != instance' gets error

### DIFF
--- a/bundle/manifests/logging.openshift.io_clusterloggings.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterloggings.yaml
@@ -39,11 +39,6 @@ spec:
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
-            properties:
-              name:
-                enum:
-                - instance
-                type: string
             type: object
           spec:
             description: Specification of the desired behavior of ClusterLogging

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -11,11 +11,3 @@ resources:
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml
-
-patches:
-  - path: singleton-patch.yaml
-    target:
-      group: apiextensions.k8s.io
-      version: v1
-      kind: CustomResourceDefinition
-      name: clusterloggings.logging.openshift.io

--- a/config/crd/singleton-patch.yaml
+++ b/config/crd/singleton-patch.yaml
@@ -1,9 +1,0 @@
-- op: replace
-  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata
-  value:
-    type: object
-    properties:
-      name:
-        type: string
-        enum:
-          - "instance"

--- a/hack/testing-olm/test-010-deploy-via-olm-minimal.sh
+++ b/hack/testing-olm/test-010-deploy-via-olm-minimal.sh
@@ -71,9 +71,6 @@ TIMEOUT_MIN=$((2 * $minute))
 # wait for operator to be ready
 os::cmd::try_until_text "oc -n $LOGGING_NS get deployment cluster-logging-operator -o jsonpath={.status.availableReplicas} --ignore-not-found" "1" ${TIMEOUT_MIN}
 
-# test the validation of an invalid cr
-os::cmd::expect_failure_and_text "oc -n $LOGGING_NS create -f ${repo_dir}/hack/cr_invalid.yaml" "invalid: metadata.name: Unsupported value"
-
 # deploy cluster logging with unmanaged state
 os::cmd::expect_success "oc -n $LOGGING_NS create -f ${repo_dir}/hack/cr-unmanaged.yaml"
 


### PR DESCRIPTION
### Description
This PR addresses the issue of creating multiple `ClusterLogging` instances. This is the removal of the singleton patch.

/cc @cahartma @syedriko 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4310

