### PR TITLE
LOG-4477: add dev-alerts feature for OCP 4.14

### DIFF
--- a/internal/visualization/console/feature_map.go
+++ b/internal/visualization/console/feature_map.go
@@ -8,12 +8,13 @@ import (
 const (
 	featureDevConsole = "dev-console"
 	featureAlerts     = "alerts"
+	featureDevAlerts  = "dev-alerts"
 )
 
 var (
 
 	// featuresIfUnmatched represents the default features to enable
-	featuresIfUnmatched = []string{featureAlerts, featureDevConsole}
+	featuresIfUnmatched = []string{featureAlerts, featureDevConsole, featureDevAlerts}
 )
 
 // FeaturesForOCP will return the list of features to enable for the console plugin given the OCP version
@@ -27,6 +28,9 @@ func FeaturesForOCP(version string) []string {
 	}
 	if semver.Compare(version, "v4.11") >= 0 && semver.Compare(version, "v4.13.0-0") < 0 {
 		return []string{featureDevConsole}
+	}
+	if semver.Compare(version, "v4.13.0-0") >= 0 && semver.Compare(version, "v4.14.0-0") < 0 {
+		return []string{featureAlerts, featureDevConsole}
 	}
 	return featuresIfUnmatched
 }

--- a/internal/visualization/console/feature_map_test.go
+++ b/internal/visualization/console/feature_map_test.go
@@ -9,11 +9,10 @@ var _ = Describe("#FeaturesForOCP", func() {
 	It("should return an empty set when there is an empty version ", func() {
 		Expect(FeaturesForOCP("")).To(Equal([]string{}))
 	})
-	It("should enable the the dev console and alerts when <= 4.13", func() {
+	It("should enable the the dev console and alerts when = 4.13", func() {
 		features := []string{featureAlerts, featureDevConsole}
 		Expect(FeaturesForOCP("4.13.0-0.nightly-2023-03-23-204038")).To(Equal(features))
 		Expect(FeaturesForOCP("4.13.0")).To(Equal(features))
-		Expect(FeaturesForOCP("4.14.0")).To(Equal(features))
 	})
 	It("should enable the dev console when <= 4.11 but < 4.13", func() {
 		features := []string{featureDevConsole}
@@ -27,5 +26,12 @@ var _ = Describe("#FeaturesForOCP", func() {
 
 	It("should not enable the dev console for OCP 4.10.51", func() {
 		Expect(FeaturesForOCP("4.10.51")).To(Equal([]string{}))
+	})
+
+	It("should enable the the dev console, alerts and dev alerts when >= 4.14", func() {
+		features := []string{featureAlerts, featureDevConsole, featureDevAlerts}
+		Expect(FeaturesForOCP("4.14.0-0.nightly-2023-03-23-204038")).To(Equal(features))
+		Expect(FeaturesForOCP("4.14.0")).To(Equal(features))
+		Expect(FeaturesForOCP("4.15.0")).To(Equal(features))
 	})
 })


### PR DESCRIPTION
### Description
This PR adds the `dev-alerts` feature to the logging view plugin for OCP 4.14

/cc @jcantrill

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4477
