### PR TITLE
LOG-4413: Overrides the name of the log field used to retrieve the timestamp to send to Splunk HEC

### DIFF
--- a/internal/generator/vector/output/splunk/splunk.go
+++ b/internal/generator/vector/output/splunk/splunk.go
@@ -39,6 +39,7 @@ inputs = {{.Inputs}}
 endpoint = "{{.Endpoint}}"
 compression = "none"
 default_token = "{{.DefaultToken}}"
+timestamp_key = "@timestamp"
 {{end}}`
 }
 

--- a/internal/generator/vector/output/splunk/splunk_test.go
+++ b/internal/generator/vector/output/splunk/splunk_test.go
@@ -73,6 +73,7 @@ inputs = ["splunk_hec_dedot"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "` + hecToken + `"
+timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
 `
@@ -83,6 +84,7 @@ inputs = ["splunk_hec_dedot"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "` + hecToken + `"
+timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
 [sinks.splunk_hec.tls]
@@ -97,6 +99,7 @@ inputs = ["splunk_hec_dedot"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "` + hecToken + `"
+timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
 [sinks.splunk_hec.tls]
@@ -113,6 +116,7 @@ inputs = ["splunk_hec_dedot"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = ""
+timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
 [sinks.splunk_hec.tls]
@@ -126,6 +130,7 @@ inputs = ["splunk_hec_dedot"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "` + hecToken + `"
+timestamp_key = "@timestamp"
 
 [sinks.splunk_hec.encoding]
 codec = "json"


### PR DESCRIPTION
### Description
This PR overrides the default name of the log field to used to retrieve the timestamp to send to Splunk HEC to the `@timestamp`. 

https://vector.dev/docs/reference/configuration/sinks/splunk_hec_logs/#timestamp_key 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4413 
- Enhancement proposal:
