### PR TITLE
LOG-4171: add expire_metrics_secs to vector global options

### DIFF
--- a/internal/generator/vector/conf.go
+++ b/internal/generator/vector/conf.go
@@ -10,6 +10,10 @@ import (
 func Conf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace string, op generator.Options) []generator.Section {
 	return []generator.Section{
 		{
+			Global(),
+			`vector global options`,
+		},
+		{
 			Sources(clfspec, namespace, op),
 			`
 			Set of all input sources, as defined in CLF spec
@@ -22,7 +26,7 @@ func Conf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clf
 		{
 			NormalizeLogs(clfspec, op),
 			`
-			- set 'level' field 
+			- set 'level' field
 			- rename fields as per data model
 			- remove unused fields
 			`,

--- a/internal/generator/vector/conf_test/complex.toml
+++ b/internal/generator/vector/conf_test/complex.toml
@@ -1,3 +1,5 @@
+expire_metrics_secs = 60
+
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"

--- a/internal/generator/vector/conf_test/complex_es_no_ver.toml
+++ b/internal/generator/vector/conf_test/complex_es_no_ver.toml
@@ -1,3 +1,5 @@
+expire_metrics_secs = 60
+
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"

--- a/internal/generator/vector/conf_test/complex_es_v6.toml
+++ b/internal/generator/vector/conf_test/complex_es_v6.toml
@@ -1,3 +1,5 @@
+expire_metrics_secs = 60
+
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"

--- a/internal/generator/vector/conf_test/es_pipeline_w_spaces.toml
+++ b/internal/generator/vector/conf_test/es_pipeline_w_spaces.toml
@@ -1,3 +1,5 @@
+expire_metrics_secs = 60
+
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"

--- a/internal/generator/vector/global.go
+++ b/internal/generator/vector/global.go
@@ -1,0 +1,29 @@
+package vector
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+)
+
+func Global() []generator.Element {
+	return []generator.Element{
+		GlobalOptions{
+			ExpireMetricsSecs: 60,
+		},
+	}
+}
+
+type GlobalOptions struct {
+	ExpireMetricsSecs int
+}
+
+func (GlobalOptions) Name() string {
+	return "globalOptionsTemplate"
+}
+
+func (g GlobalOptions) Template() string {
+	return `
+{{define "` + g.Name() + `" -}}
+expire_metrics_secs = {{.ExpireMetricsSecs}}
+{{end}}
+`
+}


### PR DESCRIPTION
### Description

Added expire_metrics_secs=60 [seconds] to vector global options, in order to cap grows of the metrics' memory footprint.

/cc @cahartma 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4171
