### PR TITLE
Cleanup from previous Dockerfile update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ RUN INSTALL_PKGS=" \
 
 COPY --from=builder $APP_DIR/bin/cluster-logging-operator /usr/bin/
 
-RUN mkdir -p /usr/share/logging/
-
 COPY --from=origincli /usr/bin/oc /usr/bin
 COPY $SRC_DIR/must-gather/collection-scripts/* /usr/bin/
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -175,27 +175,6 @@ func GetFileContents(filePath string) []byte {
 	return contents
 }
 
-const defaultShareDir = "/usr/share/logging"
-
-func GetShareDir() string {
-	// shareDir is <repo-root>/files - try to find from working dir.
-	const sep = string(os.PathSeparator)
-	const repoRoot = sep + "cluster-logging-operator"
-	wd, err := os.Getwd()
-	if err != nil {
-		log.V(3).Error(err, "Error determining share directory. Returning default", "default", defaultShareDir)
-		return defaultShareDir
-	}
-	log.V(5).Info("GetShareDir", "workingdir", wd)
-	i := strings.LastIndex(wd, repoRoot)
-	if i >= 0 {
-		shareDir := filepath.Join(wd[:i+len(repoRoot)], "files")
-		log.V(5).Info("GetShareDir", "sharedir", shareDir)
-		return shareDir
-	}
-	return defaultShareDir
-}
-
 func GetPtr[T any](value T) *T {
 	return &value
 }


### PR DESCRIPTION
### Description
A previous change to our Dockerfile removed the /usr/share/logging directory.   This caused an issue in midstream that required the same changes.    I've also removed the only function I found that used that directory.

/cc @Clee2691 @syedriko @vparfonov 
/assign @jcantrill 

### Links
- upstream change:  https://github.com/openshift/cluster-logging-operator/pull/2123/files
- midstream fix:  https://gitlab.cee.redhat.com/openshift-logging/log-collection-midstream/-/merge_requests/2208
