### PR TITLE
LOG-4451: add validations name for logfilesmetricexporter: should be named instance and be in openshift-logging namespace

### DIFF
--- a/bundle/manifests/logging.openshift.io_logfilemetricexporters.yaml
+++ b/bundle/manifests/logging.openshift.io_logfilemetricexporters.yaml
@@ -35,6 +35,11 @@ spec:
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
+            properties:
+              name:
+                enum:
+                - instance
+                type: string
             type: object
           spec:
             description: LogFileMetricExporterSpec defines the desired state of LogFileMetricExporter

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,13 +1,21 @@
-# This kustomization.yaml is not intended to be run by itself,
-# since it depends on service name and namespace that are out of this kustomize package.
-# It should be run by config/default
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - bases/logging.openshift.io_clusterlogforwarders.yaml
 - bases/logging.openshift.io_clusterloggings.yaml
 - bases/logging.openshift.io_logfilemetricexporters.yaml
 
-# +kubebuilder:scaffold:crdkustomizeresource
-
-# the following config is for teaching kustomize how to do kustomization for CRDs.
-configurations:
-- kustomizeconfig.yaml
+patches:
+  - target:
+      kind: CustomResourceDefinition
+      name: logfilemetricexporters.logging.openshift.io
+    patch: |-
+      - op: add
+        path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata
+        value:
+          type: object
+          properties:
+            name:
+              type: string
+              enum:
+              - instance

--- a/internal/validations/logfilemetricsexporter/suite_test.go
+++ b/internal/validations/logfilemetricsexporter/suite_test.go
@@ -1,0 +1,13 @@
+package logfilemetricsexporter
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][validations][clusterlogging] Suite")
+}

--- a/internal/validations/logfilemetricsexporter/validate_name.go
+++ b/internal/validations/logfilemetricsexporter/validate_name.go
@@ -1,0 +1,26 @@
+package logfilemetricsexporter
+
+import (
+	"fmt"
+	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/apis/logging/v1alpha1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/validations/errors"
+)
+
+// Check for singleton. Must be named instance and in openshift-logging namespace
+func validateName(instance *loggingv1alpha1.LogFileMetricExporter) (error, *loggingv1alpha1.LogFileMetricExporterStatus) {
+	failMessage := ""
+	fail := false
+	if instance.Name != constants.SingletonName {
+		failMessage += fmt.Sprintf("Invalid name %q, singleton instance must be named %q ", instance.Name, constants.SingletonName)
+		fail = true
+	}
+	if instance.Namespace != constants.OpenshiftNS {
+		failMessage += fmt.Sprintf("Invalid namespace name %q, instance must be in %q namespace ", instance.Namespace, constants.OpenshiftNS)
+		fail = true
+	}
+	if fail {
+		return errors.NewValidationError(failMessage), nil
+	}
+	return nil, nil
+}

--- a/internal/validations/logfilemetricsexporter/validate_name_test.go
+++ b/internal/validations/logfilemetricsexporter/validate_name_test.go
@@ -1,0 +1,37 @@
+package logfilemetricsexporter
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	loggingruntime "github.com/openshift/cluster-logging-operator/internal/runtime"
+)
+
+var _ = Describe("[internal][validations] ClusterLogForwarder", func() {
+
+	Context("#validateName", func() {
+
+		// This conflicts with the legacy CLF
+		It("should fail validation when the name is NOT 'instance' and NOT in the 'openshift-logging' namespace", func() {
+			clf := loggingruntime.NewLogFileMetricExporter("some-ns", "not-instance")
+			Expect(validateName(clf)).To(Not(Succeed()))
+		})
+
+		It("should fail validation when the name is NOT 'instance' and in any namespace other then 'openshift-logging'", func() {
+			clf := loggingruntime.NewLogFileMetricExporter("some-ns", constants.SingletonName)
+			Expect(validateName(clf)).To(Not(Succeed()))
+		})
+
+		It("should fail validation when the name is NOT 'instance' and in the 'openshift-logging' namespace", func() {
+			clf := loggingruntime.NewLogFileMetricExporter(constants.OpenshiftNS, "my-instance")
+			Expect(validateName(clf)).To(Not(Succeed()))
+		})
+
+		It("should pass validation when the name is 'instance' and in the 'openshift-logging' namespace", func() {
+			clf := loggingruntime.NewLogFileMetricExporter(constants.OpenshiftNS, constants.SingletonName)
+			Expect(validateName(clf)).To(Succeed())
+		})
+
+	})
+
+})

--- a/internal/validations/logfilemetricsexporter/validations.go
+++ b/internal/validations/logfilemetricsexporter/validations.go
@@ -1,0 +1,22 @@
+package logfilemetricsexporter
+
+import (
+	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/apis/logging/v1alpha1"
+)
+
+func Validate(instance *loggingv1alpha1.LogFileMetricExporter) (error, *loggingv1alpha1.LogFileMetricExporterStatus) {
+	returnStatus := loggingv1alpha1.LogFileMetricExporterStatus{}
+	for _, validate := range validations {
+		if err, status := validate(instance); err != nil {
+			return err, status
+		} else if status != nil {
+			returnStatus.Conditions = append(returnStatus.Conditions, status.Conditions...)
+		}
+	}
+	return nil, &returnStatus
+}
+
+// validations are the set of admission rules for validating a LogFileMetricExporter instance
+var validations = []func(instance *loggingv1alpha1.LogFileMetricExporter) (error, *loggingv1alpha1.LogFileMetricExporterStatus){
+	validateName,
+}


### PR DESCRIPTION
### Description
This PR adds validation for the name of `LogFileMetricExporter` resources and namespaces during reconciliation. Additionally, it introduces an enhancement to perform additional checking for the resource name during resource creation using `Kustomize` and a `Custom Resource Definition (CRD)`.

- In the reconciliation logic:
	* Added validation logic to ensure that the name of `LogFileMetricExporter` resources equals to `instance`.
	* Implemented checks to ensure that namespaces name equals to `openshift-logging`.

- In the `LogFileMetricExporter CRD` updated, the definition to include validation constraints for the `metadata.name` field ensures that only valid resource name `instance` is accepted

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4451
- Enhancement proposal:
