### PR TITLE
LOG-4411: fix vector config for unreferenced output

### DIFF
--- a/internal/k8s/loader/load.go
+++ b/internal/k8s/loader/load.go
@@ -60,7 +60,9 @@ func FetchClusterLogForwarder(k8sClient client.Client, namespace, name string, i
 	saTokenSecret := factory.GenerateResourceNames(forwarder).ServiceAccountTokenSecret
 	// TODO Drop migration upon introduction of v2
 	extras := map[string]bool{}
-	forwarder.Spec, extras = migrations.MigrateClusterLogForwarderSpec(namespace, name, forwarder.Spec, fetchClusterLogging().Spec.LogStore, extras, internalLogStoreSecret, saTokenSecret)
+	var migrationMessages []logging.Condition
+	forwarder.Spec, extras, migrationMessages = migrations.MigrateClusterLogForwarder(namespace, name, forwarder.Spec, fetchClusterLogging().Spec.LogStore, extras, internalLogStoreSecret, saTokenSecret)
+	setMigrationStatusConditions(&forwarder.Status, migrationMessages)
 
 	extras[constants.ClusterLoggingAvailable] = (fetchClusterLogging().Name != "")
 	if err, status = clusterlogforwarder.Validate(forwarder, k8sClient, extras); err != nil {
@@ -68,4 +70,10 @@ func FetchClusterLogForwarder(k8sClient client.Client, namespace, name string, i
 	}
 
 	return forwarder, nil, status
+}
+
+func setMigrationStatusConditions(status *logging.ClusterLogForwarderStatus, conditions []logging.Condition) {
+	for _, cond := range conditions {
+		status.Conditions.SetCondition(cond)
+	}
 }

--- a/internal/k8shandler/collection_test.go
+++ b/internal/k8shandler/collection_test.go
@@ -2,13 +2,13 @@ package k8shandler
 
 import (
 	"context"
+	"github.com/openshift/cluster-logging-operator/internal/migrations"
 
 	"github.com/openshift/cluster-logging-operator/internal/collector"
 	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 
 	"github.com/openshift/cluster-logging-operator/internal/collector/common"
-	"github.com/openshift/cluster-logging-operator/internal/migrations"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 
 	. "github.com/onsi/ginkgo"
@@ -147,7 +147,7 @@ var _ = Describe("Reconciling", func() {
 					ResourceOwner: utils.AsOwner(cluster),
 				}
 				extras[constants.MigrateDefaultOutput] = true
-				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
+				spec, extras, _ = migrations.MigrateClusterLogForwarder(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
 				clusterRequest.Forwarder.Spec = spec
 			})
 
@@ -215,7 +215,7 @@ var _ = Describe("Reconciling", func() {
 					ResourceOwner: utils.AsOwner(cluster),
 				}
 				extras[constants.MigrateDefaultOutput] = true
-				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
+				spec, extras, _ = migrations.MigrateClusterLogForwarder(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
 				clusterRequest.Forwarder.Spec = spec
 			})
 
@@ -257,7 +257,7 @@ var _ = Describe("Reconciling", func() {
 					Forwarder:     &loggingv1.ClusterLogForwarder{},
 				}
 				extras[constants.MigrateDefaultOutput] = true
-				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
+				spec, extras, _ = migrations.MigrateClusterLogForwarder(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
 				clusterRequest.Forwarder.Spec = spec
 			})
 		})
@@ -318,7 +318,7 @@ var _ = Describe("Reconciling", func() {
 					ResourceOwner: utils.AsOwner(fwder),
 				}
 				extras[constants.MigrateDefaultOutput] = true
-				spec, extras = migrations.MigrateClusterLogForwarderSpec(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
+				spec, extras, _ = migrations.MigrateClusterLogForwarder(clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.Forwarder.Spec, clusterRequest.Cluster.Spec.LogStore, extras, clusterRequest.ResourceNames.InternalLogStoreSecret, clusterRequest.ResourceNames.ServiceAccountTokenSecret)
 				clusterRequest.Forwarder.Spec = spec
 			})
 			It("should have appropriately named resources", func() {

--- a/internal/k8shandler/forwarding_test.go
+++ b/internal/k8shandler/forwarding_test.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
-	"github.com/onsi/gomega/types"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test"
 
@@ -17,29 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-// Match condition by type, status and reason if reason != "".
-// Also match messageRegex if it is not empty.
-func matchCondition(t logging.ConditionType, s bool, r logging.ConditionReason, messageRegex string) types.GomegaMatcher {
-	var status corev1.ConditionStatus
-	if s {
-		status = corev1.ConditionTrue
-	} else {
-		status = corev1.ConditionFalse
-	}
-	fields := Fields{"Type": Equal(t), "Status": Equal(status)}
-	if r != "" {
-		fields["Reason"] = Equal(r)
-	}
-	if messageRegex != "" {
-		fields["Message"] = MatchRegexp(messageRegex)
-	}
-	return MatchFields(IgnoreExtras, fields)
-}
-
-func HaveCondition(t logging.ConditionType, s bool, r logging.ConditionReason, messageRegex string) types.GomegaMatcher {
-	return ContainElement(matchCondition(t, s, r, messageRegex))
-}
 
 var _ = DescribeTable("#generateCollectorConfig",
 	func(cluster logging.ClusterLogging, forwardSpec logging.ClusterLogForwarderSpec) {

--- a/internal/migrations/clusterlogforwarder/drop_unreferenced_outputs.go
+++ b/internal/migrations/clusterlogforwarder/drop_unreferenced_outputs.go
@@ -1,0 +1,37 @@
+package clusterlogforwarder
+
+import (
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/status"
+	"github.com/openshift/cluster-logging-operator/internal/utils/sets"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+
+	// OutputDroppedCondition is the condition when an output is dropped from reconciliation
+	OutputDroppedCondition status.ConditionType = "OutputDropped"
+
+	// OutputNotReferencedReason is the reason for dropping an output when it is not referenced by a pipeline
+	OutputNotReferencedReason status.ConditionReason = "OutputNotReferencedReason"
+)
+
+// DropUnreferencedOutputs removes unreferenced outputs from ClusterLogForwarder to support backwards compatibility with
+// previous versions that handled this scenario gracefully
+func DropUnreferencedOutputs(namespace, name string, spec loggingv1.ClusterLogForwarderSpec, logStore *loggingv1.LogStoreSpec, extras map[string]bool, logstoreSecretName, saTokenSecret string) (loggingv1.ClusterLogForwarderSpec, map[string]bool, []loggingv1.Condition) {
+	warnings := []loggingv1.Condition{}
+	outputRefs := sets.NewString()
+	for _, p := range spec.Pipelines {
+		outputRefs.Insert(p.OutputRefs...)
+	}
+	outputs := []loggingv1.OutputSpec{}
+	for _, o := range spec.Outputs {
+		if outputRefs.Has(o.Name) {
+			outputs = append(outputs, o)
+		} else {
+			warnings = append(warnings, loggingv1.NewCondition(OutputDroppedCondition, corev1.ConditionTrue, OutputNotReferencedReason, "%s not referenced by any pipeline and not used during evaluation", o.Name))
+		}
+	}
+	spec.Outputs = outputs
+	return spec, extras, warnings
+}

--- a/internal/migrations/clusterlogforwarder/drop_unreferenced_outputs_test.go
+++ b/internal/migrations/clusterlogforwarder/drop_unreferenced_outputs_test.go
@@ -1,0 +1,58 @@
+package clusterlogforwarder
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+)
+
+var _ = Describe("DropUnreferencedOutputs", func() {
+
+	var (
+		spec loggingv1.ClusterLogForwarderSpec
+	)
+
+	BeforeEach(func() {
+		spec = loggingv1.ClusterLogForwarderSpec{
+			Outputs: []loggingv1.OutputSpec{
+				{Name: "dropme"},
+				{Name: "foo"},
+			},
+			Pipelines: []loggingv1.PipelineSpec{
+				{OutputRefs: []string{"foo"}},
+			},
+		}
+	})
+
+	It("should drop outputs that are not referenced by any pipeline", func() {
+		result, _, conditions := DropUnreferencedOutputs("", "", spec, nil, nil, "", "")
+		Expect(result).To(Equal(loggingv1.ClusterLogForwarderSpec{
+			Outputs: []loggingv1.OutputSpec{
+				{Name: "foo"},
+			},
+			Pipelines: []loggingv1.PipelineSpec{
+				{OutputRefs: []string{"foo"}},
+			},
+		}))
+		Expect(conditions).To(HaveCondition(OutputDroppedCondition, true, OutputNotReferencedReason, ""))
+	})
+
+	It("should ignore outputs that are referenced by a pipeline", func() {
+		spec.Pipelines = append(spec.Pipelines, loggingv1.PipelineSpec{
+			OutputRefs: []string{"dropme"},
+		})
+		result, _, conditions := DropUnreferencedOutputs("", "", spec, nil, nil, "", "")
+		Expect(result).To(Equal(loggingv1.ClusterLogForwarderSpec{
+			Outputs: []loggingv1.OutputSpec{
+				{Name: "dropme"},
+				{Name: "foo"},
+			},
+			Pipelines: []loggingv1.PipelineSpec{
+				{OutputRefs: []string{"foo"}},
+				{OutputRefs: []string{"dropme"}},
+			},
+		}))
+		Expect(conditions).To(BeEmpty())
+	})
+})

--- a/internal/migrations/clusterlogforwarder/migrate_clusterlogforwarder.go
+++ b/internal/migrations/clusterlogforwarder/migrate_clusterlogforwarder.go
@@ -1,4 +1,4 @@
-package migrations
+package clusterlogforwarder
 
 import (
 	"fmt"
@@ -9,13 +9,13 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
 )
 
-func MigrateClusterLogForwarderSpec(namespace, name string, spec loggingv1.ClusterLogForwarderSpec, logStore *loggingv1.LogStoreSpec, extras map[string]bool, logstoreSecretName, saTokenSecret string) (loggingv1.ClusterLogForwarderSpec, map[string]bool) {
+func MigrateClusterLogForwarderSpec(namespace, name string, spec loggingv1.ClusterLogForwarderSpec, logStore *loggingv1.LogStoreSpec, extras map[string]bool, logstoreSecretName, saTokenSecret string) (loggingv1.ClusterLogForwarderSpec, map[string]bool, []loggingv1.Condition) {
 	spec, extras = migrateDefaultOutput(spec, logStore, extras, logstoreSecretName, saTokenSecret)
 	if namespace == constants.OpenshiftNS && name == constants.SingletonName {
 		spec.ServiceAccountName = constants.CollectorServiceAccountName
 	}
 	spec = migratePipelines(spec)
-	return spec, extras
+	return spec, extras, nil
 }
 
 func migratePipelines(spec loggingv1.ClusterLogForwarderSpec) loggingv1.ClusterLogForwarderSpec {

--- a/internal/migrations/clusterlogforwarder/migrate_clusterlogforwarder_test.go
+++ b/internal/migrations/clusterlogforwarder/migrate_clusterlogforwarder_test.go
@@ -1,4 +1,4 @@
-package migrations
+package clusterlogforwarder
 
 import (
 	"fmt"
@@ -38,8 +38,8 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 				},
 			}
 
-			out_spec, _ := MigrateClusterLogForwarderSpec("test-ns", "test-clf", in_spec, nil, map[string]bool{}, constants.CollectorName, constants.LogCollectorToken)
-			for i, pipeline := range out_spec.Pipelines {
+			out, _, _ := MigrateClusterLogForwarderSpec("test-ns", "test-clf", in_spec, nil, map[string]bool{}, constants.CollectorName, constants.LogCollectorToken)
+			for i, pipeline := range out.Pipelines {
 				Expect(pipeline.Name).To(Equal(fmt.Sprintf("pipeline_%v", i)))
 			}
 		})
@@ -85,14 +85,14 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 		})
 
 		It("should not add service account name if forwarder not named `instance` and not in `openshift-logging` namespace", func() {
-			forwarderSpec, extras := MigrateClusterLogForwarderSpec("test-ns", "test-clf", spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+			forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec("test-ns", "test-clf", spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 			Expect(forwarderSpec).To(Equal(spec))
 			Expect(extras).To(Equal(map[string]bool{}))
 		})
 
 		It("should not add the default OutputSpec when it is not referenced by a pipeline", func() {
 			// This is equal to returning (spec, nil) and will only pass if 2nd param is nil
-			forwarderSpec, extras := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+			forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 			spec.ServiceAccountName = constants.CollectorServiceAccountName
 			Expect(forwarderSpec).To(Equal(spec))
 			Expect(extras).To(Equal(map[string]bool{}))
@@ -100,7 +100,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 
 		It("should add the default OutputSpec when default logstore exists and spec is empty ", func() {
 			logstore = &logging.LogStoreSpec{Type: logging.OutputTypeElasticsearch}
-			forwarderSpec, extras := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, logging.ClusterLogForwarderSpec{}, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+			forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, logging.ClusterLogForwarderSpec{}, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 			Expect(forwarderSpec).To(Equal(
 				logging.ClusterLogForwarderSpec{
 					Pipelines: []logging.PipelineSpec{
@@ -125,7 +125,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 				},
 			}
 
-			spec, extras = MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, logging.ClusterLogForwarderSpec{}, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+			spec, extras, _ = MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, logging.ClusterLogForwarderSpec{}, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 
 			Expect(spec).To(Equal(
 				logging.ClusterLogForwarderSpec{
@@ -181,7 +181,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 				},
 			}
 
-			spec, extras = MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+			spec, extras, _ = MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 
 			Expect(spec).To(Equal(
 				logging.ClusterLogForwarderSpec{
@@ -228,7 +228,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 				})
 
 				It("should add the default OutputSpec", func() {
-					forwarderSpec, extras := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
 					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 				})
@@ -242,7 +242,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 					exp.Outputs[1].Elasticsearch = &logging.Elasticsearch{ElasticsearchStructuredSpec: *spec.OutputDefaults.Elasticsearch}
 					exp.OutputDefaults = spec.OutputDefaults
 
-					forwarderSpec, extras := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 
 					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
 					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
@@ -270,7 +270,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 					exp.Outputs = append(outputs, NewDefaultOutput(nil, constants.CollectorName))
 					exp.ServiceAccountName = constants.CollectorServiceAccountName
 
-					forwarderSpec, extras := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
 					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 				})
@@ -286,7 +286,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 					exp.Outputs = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: &esSpec.ElasticsearchStructuredSpec}, constants.CollectorName))
 					exp.ServiceAccountName = constants.CollectorServiceAccountName
 
-					forwarderSpec, extras := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
 					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 				})
@@ -313,7 +313,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 				})
 
 				It("should add the default OutputSpec", func() {
-					forwarderSpec, extras := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
 					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 				})
@@ -326,7 +326,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 					exp.Outputs[1].Elasticsearch = &logging.Elasticsearch{ElasticsearchStructuredSpec: *spec.OutputDefaults.Elasticsearch}
 					exp.OutputDefaults = spec.OutputDefaults
 
-					forwarderSpec, extras := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 
 					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
 					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
@@ -354,7 +354,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 					exp.Outputs = append(outputs, NewDefaultOutput(nil, constants.CollectorName))
 					exp.ServiceAccountName = constants.CollectorServiceAccountName
 
-					forwarderSpec, extras := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
 					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 				})
@@ -370,7 +370,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 					exp.Outputs = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: &esSpec.ElasticsearchStructuredSpec}, constants.CollectorName))
 					exp.ServiceAccountName = constants.CollectorServiceAccountName
 
-					forwarderSpec, extras := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
 					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 				})

--- a/internal/migrations/clusterlogforwarder/suite_test.go
+++ b/internal/migrations/clusterlogforwarder/suite_test.go
@@ -1,0 +1,13 @@
+package clusterlogforwarder_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][migrations][clusterlogforwarder] suite")
+}

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -205,6 +205,11 @@ func verifyInputs(spec *loggingv1.ClusterLogForwarderSpec, status *loggingv1.Clu
 }
 
 func verifyOutputs(namespace string, clfClient client.Client, spec *loggingv1.ClusterLogForwarderSpec, status *loggingv1.ClusterLogForwarderStatus, extras map[string]bool) {
+	outputRefs := sets.NewString()
+	for _, p := range spec.Pipelines {
+		outputRefs.Insert(p.OutputRefs...)
+	}
+
 	status.Outputs = loggingv1.NamedConditions{}
 	names := sets.NewString() // Collect pipeline names
 	for i, output := range spec.Outputs {
@@ -245,6 +250,8 @@ func verifyOutputs(namespace string, clfClient client.Client, spec *loggingv1.Cl
 					output.Name))
 		case output.HasPolicy() && output.GetMaxRecordsPerSecond() < 0:
 			status.Outputs.Set(output.Name, CondInvalid("output %q: Output cannot have negative limit threshold", output.Name))
+		case !outputRefs.Has(output.Name):
+			status.Outputs.Set(output.Name, CondInvalid("output %q: Output not referenced by any pipeline", output.Name))
 		default:
 			status.Outputs.Set(output.Name, condReady)
 		}

--- a/test/matchers/condition.go
+++ b/test/matchers/condition.go
@@ -1,0 +1,35 @@
+package matchers
+
+import (
+	//"fmt"
+	"github.com/onsi/gomega/types"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	corev1 "k8s.io/api/core/v1"
+	//"k8s.io/utils/diff"
+	//"reflect"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+// Match condition by type, status and reason if reason != "".
+// Also match messageRegex if it is not empty.
+func matchCondition(t logging.ConditionType, s bool, r logging.ConditionReason, messageRegex string) types.GomegaMatcher {
+	var status corev1.ConditionStatus
+	if s {
+		status = corev1.ConditionTrue
+	} else {
+		status = corev1.ConditionFalse
+	}
+	fields := Fields{"Type": Equal(t), "Status": Equal(status)}
+	if r != "" {
+		fields["Reason"] = Equal(r)
+	}
+	if messageRegex != "" {
+		fields["Message"] = MatchRegexp(messageRegex)
+	}
+	return MatchFields(IgnoreExtras, fields)
+}
+
+func HaveCondition(t logging.ConditionType, s bool, r logging.ConditionReason, messageRegex string) types.GomegaMatcher {
+	return ContainElement(matchCondition(t, s, r, messageRegex))
+}


### PR DESCRIPTION
### Description
This PR:
* Adds CLF migration to drop outputs which are not referenced by pipelines to be consistent with previous release
* Adds validation to reject CLF that have unreferenced outputs
* Adds CLF conditions identifying when an output is not considered during reconciliation
* Adds matchers for conditions into the test package

### Links
* https://issues.redhat.com/browse/LOG-4411
