### PR TITLE
LOG-4446: CLO raises many error messages 'Could not find ServiceAccount token secret' after creating multiple-CLF

### DIFF
--- a/internal/k8s/loader/load.go
+++ b/internal/k8s/loader/load.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/cluster-logging-operator/internal/factory"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -58,9 +59,10 @@ func FetchClusterLogForwarder(k8sClient client.Client, namespace, name string, i
 	// Do not modify cached copy
 	forwarder = *proto.DeepCopy()
 	internalLogStoreSecret := factory.GenerateResourceNames(forwarder).InternalLogStoreSecret
+	saTokenSecret := factory.GenerateResourceNames(forwarder).ServiceAccountTokenSecret
 	// TODO Drop migration upon introduction of v2
 	extras := map[string]bool{}
-	forwarder.Spec, extras = migrations.MigrateClusterLogForwarderSpec(namespace, name, forwarder.Spec, fetchClusterLogging().Spec.LogStore, extras, internalLogStoreSecret)
+	forwarder.Spec, extras = migrations.MigrateClusterLogForwarderSpec(namespace, name, forwarder.Spec, fetchClusterLogging().Spec.LogStore, extras, internalLogStoreSecret, saTokenSecret)
 
 	extras[constants.ClusterLoggingAvailable] = (fetchClusterLogging().Name != "")
 	if err, status = clusterlogforwarder.Validate(forwarder, k8sClient, extras); err != nil {

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -66,11 +66,6 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 
 	// Set the output secrets if any
 	clusterRequest.SetOutputSecrets()
-	tokenSecret, err := clusterRequest.GetLogCollectorServiceAccountTokenSecret()
-	if err == nil {
-		saTokenSecretName := clusterRequest.ResourceNames.ServiceAccountTokenSecret
-		clusterRequest.OutputSecrets[saTokenSecretName] = tokenSecret
-	}
 
 	if collectorConfig, err = clusterRequest.generateCollectorConfig(); err != nil {
 		log.V(9).Error(err, "clusterRequest.generateCollectorConfig")

--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Reconciling", func() {
 					ResourceOwner: utils.AsOwner(cluster),
 				}
 				extras[constants.MigrateDefaultOutput] = true
-				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret)
+				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
 				clusterRequest.Forwarder.Spec = spec
 			})
 
@@ -215,7 +215,7 @@ var _ = Describe("Reconciling", func() {
 					ResourceOwner: utils.AsOwner(cluster),
 				}
 				extras[constants.MigrateDefaultOutput] = true
-				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret)
+				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
 				clusterRequest.Forwarder.Spec = spec
 			})
 
@@ -257,7 +257,7 @@ var _ = Describe("Reconciling", func() {
 					Forwarder:     &loggingv1.ClusterLogForwarder{},
 				}
 				extras[constants.MigrateDefaultOutput] = true
-				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret)
+				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
 				clusterRequest.Forwarder.Spec = spec
 			})
 		})
@@ -318,7 +318,7 @@ var _ = Describe("Reconciling", func() {
 					ResourceOwner: utils.AsOwner(fwder),
 				}
 				extras[constants.MigrateDefaultOutput] = true
-				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret)
+				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
 				clusterRequest.Forwarder.Spec = spec
 			})
 			It("should have appropriately named resources", func() {

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -1,7 +1,6 @@
 package k8shandler
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/tls"
@@ -66,21 +65,4 @@ func (clusterRequest *ClusterLoggingRequest) SetOutputSecrets() {
 		secret, _ := clusterRequest.GetSecret(output.Secret.Name)
 		clusterRequest.OutputSecrets[output.Name] = secret
 	}
-}
-
-func (clusterRequest *ClusterLoggingRequest) GetLogCollectorServiceAccountTokenSecret() (*corev1.Secret, error) {
-	colTokenName := clusterRequest.ResourceNames.ServiceAccountTokenSecret
-	s := &corev1.Secret{}
-	log.V(9).Info("Fetching Secret", "Name", colTokenName)
-	if err := clusterRequest.Get(colTokenName, s); err != nil {
-		log.V(3).Error(err, "Could not find ServiceAccount token secret", "Name", colTokenName)
-		return nil, errors.New("Could not retrieve ServiceAccount token")
-	}
-
-	if _, ok := s.Data[constants.TokenKey]; !ok {
-		log.V(9).Info("did not find token in secret", "Name", s.Name)
-		return nil, errors.New(colTokenName + " secret is missing token")
-	}
-
-	return s, nil
 }

--- a/internal/logstore/lokistack/logstore_lokistack.go
+++ b/internal/logstore/lokistack/logstore_lokistack.go
@@ -164,7 +164,7 @@ func newLokiStackViewClusterRole(name, logType string) func() *rbacv1.ClusterRol
 	}
 }
 
-func ProcessForwarderPipelines(logStore *loggingv1.LogStoreSpec, namespace string, spec loggingv1.ClusterLogForwarderSpec, extras map[string]bool) ([]loggingv1.OutputSpec, []loggingv1.PipelineSpec, map[string]bool) {
+func ProcessForwarderPipelines(logStore *loggingv1.LogStoreSpec, namespace string, spec loggingv1.ClusterLogForwarderSpec, extras map[string]bool, saTokenSecret string) ([]loggingv1.OutputSpec, []loggingv1.PipelineSpec, map[string]bool) {
 	needOutput := make(map[string]bool)
 	inPipelines := spec.Pipelines
 	pipelines := []loggingv1.PipelineSpec{}
@@ -218,6 +218,9 @@ func ProcessForwarderPipelines(logStore *loggingv1.LogStoreSpec, namespace strin
 			Name: FormatOutputNameFromInput(input),
 			Type: loggingv1.OutputTypeLoki,
 			URL:  lokiStackURL(logStore, namespace, tenant),
+			Secret: &loggingv1.OutputSecretSpec{
+				Name: saTokenSecret,
+			},
 		})
 	}
 

--- a/internal/logstore/lokistack/logstore_lokistack_test.go
+++ b/internal/logstore/lokistack/logstore_lokistack_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 )
 
 func TestProcessPipelinesForLokiStack(t *testing.T) {
@@ -47,6 +48,9 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 					Name: loggingv1.OutputNameDefault + "-loki-apps",
 					Type: loggingv1.OutputTypeLoki,
 					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/application",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
 				},
 			},
 			wantPipelines: []loggingv1.PipelineSpec{
@@ -75,11 +79,17 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 					Name: loggingv1.OutputNameDefault + "-loki-apps",
 					Type: loggingv1.OutputTypeLoki,
 					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/application",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
 				},
 				{
 					Name: loggingv1.OutputNameDefault + "-loki-infra",
 					Type: loggingv1.OutputTypeLoki,
 					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/infrastructure",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
 				},
 			},
 			wantPipelines: []loggingv1.PipelineSpec{
@@ -114,11 +124,17 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 					Name: loggingv1.OutputNameDefault + "-loki-apps",
 					Type: loggingv1.OutputTypeLoki,
 					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/application",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
 				},
 				{
 					Name: loggingv1.OutputNameDefault + "-loki-infra",
 					Type: loggingv1.OutputTypeLoki,
 					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/infrastructure",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
 				},
 			},
 			wantPipelines: []loggingv1.PipelineSpec{
@@ -154,6 +170,9 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 					Name: loggingv1.OutputNameDefault + "-loki-infra",
 					Type: loggingv1.OutputTypeLoki,
 					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/infrastructure",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
 				},
 			},
 			wantPipelines: []loggingv1.PipelineSpec{
@@ -188,11 +207,17 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 					Name: loggingv1.OutputNameDefault + "-loki-audit",
 					Type: loggingv1.OutputTypeLoki,
 					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/audit",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
 				},
 				{
 					Name: loggingv1.OutputNameDefault + "-loki-infra",
 					Type: loggingv1.OutputTypeLoki,
 					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/infrastructure",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
 				},
 			},
 			wantPipelines: []loggingv1.PipelineSpec{
@@ -228,7 +253,7 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 			}
 			var outputs []loggingv1.OutputSpec
 			var pipelines []loggingv1.PipelineSpec
-			outputs, pipelines, _ = ProcessForwarderPipelines(logStore, "aNamespace", tc.spec, map[string]bool{})
+			outputs, pipelines, _ = ProcessForwarderPipelines(logStore, "aNamespace", tc.spec, map[string]bool{}, constants.LogCollectorToken)
 
 			if diff := cmp.Diff(outputs, tc.wantOutputs); diff != "" {
 				t.Errorf("outputs differ: -got+want\n%s", diff)

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -332,7 +332,7 @@ func verifyOutputSecret(namespace string, clfClient client.Client, output *loggi
 		return false
 	}
 	// Only for ES. If default replaced, the "collector" secret will be created later
-	if output.Type == loggingv1.OutputTypeElasticsearch && extras[constants.MigrateDefaultOutput] {
+	if (output.Type == loggingv1.OutputTypeElasticsearch || output.Type == loggingv1.OutputTypeLoki) && extras[constants.MigrateDefaultOutput] {
 		return true
 	}
 	log.V(3).Info("getting output secret", "output", output.Name, "secret", output.Secret.Name)


### PR DESCRIPTION
### Description
This PR removes retrieval of the service account token for multi-CLF when reconciling the collection.

For the legacy case, when forwarding to the internal default lokistack store, migration of lokistack now includes adding the service account token as a secret.

/cc @cahartma @syedriko @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4446

