### PR TITLE
LOG-4487: sort Map of Routes for predictable configuration generation during reconciliation

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"bytes"
+	"sort"
 	"strings"
 	"text/template"
 )
@@ -64,6 +65,14 @@ func (g Generator) generate(es []Element) (string, error) {
 		"indent": indent,
 		"comma_separated": func(arr []string) string {
 			return strings.Join(arr, ", ")
+		},
+		"getSortedKeyFromMap": func(arg map[string]string) []string {
+			var keys []string
+			for key := range arg {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			return keys
 		},
 	}
 	f["optional"] = f["kv"]

--- a/internal/generator/vector/elements/elements.go
+++ b/internal/generator/vector/elements/elements.go
@@ -23,8 +23,10 @@ func (r Route) Template() string {
 [transforms.{{.ComponentID}}]
 type = "route"
 inputs = {{.Inputs}}
-{{- range $route_name, $route_expr := .Routes}}
-route.{{$route_name}} = {{$route_expr}}
+{{- $values := .Routes -}}
+{{- $keys := getSortedKeyFromMap .Routes -}}
+{{ range $route_name := $keys}}
+route.{{$route_name}} = {{index $values $route_name}}
 {{- end}}
 {{end}}
 `

--- a/internal/generator/vector/inputs.go
+++ b/internal/generator/vector/inputs.go
@@ -138,6 +138,11 @@ func Inputs(spec *logging.ClusterLogForwarderSpec, o Options) []Element {
 
 	userDefinedAppRouteMap := UserDefinedAppRouting(spec, o)
 	if len(userDefinedAppRouteMap) != 0 {
+		var keys []string
+		for key := range userDefinedAppRouteMap {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
 		el = append(el, Route{
 			ComponentID: RouteApplicationLogs,
 			Inputs:      helpers.MakeInputs(logging.InputNameApplication),
@@ -145,7 +150,7 @@ func Inputs(spec *logging.ClusterLogForwarderSpec, o Options) []Element {
 		})
 
 		userDefined := spec.InputMap()
-		for inRef := range userDefinedAppRouteMap {
+		for _, inRef := range keys {
 			if input, ok := userDefined[inRef]; ok && input.HasPolicy() && input.GetMaxRecordsPerSecond() > 0 {
 				// Vector Throttle component cannot have zero threshold
 				el = append(el, AddThrottle(input)...)

--- a/internal/utils/comparators/servicemonitor/comparator.go
+++ b/internal/utils/comparators/servicemonitor/comparator.go
@@ -10,7 +10,7 @@ import (
 
 // AreSame compares for equality and return true equal otherwise false
 func AreSame(current *monitoringv1.ServiceMonitor, desired *monitoringv1.ServiceMonitor) bool {
-	log.V(3).Info("Comparing Services current to desired", "current", current, "desired", desired)
+	log.V(3).Info("Comparing ServiceMonitor current to desired", "current", current, "desired", desired)
 
 	if !utils.AreMapsSame(current.ObjectMeta.Annotations, desired.ObjectMeta.Annotations) {
 		log.V(3).Info("ServiceMonitor  annotation change", "current name", current.Name)
@@ -46,27 +46,28 @@ func AreSame(current *monitoringv1.ServiceMonitor, desired *monitoringv1.Service
 	}
 
 	if len(current.Spec.PodTargetLabels) != len(desired.Spec.PodTargetLabels) {
-		log.V(3).Info("Service Selector PodTargetLabels change", "current name", current.Name)
+		log.V(3).Info("Service Monitor PodTargetLabels change", "current name", current.Name)
 		return false
 	}
 
 	for i, targetLabel := range current.Spec.PodTargetLabels {
 		t := desired.Spec.PodTargetLabels[i]
 		if targetLabel != t {
-			log.V(3).Info("Service Selector PodTargetLabels change", "current name", current.Name)
+			log.V(3).Info("Service Monitor PodTargetLabels change", "current name", current.Name)
 			return false
 		}
 	}
 
 	if len(current.Spec.Endpoints) != len(desired.Spec.Endpoints) {
-		log.V(3).Info("Service Selector Endpoints change", "current name", current.Name)
+		log.V(3).Info("Service Monitor Endpoints amount change", "current name", current.Name)
 		return false
 	}
 
 	for i, endpoint := range current.Spec.Endpoints {
 		e := desired.Spec.Endpoints[i]
 		if !reflect.DeepEqual(endpoint, e) {
-			log.V(3).Info("Service Selector Endpoints change", "current name", current.Name)
+			log.V(3).Info("Service Monitor Endpoint change", "current name", current.Name, "endpoint path",
+				endpoint.Path)
 			return false
 		}
 	}


### PR DESCRIPTION
### Description

In this PR, we aim to resolve an issue causing configuration discrepancies during reconciliation, ultimately leading to unnecessary collector pod restarts. The root of the problem lies in the behavior of the `Go range function`, which does not guarantee the same ordering in each call for the same map (see: https://go.dev/blog/maps). This unpredictability can result in occasional variations in configuration generation when processing the `Routes map` [(source),](https://github.com/openshift/cluster-logging-operator/pull/2164/files#diff-6b7baf71ad4874089f6aa160edf27cdd8914a23a5d8db2fad126e352db8459daR11) impacting the stability of the system. Although this change in ordering means nothing for `Vector`, it significantly influences MD5 hash calculations, that we use for detecting changes in configuration.

For example, if create an instance of CLF with this YAML:  
```
apiVersion: logging.openshift.io/v1
kind: ClusterLogForwarder
metadata:
  name: instance
  namespace: openshift-logging
spec:
  inputs:
  - application:
      containerLimit:
        maxRecordsPerSecond: 20
      namespaces:
      - test-1
    name: limited-rates-1
  - application:
      containerLimit:
        maxRecordsPerSecond: 20
      namespaces:
      - test-2
    name: limited-rates-2
  pipelines:
  - inputRefs:
    - limited-rates-1
    - limited-rates-2
    - infrastructure
    name: to-default
    outputRefs:
    - default 
```
Collector pods keep being recreated because of differences of md5 hash in env variable: `COLLECTOR_CONF_HASH`.
Here is diff of generated Vector config: 

```
201c201
< [transforms.source_throttle_limited-rates-2]
---
> [transforms.source_throttle_limited-rates-1]
203c203
< inputs = ["route_application_logs.limited-rates-2"]
---
> inputs = ["route_application_logs.limited-rates-1"]
209c209
< [transforms.source_throttle_limited-rates-1]
---
> [transforms.source_throttle_limited-rates-2]
211c211
< inputs = ["route_application_logs.limited-rates-1"]
---
> inputs = ["route_application_logs.limited-rates-2"]
```
and md5 hash:
```

< "collectorConfHash":"336e99a4eeadb2d0c1a2a65b51816c4b"
---
> "collectorConfHash":"02794c06255cf667f06bc8f1a86653bc"
```

To tackle this issue and ensure a consistent and predictable configuration generation process, we have introduced a solution to sort the Routes map before generating the configuration. By doing so, we establish a consistent ordering for the map's keys across multiple runs. This guarantees stability in configuration outputs and eliminates the source of discrepancies during reconciliation.



/cc @jcantrill @cahartma <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4487
- Enhancement proposal:
