### PR TITLE
LOG-4534 add multi toml and lfme to must-gather

### DIFF
--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -40,27 +40,35 @@ fi
 
 log "Gathering data for 'clusterlogging' and 'clusterlogforwarder' from namespace: $NAMESPACE"
 for r in "clusterlogging" "clusterlogforwarder" ; do
-  data="$(oc -n $NAMESPACE get $r --ignore-not-found -o yaml)"
-  if [ "$data" != "" ] ; then
-    name="$(oc -n $NAMESPACE get $r --ignore-not-found -o custom-columns=:.metadata.name)"
-    echo $data > "${clo_folder}/${r}_${name}.yaml"
-  fi
+  names="$(oc -n $NAMESPACE get $r --ignore-not-found -o jsonpath='{.items[*].metadata.name}' | sort -u)"
+  for name in ${names[@]}; do
+    data="$(oc -n $NAMESPACE get $r ${name} --ignore-not-found -o yaml)"
+    if [ "$data" != "" ] ; then
+      echo $data > "${clo_folder}/${r}_${name}.yaml"
+    fi
+  done
 done
 
 log "Gathering 'secrets' from logging namespace: $NAMESPACE"
 oc -n $NAMESPACE get secrets -o yaml > ${clo_folder}/secrets.yaml 2>&1
 
-log "Gathering 'vector.toml' from logging namespace: $NAMESPACE"
-data=$(oc -n $NAMESPACE get secret ${name}-config -o jsonpath='{.data.vector\.toml}' --ignore-not-found)
-if [ "$data" != "" ] ; then
-  echo $data | base64 -d > ${clo_folder}/vector.toml 2>&1
-fi
+log "Gathering any 'vector.toml' from logging namespace: $NAMESPACE"
+secret_names=$(oc -n $NAMESPACE get secrets -o custom-columns=:.metadata.name | grep -e '-config')
+for name in ${secret_names[@]}; do
+  data=$(oc -n $NAMESPACE get secret ${name} -o jsonpath='{.data.vector\.toml}' --ignore-not-found)
+  if [ "$data" != "" ] ; then
+    echo $data | base64 -d > ${clo_folder}/${name}_vector.toml 2>&1
+  fi
+done
 
 log "Gathering 'deployments' and 'daemonsets' and 'version' from logging namespace: $NAMESPACE"
 csv_name="$(oc -n $NAMESPACE get csv -o name | grep -E 'cluster(-?)logging')"
 oc -n $NAMESPACE get deployments -o wide > ${clo_folder}/deployments.txt --cache-dir=${KUBECACHEDIR} 2>&1
 oc -n $NAMESPACE get ds -o wide > ${clo_folder}/daemonsets.txt --cache-dir=${KUBECACHEDIR} 2>&1
 oc -n $NAMESPACE get "${csv_name}" -o jsonpath='{.spec.displayName}{"/must-gather\n"}{.spec.version}' --cache-dir=${KUBECACHEDIR} > "${clo_folder}/version"
+
+log "Gathering 'logfilemetricexporter' from namespace: $NAMESPACE"
+oc -n $NAMESPACE get lfme -o yaml > ${clo_folder}/lfme.yaml 2>&1
 
 log "Checking for legacy es and fluentd resources"
 for r in "secret/elasticsearch" "configmap/collector" ; do


### PR DESCRIPTION
### Description
Additional updates for must-gather fix original changes: https://github.com/openshift/cluster-logging-operator/pull/2143

This change adds additional vector toml files by appending the "name_" to the filename.   We are also now collecting the  "oc get lfme -o yaml" for each namespace that contains an instance.   They are being gathered in a file called "lfme.yaml"

/cc @syedriko @vparfonov 
/assign @jcantrill 

### Links
Original
- https://issues.redhat.com/browse/LOG-4404
More fixes:
- https://issues.redhat.com/browse/LOG-4534