### PR TITLE
LOG-4555: Show FluentD Buffer Usage in metrics dashboard instead of availability

### DIFF
--- a/files/dashboards/fluentd/openshift-logging-dashboard.json
+++ b/files/dashboards/fluentd/openshift-logging-dashboard.json
@@ -1400,7 +1400,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "100 - max by(plugin_id)(fluentd_output_status_buffer_available_space_ratio)",
+              "expr": "100 - min by(plugin_id)(fluentd_output_status_buffer_available_space_ratio)",
               "refId": "A"
             }
           ],
@@ -1408,7 +1408,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "FluentD Buffer Availability",
+          "title": "FluentD Buffer Usage",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

This PR:
* fixes that "FluentD Buffer Availability" can show us the buffer usage based on the most highest usage value.

If "fluentd_output_status_buffer_available_space_ratio" metrics returns 100 and 50, "max" aggregation operator(current) always show us 0%(100-100) buffer usage, not 50%(100-50) buffer usage. It's not helpful to detect collector pods in high buffer usage. So it should change it to "min" aggregation operator for showing us values based on the most highest usage of buffer.


### Links
N/A