### PR TITLE
LOG-4410: fix resource ownership for legacy CLF

### DIFF
--- a/internal/k8shandler/clusterloggingrequest_test.go
+++ b/internal/k8shandler/clusterloggingrequest_test.go
@@ -4,6 +4,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 )
 
 var _ = Describe("ClusterLoggingRequest", func() {
@@ -19,6 +22,46 @@ var _ = Describe("ClusterLoggingRequest", func() {
 		}
 
 	})
+
+	Describe("#NewClusterLoggingRequest", func() {
+		var (
+			forwarder *logging.ClusterLogForwarder
+			cl        *logging.ClusterLogging
+		)
+		BeforeEach(func() {
+			cl = runtime.NewClusterLogging(constants.OpenshiftNS, constants.SingletonName)
+			cl.SetUID("cl-uuid")
+			forwarder = runtime.NewClusterLogForwarder(constants.OpenshiftNS, constants.SingletonName)
+			forwarder.SetUID("clf-uuid")
+		})
+		Context("when reconciling legacy mode", func() {
+			It("should initialize the resource owner to ClusterLogging for a virtual ClusterLogForwarder", func() {
+				forwarder.SetUID("")
+				cr := NewClusterLoggingRequest(cl, forwarder, nil, nil, nil, "", "", nil)
+				Expect(cr.ResourceOwner).To(Equal(utils.AsOwner(cl)))
+			})
+			It("should initialize the resource owner to ClusterLogging for an actual ClusterLogForwarder", func() {
+				cr := NewClusterLoggingRequest(cl, forwarder, nil, nil, nil, "", "", nil)
+				Expect(cr.ResourceOwner).To(Equal(utils.AsOwner(cl)))
+			})
+		})
+		Context("when reconciling multi ClusterLogForwarder mode", func() {
+			BeforeEach(func() {
+				cl.SetNamespace("test-namespace")
+				forwarder.SetNamespace("test-namespace")
+			})
+			It("should initialize the resource owner to ClusterLogForwarder for a virtual ClusterLogging", func() {
+				cl.SetUID("")
+				cr := NewClusterLoggingRequest(cl, forwarder, nil, nil, nil, "", "", nil)
+				Expect(cr.ResourceOwner).To(Equal(utils.AsOwner(forwarder)))
+			})
+			It("should initialize the resource owner to ClusterLogForwarder for an actual ClusterLogging", func() {
+				cr := NewClusterLoggingRequest(cl, forwarder, nil, nil, nil, "", "", nil)
+				Expect(cr.ResourceOwner).To(Equal(utils.AsOwner(forwarder)))
+			})
+		})
+	})
+
 	Describe("#IncludesManagedStorage", func() {
 		Context("when logstore", func() {
 			Context("is defined", func() {


### PR DESCRIPTION
### Description
This PR fixes ownership for legacy CLF so that when ClusterLogging is removed the collectors are as well.  No collectors should exist when there is legacy CLF without legacy CL

### Links
* https://issues.redhat.com/browse/LOG-4410

cc @Clee2691 
