### PR TITLE
LOG-4231: CLO operator support for optional OTEL data model

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -292,4 +292,15 @@ type Http struct {
 	// +kubebuilder:validation:Enum:=GET;HEAD;POST;PUT;DELETE;OPTIONS;TRACE;PATCH
 	// +optional
 	Method string `json:"method,omitempty"`
+
+	// Schema enables configuration of the way log records are normalized.
+	//
+	// Supported models: viaq(default), opentelemetry
+	//
+	// Logs are converted to the Open Telemetry specification according to schema value
+	//
+	// +kubebuilder:validation:Enum:=opentelemetry;viaq
+	// +kubebuilder:default:viaq
+	// +optional
+	Schema string `json:"schema,omitempty"`
 }

--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -118,7 +118,7 @@ metadata:
     certified: "false"
     console.openshift.io/plugins: '["logging-view-plugin"]'
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2023-09-12T01:57:52Z"
+    createdAt: "2023-09-15T15:10:23Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing your aggregated logging stack.
     olm.skipRange: '>=5.6.0-0 <5.8.0'

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -123,16 +123,32 @@ spec:
                             format:
                               description: Format is the format of incoming log data.
                               enum:
-                              - k8s_audit
+                              - kubeAPIAudit
                               type: string
-                            port:
-                              description: Port that this receiver will listen on.
-                                Used to create a Service for this port.
-                              format: int32
-                              type: integer
+                            receiverPort:
+                              description: ReceiverPort specifies parameters for the
+                                Service fronting the HTTPReceiver
+                              properties:
+                                name:
+                                  description: Name of the service to create for this
+                                    HTTPReceiver If not specified, defaults to the
+                                    name of the containing ClusterLogForwarder input
+                                  type: string
+                                port:
+                                  description: Port the Service will listen on.
+                                  format: int32
+                                  type: integer
+                                targetPort:
+                                  description: Port the Receiver will listen on. If
+                                    not specified, defaults to the value of Port
+                                  format: int32
+                                  type: integer
+                              required:
+                              - port
+                              type: object
                           required:
                           - format
-                          - port
+                          - receiverPort
                           type: object
                       type: object
                   required:
@@ -277,6 +293,15 @@ spec:
                           - OPTIONS
                           - TRACE
                           - PATCH
+                          type: string
+                        schema:
+                          description: "Schema enables configuration of the way log
+                            records are normalized. \n Supported models: viaq(default),
+                            opentelemetry \n Logs are converted to the Open Telemetry
+                            specification according to schema value"
+                          enum:
+                          - opentelemetry
+                          - viaq
                           type: string
                         timeout:
                           description: Timeout specifies the Http request timeout

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -295,6 +295,15 @@ spec:
                           - TRACE
                           - PATCH
                           type: string
+                        schema:
+                          description: "Schema enables configuration of the way log
+                            records are normalized. \n Supported models: viaq(default),
+                            opentelemetry \n Logs are converted to the Open Telemetry
+                            specification according to schema value"
+                          enum:
+                          - opentelemetry
+                          - viaq
+                          type: string
                         timeout:
                           description: Timeout specifies the Http request timeout
                             in seconds. If not set, 10secs is used.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -133,6 +133,7 @@ const (
 	ClusterLoggingAvailable = "isClusterLoggingAvailable"
 
 	OptimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
+	OTELSchema             = "opentelemetry"
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}

--- a/internal/constants/features.go
+++ b/internal/constants/features.go
@@ -8,4 +8,8 @@ const (
 	UseOldRemoteSyslogPlugin = "clusterlogging.openshift.io/useoldremotesyslogplugin"
 
 	AnnotationDebugOutput = "logging.openshift.io/debug-output"
+
+	// AnnotationEnableSchema is the annotation to enable alternate output formats of logs.
+	// Currently only viaq & opentelemetry are supported
+	AnnotationEnableSchema = "logging.openshift.io/enableschema"
 )

--- a/internal/generator/vector/conf_test/complex_otel.toml
+++ b/internal/generator/vector/conf_test/complex_otel.toml
@@ -1,0 +1,457 @@
+expire_metrics_secs = 60
+
+# Logs from containers (including openshift containers)
+[sources.raw_container_logs]
+type = "kubernetes_logs"
+glob_minimum_cooldown_ms = 15000
+auto_partial_merge = true
+exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]
+pod_annotation_fields.pod_labels = "kubernetes.labels"
+pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
+namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+
+[sources.raw_journal_logs]
+type = "journald"
+journal_directory = "/var/log/journal"
+
+# Logs from host audit
+[sources.raw_host_audit_logs]
+type = "file"
+include = ["/var/log/audit/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+# Logs from kubernetes audit
+[sources.raw_k8s_audit_logs]
+type = "file"
+include = ["/var/log/kube-apiserver/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+# Logs from openshift audit
+[sources.raw_openshift_audit_logs]
+type = "file"
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+# Logs from ovn audit
+[sources.raw_ovn_audit_logs]
+type = "file"
+include = ["/var/log/ovn/acl-audit-log.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[transforms.container_logs]
+type = "remap"
+inputs = ["raw_container_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  if !exists(.level) {
+    .level = "default"
+    if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {
+      .level = "warn"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    } else if match!(.message, r'Notice|NOTICE|^N[0-9]+|level=notice|Value:notice|"level":"notice"|<notice>') {
+      .level = "notice"
+    } else if match!(.message, r'Alert|ALERT|^A[0-9]+|level=alert|Value:alert|"level":"alert"|<alert>') {
+      .level = "alert"
+    } else if match!(.message, r'Emergency|EMERGENCY|^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"|<emergency>') {
+      .level = "emergency"
+    }
+  }
+  pod_name = string!(.kubernetes.pod_name)
+  if starts_with(pod_name, "event-router-") {
+    parsed, err = parse_json(.message)
+    if err != null {
+      log("Unable to process EventRouter log: " + err, level: "info")
+    } else {
+      ., err = merge(.,parsed)
+      if err == null && exists(.event) && is_object(.event) {
+          if exists(.verb) {
+            .event.verb = .verb
+            del(.verb)
+          }
+          .kubernetes.event = del(.event)
+          .message = del(.kubernetes.event.message)
+          set!(., ["@timestamp"], .kubernetes.event.metadata.creationTimestamp)
+          del(.kubernetes.event.metadata.creationTimestamp)
+		  . = compact(., nullish: true)
+      } else {
+        log("Unable to merge EventRouter log message into record: " + err, level: "info")
+      }
+    }
+  }
+  del(.source_type)
+  del(.stream)
+  del(.kubernetes.pod_ips)
+  del(.kubernetes.node_labels)
+  del(.timestamp_end)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+[transforms.drop_journal_logs]
+type = "filter"
+inputs = ["raw_journal_logs"]
+condition = ".PRIORITY != \"7\" && .PRIORITY != 7"
+
+[transforms.journal_logs]
+type = "remap"
+inputs = ["drop_journal_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".journal.system"
+
+  del(.source_type)
+  del(._CPU_USAGE_NSEC)
+  del(.__REALTIME_TIMESTAMP)
+  del(.__MONOTONIC_TIMESTAMP)
+  del(._SOURCE_REALTIME_TIMESTAMP)
+  del(.JOB_RESULT)
+  del(.JOB_TYPE)
+  del(.TIMESTAMP_BOOTTIME)
+  del(.TIMESTAMP_MONOTONIC)
+
+  if .PRIORITY == "8" || .PRIORITY == 8 {
+    .level = "trace"
+  } else {
+  	priority = to_int!(.PRIORITY)
+  	.level, err = to_syslog_level(priority)
+	if err != null {
+	  log("Unable to determine level from PRIORITY: " + err, level: "error")
+	  log(., level: "error")
+	  .level = "unknown"
+	} else {
+	  del(.PRIORITY)
+	}
+  }
+
+  .hostname = del(.host)
+
+  # systemd’s kernel-specific metadata.
+  # .systemd.k = {}
+  if exists(.KERNEL_DEVICE) { .systemd.k.KERNEL_DEVICE = del(.KERNEL_DEVICE) }
+  if exists(.KERNEL_SUBSYSTEM) { .systemd.k.KERNEL_SUBSYSTEM = del(.KERNEL_SUBSYSTEM) }
+  if exists(.UDEV_DEVLINK) { .systemd.k.UDEV_DEVLINK = del(.UDEV_DEVLINK) }
+  if exists(.UDEV_DEVNODE) { .systemd.k.UDEV_DEVNODE = del(.UDEV_DEVNODE) }
+  if exists(.UDEV_SYSNAME) { .systemd.k.UDEV_SYSNAME = del(.UDEV_SYSNAME) }
+
+  # trusted journal fields, fields that are implicitly added by the journal and cannot be altered by client code.
+  .systemd.t = {}
+  if exists(._AUDIT_LOGINUID) { .systemd.t.AUDIT_LOGINUID = del(._AUDIT_LOGINUID) }
+  if exists(._BOOT_ID) { .systemd.t.BOOT_ID = del(._BOOT_ID) }
+  if exists(._AUDIT_SESSION) { .systemd.t.AUDIT_SESSION = del(._AUDIT_SESSION) }
+  if exists(._CAP_EFFECTIVE) { .systemd.t.CAP_EFFECTIVE = del(._CAP_EFFECTIVE) }
+  if exists(._CMDLINE) { .systemd.t.CMDLINE = del(._CMDLINE) }
+  if exists(._COMM) { .systemd.t.COMM = del(._COMM) }
+  if exists(._EXE) { .systemd.t.EXE = del(._EXE) }
+  if exists(._GID) { .systemd.t.GID = del(._GID) }
+  if exists(._HOSTNAME) { .systemd.t.HOSTNAME = .hostname }
+  if exists(._LINE_BREAK) { .systemd.t.LINE_BREAK = del(._LINE_BREAK) }
+  if exists(._MACHINE_ID) { .systemd.t.MACHINE_ID = del(._MACHINE_ID) }
+  if exists(._PID) { .systemd.t.PID = del(._PID) }
+  if exists(._SELINUX_CONTEXT) { .systemd.t.SELINUX_CONTEXT = del(._SELINUX_CONTEXT) }
+  if exists(._SOURCE_REALTIME_TIMESTAMP) { .systemd.t.SOURCE_REALTIME_TIMESTAMP = del(._SOURCE_REALTIME_TIMESTAMP) }
+  if exists(._STREAM_ID) { .systemd.t.STREAM_ID = ._STREAM_ID }
+  if exists(._SYSTEMD_CGROUP) { .systemd.t.SYSTEMD_CGROUP = del(._SYSTEMD_CGROUP) }
+  if exists(._SYSTEMD_INVOCATION_ID) {.systemd.t.SYSTEMD_INVOCATION_ID = ._SYSTEMD_INVOCATION_ID}
+  if exists(._SYSTEMD_OWNER_UID) { .systemd.t.SYSTEMD_OWNER_UID = del(._SYSTEMD_OWNER_UID) }
+  if exists(._SYSTEMD_SESSION) { .systemd.t.SYSTEMD_SESSION = del(._SYSTEMD_SESSION) }
+  if exists(._SYSTEMD_SLICE) { .systemd.t.SYSTEMD_SLICE = del(._SYSTEMD_SLICE) }
+  if exists(._SYSTEMD_UNIT) { .systemd.t.SYSTEMD_UNIT = del(._SYSTEMD_UNIT) }
+  if exists(._SYSTEMD_USER_UNIT) { .systemd.t.SYSTEMD_USER_UNIT = del(._SYSTEMD_USER_UNIT) }
+  if exists(._TRANSPORT) { .systemd.t.TRANSPORT = del(._TRANSPORT) }
+  if exists(._UID) { .systemd.t.UID = del(._UID) }
+
+  # fields that are directly passed from clients and stored in the journal.
+  .systemd.u = {}
+  if exists(.CODE_FILE) { .systemd.u.CODE_FILE = del(.CODE_FILE) }
+  if exists(.CODE_FUNC) { .systemd.u.CODE_FUNCTION = del(.CODE_FUNC) }
+  if exists(.CODE_LINE) { .systemd.u.CODE_LINE = del(.CODE_LINE) }
+  if exists(.ERRNO) { .systemd.u.ERRNO = del(.ERRNO) }
+  if exists(.MESSAGE_ID) { .systemd.u.MESSAGE_ID = del(.MESSAGE_ID) }
+  if exists(.SYSLOG_FACILITY) { .systemd.u.SYSLOG_FACILITY = del(.SYSLOG_FACILITY) }
+  if exists(.SYSLOG_IDENTIFIER) { .systemd.u.SYSLOG_IDENTIFIER = del(.SYSLOG_IDENTIFIER) }
+  if exists(.SYSLOG_PID) { .systemd.u.SYSLOG_PID = del(.SYSLOG_PID) }
+  if exists(.RESULT) { .systemd.u.RESULT = del(.RESULT) }
+  if exists(.UNIT) { .systemd.u.UNIT = del(.UNIT) }
+
+  .time = format_timestamp!(.timestamp, format: "%FT%T%:z")
+
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+[transforms.host_audit_logs]
+type = "remap"
+inputs = ["raw_host_audit_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".linux-audit.log"
+
+  match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
+  envelop = {}
+  envelop |= {"type": match1.type}
+
+  match2, err = parse_regex(.message, r'msg=audit\((?P<ts_record>[^ ]+)\):')
+  if err == null {
+    sp, err = split(match2.ts_record,":")
+    if err == null && length(sp) == 2 {
+        ts = parse_timestamp(sp[0],"%s.%3f") ?? ""
+        envelop |= {"record_id": sp[1]}
+        . |= {"audit.linux" : envelop}
+        . |= {"@timestamp" : format_timestamp(ts,"%+") ?? ""}
+    }
+  } else {
+    log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
+  }
+
+  .level = "default"
+'''
+
+[transforms.k8s_audit_logs]
+type = "remap"
+inputs = ["raw_k8s_audit_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".k8s-audit.log"
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+  .k8s_audit_level = .level
+  .level = "default"
+'''
+
+[transforms.openshift_audit_logs]
+type = "remap"
+inputs = ["raw_openshift_audit_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".openshift-audit.log"
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+  .openshift_audit_level = .level
+  .level = "default"
+'''
+
+[transforms.ovn_audit_logs]
+type = "remap"
+inputs = ["raw_ovn_audit_logs"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".ovn-audit.log"
+  if !exists(.level) {
+    .level = "default"
+    if match!(.message, r'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    } else if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {
+      .level = "warn"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    } else if match!(.message, r'Notice|NOTICE|^N[0-9]+|level=notice|Value:notice|"level":"notice"|<notice>') {
+      .level = "notice"
+    } else if match!(.message, r'Alert|ALERT|^A[0-9]+|level=alert|Value:alert|"level":"alert"|<alert>') {
+      .level = "alert"
+    } else if match!(.message, r'Emergency|EMERGENCY|^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"|<emergency>') {
+      .level = "emergency"
+    }
+  }
+'''
+
+[transforms.route_container_logs]
+type = "route"
+inputs = ["container_logs"]
+route.app = '!((starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube"))'
+route.infra = '(starts_with!(.kubernetes.namespace_name,"kube-")) || (starts_with!(.kubernetes.namespace_name,"openshift-")) || (.kubernetes.namespace_name == "default") || (.kubernetes.namespace_name == "openshift") || (.kubernetes.namespace_name == "kube")'
+
+# Set log_type to "application"
+[transforms.application]
+type = "remap"
+inputs = ["route_container_logs.app"]
+source = '''
+  .log_type = "application"
+'''
+
+# Set log_type to "infrastructure"
+[transforms.infrastructure]
+type = "remap"
+inputs = ["route_container_logs.infra","journal_logs"]
+source = '''
+  .log_type = "infrastructure"
+'''
+
+# Set log_type to "audit"
+[transforms.audit]
+type = "remap"
+inputs = ["host_audit_logs","k8s_audit_logs","openshift_audit_logs","ovn_audit_logs"]
+source = '''
+  .log_type = "audit"
+  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+[transforms.route_application_logs]
+type = "route"
+inputs = ["application"]
+route.mytestapp = '.kubernetes.namespace_name == "test-ns"'
+
+[transforms.pipeline_user_defined]
+type = "remap"
+inputs = ["route_application_logs.mytestapp","infrastructure","audit"]
+source = '''
+  .openshift.labels = {"key1":"value1","key2":"value2"}
+'''
+
+# Normalize log records to OTEL schema
+[transforms.http_receiver_otel]
+type = "remap"
+inputs = ["pipeline_user_defined"]
+source = '''
+# Tech preview, OTEL for application logs only
+if .log_type == "application" {
+	# Convert @timestamp to nano and delete @timestamp
+	.timeUnixNano = to_unix_timestamp(to_timestamp!(del(.@timestamp)))
+
+	.severityText = del(.level)
+
+	# Convert syslog severity keyword to number, default to 9 (unknown)
+	.severityNumber = to_syslog_severity(.severityText) ?? 9
+
+	# resources
+	.resources.logs.file.path = del(.file)
+	.resources.host.name= del(.hostname)
+	.resources.container.name = del(.kubernetes.container_name)
+	.resources.container.id = del(.kubernetes.container_id)
+
+	# split image name and tag into separate fields
+	container_image_slice = split!(.kubernetes.container_image, ":", limit: 2)
+	if null != container_image_slice[0] { .resources.container.image.name = container_image_slice[0] }
+	if null != container_image_slice[1] { .resources.container.image.tag = container_image_slice[1] }
+	del(.kubernetes.container_image)
+	
+	# kuberenetes
+	.resources.k8s.pod.name = del(.kubernetes.pod_name)
+	.resources.k8s.pod.uid = del(.kubernetes.pod_id)
+	.resources.k8s.pod.ip = del(.kubernetes.pod_ip)
+	.resources.k8s.pod.owner = .kubernetes.pod_owner
+	.resources.k8s.pod.annotations = del(.kubernetes.annotations)
+	.resources.k8s.pod.labels = del(.kubernetes.labels)
+	.resources.k8s.namespace.id = del(.kubernetes.namespace_id)
+	.resources.k8s.namespace.name = .kubernetes.namespace_labels."kubernetes.io/metadata.name"
+	.resources.k8s.namespace.labels = del(.kubernetes.namespace_labels)
+	.resources.attributes.log_type = del(.log_type)
+}
+'''
+
+[transforms.http_receiver_normalize_http]
+type = "remap"
+inputs = ["http_receiver_otel"]
+source = '''
+  del(.file)
+'''
+
+[transforms.http_receiver_dedot]
+type = "lua"
+inputs = ["http_receiver_normalize_http"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+    function init()
+        count = 0
+    end
+    function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+		dedot(event.log.kubernetes.namespace_labels)
+        dedot(event.log.kubernetes.labels)
+        emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "[./]", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+'''
+
+[sinks.http_receiver]
+type = "http"
+inputs = ["http_receiver_dedot"]
+uri = "https://my-logstore.com"
+method = "post"
+
+[sinks.http_receiver.encoding]
+codec = "json"
+
+[sinks.http_receiver.request]
+timeout_secs = 10
+headers = {"h1"="v1","h2"="v2"}
+
+[sinks.http_receiver.tls]
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
+
+# Basic Auth Config
+[sinks.http_receiver.auth]
+strategy = "basic"
+user = "username"
+password = "password"
+
+[transforms.add_nodename_to_metric]
+type = "remap"
+inputs = ["internal_metrics"]
+source = '''
+.tags.hostname = get_env_var!("VECTOR_SELF_NODE_NAME")
+'''
+
+[sinks.prometheus_output]
+type = "prometheus_exporter"
+inputs = ["add_nodename_to_metric"]
+address = "[::]:24231"
+default_namespace = "collector"
+
+[sinks.prometheus_output.tls]
+enabled = true
+key_file = "/etc/collector/metrics/tls.key"
+crt_file = "/etc/collector/metrics/tls.crt"
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"

--- a/internal/generator/vector/normalize/schema/otel/transform.go
+++ b/internal/generator/vector/normalize/schema/otel/transform.go
@@ -1,0 +1,58 @@
+package otel
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/openshift/cluster-logging-operator/internal/generator"
+	. "github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+)
+
+func ID(id1, id2 string) string {
+	return fmt.Sprintf("%s_%s", id1, id2)
+}
+
+func Transform(id string, inputs []string) Element {
+	return Remap{
+		Desc:        "Normalize log records to OTEL schema",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL: strings.TrimSpace(`
+# Tech preview, OTEL for application logs only
+if .log_type == "application" {
+	# Convert @timestamp to nano and delete @timestamp
+	.timeUnixNano = to_unix_timestamp(to_timestamp!(del(.@timestamp)))
+
+	.severityText = del(.level)
+
+	# Convert syslog severity keyword to number, default to 9 (unknown)
+	.severityNumber = to_syslog_severity(.severityText) ?? 9
+
+	# resources
+	.resources.logs.file.path = del(.file)
+	.resources.host.name= del(.hostname)
+	.resources.container.name = del(.kubernetes.container_name)
+	.resources.container.id = del(.kubernetes.container_id)
+  
+	# split image name and tag into separate fields
+	container_image_slice = split!(.kubernetes.container_image, ":", limit: 2)
+	if null != container_image_slice[0] { .resources.container.image.name = container_image_slice[0] }
+	if null != container_image_slice[1] { .resources.container.image.tag = container_image_slice[1] }
+	del(.kubernetes.container_image)
+	
+	# kuberenetes
+	.resources.k8s.pod.name = del(.kubernetes.pod_name)
+	.resources.k8s.pod.uid = del(.kubernetes.pod_id)
+	.resources.k8s.pod.ip = del(.kubernetes.pod_ip)
+	.resources.k8s.pod.owner = .kubernetes.pod_owner
+	.resources.k8s.pod.annotations = del(.kubernetes.annotations)
+	.resources.k8s.pod.labels = del(.kubernetes.labels)
+	.resources.k8s.namespace.id = del(.kubernetes.namespace_id)
+	.resources.k8s.namespace.name = .kubernetes.namespace_labels."kubernetes.io/metadata.name"
+	.resources.k8s.namespace.labels = del(.kubernetes.namespace_labels)
+	.resources.attributes.log_type = del(.log_type)
+}
+`),
+	}
+}

--- a/internal/generator/vector/output/http/http_test.go
+++ b/internal/generator/vector/output/http/http_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
-	v1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
 	"github.com/openshift/cluster-logging-operator/internal/generator/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -18,7 +18,7 @@ import (
 var _ = Describe("Generate vector config", func() {
 	inputPipeline := []string{"application"}
 	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op generator.Options) []generator.Element {
-		return Conf(clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], generator.NoOptions)
+		return Conf(clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], op)
 	}
 	DescribeTable("for Http output", helpers.TestGenerateConfWith(f),
 		Entry("", helpers.ConfGenerateTest{
@@ -238,7 +238,7 @@ token = "token-for-custom-http"
 						Type: logging.OutputTypeHttp,
 						Name: "http-receiver",
 						URL:  "https://my-logstore.com",
-						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
+						OutputTypeSpec: logging.OutputTypeSpec{Http: &logging.Http{
 							Timeout: "50",
 							Headers: map[string]string{
 								"k1": "v1",
@@ -340,7 +340,7 @@ token = "token-for-custom-http"
 						Type: logging.OutputTypeHttp,
 						Name: "http-receiver",
 						URL:  "https://my-logstore.com",
-						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
+						OutputTypeSpec: logging.OutputTypeSpec{Http: &logging.Http{
 							Timeout: "50",
 							Headers: map[string]string{
 								"k1": "v1",
@@ -442,7 +442,7 @@ token = "token-for-custom-http"
 						Type: logging.OutputTypeHttp,
 						Name: "http-receiver",
 						URL:  "https://my-logstore.com",
-						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
+						OutputTypeSpec: logging.OutputTypeSpec{Http: &logging.Http{
 							Timeout: "50",
 							Headers: map[string]string{
 								"k1": "v1",
@@ -548,6 +548,253 @@ ca_file = "/var/run/ocp-collector/secrets/http-receiver/ca-bundle.crt"
 [sinks.http_receiver.auth]
 strategy = "bearer"
 token = "token-for-custom-http"
+`,
+		}),
+		Entry("with AnnotationEnableSchema = 'enabled' & o.HTTP.schema = 'opentelemetry'", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeHttp,
+						Name: "http-receiver",
+						URL:  "https://my-logstore.com",
+						Secret: &logging.OutputSecretSpec{
+							Name: "http-receiver",
+						},
+						OutputTypeSpec: logging.OutputTypeSpec{
+							Http: &logging.Http{
+								Headers: map[string]string{
+									"h2": "v2",
+									"h1": "v1",
+								},
+								Method: "POST",
+								Schema: constants.OTELSchema,
+							},
+						},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"http-receiver": {
+					Data: map[string][]byte{
+						"username": []byte("username"),
+						"password": []byte("password"),
+					},
+				},
+			},
+			Options: generator.Options{constants.AnnotationEnableSchema: "true"},
+			ExpectedConf: `
+# Normalize log records to OTEL schema
+[transforms.http_receiver_otel]
+type = "remap"
+inputs = ["application"]
+source = '''
+# Tech preview, OTEL for application logs only
+if .log_type == "application" {
+	# Convert @timestamp to nano and delete @timestamp
+	.timeUnixNano = to_unix_timestamp(to_timestamp!(del(.@timestamp)))
+
+	.severityText = del(.level)
+
+	# Convert syslog severity keyword to number, default to 9 (unknown)
+	.severityNumber = to_syslog_severity(.severityText) ?? 9
+
+	# resources
+	.resources.logs.file.path = del(.file)
+	.resources.host.name= del(.hostname)
+	.resources.container.name = del(.kubernetes.container_name)
+	.resources.container.id = del(.kubernetes.container_id)
+  
+	# split image name and tag into separate fields
+	container_image_slice = split!(.kubernetes.container_image, ":", limit: 2)
+	if null != container_image_slice[0] { .resources.container.image.name = container_image_slice[0] }
+	if null != container_image_slice[1] { .resources.container.image.tag = container_image_slice[1] }
+	del(.kubernetes.container_image)
+	
+	# kuberenetes
+	.resources.k8s.pod.name = del(.kubernetes.pod_name)
+	.resources.k8s.pod.uid = del(.kubernetes.pod_id)
+	.resources.k8s.pod.ip = del(.kubernetes.pod_ip)
+	.resources.k8s.pod.owner = .kubernetes.pod_owner
+	.resources.k8s.pod.annotations = del(.kubernetes.annotations)
+	.resources.k8s.pod.labels = del(.kubernetes.labels)
+	.resources.k8s.namespace.id = del(.kubernetes.namespace_id)
+	.resources.k8s.namespace.name = .kubernetes.namespace_labels."kubernetes.io/metadata.name"
+	.resources.k8s.namespace.labels = del(.kubernetes.namespace_labels)
+	.resources.attributes.log_type = del(.log_type)
+}
+'''
+
+[transforms.http_receiver_normalize_http]
+type = "remap"
+inputs = ["http_receiver_otel"]
+source = '''
+  del(.file)
+'''
+
+[transforms.http_receiver_dedot]
+type = "lua"
+inputs = ["http_receiver_normalize_http"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+    function init()
+        count = 0
+    end
+    function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+		dedot(event.log.kubernetes.namespace_labels)
+        dedot(event.log.kubernetes.labels)
+        emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "[./]", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+'''
+
+[sinks.http_receiver]
+type = "http"
+inputs = ["http_receiver_dedot"]
+uri = "https://my-logstore.com"
+method = "post"
+
+[sinks.http_receiver.encoding]
+codec = "json"
+
+[sinks.http_receiver.request]
+timeout_secs = 10
+headers = {"h1"="v1","h2"="v2"}
+
+# Basic Auth Config
+[sinks.http_receiver.auth]
+strategy = "basic"
+user = "username"
+password = "password"
+`,
+		}),
+		Entry("with AnnotationEnableSchema = 'enabled' & no HTTP spec", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeHttp,
+						Name: "http-receiver",
+						URL:  "https://my-logstore.com",
+						Secret: &logging.OutputSecretSpec{
+							Name: "http-receiver",
+						},
+						OutputTypeSpec: logging.OutputTypeSpec{},
+					},
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				"http-receiver": {
+					Data: map[string][]byte{
+						"username": []byte("username"),
+						"password": []byte("password"),
+					},
+				},
+			},
+			Options: generator.Options{constants.AnnotationEnableSchema: "true"},
+			ExpectedConf: `
+[transforms.http_receiver_normalize_http]
+type = "remap"
+inputs = ["application"]
+source = '''
+  del(.file)
+'''
+
+[transforms.http_receiver_dedot]
+type = "lua"
+inputs = ["http_receiver_normalize_http"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+    function init()
+        count = 0
+    end
+    function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+		dedot(event.log.kubernetes.namespace_labels)
+        dedot(event.log.kubernetes.labels)
+        emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "[./]", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+'''
+
+[sinks.http_receiver]
+type = "http"
+inputs = ["http_receiver_dedot"]
+uri = "https://my-logstore.com"
+method = "post"
+
+[sinks.http_receiver.encoding]
+codec = "json"
+
+[sinks.http_receiver.request]
+timeout_secs = 10
+
+# Basic Auth Config
+[sinks.http_receiver.auth]
+strategy = "basic"
+user = "username"
+password = "password"
 `,
 		}),
 	)

--- a/internal/generator/vector/pipelines.go
+++ b/internal/generator/vector/pipelines.go
@@ -66,6 +66,7 @@ if .log_type == "application" {
 `
 			vrls = append(vrls, parse)
 		}
+
 		vrl := SrcPassThrough
 		if len(vrls) != 0 {
 			vrl = strings.Join(helpers.TrimSpaces(vrls), "\n\n")

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -31,6 +31,11 @@ func EvaluateAnnotationsForEnabledCapabilities(forwarder *logging.ClusterLogForw
 			if strings.ToLower(value) == "true" {
 				options[helpers.EnableDebugOutput] = "true"
 			}
+
+		case constants.AnnotationEnableSchema:
+			if strings.ToLower(value) == constants.Enabled {
+				options[constants.AnnotationEnableSchema] = "true"
+			}
 		}
 	}
 }

--- a/test/framework/functional/cluster_log_forwarder.go
+++ b/test/framework/functional/cluster_log_forwarder.go
@@ -118,6 +118,24 @@ func (p *PipelineBuilder) ToHttpOutput() *ClusterLogForwarderBuilder {
 	return p.ToOutputWithVisitor(func(output *logging.OutputSpec) {}, logging.OutputTypeHttp)
 }
 
+func (p *PipelineBuilder) ToHttpOutputWithSchema(schema string) *ClusterLogForwarderBuilder {
+	httpVisitor := func(output *logging.OutputSpec) {
+		output.Name = logging.OutputTypeHttp
+		output.Type = logging.OutputTypeHttp
+		output.URL = "http://localhost:8090"
+		output.OutputTypeSpec = logging.OutputTypeSpec{
+			Http: &logging.Http{
+				Headers: map[string]string{
+					"k1": "v1",
+				},
+				Method: "POST",
+				Schema: schema,
+			},
+		}
+	}
+	return p.ToOutputWithVisitor(httpVisitor, logging.OutputTypeHttp)
+}
+
 func (p *PipelineBuilder) ToOutputWithVisitor(visit OutputSpecVisitor, outputName string) *ClusterLogForwarderBuilder {
 	clf := p.clfb.Forwarder
 	outputs := clf.Spec.OutputMap()

--- a/test/functional/normalization/schema/otel_test.go
+++ b/test/functional/normalization/schema/otel_test.go
@@ -1,0 +1,62 @@
+// go:build vector
+package schema
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	"github.com/openshift/cluster-logging-operator/test/helpers/schema/otel"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+)
+
+const (
+	timestamp           = "2023-08-28T12:59:28.573159188+00:00"
+	timestampNano int64 = 1693227568
+)
+
+var _ = Describe("[Functional][Normalization][Schema] OTEL", func() {
+	var (
+		framework    *functional.CollectorFunctionalFramework
+		appNamespace string
+	)
+
+	BeforeEach(func() {
+		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(loggingv1.LogCollectionTypeVector)
+		framework.Forwarder.Annotations = map[string]string{constants.AnnotationEnableSchema: constants.Enabled}
+	})
+
+	AfterEach(func() {
+		framework.Cleanup()
+	})
+
+	It("should normalize application logs to OTEL format for HTTP sink", func() {
+		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+			FromInput(loggingv1.InputNameApplication).
+			ToHttpOutputWithSchema(constants.OTELSchema)
+
+		ExpectOK(framework.Deploy())
+
+		appNamespace = framework.Pod.Namespace
+
+		// Write message to namespace
+		crioLine := functional.NewCRIOLogMessage(timestamp, "Format me to OTEL!", false)
+		Expect(framework.WriteMessagesToNamespace(crioLine, appNamespace, 1)).To(Succeed())
+		// Read log
+		raw, err := framework.ReadRawApplicationLogsFrom(loggingv1.OutputTypeHttp)
+		Expect(err).To(BeNil(), "Expected no errors reading the logs for type")
+
+		logs, err := otel.ParseLogs(utils.ToJsonLogs(raw))
+
+		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+		otelLog := logs[0].ContainerLog
+		Expect(otelLog.TimeUnixNano).To(Equal(timestampNano), "Expect timestamp to be converted into unix nano")
+		Expect(otelLog.SeverityText).ToNot(BeNil(), "Expect severityText to exist")
+		Expect(otelLog.SeverityNumber).To(Equal(9), "Expect severityNumber to parse to 9")
+		Expect(otelLog.Resources).ToNot(BeNil(), "Expect resources to exist")
+		Expect(otelLog.Resources.K8s.Namespace.Name).To(Equal(appNamespace), "Expect namespace name to be nested under k8s.namespace")
+	})
+
+})

--- a/test/functional/normalization/schema/suite_test.go
+++ b/test/functional/normalization/schema/suite_test.go
@@ -1,0 +1,13 @@
+package schema
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSchema(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ClusterLogging Functional Normalization Schema Suite")
+}

--- a/test/helpers/schema/otel/types.go
+++ b/test/helpers/schema/otel/types.go
@@ -1,0 +1,87 @@
+package otel
+
+import (
+	"encoding/json"
+)
+
+type AllOTELLog struct {
+	ContainerLog `json:",inline,omitempty"`
+}
+
+type OTELLogs []AllOTELLog
+
+type ContainerLog struct {
+	ApplicationLog `json:",inline,omitempty"`
+}
+
+type ApplicationLog struct {
+	Resources      Resources `json:"resources,omitempty"`
+	SeverityNumber int       `json:"severityNumber,omitempty"`
+	SeverityText   string    `json:"severityText,omitempty"`
+	TimeUnixNano   int64     `json:"timeUnixNano,omitempty"`
+}
+
+type Resources struct {
+	Attributes map[string]string `json:"attributes,omitempty"`
+	Container  Container         `json:"container,omitempty"`
+	Host       Host              `json:"host,omitempty"`
+	K8s        K8s               `json:"k8s,omitempty"`
+}
+
+type Container struct {
+	Id    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Image Image  `json:"image,omitempty"`
+}
+
+type Image struct {
+	Name string `json:"name,omitempty"`
+	Tag  string `json:"tag,omitempty"`
+}
+
+type Host struct {
+	Name string `json:"name,omitempty"`
+}
+
+type K8s struct {
+	Namespace Namespace `json:"namespace,omitempty"`
+	Pod       Pod       `json:"pod,omitempty"`
+	Logs      Logs      `json:"logs,omitempty"`
+}
+
+type Namespace struct {
+	Name   string            `json:"name,omitempty"`
+	Id     string            `json:"id,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+type Pod struct {
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Ip          string            `json:"ip,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Owner       string            `json:"owner,omitempty"`
+	UID         string            `json:"uid,omitempty"`
+}
+
+type Logs struct {
+	File File `json:"file,omitempty"`
+}
+
+type File struct {
+	Path string `json:"path,omitempty"`
+}
+
+func ParseLogs(in string) (OTELLogs, error) {
+	logs := OTELLogs{}
+	if in == "" {
+		return logs, nil
+	}
+
+	err := json.Unmarshal([]byte(in), &logs)
+	if err != nil {
+		return nil, err
+	}
+
+	return logs, nil
+}

--- a/test/helpers/types/types.go
+++ b/test/helpers/types/types.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	rand2 "github.com/openshift/cluster-logging-operator/test/helpers/rand"
 	"math/rand"
 	"strings"
 	"time"
+
+	rand2 "github.com/openshift/cluster-logging-operator/test/helpers/rand"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	v1 "k8s.io/api/core/v1"


### PR DESCRIPTION
## Description
This PR is a continuation of the effort by Jatin Suri to support transforming the log record formats to the OpenTelemetry semantic.

This feature is:
- Locked behind a feature-gate
- Applies only to `application` logs
- Can only be defined for `HTTP` outputs under the `HTTP` output spec

## Field Changes:
| Original| New	|
|---|---|
| @timestamp |	timeUnixNano |
| level	|severityText |
| N/A	|	severityNumber |
| file	|resources.logs.file.path |
| hostname	|resources.host.name |
| kubernetes.container_name	|resources.container.name |
| kubernetes.container_id	|resources.container.id |
| kubernetes.container_image	|resources.container.image.name |
| N/A	|resources.container.image.tag |
| kubernetes.pod_name	|resources.k8s.pod.name |
| kubernetes.pod_id	|resources.k8s.pod.uid |
| kubernetes.pod_ip	|resources.k8s.pod.ip |
| kubernetes.pod_owner	|resources.k8s.pod.owner |
| kubernetes.annotations	|resources.k8s.pod.annotations |
| kubernetes.labels	|resources.k8s.pod.labels |
| kubernetes.namespace_id	|resources.k8s.namespace.id |
| kubernetes.namespace_labels."kubernetes.io/metadata.name"	|resources.k8s.namespace.name |
| kubernetes.namespace_labels	|resources.k8s.namespace.labels |
| log_type	|resources.attributes.log_type |

/cc @alanconway @cahartma
/assign @jcantrill 

### Links
- Based on PR: https://github.com/openshift/cluster-logging-operator/pull/2142
- JIRA: https://issues.redhat.com/browse/LOG-4231
- Enhancement Proposal: https://github.com/openshift/enhancements/pull/1442
