### PR TITLE
Fix pod logs path filter, to read uncompressed rotated file by kubectl

### DIFF
--- a/internal/generator/fluentd/sources.go
+++ b/internal/generator/fluentd/sources.go
@@ -101,7 +101,7 @@ func LogSources(spec *logging.ClusterLogForwarderSpec, tunings *logging.FluentdI
 }
 
 func ContainerLogPaths() string {
-	return fmt.Sprintf("%q", "/var/log/pods/*/*/*.log")
+	return fmt.Sprintf("%q", "/var/log/pods/*/*/*.log,/var/log/pods/*/*/*.log*")
 }
 
 func ExcludeContainerPaths(namespace string) string {


### PR DESCRIPTION
### Description

The intention of this pull request is to solve github issue 2175, so that fluent.conf can read all uncompressed rotated log files.


/cc @jcantrill 
/assign @vimalk78 

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Github issue: https://github.com/openshift/cluster-logging-operator/issues/2175

