### PR TITLE
WIP: CLO support for optional OTEL data model

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder_types.go
+++ b/apis/logging/v1/cluster_log_forwarder_types.go
@@ -324,6 +324,14 @@ type PipelineSpec struct {
 	//
 	// +optional
 	DetectMultilineErrors bool `json:"detectMultilineErrors,omitempty"`
+
+	// Schema enables switching log records to the Open Telemetry specification
+	//
+	// Logs are converted to the Open Telemetry specification according to schema value
+	//
+	// +kubebuilder:validation:Enum:=opentelemetry;viaq;none
+	// +optional
+	Schema string `json:"schema,omitempty"`
 }
 
 type OutputDefaults struct {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -133,6 +133,8 @@ const (
 	ClusterLoggingAvailable = "isClusterLoggingAvailable"
 
 	OptimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
+
+	OtelSchema = "opentelemetry"
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}

--- a/internal/constants/features.go
+++ b/internal/constants/features.go
@@ -8,4 +8,7 @@ const (
 	UseOldRemoteSyslogPlugin = "clusterlogging.openshift.io/useoldremotesyslogplugin"
 
 	AnnotationDebugOutput = "logging.openshift.io/debug-output"
+
+	// OpenTelemetry is the annotation to enable OpenTelemetry output
+	OpenTelemetry = "logging.openshift.io/opentelemetry"
 )

--- a/internal/generator/helpers/otel.go
+++ b/internal/generator/helpers/otel.go
@@ -1,0 +1,22 @@
+package helpers
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator"
+	elements2 "github.com/openshift/cluster-logging-operator/internal/generator/fluentd/elements"
+)
+
+const (
+	EnableOtel = "otel-output"
+)
+
+func IsOtelOutput(op generator.Options) bool {
+	_, ok := op[EnableOtel]
+	return ok
+}
+
+var OtelOutput = generator.ConfLiteral{
+	Desc:         "Sending records to stdout for debug purposes",
+	TemplateName: "toStdout",
+	Pattern:      "**",
+	TemplateStr:  elements2.ToStdOut,
+}

--- a/internal/generator/vector/pipelines.go
+++ b/internal/generator/vector/pipelines.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 	. "github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	genhelper "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 )
 
 const (
@@ -61,6 +62,62 @@ if .log_type == "application" {
 }
 `
 			vrls = append(vrls, parse)
+		}
+		if p.Schema == constants.OtelSchema && genhelper.IsOtelOutput(op){
+			schema := `
+					.timeUnixNano = to_unix_timestamp(to_timestamp!(del(.@timestamp)))
+					.severityText = del(.level)
+			  
+					# Convert syslog severity to number, default to 9 (unknown)
+					if .severityText == "trace"{
+						.severityNumber = "8"
+					}else if .severityText == "debug"{
+						.severityNumber = "7"
+					}else if .severityText == "info"{
+						.severityNumber = "6"
+					}else if .severityText == "notice"{
+						.severityNumber = "5"
+					}else if .severityText == "warn"{
+						.severityNumber = "4"
+					}else if .severityText == "err"{
+						.severityNumber = "3"
+					}else if .severityText == "crit"{
+						.severityNumber = "2"
+					}else if .severityText == "alert"{
+						.severityNumber = "1"
+					}else if .severityText == "emerg"{
+						.severityNumber = "0"
+					}else{
+						.severityNumber = "9"
+					}
+					
+					# resources
+					.resources.logs.file.path = del(.file)
+					.resources.host.name= del(.hostname)
+					.resources.container.name = del(.kubernetes.container_name)
+					.resources.container.id = del(.kubernetes.container_id)
+			  
+					# split image name and tag into separate fields
+					container_image_slice = split!(.kubernetes.container_image, ":", limit: 2)
+					.resources.container.image.name = container_image_slice[0]
+					.resources.container.image.tag = container_image_slice[1]
+					del(.kubernetes.container_image)
+			  
+					#kuberenetes
+					.resources.k8s.pod.name = del(.kubernetes.pod_name)
+					.resources.k8s.pod.uid = del(.kubernetes.pod_id)
+					.resources.k8s.pod.ip = del(.kubernetes.pod_ip)
+					.resources.k8s.pod.owner = .kubernetes.pod_owner
+					.resources.k8s.pod.annotations = del(.kubernetes.annotations)
+					.resources.k8s.pod.labels = del(.kubernetes.labels)
+					.resources.k8s.namespace.id = del(.kubernetes.namespace_id)
+			  
+					.resources.k8s.namespace.name = .kubernetes.namespace_labels."kubernetes.io/metadata.name"
+					.resources.k8s.namespace.labels = del(.kubernetes.namespace_labels)
+					.resources.attributes.key = "log_type"
+					.resources.attributes.value = del(.log_type)
+			  `
+			vrls = append(vrls, schema)
 		}
 		vrl := SrcPassThrough
 		if len(vrls) != 0 {

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -31,6 +31,10 @@ func EvaluateAnnotationsForEnabledCapabilities(forwarder *logging.ClusterLogForw
 			if strings.ToLower(value) == "true" {
 				options[helpers.EnableDebugOutput] = "true"
 			}
+		case constants.OpenTelemetry:
+			if strings.ToLower(value) == constants.Enabled {
+				options[helpers.EnableOtel] = "true"
+			}
 		}
 	}
 }

--- a/test/functional/flowcontrol/otel_format_test.go
+++ b/test/functional/flowcontrol/otel_format_test.go
@@ -1,0 +1,90 @@
+// go:build !fluentd
+package flowcontrol
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	testfw "github.com/openshift/cluster-logging-operator/test/functional"
+	"github.com/openshift/cluster-logging-operator/test/helpers/loki"
+)
+
+var _ = Describe("[Functional][FlowControl] Policies at Output", func() {
+	var (
+		f *functional.CollectorFunctionalFramework
+		l *loki.Receiver
+	)
+
+	BeforeEach(func() {
+		f = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
+		// Start a Loki server
+		l = loki.NewReceiver(f.Namespace, "loki-server")
+		Expect(l.Create(f.Test.Client)).To(Succeed())
+
+		// Set up the common template forwarder configuration.
+		f.Forwarder.Spec.Outputs = append(f.Forwarder.Spec.Outputs,
+			logging.OutputSpec{
+				Name: logging.OutputTypeLoki,
+				Type: logging.OutputTypeLoki,
+				URL:  l.InternalURL("").String(),
+				OutputTypeSpec: logging.OutputTypeSpec{
+					Loki: &logging.Loki{},
+				},
+			})
+
+		f.Forwarder.Spec.Pipelines = append(f.Forwarder.Spec.Pipelines,
+			logging.PipelineSpec{
+				InputRefs:  []string{logging.InputNameApplication},
+				OutputRefs: []string{logging.OutputTypeLoki},
+				Name:       "flow-control",
+			},
+		)
+	})
+
+	AfterEach(func() {
+		f.Cleanup()
+	})
+
+	FDescribe("when Output is Loki", func() {
+		It("using flow control policy", func() {
+			if testfw.LogCollectionType == logging.LogCollectionTypeFluentd {
+				Skip("Skipping test since flow-control is not supported with fluentd")
+			}
+
+			f.Forwarder.Spec.Outputs[0].Limit = &logging.LimitSpec{
+				MaxRecordsPerSecond: 10,
+			}
+
+			Expect(f.Deploy()).To(BeNil())
+			Expect(f.WritesApplicationLogsWithDelay(1000, 0.0001)).To(Succeed())
+
+			if _, err := l.QueryUntil(fmt.Sprintf(LokiNsQuery, AllLogs), "", 10); err != nil {
+				Fail(fmt.Sprintf("Failed to read logs from Loki Server: %v", err))
+			}
+			r, err := l.Query(fmt.Sprintf(LokiNsQuery, AllLogs), "", 20)
+			Expect(err).To(BeNil())
+			records := r[0].Records()
+
+			var jsonObject map[string]interface{}
+			jsonStr := `{timeUnixNano: nil}`
+			json.Unmarshal([]byte(jsonStr), &jsonObject)
+
+			Expect(records[0]).To(Equal(jsonObject))
+
+			//Check if the expected field is present in each record
+			// expectedField := "timeUnixNano"
+
+			// for _, record := range records[0] {
+			// 	var jsonObject map[string]interface{}
+			// 	json.Unmarshal([]byte(record), &jsonObject)
+
+			// 	Expect(jsonObject).To(HaveKey(expectedField))
+			// }
+
+		})
+	})
+})


### PR DESCRIPTION
### Description
Allow the Cluster Logging Operator to support the Open Telemetry data model via a filter in the Pipelines.go file

/cc @alanconway 
/assign @alanconway

### Links
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4231
- Enhancement proposal: https://github.com/openshift/enhancements/pull/1442
