### PR TITLE
LOG-4181: fix loki test flake caused by rate limiting

### DIFF
--- a/test/helpers/loki/receiver.go
+++ b/test/helpers/loki/receiver.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	Image        = "grafana/loki:2.5.0"
+	Image        = "grafana/loki:2.8.4"
 	Port         = int32(3100)
 	lokiReceiver = "loki-receiver"
 )
@@ -55,6 +55,13 @@ func NewReceiver(ns, name string) *Receiver {
 		Name:  name,
 		Image: Image,
 		Ports: []corev1.ContainerPort{{Name: name, ContainerPort: Port}},
+		Args: []string{
+			"-config.file=/etc/loki/local-config.yaml",
+			"-print-config-stderr=true",
+			"-server.grpc-max-recv-msg-size-bytes", "20971520",
+			"-distributor.ingestion-rate-limit-mb", "200",
+			"-distributor.ingestion-burst-size-mb", "200",
+		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: utils.GetPtr(false),
 			Capabilities: &corev1.Capabilities{

--- a/test/helpers/loki/receiver_test.go
+++ b/test/helpers/loki/receiver_test.go
@@ -14,14 +14,14 @@ func TestLokiReceiverCanPushAndQueryLogs(t *testing.T) {
 	l := loki.NewReceiver(c.NS.Name, "loki")
 	require.NoError(t, l.Create(c.Client))
 	sv := loki.StreamValues{
-		Stream: map[string]string{"test": "loki"},
+		Stream: map[string]string{"test": "loki", "functional": "test"},
 		Values: loki.MakeValues([]string{"hello", "there", "mr. frog"}),
 	}
 	require.NoError(t, l.Push(sv))
 
 	labels, err := l.Labels()
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, []string{"__name__", "test"}, labels)
+	assert.ElementsMatch(t, []string{"test", "functional"}, labels)
 
 	result, err := l.QueryUntil(`{test="loki"}`, "", 3)
 	require.NoError(t, err)


### PR DESCRIPTION
### Description
This PR:
* Updates the loki test image to 2.8.4
* Modifies the ingestion rates and limits to address e2e loki test flake

### Links
* https://issues.redhat.com/browse/LOG-4181