### PR TITLE
LOG-4178: fix vector eventrouter collection to rely on template name

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -170,7 +170,7 @@ source = '''
     }
   }
   pod_name = string!(.kubernetes.pod_name)
-  if starts_with(pod_name, "event-router-") {
+  if starts_with(pod_name, "eventrouter-") {
     parsed, err = parse_json(.message)
     if err != null {
       log("Unable to process EventRouter log: " + err, level: "info")
@@ -627,7 +627,7 @@ source = '''
     }
   }
   pod_name = string!(.kubernetes.pod_name)
-  if starts_with(pod_name, "event-router-") {
+  if starts_with(pod_name, "eventrouter-") {
     parsed, err = parse_json(.message)
     if err != null {
       log("Unable to process EventRouter log: " + err, level: "info")
@@ -1263,7 +1263,7 @@ source = '''
     }
   }
   pod_name = string!(.kubernetes.pod_name)
-  if starts_with(pod_name, "event-router-") {
+  if starts_with(pod_name, "eventrouter-") {
     parsed, err = parse_json(.message)
     if err != null {
       log("Unable to process EventRouter log: " + err, level: "info")
@@ -1983,7 +1983,7 @@ source = '''
     }
   }
   pod_name = string!(.kubernetes.pod_name)
-  if starts_with(pod_name, "event-router-") {
+  if starts_with(pod_name, "eventrouter-") {
     parsed, err = parse_json(.message)
     if err != null {
       log("Unable to process EventRouter log: " + err, level: "info")

--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -37,7 +37,7 @@ if !exists(.level) {
 	RemoveSourceType     = `del(.source_type)`
 	HandleEventRouterLog = `
 pod_name = string!(.kubernetes.pod_name)
-if starts_with(pod_name, "event-router-") {
+if starts_with(pod_name, "eventrouter-") {
   parsed, err = parse_json(.message)
   if err != null {
     log("Unable to process EventRouter log: " + err, level: "info")

--- a/internal/generator/vector/normalize_test.go
+++ b/internal/generator/vector/normalize_test.go
@@ -58,7 +58,7 @@ source = '''
     }
   }
   pod_name = string!(.kubernetes.pod_name)
-  if starts_with(pod_name, "event-router-") {
+  if starts_with(pod_name, "eventrouter-") {
     parsed, err = parse_json(.message)
     if err != null {
       log("Unable to process EventRouter log: " + err, level: "info")
@@ -127,7 +127,7 @@ source = '''
     }
   }
   pod_name = string!(.kubernetes.pod_name)
-  if starts_with(pod_name, "event-router-") {
+  if starts_with(pod_name, "eventrouter-") {
     parsed, err = parse_json(.message)
     if err != null {
       log("Unable to process EventRouter log: " + err, level: "info")

--- a/test/functional/normalization/eventrouter_test.go
+++ b/test/functional/normalization/eventrouter_test.go
@@ -100,7 +100,7 @@ var _ = Describe("[Functional][Normalization] Messages from EventRouter", func()
 				return framework.WriteMessagesToApplicationLog(msg, 1)
 			}
 			framework.VisitConfig = func(conf string) string {
-				return strings.Replace(conf, `pod_name, "event-router-"`, `pod_name, "functional"`, 1)
+				return strings.Replace(conf, `pod_name, "eventrouter-"`, `pod_name, "functional"`, 1)
 			}
 		}
 		Expect(framework.Deploy()).To(BeNil())


### PR DESCRIPTION
### Description
This PR additionally fixes eventrouter normalization to assume deployment based upon  openshift docs template: https://docs.openshift.com/container-platform/4.13/logging/cluster-logging-eventrouter.html 

### Links
https://issues.redhat.com/browse/LOG-4178

Events are parsed as expected when podman begins with "eventrouter-"

![image](https://github.com/openshift/cluster-logging-operator/assets/4548408/dda5fefc-689b-4e02-aa63-4a3706034ff8)


