### PR TITLE
LOG-4556: Enable vector API and CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,10 +273,11 @@ test-functional-vector: test-functional-benchmarker-vector
 		./test/functional/outputs/cloudwatch/... \
 		./test/functional/outputs/loki/... \
 		./test/functional/outputs/http/... \
-		./test/functional/normalization \
 		./test/functional/outputs/syslog/... \
+		./test/functional/normalization \
 		./test/functional/flowcontrol/... \
 		./test/functional/inputs/http/... \
+		./test/functional/misc/... \
 		-ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
 
 .PHONY: test-forwarder-generator

--- a/internal/generator/vector/conf_test/complex.toml
+++ b/internal/generator/vector/conf_test/complex.toml
@@ -1,5 +1,8 @@
 expire_metrics_secs = 60
 
+[api]
+enabled = true
+
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"

--- a/internal/generator/vector/conf_test/complex_custom_data_dir.toml
+++ b/internal/generator/vector/conf_test/complex_custom_data_dir.toml
@@ -1,6 +1,8 @@
 expire_metrics_secs = 60
 data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
 
+[api]
+enabled = true
 
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]

--- a/internal/generator/vector/conf_test/complex_es_no_ver.toml
+++ b/internal/generator/vector/conf_test/complex_es_no_ver.toml
@@ -1,5 +1,8 @@
 expire_metrics_secs = 60
 
+[api]
+enabled = true
+
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"

--- a/internal/generator/vector/conf_test/complex_es_v6.toml
+++ b/internal/generator/vector/conf_test/complex_es_v6.toml
@@ -1,5 +1,8 @@
 expire_metrics_secs = 60
 
+[api]
+enabled = true
+
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"

--- a/internal/generator/vector/conf_test/complex_otel.toml
+++ b/internal/generator/vector/conf_test/complex_otel.toml
@@ -1,5 +1,8 @@
 expire_metrics_secs = 60
 
+[api]
+enabled = true
+
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"

--- a/internal/generator/vector/conf_test/es_pipeline_w_spaces.toml
+++ b/internal/generator/vector/conf_test/es_pipeline_w_spaces.toml
@@ -1,5 +1,8 @@
 expire_metrics_secs = 60
 
+[api]
+enabled = true
+
 # Logs from containers (including openshift containers)
 [sources.raw_container_logs]
 type = "kubernetes_logs"

--- a/internal/generator/vector/global.go
+++ b/internal/generator/vector/global.go
@@ -31,9 +31,12 @@ func (g GlobalOptions) Template() string {
 	return `
 {{define "` + g.Name() + `" -}}
 expire_metrics_secs = {{.ExpireMetricsSecs}}
-{{ if .DataDir}} 
+{{ if .DataDir}}
 data_dir = "{{.DataDir}}"
 {{end}}
+
+[api]
+enabled = true
 {{end}}
 `
 }

--- a/test/functional/inputs/http/http_input_test.go
+++ b/test/functional/inputs/http/http_input_test.go
@@ -67,7 +67,7 @@ var _ = Describe("[Functional][Inputs][Http] Functional tests", func() {
 		Expect(testfw.LogCollectionType).To(Equal(logging.LogCollectionTypeVector))
 		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
 		framework.VisitConfig = func(conf string) string {
-			return strings.Replace(conf, "enabled = true", "enabled = false", 1) // turn off TLS for testing
+			return strings.Replace(conf, "enabled = true", "enabled = false", 2) // turn off TLS for testing
 		}
 		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
 			FromInputWithVisitor(httpInputName,

--- a/test/functional/misc/suite_test.go
+++ b/test/functional/misc/suite_test.go
@@ -1,0 +1,13 @@
+package misc
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogForwarding(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[Functional][Misc] Suite")
+}

--- a/test/functional/misc/vector_api_cli_test.go
+++ b/test/functional/misc/vector_api_cli_test.go
@@ -1,0 +1,39 @@
+// go:build !fluentd
+package misc
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	testfw "github.com/openshift/cluster-logging-operator/test/functional"
+)
+
+var _ = Describe("[Functional][Misc][API_CLI] Functional test", func() {
+
+	if testfw.LogCollectionType != logging.LogCollectionTypeVector {
+		defer GinkgoRecover()
+		Skip("skip for non-vector")
+	}
+
+	var framework *functional.CollectorFunctionalFramework
+
+	BeforeEach(func() {
+		Expect(testfw.LogCollectionType).To(Equal(logging.LogCollectionTypeVector))
+		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
+		functional.NewClusterLogForwarderBuilder(framework.Forwarder).FromInput(logging.InputNameInfrastructure).ToHttpOutput()
+	})
+
+	AfterEach(func() {
+		framework.Cleanup()
+	})
+
+	Context("invoking vector CLI commands that talk to the vector API", func() {
+		It("should work", func() {
+			Expect(framework.Deploy()).To(BeNil())
+			out, _ := framework.RunCommand(constants.CollectorName, `curl`, `-sv`, `-m`, `5`, `--connect-timeout`, `3`, `http://127.0.0.1:8686/health`)
+			Expect(out).To(ContainSubstring(`{"ok":true}`))
+		})
+	})
+})


### PR DESCRIPTION
### Description

Enables vector GraphQL API for the vector CLI to work against a running vector instance, to improve ergonomics of troubleshooting.

/cc @cahartma
/assign @jcantrill

### Links
- Depending on PR(s): https://github.com/ViaQ/vector/pull/152
- JIRA: 
https://issues.redhat.com/browse/LOG-4556
https://issues.redhat.com/browse/OBSDA-482