### PR TITLE
LOG-3949: increase max_read_bytes for container logs to release file …

### DIFF
--- a/internal/generator/vector/conf_test/complex.toml
+++ b/internal/generator/vector/conf_test/complex.toml
@@ -3,6 +3,7 @@ expire_metrics_secs = 60
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]

--- a/internal/generator/vector/conf_test/complex_custom_data_dir.toml
+++ b/internal/generator/vector/conf_test/complex_custom_data_dir.toml
@@ -5,6 +5,7 @@ data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]

--- a/internal/generator/vector/conf_test/complex_es_no_ver.toml
+++ b/internal/generator/vector/conf_test/complex_es_no_ver.toml
@@ -3,6 +3,7 @@ expire_metrics_secs = 60
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]

--- a/internal/generator/vector/conf_test/complex_es_v6.toml
+++ b/internal/generator/vector/conf_test/complex_es_v6.toml
@@ -3,6 +3,7 @@ expire_metrics_secs = 60
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]

--- a/internal/generator/vector/conf_test/complex_otel.toml
+++ b/internal/generator/vector/conf_test/complex_otel.toml
@@ -3,6 +3,7 @@ expire_metrics_secs = 60
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]

--- a/internal/generator/vector/conf_test/es_pipeline_w_spaces.toml
+++ b/internal/generator/vector/conf_test/es_pipeline_w_spaces.toml
@@ -3,6 +3,7 @@ expire_metrics_secs = 60
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]

--- a/internal/generator/vector/elements/elements.go
+++ b/internal/generator/vector/elements/elements.go
@@ -80,27 +80,6 @@ source = '''
 `
 }
 
-type DetectExceptions struct {
-	ComponentID string
-	Inputs      string
-}
-
-func (d DetectExceptions) Name() string {
-	return "detectExceptions"
-}
-
-func (d DetectExceptions) Template() string {
-	return `{{define "detectExceptions" -}}
-[transforms.{{.ComponentID}}]
-type = "detect_exceptions"
-inputs = {{.Inputs}}
-languages = ["All"]
-group_by = ["kubernetes.namespace_name","kubernetes.pod_name","kubernetes.container_name", "kubernetes.pod_id"]
-expire_after_ms = 2000
-multiline_flush_interval_ms = 1000
-{{end}}`
-}
-
 func Debug(id string, inputs string) generator.Element {
 	return generator.ConfLiteral{
 		Desc:         "Sending records to stdout for debug purposes",
@@ -117,34 +96,4 @@ encoding.codec = "json"
 {{end}}
 `,
 	}
-}
-
-type Throttle struct {
-	ComponentID string
-	Desc        string
-	Inputs      string
-	Threshold   int64
-	KeyField    string
-}
-
-func (t Throttle) Name() string {
-	return "throttleTemplate"
-}
-
-func (t Throttle) Template() string {
-	return `
-{{define "throttleTemplate" -}}
-{{- if .Desc}}
-# {{.Desc}}
-{{- end}}
-[transforms.{{.ComponentID}}]
-type = "throttle"
-inputs = {{.Inputs}}
-window_secs = 1
-threshold = {{.Threshold}}
-{{- if .KeyField}}
-key_field = {{ .KeyField }}
-{{- end}}
-{{end}}
-`
 }

--- a/internal/generator/vector/inputs.go
+++ b/internal/generator/vector/inputs.go
@@ -75,7 +75,7 @@ func AddThrottle(spec *logging.InputSpec) []generator.Element {
 		threshold = spec.Application.GroupLimit.MaxRecordsPerSecond
 	}
 
-	el = append(el, Throttle{
+	el = append(el, normalize.Throttle{
 		ComponentID: fmt.Sprintf(UserDefinedSourceThrottle, spec.Name),
 		Inputs:      helpers.MakeInputs([]string{input}...),
 		Threshold:   threshold,

--- a/internal/generator/vector/normalize/detect_exceptions.go
+++ b/internal/generator/vector/normalize/detect_exceptions.go
@@ -1,0 +1,22 @@
+package normalize
+
+type DetectExceptions struct {
+	ComponentID string
+	Inputs      string
+}
+
+func (d DetectExceptions) Name() string {
+	return "detectExceptions"
+}
+
+func (d DetectExceptions) Template() string {
+	return `{{define "detectExceptions" -}}
+[transforms.{{.ComponentID}}]
+type = "detect_exceptions"
+inputs = {{.Inputs}}
+languages = ["All"]
+group_by = ["kubernetes.namespace_name","kubernetes.pod_name","kubernetes.container_name", "kubernetes.pod_id"]
+expire_after_ms = 2000
+multiline_flush_interval_ms = 1000
+{{end}}`
+}

--- a/internal/generator/vector/normalize/throttle.go
+++ b/internal/generator/vector/normalize/throttle.go
@@ -1,0 +1,31 @@
+package normalize
+
+type Throttle struct {
+	ComponentID string
+	Desc        string
+	Inputs      string
+	Threshold   int64
+	KeyField    string
+}
+
+func (t Throttle) Name() string {
+	return "throttleTemplate"
+}
+
+func (t Throttle) Template() string {
+	return `
+{{define "throttleTemplate" -}}
+{{- if .Desc}}
+# {{.Desc}}
+{{- end}}
+[transforms.{{.ComponentID}}]
+type = "throttle"
+inputs = {{.Inputs}}
+window_secs = 1
+threshold = {{.Threshold}}
+{{- if .KeyField}}
+key_field = {{ .KeyField }}
+{{- end}}
+{{end}}
+`
+}

--- a/internal/generator/vector/outputs.go
+++ b/internal/generator/vector/outputs.go
@@ -2,12 +2,12 @@ package vector
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
-	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/cloudwatch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/elasticsearch"
@@ -39,7 +39,7 @@ func OutputFromPipelines(spec *logging.ClusterLogForwarderSpec, op generator.Opt
 func AddThrottleForSink(spec *logging.OutputSpec, inputs []string) []generator.Element {
 	el := []generator.Element{}
 
-	el = append(el, elements.Throttle{
+	el = append(el, normalize.Throttle{
 		ComponentID: fmt.Sprintf(UserDefinedSinkThrottle, spec.Name),
 		Inputs:      helpers.MakeInputs(inputs...),
 		Threshold:   spec.Limit.MaxRecordsPerSecond,

--- a/internal/generator/vector/pipelines.go
+++ b/internal/generator/vector/pipelines.go
@@ -3,6 +3,7 @@ package vector
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 	"strings"
 
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
@@ -42,7 +43,7 @@ func Pipelines(spec *logging.ClusterLogForwarderSpec, op generator.Options) []ge
 		}
 
 		if p.DetectMultilineErrors {
-			d := DetectExceptions{
+			d := normalize.DetectExceptions{
 				ComponentID: fmt.Sprintf("detect_exceptions_%s", p.Name),
 				Inputs:      helpers.MakeInputs(inputs...),
 			}

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -19,6 +19,7 @@ func (kl KubernetesLogs) Template() string {
 # {{.Desc}}
 [sources.{{.ComponentID}}]
 type = "kubernetes_logs"
+max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = {{.ExcludePaths}}

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -33,6 +33,7 @@ var _ = Describe("Vector Config Generation", func() {
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]
@@ -60,6 +61,7 @@ namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]
@@ -135,6 +137,7 @@ glob_minimum_cooldown_ms = 15000
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"
+max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]


### PR DESCRIPTION
…handles sooner

### Description
This PR:
* Increases the max_read_bytes of container logs so vector will read rolled over files faster and release file descriptors sooner
* The value was increased to ~30% of the default log rotation settings or ~3mb


### Links
* https://issues.redhat.com/browse/LOG-3949
* forward port of: #2146 

Gra
![image](https://github.com/openshift/cluster-logging-operator/assets/4548408/526ea1c6-babb-4b61-9f03-e1cc87ec321f)

This graph was produced by testing loading services with high volume that produce rollover frequently.  My observation was a change from a gradual increase in FDs to a more horizontal profile.  I additionally `lsof` of deleted files and observed a change from a steady increase to  varying around 3 to 5 at any one time. 

This change looks to improve the overall behavior but will not resolve cases where the collector is unable to keep up with the incoming logs; it still has to be capable of pushing logs faster then reading them otherwise the FDs will continue to pile up while vector churns through the rotated files.

