### PR TITLE
LOG-3856: Add standalone ocp console support for LokiStack migration

### DIFF
--- a/internal/constants/features.go
+++ b/internal/constants/features.go
@@ -12,4 +12,9 @@ const (
 	// AnnotationEnableSchema is the annotation to enable alternate output formats of logs.
 	// Currently only viaq & opentelemetry are supported
 	AnnotationEnableSchema = "logging.openshift.io/enableschema"
+
+	// AnnotationOCPConsoleMigrationTarget is to be used to enable the OCP Console for Logs
+	// without switching the default `logStore` to LokiStack. The value should be the
+	// LokiStack resource name representing the target store for the migration.
+	AnnotationOCPConsoleMigrationTarget = "logging.openshift.io/force-enable-ocp-console-target"
 )

--- a/internal/k8shandler/visualization.go
+++ b/internal/k8shandler/visualization.go
@@ -3,6 +3,7 @@ package k8shandler
 import (
 	"context"
 	"fmt"
+
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
@@ -31,16 +32,11 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateVisualization() error
 		errs = append(errs, clusterRequest.createOrUpdateKibana())
 	}
 
-	var consoleSpec *logging.OCPConsoleSpec
-	if spec.Visualization != nil && spec.Visualization.Type == logging.VisualizationTypeOCPConsole {
-		consoleSpec = spec.Visualization.OCPConsole
-		errs = append(errs, console.ReconcilePlugin(clusterRequest.Client, clusterRequest.Cluster.Spec.LogStore, clusterRequest.Cluster, clusterRequest.ClusterVersion, consoleSpec))
-	}
+	errs = append(errs, console.ReconcilePlugin(clusterRequest.Client, clusterRequest.Cluster, clusterRequest.Cluster, clusterRequest.ClusterVersion))
 	return utilerrors.NewAggregate(errs)
 }
 
 func (clusterRequest *ClusterLoggingRequest) createOrUpdateKibana() (err error) {
-
 	if clusterRequest.Cluster.Spec.Visualization == nil || clusterRequest.Cluster.Spec.Visualization.Type == "" {
 		return clusterRequest.removeKibana()
 	}
@@ -96,7 +92,7 @@ func (clusterRequest *ClusterLoggingRequest) UpdateKibanaStatus() (err error) {
 }
 
 func (clusterRequest *ClusterLoggingRequest) getKibanaCR() (*es.Kibana, error) {
-	var kb = &es.Kibana{
+	kb := &es.Kibana{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Kibana",
 			APIVersion: es.GroupVersion.String(),
@@ -108,7 +104,6 @@ func (clusterRequest *ClusterLoggingRequest) getKibanaCR() (*es.Kibana, error) {
 			Namespace: clusterRequest.Cluster.Namespace,
 			Name:      constants.KibanaName,
 		}, kb)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/visualization/console/plugin.go
+++ b/internal/visualization/console/plugin.go
@@ -2,21 +2,45 @@ package console
 
 import (
 	"context"
+
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ReconcilePlugin reconciles the console plugin to expose log querying of storage
-func ReconcilePlugin(k8sClient client.Client, logStore *logging.LogStoreSpec, owner client.Object, clusterVersion string, consoleSpec *logging.OCPConsoleSpec) error {
-	lokiService := lokistack.LokiStackGatewayService(logStore)
+func ReconcilePlugin(k8sClient client.Client, cl *logging.ClusterLogging, owner client.Object, clusterVersion string) error {
+	lokiService := lokiServiceName(cl)
+
+	var consoleSpec *logging.OCPConsoleSpec
+	if cl != nil && cl.Spec.Visualization != nil {
+		consoleSpec = cl.Spec.Visualization.OCPConsole
+	}
+
 	r := NewReconciler(k8sClient, NewConfig(owner, lokiService, FeaturesForOCP(clusterVersion)), consoleSpec)
-	if logStore != nil && logStore.Type == logging.LogStoreTypeLokiStack {
+	if lokiService != "" {
 		log.V(3).Info("Enabling logging console plugin", "created-by", r.CreatedBy(), "loki-service", lokiService)
 		return r.Reconcile(context.TODO())
 	} else {
 		log.V(3).Info("Removing logging console plugin", "created-by", r.CreatedBy(), "loki-service", lokiService)
 		return r.Delete(context.TODO())
 	}
+}
+
+func lokiServiceName(cl *logging.ClusterLogging) string {
+	if cl.Spec.LogStore != nil && cl.Spec.LogStore.Type == logging.LogStoreTypeLokiStack {
+		return lokistack.LokiStackGatewayService(cl.Spec.LogStore)
+	}
+
+	if stackName, ok := cl.Annotations[constants.AnnotationOCPConsoleMigrationTarget]; ok {
+		return lokistack.LokiStackGatewayService(&logging.LogStoreSpec{
+			LokiStack: logging.LokiStackStoreSpec{
+				Name: stackName,
+			},
+		})
+	}
+
+	return ""
 }


### PR DESCRIPTION
### Description
Users migrating from Elasticsearch to LokiStack as the OpenShift Logging log store want to keep the flexibility to keep the existing stack while migrating to the new one. As per LokiStack installations being decoupled from ClusterLogging resources, this PR enables standalone OCP console installations via an ephemeral annotation `logging.openshift.io/ocp-console-migration-target` set to the LokiStack name w/o changing the `spec.logStore.Type` to `lokistack`. e.g.:

```yaml
apiVersion: logging.openshift.io/v1
kind: ClusterLogging
metadata:
  name: instance
  annotations:
    logging.openshift.io/ocp-console-migration-target: "lokistack-dev"
spec:
  managementState: Managed
  logStore:
    type: elasticsearch
    retentionPolicy:
      application:
        maxAge: 1d
      infra:
        maxAge: 7d
      audit:
        maxAge: 7d
    elasticsearch:
      nodeCount: 3
      storage:
        storageClassName: gp3-csi
        size: 20G
      resources:
        limits:
          memory: 2Gi
        requests:
          cpu: 200m
          memory: 2Gi
      proxy:
        resources:
          limits:
            memory: 256Mi
          requests:
            memory: 256Mi
      redundancyPolicy: SingleRedundancy
  visualization:
    type: kibana
    kibana:
      replicas: 1
  collection:
    logs:
      type: fluentd
      fluentd: { }
```

/cc @xperimental 
/assign @jcantrill 