### PR TITLE
LOG-4397: LFME pods are not removed

### DIFF
--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -1,4 +1,4 @@
-package collector
+package auth
 
 import (
 	"github.com/openshift/cluster-logging-operator/internal/factory"
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ReconcileRBAC reconciles the service specifically for the collector that exposes the collector metrics
+// ReconcileRBAC reconciles the RBAC specifically for the service account and SCC
 func ReconcileRBAC(er record.EventRecorder, k8sClient client.Client, saNamespace string, resNames *factory.ForwarderResourceNames, owner metav1.OwnerReference) error {
 	desiredCRB := NewMetaDataReaderClusterRoleBinding(saNamespace, resNames.MetadataReaderClusterRoleBinding, resNames.ServiceAccount, owner)
 	if err := reconcile.ClusterRoleBinding(k8sClient, resNames.MetadataReaderClusterRoleBinding, func() *rbacv1.ClusterRoleBinding { return desiredCRB }); err != nil {

--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -1,9 +1,9 @@
-package collector_test
+package auth_test
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/cluster-logging-operator/internal/collector"
+	auth "github.com/openshift/cluster-logging-operator/internal/auth"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("NewMetaDataReaderClusterRoleBinding", func() {
 	It("should stub a well-formed clusterrolebinding", func() {
-		Expect(test.YAMLString(collector.NewMetaDataReaderClusterRoleBinding(constants.OpenshiftNS, "cluster-logging-metadata-reader", "logcollector", metav1.OwnerReference{}))).To(MatchYAML(
+		Expect(test.YAMLString(auth.NewMetaDataReaderClusterRoleBinding(constants.OpenshiftNS, "cluster-logging-metadata-reader", "logcollector", metav1.OwnerReference{}))).To(MatchYAML(
 			`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -34,7 +34,7 @@ subjects:
 
 var _ = Describe("ServiceAccount SCC Role & RoleBinding", func() {
 	It("should stub a well-formed role", func() {
-		Expect(test.YAMLString(collector.NewServiceAccountSCCRole(constants.OpenshiftNS, "scc", metav1.OwnerReference{}))).To(MatchYAML(
+		Expect(test.YAMLString(auth.NewServiceAccountSCCRole(constants.OpenshiftNS, "scc", metav1.OwnerReference{}))).To(MatchYAML(
 			`apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -48,7 +48,7 @@ rules:
 - apiGroups:
     - security.openshift.io
   resourceNames:
-    - log-collector-scc
+    - logging-scc
   resources:
     - securitycontextconstraints
   verbs:
@@ -57,7 +57,7 @@ rules:
 	})
 
 	It("should stub a well-formed roleBinding", func() {
-		Expect(test.YAMLString(collector.NewServiceAccountSCCRoleBinding(constants.OpenshiftNS, "scc", "customSA", metav1.OwnerReference{}))).To(MatchYAML(
+		Expect(test.YAMLString(auth.NewServiceAccountSCCRoleBinding(constants.OpenshiftNS, "scc", "customSA", metav1.OwnerReference{}))).To(MatchYAML(
 			`apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/internal/auth/securitycontextconstraint.go
+++ b/internal/auth/securitycontextconstraint.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	security "github.com/openshift/api/security/v1"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const sccName = "logging-scc"
+
+var (
+	RequiredDropCapabilities = []corev1.Capability{
+		"CHOWN",
+		"DAC_OVERRIDE",
+		"FSETID",
+		"FOWNER",
+		"SETGID",
+		"SETUID",
+		"SETPCAP",
+		"NET_BIND_SERVICE",
+		"KILL",
+	}
+
+	DesiredSCCVolumes = []security.FSType{"configMap", "secret", "emptyDir", "projected"}
+)
+
+func NewSCC() *security.SecurityContextConstraints {
+
+	scc := runtime.NewSCC(sccName)
+	scc.AllowPrivilegedContainer = false
+	scc.RequiredDropCapabilities = RequiredDropCapabilities
+	scc.AllowHostDirVolumePlugin = true
+	scc.Volumes = DesiredSCCVolumes
+	scc.DefaultAllowPrivilegeEscalation = utils.GetPtr(false)
+	scc.AllowPrivilegeEscalation = utils.GetPtr(false)
+	scc.RunAsUser = security.RunAsUserStrategyOptions{
+		Type: security.RunAsUserStrategyRunAsAny,
+	}
+	scc.SELinuxContext = security.SELinuxContextStrategyOptions{
+		Type: security.SELinuxStrategyRunAsAny,
+	}
+	scc.ReadOnlyRootFilesystem = true
+	scc.ForbiddenSysctls = []string{"*"}
+	scc.SeccompProfiles = []string{"runtime/default"}
+	return scc
+}
+
+func RemoveSecurityContextConstraint(k8sClient client.Client, sccName string) error {
+	scc := runtime.NewSCC(sccName)
+
+	err := k8sClient.Delete(context.TODO(), scc)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failure deleting %v security context constraint %v", sccName, err)
+	}
+	return nil
+}

--- a/internal/auth/suite_test.go
+++ b/internal/auth/suite_test.go
@@ -1,0 +1,13 @@
+package auth_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAuth(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][auth] suite")
+}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -3,9 +3,9 @@ package collector
 import (
 	"path"
 
-	"github.com/openshift/cluster-logging-operator/internal/runtime"
-
+	"github.com/openshift/cluster-logging-operator/internal/auth"
 	"github.com/openshift/cluster-logging-operator/internal/collector/common"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -229,7 +229,7 @@ func AddSecretVolumes(podSpec *v1.PodSpec, pipelineSpec logging.ClusterLogForwar
 func AddSecurityContextTo(container *v1.Container) *v1.Container {
 	container.SecurityContext = &v1.SecurityContext{
 		Capabilities: &v1.Capabilities{
-			Drop: RequiredDropCapabilities,
+			Drop: auth.RequiredDropCapabilities,
 		},
 		SELinuxOptions: &v1.SELinuxOptions{
 			Type: "spc_t",

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"path"
 
+	"github.com/openshift/cluster-logging-operator/internal/auth"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 
 	. "github.com/onsi/ginkgo"
@@ -53,7 +54,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 		It("should set a security context", func() {
 			Expect(collector.SecurityContext).To(Equal(&v1.SecurityContext{
 				Capabilities: &v1.Capabilities{
-					Drop: RequiredDropCapabilities,
+					Drop: auth.RequiredDropCapabilities,
 				},
 				SELinuxOptions: &v1.SELinuxOptions{
 					Type: "spc_t",

--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Reconciling", func() {
 				},
 			},
 		}
+
 		fluentdSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      constants.CollectorName,
@@ -68,6 +69,7 @@ var _ = Describe("Reconciling", func() {
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					{
+						Kind:       "ClusterLogging",
 						Name:       "instance",
 						APIVersion: "logging.openshift.io/v1",
 						Controller: utils.GetPtr(true),
@@ -128,6 +130,7 @@ var _ = Describe("Reconciling", func() {
 				}
 			)
 			BeforeEach(func() {
+				cluster.TypeMeta.SetGroupVersionKind(loggingv1.GroupVersion.WithKind("ClusterLogging"))
 				client = fake.NewFakeClient( //nolint
 					cluster,
 					fluentdSecret,

--- a/internal/metrics/logfilemetricexporter/daemonset.go
+++ b/internal/metrics/logfilemetricexporter/daemonset.go
@@ -1,7 +1,6 @@
 package logfilemetricexporter
 
 import (
-	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/apis/logging/v1alpha1"
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
@@ -18,11 +17,10 @@ func ReconcileDaemonset(exporter loggingv1alpha1.LogFileMetricExporter,
 	k8sClient client.Client,
 	namespace,
 	name string,
-	collectionType loggingv1.LogCollectionType,
 	owner metav1.OwnerReference, visitors ...func(o runtime.Object)) error {
 
 	tlsProfile, _ := tls.FetchAPIServerTlsProfile(k8sClient)
-	desired := NewDaemonSet(exporter, namespace, name, collectionType, tls.GetClusterTLSProfileSpec(tlsProfile), visitors...)
+	desired := NewDaemonSet(exporter, namespace, name, tls.GetClusterTLSProfileSpec(tlsProfile), visitors...)
 	utils.AddOwnerRefToObject(desired, owner)
 	return reconcile.DaemonSet(er, k8sClient, desired)
 }

--- a/internal/metrics/logfilemetricexporter/daemonset_test.go
+++ b/internal/metrics/logfilemetricexporter/daemonset_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Reconcile LogFileMetricExporter Daemonset", func() {
 			recorder,
 			reqClient,
 			constants.OpenshiftNS,
-			constants.LogfilesmetricexporterName, cluster.Spec.Collection.Type, dsOwner)).To(Succeed())
+			constants.LogfilesmetricexporterName, dsOwner)).To(Succeed())
 
 		// Check if daemonset is available
 		Expect(reqClient.Get(context.TODO(), dsKey, dsInstance)).Should(Succeed())
@@ -100,7 +100,7 @@ var _ = Describe("Reconcile LogFileMetricExporter Daemonset", func() {
 			recorder,
 			reqClient,
 			constants.OpenshiftNS,
-			constants.LogfilesmetricexporterName, cluster.Spec.Collection.Type, dsOwner)).To(Succeed())
+			constants.LogfilesmetricexporterName, dsOwner)).To(Succeed())
 
 		// Get and check the daemonset
 		Expect(reqClient.Get(context.TODO(), dsKey, dsInstance)).Should(Succeed())
@@ -128,7 +128,7 @@ var _ = Describe("Reconcile LogFileMetricExporter Daemonset", func() {
 			recorder,
 			reqClient,
 			constants.OpenshiftNS,
-			constants.LogfilesmetricexporterName, cluster.Spec.Collection.Type, dsOwner)).To(Succeed())
+			constants.LogfilesmetricexporterName, dsOwner)).To(Succeed())
 
 		// Get and check the daemonset
 		Expect(reqClient.Get(context.TODO(), dsKey, dsInstance)).Should(Succeed())
@@ -164,7 +164,7 @@ var _ = Describe("Reconcile LogFileMetricExporter Daemonset", func() {
 			recorder,
 			reqClient,
 			constants.OpenshiftNS,
-			constants.LogfilesmetricexporterName, cluster.Spec.Collection.Type, dsOwner)).To(Succeed())
+			constants.LogfilesmetricexporterName, dsOwner)).To(Succeed())
 
 		// Get and check the daemonset
 		Expect(reqClient.Get(context.TODO(), dsKey, dsInstance)).Should(Succeed())

--- a/internal/metrics/logfilemetricexporter/factory.go
+++ b/internal/metrics/logfilemetricexporter/factory.go
@@ -10,7 +10,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
-	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	loggingv1a1 "github.com/openshift/cluster-logging-operator/apis/logging/v1alpha1"
 	"github.com/openshift/cluster-logging-operator/internal/collector"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
@@ -68,9 +67,9 @@ func tolerations(exporter loggingv1a1.LogFileMetricExporter) []v1.Toleration {
 	return finalTolerations
 }
 
-func NewDaemonSet(exporter loggingv1a1.LogFileMetricExporter, namespace, name string, collectionType loggingv1.LogCollectionType, tlsProfileSpec configv1.TLSProfileSpec, visitors ...func(o runtime.Object)) *apps.DaemonSet {
+func NewDaemonSet(exporter loggingv1a1.LogFileMetricExporter, namespace, name string, tlsProfileSpec configv1.TLSProfileSpec, visitors ...func(o runtime.Object)) *apps.DaemonSet {
 	podSpec := NewPodSpec(exporter, tlsProfileSpec)
-	ds := coreFactory.NewDaemonSet(name, namespace, constants.LogfilesmetricexporterName, constants.LogfilesmetricexporterName, string(collectionType), *podSpec, visitors...)
+	ds := coreFactory.NewDaemonSet(name, namespace, constants.LogfilesmetricexporterName, constants.LogfilesmetricexporterName, "", *podSpec, visitors...)
 	return ds
 }
 
@@ -79,7 +78,7 @@ func NewPodSpec(exporter loggingv1a1.LogFileMetricExporter, tlsProfileSpec confi
 	podSpec := &v1.PodSpec{
 		NodeSelector:                  utils.EnsureLinuxNodeSelector(nodeSelector(exporter)),
 		PriorityClassName:             clusterLoggingPriorityClassName,
-		ServiceAccountName:            constants.CollectorServiceAccountName,
+		ServiceAccountName:            constants.LogfilesmetricexporterName,
 		TerminationGracePeriodSeconds: utils.GetPtr[int64](10),
 		Tolerations:                   tolerations(exporter),
 		Volumes: []v1.Volume{

--- a/internal/metrics/logfilemetricexporter/metric_exporter.go
+++ b/internal/metrics/logfilemetricexporter/metric_exporter.go
@@ -4,13 +4,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openshift/cluster-logging-operator/internal/auth"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/metrics"
 	"github.com/openshift/cluster-logging-operator/internal/metrics/telemetry"
 	"github.com/openshift/cluster-logging-operator/internal/network"
+	"github.com/openshift/cluster-logging-operator/internal/reconcile"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
-	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/apis/logging/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -22,12 +24,33 @@ import (
 func Reconcile(lfmeInstance *loggingv1alpha1.LogFileMetricExporter,
 	requestClient client.Client,
 	er record.EventRecorder,
-	clInstance loggingv1.ClusterLogging,
 	owner metav1.OwnerReference) error {
 
 	// Adding common labels
 	commonLabels := func(o runtime.Object) {
 		runtime.SetCommonLabels(o, "lfme-service", constants.LogfilesmetricexporterName, constants.LogfilesmetricexporterName)
+	}
+
+	if err := reconcile.SecurityContextConstraints(requestClient, auth.NewSCC()); err != nil {
+		log.V(9).Error(err, "logfilemetricexporter.SecurityContextConstraints")
+		return err
+	}
+
+	resNames := &factory.ForwarderResourceNames{
+		CommonName:                       constants.LogfilesmetricexporterName,
+		ServiceAccount:                   constants.LogfilesmetricexporterName,
+		ServiceAccountTokenSecret:        constants.LogfilesmetricexporterName + "-token",
+		MetadataReaderClusterRoleBinding: "cluster-logging-" + constants.LogfilesmetricexporterName + "-metadata-reader",
+	}
+
+	if err := auth.ReconcileServiceAccount(er, requestClient, lfmeInstance.Namespace, resNames, owner); err != nil {
+		log.Error(err, "logfilemetricexporter.ReconcileServiceAccount")
+		return err
+	}
+
+	if err := auth.ReconcileRBAC(er, requestClient, constants.OpenshiftNS, resNames, owner); err != nil {
+		log.Error(err, "logfilemetricexporter.ReconcileRBAC")
+		return err
 	}
 
 	if err := network.ReconcileService(er, requestClient, lfmeInstance.Namespace, constants.LogfilesmetricexporterName, constants.LogfilesmetricexporterName, ExporterPortName, ExporterMetricsSecretName, ExporterPort, owner, commonLabels); err != nil {
@@ -45,7 +68,6 @@ func Reconcile(lfmeInstance *loggingv1alpha1.LogFileMetricExporter,
 		requestClient,
 		lfmeInstance.Namespace,
 		constants.LogfilesmetricexporterName,
-		clInstance.Spec.Collection.Type,
 		owner,
 		commonLabels); err != nil {
 		msg := fmt.Sprintf("Unable to reconcile LogFileMetricExporter: %v", err)

--- a/internal/metrics/logfilemetricexporter/metric_exporter_test.go
+++ b/internal/metrics/logfilemetricexporter/metric_exporter_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	securityv1 "github.com/openshift/api/security/v1"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/apis/logging/v1alpha1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
@@ -25,7 +26,8 @@ import (
 var _ = Describe("Reconcile LogFileMetricExporter", func() {
 
 	defer GinkgoRecover()
-	_ = monitoringv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	_ = monitoringv1.AddToScheme(scheme.Scheme)
+	_ = securityv1.AddToScheme(scheme.Scheme)
 
 	var (
 		cluster = &loggingv1.ClusterLogging{
@@ -96,7 +98,7 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		}
 
 		// Reconcile the LogFileMetricExporter
-		Expect(Reconcile(lfmeInstance, reqClient, recorder, *cluster, utils.AsOwner(lfmeInstance))).To(Succeed())
+		Expect(Reconcile(lfmeInstance, reqClient, recorder, utils.AsOwner(lfmeInstance))).To(Succeed())
 
 		// Daemonset
 		// Get and check the daemonset

--- a/internal/utils/comparators/scc/comparator_test.go
+++ b/internal/utils/comparators/scc/comparator_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	security "github.com/openshift/api/security/v1"
-	"github.com/openshift/cluster-logging-operator/internal/collector"
+	"github.com/openshift/cluster-logging-operator/internal/auth"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	. "github.com/openshift/cluster-logging-operator/internal/utils/comparators/scc"
 )
@@ -15,14 +15,14 @@ import (
 var _ = Describe("scc#AreSame", func() {
 
 	It("should succeed when they are the same", func() {
-		left := collector.NewSCC()
+		left := auth.NewSCC()
 		right := left.DeepCopy()
 		same, reason := AreSame(*left, *right)
 		Expect(same).To(BeTrue(), fmt.Sprintf("Exp. comparator to succeed when fields are the same, reason: %s are different", reason))
 	})
 
 	DescribeTable("should fail with different", func(modifications ...func(*security.SecurityContextConstraints)) {
-		left := collector.NewSCC()
+		left := auth.NewSCC()
 		right := left.DeepCopy()
 		if len(modifications) > 0 {
 			modifications[0](right)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -46,7 +46,7 @@ func AsOwner(o runtime.Object) metav1.OwnerReference {
 		panic(err)
 	}
 	return metav1.OwnerReference{
-		APIVersion: logging.GroupVersion.String(),
+		APIVersion: fmt.Sprintf("%s/%s", o.GetObjectKind().GroupVersionKind().Group, o.GetObjectKind().GroupVersionKind().Version),
 		Kind:       o.GetObjectKind().GroupVersionKind().Kind,
 		Name:       m.GetName(),
 		UID:        m.GetUID(),


### PR DESCRIPTION
### Description
This PR:
- Fixes LFME resource cleanup
- Remove creation of a "virtual" LFME resource when `ClusterLogging` CR is created without a LFME CR
- Remove dependence of LFME on a `ClusterLogging` instance

/cc @cahartma @syedriko 
/assign @jcantrill 
### Links
- JIRA: https://issues.redhat.com/browse/LOG-4397

