### PR TITLE
LOG-4433: fix only clusterrolebindings are allowed to collect logs

### DIFF
--- a/hack/testing-olm/test-1343-minimal-multi-clf.sh
+++ b/hack/testing-olm/test-1343-minimal-multi-clf.sh
@@ -58,7 +58,7 @@ os::cmd::expect_success "oc create ns $LOGGING_NS"
 
 # deploy ClusterLogForwarder
 os::cmd::expect_success "oc -n $LOGGING_NS create sa mine"
-os::cmd::expect_success "oc -n $LOGGING_NS create rolebinding collect-application-logs --clusterrole=collect-application-logs --serviceaccount=$LOGGING_NS:mine"
+os::cmd::expect_success "oc -n $LOGGING_NS create clusterrolebinding collect-application-logs --clusterrole=collect-application-logs --serviceaccount=$LOGGING_NS:mine"
 os::cmd::expect_success "oc -n $LOGGING_NS create -f ${repo_dir}/hack/clusterlogforwarder/cr.yaml"
 
 assert_collector_exist my-collector

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
@@ -18,6 +18,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	//allNamesapces is used for determining cluster scoped bindings
+	allNamespaces = ""
+)
+
 func ValidateServiceAccount(clf loggingv1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *loggingv1.ClusterLogForwarderStatus) {
 	// Do not need to validate SA if legacy forwarder
 	if clf.Name == constants.SingletonName && clf.Namespace == constants.OpenshiftNS {
@@ -70,7 +75,7 @@ func validateServiceAccountPermissions(k8sClient client.Client, inputs sets.Stri
 	var failedInputs []string
 	for _, input := range inputs.List() {
 		log.V(3).Info(fmt.Sprintf("[ValidateServiceAccountPermissions] validating %q for user: %v", inputs, username))
-		sar := createSubjectAccessReview(username, clfNamespace, "collect", "logs", input, loggingv1.GroupVersion.Group)
+		sar := createSubjectAccessReview(username, allNamespaces, "collect", "logs", input, loggingv1.GroupVersion.Group)
 		if err = k8sClient.Create(context.TODO(), sar); err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description
This PR:
* fixes SA permissions match the enhancement to only allow ClusterRoleBindings to define log types to be collected

### Links
*  https://issues.redhat.com/browse/LOG-4433

cc @Clee2691 