### PR TITLE
LOG-4481: make unique paths for Vector checkpoints file according to multiple-CLFs installation

### DIFF
--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 			Visit:         fluentd.CollectorVisitor,
 			ResourceNames: coreFactory.GenerateResourceNames(*runtime.NewClusterLogForwarder(constants.OpenshiftNS, constants.SingletonName)),
 		}
-		podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil)
+		podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
 		collector = podSpec.Containers[0]
 	})
 	Describe("when creating of the collector container", func() {
@@ -73,7 +73,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 					Name:      "custom-clf-metrics",
 					ReadOnly:  true,
 					MountPath: metricsVolumePath}
-				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil)
+				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
 				collector = podSpec.Containers[0]
 				Expect(collector.VolumeMounts).To(ContainElement(expectedContainerVolume))
 			})
@@ -123,7 +123,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 						},
 					},
 				}
-				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil)
+				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
 				expTolerations := append(constants.DefaultTolerations(), providedToleration)
 				Expect(podSpec.Tolerations).To(Equal(expTolerations))
 			})
@@ -147,7 +147,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 						},
 					},
 				}
-				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil)
+				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
 				Expect(podSpec.NodeSelector).To(Equal(expSelector))
 			})
 
@@ -190,7 +190,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 					Data: map[string]string{
 						constants.TrustedCABundleKey: caBundle,
 					},
-				}, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil)
+				}, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
 				collector = podSpec.Containers[0]
 
 				verifyEnvVar(collector, "http_proxy", httpproxy)
@@ -222,7 +222,7 @@ var _ = Describe("Factory#NewPodSpec", func() {
 					Data: map[string]string{
 						constants.TrustedCABundleKey: caBundle,
 					},
-				}, logging.ClusterLogForwarderSpec{}, "foobar", "", tls.GetClusterTLSProfileSpec(nil), nil)
+				}, logging.ClusterLogForwarderSpec{}, "foobar", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
 
 				collector = podSpec.Containers[0]
 				Expect(podSpec.Volumes).To(ContainElement(expectedPodSpecMetricsVol))
@@ -355,7 +355,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch STS Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil)
+				}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
 				collector := podSpec.Containers[0]
 
 				// LOG-4084 fluentd no longer setting env vars
@@ -387,7 +387,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch STS Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil)
+				}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
 				collector := podSpec.Containers[0]
 
 				// LOG-4084 fluentd no longer setting env vars
@@ -422,7 +422,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch STS Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil)
+				}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
 				collector := podSpec.Containers[0]
 
 				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
@@ -457,7 +457,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch STS Resources", func() {
 				podSpec := *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{
 					Outputs:   outputs,
 					Pipelines: pipelines,
-				}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil)
+				}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
 				collector := podSpec.Containers[0]
 
 				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{

--- a/internal/collector/config.go
+++ b/internal/collector/config.go
@@ -1,9 +1,11 @@
 package collector
 
 import (
+	"fmt"
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/collector/fluentd"
+	"github.com/openshift/cluster-logging-operator/internal/collector/vector"
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
@@ -30,11 +32,13 @@ func (f *Factory) ReconcileCollectorConfig(er record.EventRecorder, k8sClient cl
 		utils.AddOwnerRefToObject(collectorConfigMap, owner)
 		return reconcile.Configmap(k8sClient, reader, collectorConfigMap)
 	} else if f.CollectorType == logging.LogCollectionTypeVector {
+
 		secret := runtime.NewSecret(
 			namespace,
 			f.ResourceNames.ConfigMap,
 			map[string][]byte{
-				"vector.toml": []byte(collectorConfig),
+				vector.ConfigFile:    []byte(collectorConfig),
+				vector.RunVectorFile: []byte(fmt.Sprintf(vector.RunVectorScript, vector.GetDataPath(namespace, f.ResourceNames.ForwarderName))),
 			},
 			f.CommonLabelInitializer)
 

--- a/internal/collector/fluentd/visitors.go
+++ b/internal/collector/fluentd/visitors.go
@@ -21,7 +21,7 @@ var (
 	DefaultCpuRequest = resource.MustParse("100m")
 )
 
-func CollectorVisitor(collectorContainer *v1.Container, podSpec *v1.PodSpec, resNames *factory.ForwarderResourceNames) {
+func CollectorVisitor(collectorContainer *v1.Container, podSpec *v1.PodSpec, resNames *factory.ForwarderResourceNames, namespace string) {
 
 	collectorContainer.Env = append(collectorContainer.Env,
 		v1.EnvVar{

--- a/internal/collector/vector/run_script.go
+++ b/internal/collector/vector/run_script.go
@@ -1,0 +1,14 @@
+package vector
+
+// RunVectorScript is the run-vector.sh script for launching the Vector container process
+// will override content of /scripts/run-vector.sh in https://github.com/ViaQ/vector
+const RunVectorScript = `
+#!/bin/bash
+# The directory used for persisting Vector state, such as on-disk buffers, file checkpoints, and more.
+VECTOR_DATA_DIR=%s
+echo "Creating the directory used for persisting Vector state $VECTOR_DATA_DIR"
+mkdir -p $VECTOR_DATA_DIR
+echo "Starting Vector process..."
+exec "/usr/bin/vector"
+
+`

--- a/internal/collector/vector/utils.go
+++ b/internal/collector/vector/utils.go
@@ -1,0 +1,23 @@
+package vector
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"path"
+)
+
+const (
+	RunVectorFile    = "run-vector.sh"
+	DefaultDataPath  = "/var/lib/vector"
+	ConfigFile       = "vector.toml"
+	vectorConfigPath = "/etc/vector"
+	entrypointValue  = "/usr/bin/run-vector.sh"
+)
+
+func GetDataPath(namespace, forwarderName string) string {
+	//legacy installation
+	if constants.OpenshiftNS == namespace && constants.SingletonName == forwarderName {
+		return DefaultDataPath
+	}
+	//make data path unique to avoid collision in Multi CLF installation
+	return path.Join(DefaultDataPath, namespace, forwarderName)
+}

--- a/internal/factory/resource_names.go
+++ b/internal/factory/resource_names.go
@@ -16,6 +16,7 @@ type ForwarderResourceNames struct {
 	ServiceAccount                   string
 	InternalLogStoreSecret           string
 	ServiceAccountTokenSecret        string
+	ForwarderName                    string
 }
 
 func (f *ForwarderResourceNames) DaemonSetName() string {
@@ -34,6 +35,7 @@ func GenerateResourceNames(clf logging.ClusterLogForwarder) *ForwarderResourceNa
 		SecretMetrics:                    resBaseName + "-metrics",
 		ConfigMap:                        resBaseName + "-config",
 		MetadataReaderClusterRoleBinding: fmt.Sprintf("cluster-logging-%s-%s-metadata-reader", clf.Namespace, resBaseName),
+		ForwarderName:                    clf.Name,
 	}
 
 	if clf.Namespace == constants.OpenshiftNS && clf.Name == constants.SingletonName {
@@ -47,6 +49,5 @@ func GenerateResourceNames(clf logging.ClusterLogForwarder) *ForwarderResourceNa
 		forwarderResNames.InternalLogStoreSecret = clf.Spec.ServiceAccountName + "-default"
 		forwarderResNames.ServiceAccountTokenSecret = clf.Spec.ServiceAccountName + "-token"
 	}
-
 	return forwarderResNames
 }

--- a/internal/factory/resource_names_test.go
+++ b/internal/factory/resource_names_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Collector Resource Name Generator", func() {
 			ServiceAccountTokenSecret:        constants.LogCollectorToken,
 			MetadataReaderClusterRoleBinding: fmt.Sprintf("cluster-logging-%s-%s-metadata-reader", constants.OpenshiftNS, constants.CollectorName),
 			ConfigMap:                        constants.CollectorConfigSecretName,
+			ForwarderName:                    constants.SingletonName,
 		}
 
 		clf := *runtime.NewClusterLogForwarder(constants.OpenshiftNS, clfName)
@@ -45,6 +46,7 @@ var _ = Describe("Collector Resource Name Generator", func() {
 			ServiceAccountTokenSecret:        clfName + "-token",
 			MetadataReaderClusterRoleBinding: fmt.Sprintf("cluster-logging-%s-%s-metadata-reader", constants.OpenshiftNS, clfName),
 			ConfigMap:                        clfName + "-config",
+			ForwarderName:                    clfName,
 		}
 
 		clf := *runtime.NewClusterLogForwarder(constants.OpenshiftNS, clfName)

--- a/internal/generator/fluentd/conf.go
+++ b/internal/generator/fluentd/conf.go
@@ -7,7 +7,7 @@ import (
 )
 
 //nolint:govet // using declarative style
-func Conf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace string, op generator.Options) []generator.Section {
+func Conf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, name string, op generator.Options) []generator.Section {
 	return []generator.Section{
 		{
 			Header(op),

--- a/internal/generator/fluentd/conf_test.go
+++ b/internal/generator/fluentd/conf_test.go
@@ -28,7 +28,7 @@ var ExpectedFluentConf string
 var _ = Describe("Testing Complete Config Generation", func() {
 	var f = func(testcase testhelpers.ConfGenerateTest) {
 		g := generator.MakeGenerator()
-		e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, constants.OpenshiftNS, generator.Options{generator.ClusterTLSProfileSpec: tls.GetClusterTLSProfileSpec(nil)}))
+		e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, constants.OpenshiftNS, constants.SingletonName, generator.Options{generator.ClusterTLSProfileSpec: tls.GetClusterTLSProfileSpec(nil)}))
 		conf, err := g.GenerateConf(e...)
 		Expect(err).To(BeNil())
 		diff := cmp.Diff(

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Generating fluentd config", func() {
 				Data: secretData,
 			},
 		}
-		c := generator.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, op))
+		c := generator.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())
 
@@ -286,7 +286,7 @@ var _ = Describe("Generating fluentd config", func() {
 				Data: secretData,
 			},
 		}
-		c := generator.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, op))
+		c := generator.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(ExpectedPodLabelsConf))
@@ -366,7 +366,7 @@ var _ = Describe("Generating fluentd config", func() {
 				Data: secretData,
 			},
 		}
-		c := generator.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, op))
+		c := generator.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(ExpectedPodLabelsNSConf))
@@ -389,14 +389,14 @@ var _ = Describe("Generating fluentd config", func() {
 				},
 			},
 		}
-		c := generator.MergeSections(Conf(nil, nil, forwarder, constants.OpenshiftNS, op))
+		c := generator.MergeSections(Conf(nil, nil, forwarder, constants.OpenshiftNS, constants.SingletonName, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(ExpectedExcludeConf))
 	})
 
 	It("should produce well formed fluent.conf", func() {
-		c := generator.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, op))
+		c := generator.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(ExpectedWellFormedConf))
@@ -479,7 +479,7 @@ var _ = Describe("Generating fluentd config", func() {
 			var spec logging.ClusterLogForwarderSpec
 			Expect(yaml.Unmarshal([]byte(yamlSpec), &spec)).To(Succeed())
 			g := generator.MakeGenerator()
-			s := Conf(nil, security.NoSecrets, &spec, constants.OpenshiftNS, op)
+			s := Conf(nil, security.NoSecrets, &spec, constants.OpenshiftNS, constants.SingletonName, op)
 			gotFluentdConf, err := g.GenerateConf(generator.MergeSections(s)...)
 			Expect(err).To(Succeed())
 			Expect(gotFluentdConf).To(EqualTrimLines(wantFluentdConf))

--- a/internal/generator/forwarder/generator.go
+++ b/internal/generator/forwarder/generator.go
@@ -28,7 +28,7 @@ var (
 
 type ConfigGenerator struct {
 	g      generator.Generator
-	conf   func(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace string, op generator.Options) []generator.Section
+	conf   func(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, forwarderName string, op generator.Options) []generator.Section
 	format func(conf string) string
 }
 
@@ -49,8 +49,8 @@ func New(collectorType logging.LogCollectionType) *ConfigGenerator {
 	return g
 }
 
-func (cg *ConfigGenerator) GenerateConf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace string, op generator.Options) (string, error) {
-	sections := cg.conf(clspec, secrets, clfspec, namespace, op)
+func (cg *ConfigGenerator) GenerateConf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, forwarderName string, op generator.Options) (string, error) {
+	sections := cg.conf(clspec, secrets, clfspec, namespace, forwarderName, op)
 	conf, err := cg.g.GenerateConf(generator.MergeSections(sections)...)
 	return cg.format(conf), err
 }

--- a/internal/generator/vector/conf.go
+++ b/internal/generator/vector/conf.go
@@ -7,10 +7,10 @@ import (
 )
 
 //nolint:govet // using declarative style
-func Conf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace string, op generator.Options) []generator.Section {
+func Conf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, forwarderName string, op generator.Options) []generator.Section {
 	return []generator.Section{
 		{
-			Global(),
+			Global(namespace, forwarderName),
 			`vector global options`,
 		},
 		{

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -3,9 +3,8 @@ package vector
 import (
 	_ "embed"
 	"fmt"
-	"strings"
-
 	configv1 "github.com/openshift/api/config/v1"
+	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/tls"
@@ -36,6 +35,9 @@ var ExpectedComplexEsV6Toml string
 //go:embed conf_test/es_pipeline_w_spaces.toml
 var ExpectedEsPipelineWSpacesToml string
 
+//go:embed conf_test/complex_custom_data_dir.toml
+var ExpectedComplexCustomDataDirToml string
+
 // TODO: Use a detailed CLF spec
 var _ = Describe("Testing Complete Config Generation", func() {
 	var (
@@ -44,7 +46,18 @@ var _ = Describe("Testing Complete Config Generation", func() {
 			if testcase.Options == nil {
 				testcase.Options = generator.Options{generator.ClusterTLSProfileSpec: tls.GetClusterTLSProfileSpec(nil)}
 			}
-			e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, constants.OpenshiftNS, testcase.Options))
+			e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, constants.OpenshiftNS, constants.SingletonName, testcase.Options))
+			conf, err := g.GenerateConf(e...)
+			Expect(err).To(BeNil())
+			Expect(strings.TrimSpace(testcase.ExpectedConf)).To(matchers.EqualTrimLines(conf))
+		}
+
+		namedForwarder = func(testcase testhelpers.ConfGenerateTest) {
+			g := generator.MakeGenerator()
+			if testcase.Options == nil {
+				testcase.Options = generator.Options{generator.ClusterTLSProfileSpec: tls.GetClusterTLSProfileSpec(nil)}
+			}
+			e := generator.MergeSections(Conf(&testcase.CLSpec, testcase.Secrets, &testcase.CLFSpec, constants.OpenshiftNS, "my-forwarder", testcase.Options))
 			conf, err := g.GenerateConf(e...)
 			Expect(err).To(BeNil())
 			Expect(strings.TrimSpace(testcase.ExpectedConf)).To(matchers.EqualTrimLines(conf))
@@ -269,6 +282,64 @@ var _ = Describe("Testing Complete Config Generation", func() {
 				},
 			},
 			ExpectedConf: ExpectedEsPipelineWSpacesToml,
+		}),
+	)
+
+	DescribeTable("Generate full vector.toml with custom data dir", namedForwarder,
+		Entry("with complex spec custom data dir", testhelpers.ConfGenerateTest{
+			Options: generator.Options{
+				generator.ClusterTLSProfileSpec: tls.GetClusterTLSProfileSpec(nil),
+			},
+			CLSpec: logging.CollectionSpec{
+				Fluentd: &logging.FluentdForwarderSpec{
+					Buffer: &logging.FluentdBufferSpec{
+						ChunkLimitSize: "8m",
+						TotalLimitSize: "800000000",
+						OverflowAction: "throw_exception",
+					},
+				},
+			},
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Inputs: []logging.InputSpec{
+					{
+						Name: "mytestapp",
+						Application: &logging.Application{
+							Namespaces: []string{"test-ns"},
+						},
+					},
+				},
+				Pipelines: []logging.PipelineSpec{
+					{
+						InputRefs: []string{
+							"mytestapp",
+							logging.InputNameInfrastructure,
+							logging.InputNameAudit},
+						OutputRefs: []string{"kafka-receiver"},
+						Name:       "pipeline",
+						Labels:     map[string]string{"key1": "value1", "key2": "value2"},
+					},
+				},
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeKafka,
+						Name: "kafka-receiver",
+						URL:  "tls://broker1-kafka.svc.messaging.cluster.local:9092/topic",
+						Secret: &logging.OutputSecretSpec{
+							Name: "kafka-receiver-1",
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"kafka-receiver": {
+					Data: map[string][]byte{
+						"tls.key":       []byte("junk"),
+						"tls.crt":       []byte("junk"),
+						"ca-bundle.crt": []byte("junk"),
+					},
+				},
+			},
+			ExpectedConf: ExpectedComplexCustomDataDirToml,
 		}),
 	)
 

--- a/internal/generator/vector/conf_test/complex_custom_data_dir.toml
+++ b/internal/generator/vector/conf_test/complex_custom_data_dir.toml
@@ -1,0 +1,407 @@
+expire_metrics_secs = 60
+data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
+
+
+# Logs from containers (including openshift containers)
+[sources.raw_container_logs]
+type = "kubernetes_logs"
+glob_minimum_cooldown_ms = 15000
+auto_partial_merge = true
+exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]
+pod_annotation_fields.pod_labels = "kubernetes.labels"
+pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
+namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+
+[sources.raw_journal_logs]
+type = "journald"
+journal_directory = "/var/log/journal"
+
+# Logs from host audit
+[sources.raw_host_audit_logs]
+type = "file"
+include = ["/var/log/audit/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+# Logs from kubernetes audit
+[sources.raw_k8s_audit_logs]
+type = "file"
+include = ["/var/log/kube-apiserver/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+# Logs from openshift audit
+[sources.raw_openshift_audit_logs]
+type = "file"
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+# Logs from ovn audit
+[sources.raw_ovn_audit_logs]
+type = "file"
+include = ["/var/log/ovn/acl-audit-log.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[transforms.container_logs]
+type = "remap"
+inputs = ["raw_container_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  if !exists(.level) {
+    .level = "default"
+    if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {
+      .level = "warn"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    } else if match!(.message, r'Notice|NOTICE|^N[0-9]+|level=notice|Value:notice|"level":"notice"|<notice>') {
+      .level = "notice"
+    } else if match!(.message, r'Alert|ALERT|^A[0-9]+|level=alert|Value:alert|"level":"alert"|<alert>') {
+      .level = "alert"
+    } else if match!(.message, r'Emergency|EMERGENCY|^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"|<emergency>') {
+      .level = "emergency"
+    }
+  }
+  pod_name = string!(.kubernetes.pod_name)
+  if starts_with(pod_name, "event-router-") {
+    parsed, err = parse_json(.message)
+    if err != null {
+      log("Unable to process EventRouter log: " + err, level: "info")
+    } else {
+      ., err = merge(.,parsed)
+      if err == null && exists(.event) && is_object(.event) {
+          if exists(.verb) {
+            .event.verb = .verb
+            del(.verb)
+          }
+          .kubernetes.event = del(.event)
+          .message = del(.kubernetes.event.message)
+          set!(., ["@timestamp"], .kubernetes.event.metadata.creationTimestamp)
+          del(.kubernetes.event.metadata.creationTimestamp)
+		  . = compact(., nullish: true)
+      } else {
+        log("Unable to merge EventRouter log message into record: " + err, level: "info")
+      }
+    }
+  }
+  del(.source_type)
+  del(.stream)
+  del(.kubernetes.pod_ips)
+  del(.kubernetes.node_labels)
+  del(.timestamp_end)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+[transforms.drop_journal_logs]
+type = "filter"
+inputs = ["raw_journal_logs"]
+condition = ".PRIORITY != \"7\" && .PRIORITY != 7"
+
+[transforms.journal_logs]
+type = "remap"
+inputs = ["drop_journal_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".journal.system"
+
+  del(.source_type)
+  del(._CPU_USAGE_NSEC)
+  del(.__REALTIME_TIMESTAMP)
+  del(.__MONOTONIC_TIMESTAMP)
+  del(._SOURCE_REALTIME_TIMESTAMP)
+  del(.JOB_RESULT)
+  del(.JOB_TYPE)
+  del(.TIMESTAMP_BOOTTIME)
+  del(.TIMESTAMP_MONOTONIC)
+
+  if .PRIORITY == "8" || .PRIORITY == 8 {
+    .level = "trace"
+  } else {
+  	priority = to_int!(.PRIORITY)
+  	.level, err = to_syslog_level(priority)
+	if err != null {
+	  log("Unable to determine level from PRIORITY: " + err, level: "error")
+	  log(., level: "error")
+	  .level = "unknown"
+	} else {
+	  del(.PRIORITY)
+	}
+  }
+
+  .hostname = del(.host)
+
+  # systemd’s kernel-specific metadata.
+  # .systemd.k = {}
+  if exists(.KERNEL_DEVICE) { .systemd.k.KERNEL_DEVICE = del(.KERNEL_DEVICE) }
+  if exists(.KERNEL_SUBSYSTEM) { .systemd.k.KERNEL_SUBSYSTEM = del(.KERNEL_SUBSYSTEM) }
+  if exists(.UDEV_DEVLINK) { .systemd.k.UDEV_DEVLINK = del(.UDEV_DEVLINK) }
+  if exists(.UDEV_DEVNODE) { .systemd.k.UDEV_DEVNODE = del(.UDEV_DEVNODE) }
+  if exists(.UDEV_SYSNAME) { .systemd.k.UDEV_SYSNAME = del(.UDEV_SYSNAME) }
+
+  # trusted journal fields, fields that are implicitly added by the journal and cannot be altered by client code.
+  .systemd.t = {}
+  if exists(._AUDIT_LOGINUID) { .systemd.t.AUDIT_LOGINUID = del(._AUDIT_LOGINUID) }
+  if exists(._BOOT_ID) { .systemd.t.BOOT_ID = del(._BOOT_ID) }
+  if exists(._AUDIT_SESSION) { .systemd.t.AUDIT_SESSION = del(._AUDIT_SESSION) }
+  if exists(._CAP_EFFECTIVE) { .systemd.t.CAP_EFFECTIVE = del(._CAP_EFFECTIVE) }
+  if exists(._CMDLINE) { .systemd.t.CMDLINE = del(._CMDLINE) }
+  if exists(._COMM) { .systemd.t.COMM = del(._COMM) }
+  if exists(._EXE) { .systemd.t.EXE = del(._EXE) }
+  if exists(._GID) { .systemd.t.GID = del(._GID) }
+  if exists(._HOSTNAME) { .systemd.t.HOSTNAME = .hostname }
+  if exists(._LINE_BREAK) { .systemd.t.LINE_BREAK = del(._LINE_BREAK) }
+  if exists(._MACHINE_ID) { .systemd.t.MACHINE_ID = del(._MACHINE_ID) }
+  if exists(._PID) { .systemd.t.PID = del(._PID) }
+  if exists(._SELINUX_CONTEXT) { .systemd.t.SELINUX_CONTEXT = del(._SELINUX_CONTEXT) }
+  if exists(._SOURCE_REALTIME_TIMESTAMP) { .systemd.t.SOURCE_REALTIME_TIMESTAMP = del(._SOURCE_REALTIME_TIMESTAMP) }
+  if exists(._STREAM_ID) { .systemd.t.STREAM_ID = ._STREAM_ID }
+  if exists(._SYSTEMD_CGROUP) { .systemd.t.SYSTEMD_CGROUP = del(._SYSTEMD_CGROUP) }
+  if exists(._SYSTEMD_INVOCATION_ID) {.systemd.t.SYSTEMD_INVOCATION_ID = ._SYSTEMD_INVOCATION_ID}
+  if exists(._SYSTEMD_OWNER_UID) { .systemd.t.SYSTEMD_OWNER_UID = del(._SYSTEMD_OWNER_UID) }
+  if exists(._SYSTEMD_SESSION) { .systemd.t.SYSTEMD_SESSION = del(._SYSTEMD_SESSION) }
+  if exists(._SYSTEMD_SLICE) { .systemd.t.SYSTEMD_SLICE = del(._SYSTEMD_SLICE) }
+  if exists(._SYSTEMD_UNIT) { .systemd.t.SYSTEMD_UNIT = del(._SYSTEMD_UNIT) }
+  if exists(._SYSTEMD_USER_UNIT) { .systemd.t.SYSTEMD_USER_UNIT = del(._SYSTEMD_USER_UNIT) }
+  if exists(._TRANSPORT) { .systemd.t.TRANSPORT = del(._TRANSPORT) }
+  if exists(._UID) { .systemd.t.UID = del(._UID) }
+
+  # fields that are directly passed from clients and stored in the journal.
+  .systemd.u = {}
+  if exists(.CODE_FILE) { .systemd.u.CODE_FILE = del(.CODE_FILE) }
+  if exists(.CODE_FUNC) { .systemd.u.CODE_FUNCTION = del(.CODE_FUNC) }
+  if exists(.CODE_LINE) { .systemd.u.CODE_LINE = del(.CODE_LINE) }
+  if exists(.ERRNO) { .systemd.u.ERRNO = del(.ERRNO) }
+  if exists(.MESSAGE_ID) { .systemd.u.MESSAGE_ID = del(.MESSAGE_ID) }
+  if exists(.SYSLOG_FACILITY) { .systemd.u.SYSLOG_FACILITY = del(.SYSLOG_FACILITY) }
+  if exists(.SYSLOG_IDENTIFIER) { .systemd.u.SYSLOG_IDENTIFIER = del(.SYSLOG_IDENTIFIER) }
+  if exists(.SYSLOG_PID) { .systemd.u.SYSLOG_PID = del(.SYSLOG_PID) }
+  if exists(.RESULT) { .systemd.u.RESULT = del(.RESULT) }
+  if exists(.UNIT) { .systemd.u.UNIT = del(.UNIT) }
+
+  .time = format_timestamp!(.timestamp, format: "%FT%T%:z")
+
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+[transforms.host_audit_logs]
+type = "remap"
+inputs = ["raw_host_audit_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".linux-audit.log"
+
+  match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
+  envelop = {}
+  envelop |= {"type": match1.type}
+
+  match2, err = parse_regex(.message, r'msg=audit\((?P<ts_record>[^ ]+)\):')
+  if err == null {
+    sp, err = split(match2.ts_record,":")
+    if err == null && length(sp) == 2 {
+        ts = parse_timestamp(sp[0],"%s.%3f") ?? ""
+        envelop |= {"record_id": sp[1]}
+        . |= {"audit.linux" : envelop}
+        . |= {"@timestamp" : format_timestamp(ts,"%+") ?? ""}
+    }
+  } else {
+    log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
+  }
+
+  .level = "default"
+'''
+
+[transforms.k8s_audit_logs]
+type = "remap"
+inputs = ["raw_k8s_audit_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".k8s-audit.log"
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+  .k8s_audit_level = .level
+  .level = "default"
+'''
+
+[transforms.openshift_audit_logs]
+type = "remap"
+inputs = ["raw_openshift_audit_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".openshift-audit.log"
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+  .openshift_audit_level = .level
+  .level = "default"
+'''
+
+[transforms.ovn_audit_logs]
+type = "remap"
+inputs = ["raw_ovn_audit_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".ovn-audit.log"
+  if !exists(.level) {
+    .level = "default"
+    if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {
+      .level = "warn"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    } else if match!(.message, r'Notice|NOTICE|^N[0-9]+|level=notice|Value:notice|"level":"notice"|<notice>') {
+      .level = "notice"
+    } else if match!(.message, r'Alert|ALERT|^A[0-9]+|level=alert|Value:alert|"level":"alert"|<alert>') {
+      .level = "alert"
+    } else if match!(.message, r'Emergency|EMERGENCY|^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"|<emergency>') {
+      .level = "emergency"
+    }
+  }
+'''
+
+[transforms.route_container_logs]
+type = "route"
+inputs = ["container_logs"]
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
+route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube")'
+
+# Set log_type to "application"
+[transforms.application]
+type = "remap"
+inputs = ["route_container_logs.app"]
+source = '''
+  .log_type = "application"
+'''
+
+# Set log_type to "infrastructure"
+[transforms.infrastructure]
+type = "remap"
+inputs = ["route_container_logs.infra","journal_logs"]
+source = '''
+  .log_type = "infrastructure"
+'''
+
+# Set log_type to "audit"
+[transforms.audit]
+type = "remap"
+inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
+source = '''
+  .log_type = "audit"
+  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+[transforms.route_application_logs]
+type = "route"
+inputs = ["application"]
+route.mytestapp = '.kubernetes.namespace_name == "test-ns"'
+
+[transforms.pipeline_user_defined]
+type = "remap"
+inputs = ["route_application_logs.mytestapp","infrastructure","audit"]
+source = '''
+  .openshift.labels = {"key1":"value1","key2":"value2"}
+'''
+
+[transforms.kafka_receiver_dedot]
+type = "lua"
+inputs = ["pipeline_user_defined"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+    function init()
+        count = 0
+    end
+    function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+		dedot(event.log.kubernetes.namespace_labels)
+        dedot(event.log.kubernetes.labels)
+        emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "[./]", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+'''
+
+# Kafka config
+[sinks.kafka_receiver]
+type = "kafka"
+inputs = ["kafka_receiver_dedot"]
+bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
+topic = "topic"
+
+[sinks.kafka_receiver.encoding]
+codec = "json"
+timestamp_format = "rfc3339"
+
+[sinks.kafka_receiver.tls]
+enabled = true
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
+key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
+crt_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.crt"
+ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"
+
+[transforms.add_nodename_to_metric]
+type = "remap"
+inputs = ["internal_metrics"]
+source = '''
+.tags.hostname = get_env_var!("VECTOR_SELF_NODE_NAME")
+'''
+
+[sinks.prometheus_output]
+type = "prometheus_exporter"
+inputs = ["add_nodename_to_metric"]
+address = "[::]:24231"
+default_namespace = "collector"
+
+[sinks.prometheus_output.tls]
+enabled = true
+key_file = "/etc/collector/metrics/tls.key"
+crt_file = "/etc/collector/metrics/tls.crt"
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"

--- a/internal/generator/vector/global.go
+++ b/internal/generator/vector/global.go
@@ -1,19 +1,26 @@
 package vector
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/collector/vector"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 )
 
-func Global() []generator.Element {
+func Global(namespace, forwarderName string) []generator.Element {
+	dataDir := vector.GetDataPath(namespace, forwarderName)
+	if dataDir == vector.DefaultDataPath {
+		dataDir = ""
+	}
 	return []generator.Element{
 		GlobalOptions{
 			ExpireMetricsSecs: 60,
+			DataDir:           dataDir,
 		},
 	}
 }
 
 type GlobalOptions struct {
 	ExpireMetricsSecs int
+	DataDir           string
 }
 
 func (GlobalOptions) Name() string {
@@ -24,6 +31,9 @@ func (g GlobalOptions) Template() string {
 	return `
 {{define "` + g.Name() + `" -}}
 expire_metrics_secs = {{.ExpireMetricsSecs}}
+{{ if .DataDir}} 
+data_dir = "{{.DataDir}}"
+{{end}}
 {{end}}
 `
 }

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -43,7 +43,7 @@ func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config s
 	EvaluateAnnotationsForEnabledCapabilities(clusterRequest.Forwarder, op)
 
 	g := forwardergenerator.New(clusterRequest.Cluster.Spec.Collection.Type)
-	generatedConfig, err := g.GenerateConf(clusterRequest.Cluster.Spec.Collection, clusterRequest.OutputSecrets, &clusterRequest.Forwarder.Spec, clusterRequest.Forwarder.Namespace, op)
+	generatedConfig, err := g.GenerateConf(clusterRequest.Cluster.Spec.Collection, clusterRequest.OutputSecrets, &clusterRequest.Forwarder.Spec, clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, op)
 
 	if err != nil {
 		log.Error(err, "Unable to generate log configuration")

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -87,5 +87,5 @@ func Generate(collectionType logging.LogCollectionType, clfYaml string, includeD
 	if configGenerator == nil {
 		return "", errors.New("unsupported collector implementation")
 	}
-	return configGenerator.GenerateConf(&clspec, clRequest.OutputSecrets, &forwarder.Spec, clRequest.Cluster.Namespace, op)
+	return configGenerator.GenerateConf(&clspec, clRequest.OutputSecrets, &forwarder.Spec, clRequest.Cluster.Namespace, forwarder.Name, op)
 }

--- a/test/framework/functional/fluentd/deploy.go
+++ b/test/framework/functional/fluentd/deploy.go
@@ -22,7 +22,7 @@ func (c *FluentdCollector) String() string {
 	return constants.FluentdName
 }
 
-func (c *FluentdCollector) DeployConfigMapForConfig(name, config, clfYaml string) error {
+func (c *FluentdCollector) DeployConfigMapForConfig(name, config, clfName, clfYaml string) error {
 	log.V(2).Info("Creating config configmap")
 	configmap := runtime.NewConfigMap(c.NS.Name, name, map[string]string{})
 

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -43,7 +43,7 @@ var TestAPIAdapterConfigVisitor = func(conf string) string {
 }
 
 type CollectorFramework interface {
-	DeployConfigMapForConfig(name, config, clfYaml string) error
+	DeployConfigMapForConfig(name, config, clfName, clfYaml string) error
 	BuildCollectorContainer(*runtime.ContainerBuilder, string) *runtime.ContainerBuilder
 	IsStarted(string) bool
 	Image() string
@@ -204,7 +204,7 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 		f.Conf = f.VisitConfig(f.Conf)
 	}
 
-	if err = f.collector.DeployConfigMapForConfig(f.Name, f.Conf, string(clfYaml)); err != nil {
+	if err = f.collector.DeployConfigMapForConfig(f.Name, f.Conf, f.Forwarder.Name, string(clfYaml)); err != nil {
 		return err
 	}
 

--- a/test/framework/functional/vector/deploy.go
+++ b/test/framework/functional/vector/deploy.go
@@ -1,6 +1,8 @@
 package vector
 
 import (
+	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/collector/vector"
 	"regexp"
 	"strings"
 
@@ -13,7 +15,7 @@ import (
 )
 
 const entrypointScript = `#!/bin/bash
-mkdir -p /var/lib/vector
+mkdir -p %s
 
 /usr/bin/vector
 `
@@ -26,13 +28,13 @@ func (c *VectorCollector) String() string {
 	return constants.VectorName
 }
 
-func (c *VectorCollector) DeployConfigMapForConfig(name, config, clfYaml string) error {
+func (c *VectorCollector) DeployConfigMapForConfig(name, config, clfName, clfYaml string) error {
 	log.V(2).Info("Creating config configmap")
 	configmap := runtime.NewConfigMap(c.NS.Name, name, map[string]string{})
 	runtime.NewConfigMapBuilder(configmap).
 		Add("vector.toml", config).
 		Add("clfyaml", clfYaml).
-		Add("run.sh", entrypointScript)
+		Add("run.sh", fmt.Sprintf(entrypointScript, vector.GetDataPath(c.NS.Name, clfName)))
 	if err := c.Create(configmap); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description
This PR:

- Adding a Run Script for Vector:
A run script for Vector is being added. This script will enable pre-run tasks, such as creating custom directories for persisting Vector state. This can be useful for setting up Vector environment or configuration before it starts processing data.

- Making Paths for Vector Checkpoints Unique:
To ensure uniqueness for Vector checkpoints files, the PR proposes adding the namespace name and the name of the CLF (Cloud Logging Framework) to the path. This means that the path to the checkpoints file will include both the namespace and CLF name, making it easier to manage and identify Vector instances for different namespaces and CLFs.


For example, the path to a Vector checkpoint file could look like this:` /var/lib/vector/openshift-logging/my-instance`, where:

`/var/lib/vector` is the base directory.
`openshift-logging` is the namespace name.
`my-instance` is the name of the CLF.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com//browse/LOG-4481
- Enhancement proposal:
