### PR TITLE
LOG-4488: CLF status is inaccurate for legacy mode

### DIFF
--- a/apis/logging/v1/conditions.go
+++ b/apis/logging/v1/conditions.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+
 	"github.com/openshift/cluster-logging-operator/internal/status"
 
 	corev1 "k8s.io/api/core/v1"
@@ -89,7 +90,7 @@ func (nc NamedConditions) IsAllReady() bool {
 var CondReady = Condition{Type: ConditionReady, Status: corev1.ConditionTrue}
 
 func CondNotReady(r ConditionReason, format string, args ...interface{}) Condition {
-	return NewCondition(ConditionReady, corev1.ConditionTrue, r, format, args...)
+	return NewCondition(ConditionReady, corev1.ConditionFalse, r, format, args...)
 }
 
 func CondInvalid(format string, args ...interface{}) Condition {

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -2,6 +2,7 @@ package k8shandler
 
 import (
 	"fmt"
+
 	"github.com/openshift/cluster-logging-operator/internal/factory"
 	eslogstore "github.com/openshift/cluster-logging-operator/internal/logstore/elasticsearch"
 	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
@@ -13,7 +14,6 @@ import (
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/apis/logging/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -79,16 +79,6 @@ func removeCollectorAndUpdate(clusterRequest ClusterLoggingRequest) {
 	log.V(3).Info("forwarder not found and logStore not found so removing collector")
 	if err := clusterRequest.removeCollector(); err != nil {
 		log.Error(err, "Error removing collector")
-		telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
-	}
-
-	if updateError := clusterRequest.UpdateCondition(
-		logging.CollectorDeadEnd,
-		"Collectors are defined but there is no defined LogStore or LogForward destinations",
-		"No defined logstore or logforward destination",
-		corev1.ConditionTrue,
-	); updateError != nil {
-		log.Error(updateError, "Unable to update the clusterlogging status", "conditionType", logging.CollectorDeadEnd)
 		telemetry.Data.CLInfo.Set("healthStatus", constants.UnHealthyStatus)
 	}
 }


### PR DESCRIPTION
### Description
This PR fixes the status section of `ClusterLogForwarders` (CLF)s for the legacy mode. When a CLF is defined without a `ClusterLogging` instance, it will now add the appropriate validation error to the CLF's status section after reconciliation.

Additionally, the status `CollectorDeadEnd` is removed.

/cc @cahartma @syedriko @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4488

