### PR TITLE
LOG-4460: fix loki custom labelKeys for vector

### DIFF
--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -160,8 +160,8 @@ func lokiLabelKeys(l *logging.Loki) []string {
 func lokiLabels(lo *logging.Loki) []Label {
 	ls := []Label{}
 	for _, k := range lokiLabelKeys(lo) {
-		name := strings.ReplaceAll(k, ".", "_")
-		name = strings.ReplaceAll(name, "/", "_")
+		r := strings.NewReplacer(".", "_", "/", "_", "\\", "_", "-", "_")
+		name := r.Replace(k)
 		l := Label{
 			Name:  name,
 			Value: formatLokiLabelValue(k),
@@ -180,8 +180,9 @@ func lokiLabels(lo *logging.Loki) []Label {
 func formatLokiLabelValue(value string) string {
 	if strings.HasPrefix(value, "kubernetes.labels.") || strings.HasPrefix(value, "kubernetes.namespace_labels.") {
 		parts := strings.SplitAfterN(value, "labels.", 2)
-		key := strings.ReplaceAll(parts[1], "/", "_")
-		key = strings.ReplaceAll(key, ".", "_")
+		r := strings.NewReplacer("/", "_", ".", "_")
+		key := r.Replace(parts[1])
+		key = fmt.Sprintf(`\"%s\"`, key)
 		value = fmt.Sprintf("%s%s", parts[0], key)
 	}
 	return fmt.Sprintf("{{%s}}", value)

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -247,7 +247,7 @@ codec = "json"
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
-kubernetes_labels_app = "{{kubernetes.labels.app}}"
+kubernetes_labels_app = "{{kubernetes.labels.\"app\"}}"
 
 # Basic Auth Config
 [sinks.loki_receiver.auth]

--- a/internal/generator/vector/output/loki/loki_test.go
+++ b/internal/generator/vector/output/loki/loki_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 )
 
 var _ = Describe("Loki generator helpers", func() {
@@ -12,11 +13,26 @@ var _ = Describe("Loki generator helpers", func() {
 	DescribeTable("#formatLokiLabelValue should correctly format", func(label, exp string) {
 		Expect(fmt.Sprintf("{{%s}}", exp)).To(Equal(formatLokiLabelValue(label)))
 	},
-		Entry(" for a complex label", "kubernetes.labels.app.kubernetes.io/name", "kubernetes.labels.app_kubernetes_io_name"),
-		Entry(" for a label with only a slash", "kubernetes.labels.foo/bar", "kubernetes.labels.foo_bar"),
-		Entry(" for a namespacelabel with only a slash", "kubernetes.namespace_labels.foo/bar", "kubernetes.namespace_labels.foo_bar"),
-		Entry(" for a simple label", "kubernetes.labels.foo", "kubernetes.labels.foo"),
-		Entry(" for a label without kubernetes.labels prefix", "kubernetes.host", "kubernetes.host"),
+		Entry(" for a complex label", "kubernetes.labels.app.kubernetes.io/name", `kubernetes.labels.\"app_kubernetes_io_name\"`),
+		Entry(" for a label with only a slash", "kubernetes.labels.foo/bar", `kubernetes.labels.\"foo_bar\"`),
+		Entry(" for a namespacelabel with only a slash", "kubernetes.namespace_labels.foo/bar", `kubernetes.namespace_labels.\"foo_bar\"`),
+		Entry(" for a simple label", "kubernetes.labels.foo", `kubernetes.labels.\"foo\"`),
+		Entry(" for a label without kubernetes.labels prefix", "kubernetes.host", `kubernetes.host`),
+	)
+
+	DescribeTable("#lokiLabels should correctly format labels", func(label, expKey, expValue string) {
+		lo := &logging.Loki{
+			LabelKeys: []string{label},
+		}
+		labels := lokiLabels(lo)
+		Expect(labels).To(ContainElement(Label{
+			Name:  expKey,
+			Value: expValue,
+		}))
+	},
+		Entry(" for kubernetes.host", "kubernetes.host", `kubernetes_host`, `${VECTOR_SELF_NODE_NAME}`),
+		Entry(" for kubernetes.namespace_name", "kubernetes.namespace_name", "kubernetes_namespace_name", `{{kubernetes.namespace_name}}`),
+		Entry(" for complex label", `kubernetes.labels.foo-bar-xyz.abc/bar`, "kubernetes_labels_foo_bar_xyz_abc_bar", `{{kubernetes.labels.\"foo-bar-xyz_abc_bar\"}}`),
 	)
 
 })

--- a/test/functional/outputs/loki/application_logs_vector_test.go
+++ b/test/functional/outputs/loki/application_logs_vector_test.go
@@ -81,14 +81,16 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 			Expect(strings.Contains(lines[2], "Present days")).To(BeTrue())
 		})
 	})
-	Context("when label keys are defined that include slashes. Ref LOG-4095", func() {
+	Context("when label keys are defined that include slashes and dashes. Ref(LOG-4095, LOG-4460)", func() {
 		const myValue = "foobarvalue"
 		BeforeEach(func() {
 			f.Labels["app.kubernetes.io/name"] = myValue
+			f.Labels["prefix-cloud_com_platform-stage"] = "dev"
 			f.Forwarder.Spec.Outputs[0].Loki.LabelKeys = []string{
 				"kubernetes.namespace_name",
 				"kubernetes.pod_name",
 				"kubernetes.labels.app.kubernetes.io/name",
+				"kubernetes.labels.prefix-cloud_com_platform-stage",
 			}
 			Expect(f.Deploy()).To(BeNil())
 		})


### PR DESCRIPTION
### Description
This PR fixes using loki custom label keys for vector:

* quoting template values to ensure valid VRL path
* replaces dash in keys for compatibility with fluent loki plugin


### Links
* https://issues.redhat.com/browse/LOG-4460
