### PR TITLE
LOG-4431: fix collector not reconciling on permission change

### DIFF
--- a/internal/collector/daemonset.go
+++ b/internal/collector/daemonset.go
@@ -1,9 +1,14 @@
 package collector
 
 import (
+	"context"
+	"fmt"
+	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/tls"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,7 +19,16 @@ func (f *Factory) ReconcileDaemonset(er record.EventRecorder, k8sClient client.C
 	trustedCABundle, trustHash := GetTrustedCABundle(k8sClient, namespace, f.ResourceNames.CaTrustBundle)
 	f.TrustedCAHash = trustHash
 	tlsProfile, _ := tls.FetchAPIServerTlsProfile(k8sClient)
-	desired := f.NewDaemonSet(namespace, f.ResourceNames.CommonName, trustedCABundle, tls.GetClusterTLSProfileSpec(tlsProfile))
+	desired := f.NewDaemonSet(namespace, f.ResourceNames.DaemonSetName(), trustedCABundle, tls.GetClusterTLSProfileSpec(tlsProfile))
 	utils.AddOwnerRefToObject(desired, owner)
 	return reconcile.DaemonSet(er, k8sClient, desired)
+}
+
+func Remove(k8sClient client.Client, namespace, name string) (err error) {
+	log.V(3).Info("Removing collector", "namespace", namespace, "name", name)
+	ds := runtime.NewDaemonSet(namespace, name)
+	if err = k8sClient.Delete(context.TODO(), ds); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("Failure deleting daemonset %s/%s: %v", namespace, name, err)
+	}
+	return nil
 }

--- a/internal/factory/resource_names.go
+++ b/internal/factory/resource_names.go
@@ -18,6 +18,10 @@ type ForwarderResourceNames struct {
 	ServiceAccountTokenSecret        string
 }
 
+func (f *ForwarderResourceNames) DaemonSetName() string {
+	return f.CommonName
+}
+
 // GenerateResourceNames is a factory for naming of objects based on ClusterLogForwarder namespace and name
 func GenerateResourceNames(clf logging.ClusterLogForwarder) *ForwarderResourceNames {
 	resBaseName := clf.Name

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
@@ -81,7 +81,7 @@ func validateServiceAccountPermissions(k8sClient client.Client, inputs sets.Stri
 		}
 		// If input is spec'd but SA isn't authorized to collect it, fail validation
 		if !sar.Status.Allowed {
-			log.V(3).Info(fmt.Sprintf("[ValidateServiceAccountPermissions] Not authorized to collect %s-logs", input))
+			log.V(3).Info(fmt.Sprintf("[ValidateServiceAccountPermissions] %s %s-logs", errors.NotAuthorizedToCollect, input))
 			failedInputs = append(failedInputs, input)
 		}
 	}

--- a/internal/validations/errors/errors.go
+++ b/internal/validations/errors/errors.go
@@ -3,6 +3,11 @@ package errors
 import (
 	"fmt"
 	"reflect"
+	"strings"
+)
+
+const (
+	NotAuthorizedToCollect = "Not authorized to collect"
 )
 
 type ValidationError struct {
@@ -24,4 +29,8 @@ func NewValidationError(msg string, args ...interface{}) *ValidationError {
 
 func IsValidationError(err error) bool {
 	return reflect.TypeOf(err).AssignableTo(validationErrorType)
+}
+
+func MustUndeployCollector(err error) bool {
+	return !strings.Contains(err.Error(), NotAuthorizedToCollect)
 }

--- a/internal/validations/errors/errors_test.go
+++ b/internal/validations/errors/errors_test.go
@@ -20,5 +20,21 @@ var _ = Describe("[internal][validations][errors]", func() {
 		})
 
 	})
+	Context("#MustUndeployCollector", func() {
+
+		It("should fail when not authorized to collect", func() {
+			myerror := &ValidationError{
+				msg: "something" + NotAuthorizedToCollect,
+			}
+			Expect(MustUndeployCollector(myerror)).To(BeFalse())
+		})
+		It("should pass does not mention authorized to collect", func() {
+			myerror := &ValidationError{
+				msg: "something",
+			}
+			Expect(MustUndeployCollector(myerror)).To(BeTrue())
+		})
+
+	})
 
 })


### PR DESCRIPTION
### Description
This PR fixes not reconciling on permission change:
* Adds a periodic requeue of CLF because we can not efficiently watch ClusterRoleBindings
* Removes collector DaemonSet when permissions are not allowed

### Links
* https://issues.redhat.com/browse/LOG-4431

cc @xperimental @Clee2691 @cahartma 
