### PR TITLE
LOG-4231: Add open on every update fluentd tuning options

### DIFF
--- a/apis/logging/v1/clusterlogging_types.go
+++ b/apis/logging/v1/clusterlogging_types.go
@@ -449,6 +449,10 @@ type FluentdInFileSpec struct {
 	//ReadLinesLimit represents the number of lines to read with each I/O operation
 	// +optional
 	ReadLinesLimit int `json:"readLinesLimit"`
+
+	//OpenOnEveryUpdate Opens and closes the file on every update instead of leaving it open until it gets rotated.
+	// +optional
+	OpenOnEveryUpdate bool `json:"openOnEveryUpdate"`
 }
 
 // FluentdBufferSpec represents a subset of fluentd buffer parameters to tune

--- a/bundle/manifests/logging.openshift.io_clusterloggings.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterloggings.yaml
@@ -145,6 +145,11 @@ spec:
                           all fluentd in-tail inputs. \n For general parameters refer
                           to: https://docs.fluentd.org/input/tail#parameters"
                         properties:
+                          openOnEveryUpdate:
+                            description: OpenOnEveryUpdate Opens and closes the file
+                              on every update instead of leaving it open until it
+                              gets rotated.
+                            type: boolean
                           readLinesLimit:
                             description: ReadLinesLimit represents the number of lines
                               to read with each I/O operation
@@ -519,6 +524,11 @@ spec:
                           all fluentd in-tail inputs. \n For general parameters refer
                           to: https://docs.fluentd.org/input/tail#parameters"
                         properties:
+                          openOnEveryUpdate:
+                            description: OpenOnEveryUpdate Opens and closes the file
+                              on every update instead of leaving it open until it
+                              gets rotated.
+                            type: boolean
                           readLinesLimit:
                             description: ReadLinesLimit represents the number of lines
                               to read with each I/O operation

--- a/config/crd/bases/logging.openshift.io_clusterloggings.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterloggings.yaml
@@ -141,6 +141,11 @@ spec:
                           all fluentd in-tail inputs. \n For general parameters refer
                           to: https://docs.fluentd.org/input/tail#parameters"
                         properties:
+                          openOnEveryUpdate:
+                            description: OpenOnEveryUpdate Opens and closes the file
+                              on every update instead of leaving it open until it
+                              gets rotated.
+                            type: boolean
                           readLinesLimit:
                             description: ReadLinesLimit represents the number of lines
                               to read with each I/O operation
@@ -515,6 +520,11 @@ spec:
                           all fluentd in-tail inputs. \n For general parameters refer
                           to: https://docs.fluentd.org/input/tail#parameters"
                         properties:
+                          openOnEveryUpdate:
+                            description: OpenOnEveryUpdate Opens and closes the file
+                              on every update instead of leaving it open until it
+                              gets rotated.
+                            type: boolean
                           readLinesLimit:
                             description: ReadLinesLimit represents the number of lines
                               to read with each I/O operation

--- a/docs/reference/operator/api.adoc
+++ b/docs/reference/operator/api.adoc
@@ -441,6 +441,7 @@ https://docs.fluentd.org/input/tail#parameters
 |======================
 |Property|Type|Description
 
+|openOnEveryUpdate|bool|  *(optional)* OpenOnEveryUpdate Opens and closes the file on every update instead of leaving it open until it gets rotated.
 |readLinesLimit|int|  *(optional)* ReadLinesLimit represents the number of lines to read with each I/O operation
 |======================
 
@@ -712,6 +713,7 @@ https://docs.fluentd.org/input/tail#parameters
 |======================
 |Property|Type|Description
 
+|openOnEveryUpdate|bool|  *(optional)* OpenOnEveryUpdate Opens and closes the file on every update instead of leaving it open until it gets rotated.
 |readLinesLimit|int|  *(optional)* ReadLinesLimit represents the number of lines to read with each I/O operation
 |======================
 

--- a/internal/generator/fluentd/source/audit_logs.go
+++ b/internal/generator/fluentd/source/audit_logs.go
@@ -19,6 +19,13 @@ func (cl AuditLog) ReadLinesLimit() string {
 	return "\n  read_lines_limit " + strconv.Itoa(cl.Tunings.ReadLinesLimit)
 }
 
+func (cl AuditLog) OpenOnEveryUpdate() string {
+	if cl.Tunings == nil || !cl.Tunings.OpenOnEveryUpdate {
+		return ""
+	}
+	return "\n  open_on_every_update true"
+}
+
 const HostAuditLogTemplate = `
 {{define "inputSourceHostAuditTemplate" -}}
 # {{.Desc}}
@@ -30,6 +37,7 @@ const HostAuditLogTemplate = `
   pos_file "/var/lib/fluentd/pos/audit.log.pos"
   follow_inodes true
   {{- .ReadLinesLimit }}
+  {{- .OpenOnEveryUpdate }}
   tag linux-audit.log
   <parse>
     @type viaq_host_audit

--- a/internal/generator/fluentd/source/audit_logs_test.go
+++ b/internal/generator/fluentd/source/audit_logs_test.go
@@ -27,4 +27,13 @@ var _ = Describe("AuditLog", func() {
 			Expect(conf.ReadLinesLimit()).To(Equal("\n  read_lines_limit 12"))
 		})
 	})
+	Context("#OpenOnEveryUpdate", func() {
+		It("should return nothing when there are no InFile tuning", func() {
+			Expect(conf.OpenOnEveryUpdate()).To(BeEmpty())
+		})
+		It("should return nothing when the InFile tuning is a negative number", func() {
+			conf.Tunings = &logging.FluentdInFileSpec{OpenOnEveryUpdate: true}
+			Expect(conf.OpenOnEveryUpdate()).To(Equal("\n  open_on_every_update true"))
+		})
+	})
 })

--- a/internal/generator/fluentd/source/container_logs.go
+++ b/internal/generator/fluentd/source/container_logs.go
@@ -22,6 +22,13 @@ func (cl ContainerLogs) ReadLinesLimit() string {
 	return "\n  read_lines_limit " + strconv.Itoa(cl.Tunings.ReadLinesLimit)
 }
 
+func (cl ContainerLogs) OpenOnEveryUpdate() string {
+	if cl.Tunings == nil || !cl.Tunings.OpenOnEveryUpdate {
+		return ""
+	}
+	return "\n  open_on_every_update true"
+}
+
 func (cl ContainerLogs) Name() string {
 	return "inputContainerSourceTemplate"
 }
@@ -41,6 +48,7 @@ func (cl ContainerLogs) Template() string {
   tag kubernetes.*
   read_from_head "true"
   {{- .ReadLinesLimit }}
+  {{- .OpenOnEveryUpdate }}
   skip_refresh_on_startup true
   @label @{{.OutLabel}}
   <parse>

--- a/internal/generator/fluentd/source/container_logs_test.go
+++ b/internal/generator/fluentd/source/container_logs_test.go
@@ -27,4 +27,13 @@ var _ = Describe("ContainerLogs", func() {
 			Expect(conf.ReadLinesLimit()).To(Equal("\n  read_lines_limit 12"))
 		})
 	})
+	Context("#OpenOnEveryUpdate", func() {
+		It("should return nothing when there are no InFile tuning", func() {
+			Expect(conf.OpenOnEveryUpdate()).To(BeEmpty())
+		})
+		It("should return nothing when the InFile tuning is a negative number", func() {
+			conf.Tunings = &logging.FluentdInFileSpec{OpenOnEveryUpdate: true}
+			Expect(conf.OpenOnEveryUpdate()).To(Equal("\n  open_on_every_update true"))
+		})
+	})
 })

--- a/test/helpers/loki/receiver.go
+++ b/test/helpers/loki/receiver.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	Image        = "grafana/loki:2.5.0"
+	Image        = "grafana/loki:2.8.4"
 	Port         = int32(3100)
 	lokiReceiver = "loki-receiver"
 )
@@ -54,6 +54,13 @@ func NewReceiver(ns, name string) *Receiver {
 		Name:  name,
 		Image: Image,
 		Ports: []corev1.ContainerPort{{Name: name, ContainerPort: Port}},
+		Args: []string{
+			"-config.file=/etc/loki/local-config.yaml",
+			"-print-config-stderr=true",
+			"-server.grpc-max-recv-msg-size-bytes", "20971520",
+			"-distributor.ingestion-rate-limit-mb", "200",
+			"-distributor.ingestion-burst-size-mb", "200",
+		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: utils.GetBool(false),
 			Capabilities: &corev1.Capabilities{

--- a/test/helpers/loki/receiver_test.go
+++ b/test/helpers/loki/receiver_test.go
@@ -14,14 +14,14 @@ func TestLokiReceiverCanPushAndQueryLogs(t *testing.T) {
 	l := loki.NewReceiver(c.NS.Name, "loki")
 	require.NoError(t, l.Create(c.Client))
 	sv := loki.StreamValues{
-		Stream: map[string]string{"test": "loki"},
+		Stream: map[string]string{"test": "loki", "functional": "test"},
 		Values: loki.MakeValues([]string{"hello", "there", "mr. frog"}),
 	}
 	require.NoError(t, l.Push(sv))
 
 	labels, err := l.Labels()
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, []string{"__name__", "test"}, labels)
+	assert.ElementsMatch(t, []string{"functional", "test"}, labels)
 
 	result, err := l.QueryUntil(`{test="loki"}`, "", 3)
 	require.NoError(t, err)


### PR DESCRIPTION
### Description
This PR:

* adds a tuning option for fluentd to allow opening files on every update to mitigate file handles not being closed

### Links
* https://issues.redhat.com/browse/LOG-4241
