### PR TITLE
LOG-4470: fix unallowed clf name

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_name.go
+++ b/internal/validations/clusterlogforwarder/validate_name.go
@@ -4,6 +4,7 @@ import (
 	v1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/validations/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -12,5 +13,10 @@ func validateName(clf v1.ClusterLogForwarder, k8sClient client.Client, extras ma
 	if clf.Namespace == constants.OpenshiftNS && clf.Name == constants.CollectorName {
 		return errors.NewValidationError("Name %q conflicts with an object for the legacy ClusterLogForwarder deployment.  Choose another", clf.Name), nil
 	}
+
+	if nameErrors := validation.IsDNS1035Label(clf.Name); len(nameErrors) != 0 {
+		return errors.NewValidationError("Name %q will result in an invalid object: %v", clf.Name, nameErrors), nil
+	}
+
 	return nil, nil
 }

--- a/internal/validations/clusterlogforwarder/validate_name_test.go
+++ b/internal/validations/clusterlogforwarder/validate_name_test.go
@@ -29,6 +29,13 @@ var _ = Describe("[internal][validations] ClusterLogForwarder", func() {
 			Expect(validateName(*clf, k8sClient, extras)).To(Succeed())
 		})
 
+		It("should fail validation when the name results in an object that will fail name validation (e.g. service)", func() {
+			clf := runtime.NewClusterLogForwarder()
+			clf.Namespace = "foobar"
+			clf.Name = "65409debug-3y8sw019"
+			Expect(validateName(*clf, k8sClient, extras)).To(Not(Succeed()))
+		})
+
 	})
 
 })


### PR DESCRIPTION
### Description
This PR:
* restricts the CLF name to one that will result in admisable kubernetes objects (e.g. service) 

### Links
* https://issues.redhat.com/browse/LOG-4470
