### PR TITLE
LOG-4362: remove GroupLimit from flow control

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder_types.go
+++ b/apis/logging/v1/cluster_log_forwarder_types.go
@@ -164,10 +164,12 @@ type Application struct {
 
 	// Group limit applied to the aggregated log
 	// flow to this input. The total log flow from this input
-	// cannot exceed the limit.
+	// cannot exceed the limit. Unsupported
 	//
 	// +optional
-	GroupLimit *LimitSpec `json:"groupLimit,omitempty"`
+	// +docgen:ignore
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	GroupLimit *LimitSpec `json:"-"` //`json:"groupLimit,omitempty"`
 
 	// Container limit applied to each container selected
 	// by this input. No container selected by this input can

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -269,17 +269,6 @@ spec:
                               format: int64
                               type: integer
                           type: object
-                        groupLimit:
-                          description: Group limit applied to the aggregated log flow
-                            to this input. The total log flow from this input cannot
-                            exceed the limit.
-                          properties:
-                            maxRecordsPerSecond:
-                              description: MaxRecordsPerSecond is the maximum number
-                                of log records allowed per input/output in a pipeline
-                              format: int64
-                              type: integer
-                          type: object
                         namespaces:
                           description: Namespaces from which to collect application
                             logs. Only messages from these namespaces are collected.

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -270,17 +270,6 @@ spec:
                               format: int64
                               type: integer
                           type: object
-                        groupLimit:
-                          description: Group limit applied to the aggregated log flow
-                            to this input. The total log flow from this input cannot
-                            exceed the limit.
-                          properties:
-                            maxRecordsPerSecond:
-                              description: MaxRecordsPerSecond is the maximum number
-                                of log records allowed per input/output in a pipeline
-                              format: int64
-                              type: integer
-                          type: object
                         namespaces:
                           description: Namespaces from which to collect application
                             logs. Only messages from these namespaces are collected.

--- a/docs/reference/operator/api.adoc
+++ b/docs/reference/operator/api.adoc
@@ -95,25 +95,11 @@ All conditions in the selector must be satisfied (logical AND) to select logs.
 |Property|Type|Description
 
 |containerLimit|object|  *(optional)* Container limit applied to each container selected
-|groupLimit|object|  *(optional)* Group limit applied to the aggregated log
 |namespaces|array|  *(optional)* Namespaces from which to collect application logs.
 |selector|object|  *(optional)* Selector for logs from pods with matching labels.
 |======================
 
 === .spec.inputs[].application.containerLimit
-===== Description
-
-=====  Type
-* object
-
-[options="header"]
-|======================
-|Property|Type|Description
-
-|maxRecordsPerSecond|int|  MaxRecordsPerSecond is the maximum number of log records
-|======================
-
-=== .spec.inputs[].application.groupLimit
 ===== Description
 
 =====  Type

--- a/test/e2e/flowcontrol/flowcontrol_test.go
+++ b/test/e2e/flowcontrol/flowcontrol_test.go
@@ -93,8 +93,8 @@ var _ = Describe("[E2E] FlowControl", func() {
 				Name: "custom-app-0",
 				Application: &loggingv1.Application{
 					Namespaces: []string{stressorNS},
-					GroupLimit: &loggingv1.LimitSpec{
-						MaxRecordsPerSecond: 100,
+					ContainerLimit: &loggingv1.LimitSpec{
+						MaxRecordsPerSecond: 50,
 					}, // 10 files and 100 group limit, so 10 lines per file,
 				},
 			},
@@ -103,7 +103,7 @@ var _ = Describe("[E2E] FlowControl", func() {
 				Application: &loggingv1.Application{
 					Namespaces: []string{stressorNS},
 					ContainerLimit: &loggingv1.LimitSpec{
-						MaxRecordsPerSecond: 100,
+						MaxRecordsPerSecond: 50,
 					}, // 10 files and 100 group limit, so 10 lines per file,
 				},
 			},
@@ -156,7 +156,7 @@ var _ = Describe("[E2E] FlowControl", func() {
 		time.Sleep(30 * time.Second)
 
 		promQuery = fmt.Sprintf(VectorCompSentEvents, "group-policy-at-application")
-		ExpectMetricsWithinRange(GetCollectorMetrics(promQuery), 0, 102)
+		ExpectMetricsWithinRange(GetCollectorMetrics(promQuery), 0, 0)
 
 		promQuery = fmt.Sprintf(SumMetric, VectorCompSentEvents)
 		promQuery = fmt.Sprintf(promQuery, "container-policy-at-application") // Max number of logs allowed per second is 10 * 100 lines/sec
@@ -171,7 +171,11 @@ var _ = Describe("[E2E] FlowControl", func() {
 			{
 				Name: "custom-app-2",
 				Application: &loggingv1.Application{
-					GroupLimit: &loggingv1.LimitSpec{
+					//LOG-4362
+					//GroupLimit: &loggingv1.LimitSpec{
+					//	MaxRecordsPerSecond: 200,
+					//},
+					ContainerLimit: &loggingv1.LimitSpec{
 						MaxRecordsPerSecond: 200,
 					},
 				},

--- a/test/functional/flowcontrol/application_test.go
+++ b/test/functional/flowcontrol/application_test.go
@@ -24,7 +24,7 @@ var _ = Describe("[Functional][FlowControl] Policies at Input", func() {
 		f *functional.CollectorFunctionalFramework
 		l *loki.Receiver
 	)
-	appLabels := map[string]string{"name": "app1", "env": "env1"}
+	//appLabels := map[string]string{"name": "app1", "env": "env1"}
 
 	BeforeEach(func() {
 		f = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
@@ -89,47 +89,48 @@ var _ = Describe("[Functional][FlowControl] Policies at Input", func() {
 			})
 		})
 	})
-	Describe("when Source is Application", func() {
-		Describe("rate limiting logs by label selector", func() {
-			It("applying policy at group level", func() {
-				if testfw.LogCollectionType == logging.LogCollectionTypeFluentd {
-					Skip("Skipping test since flow-control is not supported with fluentd")
-				}
-				f.Labels = map[string]string{
-					"name": "app1",
-					"env":  "env1",
-				}
-				f.Forwarder.Spec.Inputs[0].Application.Selector = &logging.LabelSelector{
-					MatchLabels: appLabels,
-				}
-
-				f.Forwarder.Spec.Inputs[0].Application.GroupLimit = &logging.LimitSpec{
-					MaxRecordsPerSecond: 10,
-				}
-
-				Expect(f.Deploy()).To(BeNil())
-				Expect(f.WritesApplicationLogsWithDelay(1000, 0.0001)).To(Succeed())
-
-				r, err := l.QueryUntil(fmt.Sprintf(LokiNsQuery, AllLogs), "", 10)
-				Expect(err).To(BeNil())
-
-				totalRecords := 0
-				for _, record := range r[0].Records() {
-					record = record["kubernetes"].(map[string]interface{})["labels"].(map[string]interface{})
-					Expect(record["name"].(string) == "app1").To(BeTrue())
-					Expect(record["env"].(string) == "env1").To(BeTrue())
-					totalRecords++
-				}
-				Expect(totalRecords >= 10).To(BeTrue())
-				Expect(totalRecords <= 15).To(BeTrue())
-
-				r, err = l.Query(fmt.Sprintf(LokiNsQuery, AllLogs), "", 40)
-				Expect(err).To(BeNil())
-				Expect(len(r[0].Records()) >= 10).To(BeTrue())
-				Expect(len(r[0].Records()) <= 15).To(BeTrue())
-
-			})
-		})
-	})
+	// TODO: L0G-4362 Re-Enable group limit
+	//Describe("when Source is Application", func() {
+	//	Describe("rate limiting logs by label selector", func() {
+	//		It("applying policy at group level", func() {
+	//			if testfw.LogCollectionType == logging.LogCollectionTypeFluentd {
+	//				Skip("Skipping test since flow-control is not supported with fluentd")
+	//			}
+	//			f.Labels = map[string]string{
+	//				"name": "app1",
+	//				"env":  "env1",
+	//			}
+	//			f.Forwarder.Spec.Inputs[0].Application.Selector = &logging.LabelSelector{
+	//				MatchLabels: appLabels,
+	//			}
+	//
+	//			f.Forwarder.Spec.Inputs[0].Application.GroupLimit = &logging.LimitSpec{
+	//				MaxRecordsPerSecond: 10,
+	//			}
+	//
+	//			Expect(f.Deploy()).To(BeNil())
+	//			Expect(f.WritesApplicationLogsWithDelay(1000, 0.0001)).To(Succeed())
+	//
+	//			r, err := l.QueryUntil(fmt.Sprintf(LokiNsQuery, AllLogs), "", 10)
+	//			Expect(err).To(BeNil())
+	//
+	//			totalRecords := 0
+	//			for _, record := range r[0].Records() {
+	//				record = record["kubernetes"].(map[string]interface{})["labels"].(map[string]interface{})
+	//				Expect(record["name"].(string) == "app1").To(BeTrue())
+	//				Expect(record["env"].(string) == "env1").To(BeTrue())
+	//				totalRecords++
+	//			}
+	//			Expect(totalRecords >= 10).To(BeTrue())
+	//			Expect(totalRecords <= 15).To(BeTrue())
+	//
+	//			r, err = l.Query(fmt.Sprintf(LokiNsQuery, AllLogs), "", 40)
+	//			Expect(err).To(BeNil())
+	//			Expect(len(r[0].Records()) >= 10).To(BeTrue())
+	//			Expect(len(r[0].Records()) <= 15).To(BeTrue())
+	//
+	//		})
+	//	})
+	//})
 
 })


### PR DESCRIPTION
### Description
This PR drops support of GroupLimit in the flow control epic by:
* disabling JSON serialization of the field
* removing it from the CRD and generated API docs

GroupLimit applies per instance of the collector so it can be misleading from an API perspective.  We agreed we need to revisit how to convey applying it to a group of pods that may be dispersed across several nodes.  Leaving the implementation to facilitate future corrections

### Links
* https://issues.redhat.com/browse/LOG-4362

cc @alanconway 