### PR TITLE
LOG-3651: Add ability to change the Splunk's index within the ClusterLogForwarder

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -276,6 +276,12 @@ type Splunk struct {
 	// Should be a valid JSON object
 	// +optional
 	Fields []string `json:"fields,omitempty"`
+
+	// https://vector.dev/docs/reference/configuration/sinks/splunk_hec_logs/#index
+	// The name of the index to send events to.
+	// If not specified, the default index defined within Splunk is used.
+	// +optional
+	Index string `json:"index,omitempty"`
 }
 
 // Http provided configuration for sending json encoded logs to a generic http endpoint.

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -612,6 +612,11 @@ spec:
                           items:
                             type: string
                           type: array
+                        index:
+                          description: https://vector.dev/docs/reference/configuration/sinks/splunk_hec_logs/#index
+                            The name of the index to send events to. If not specified,
+                            the default index defined within Splunk is used.
+                          type: string
                       type: object
                     syslog:
                       description: Syslog provides optional extra properties for output

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -613,6 +613,11 @@ spec:
                           items:
                             type: string
                           type: array
+                        index:
+                          description: https://vector.dev/docs/reference/configuration/sinks/splunk_hec_logs/#index
+                            The name of the index to send events to. If not specified,
+                            the default index defined within Splunk is used.
+                          type: string
                       type: object
                     syslog:
                       description: Syslog provides optional extra properties for output

--- a/docs/features/logforwarding/outputs/splunk-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/splunk-forwarding.adoc
@@ -57,3 +57,42 @@ spec:
         - splunk-receiver
 ----
 +
+
+. To customize the index where you send events to in Splunk, you  need to configure it in your log forwarding configuration (If not specified, the default index defined within Splunk is used.):
++
+----
+ oc apply -f cluster-log-forwarder.yaml
+----
++
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+kind: ClusterLogForwarder
+apiVersion: logging.openshift.io/v1
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  outputs:
+    - name: splunk-receiver
+      type: splunk
+      splunk:
+       index: "my_index"
+      secret:
+        name: splunk-secret
+      url: 'http://example-splunk-hec-service:8088'
+  pipelines:
+    - name: my-logs
+      inputRefs:
+        - application
+        - infrastructure
+      outputRefs:
+        - splunk-receiver
+----
+
+NOTE:  _Index_ parameter supports https://vector.dev/docs/reference/configuration/template-syntax/[Vector's template syntax], which enables you to use dynamic per-event values.
+For example, you can use Kubernetes Namespace in index names:
+[source,yaml]
+----
+index: "{{.kubernetes.namespace_name}}_index"
+----

--- a/internal/generator/vector/output/splunk/splunk_test.go
+++ b/internal/generator/vector/output/splunk/splunk_test.go
@@ -83,6 +83,25 @@ when_full = "drop_newest"
 [sinks.splunk_hec.request]
 retry_attempts = 17
 `
+		splunkSinkCustomIndex = splunkDedot + `
+[sinks.splunk_hec]
+type = "splunk_hec_logs"
+inputs = ["splunk_hec_dedot"]
+endpoint = "https://splunk-web:8088/endpoint"
+compression = "none"
+default_token = ""
+timestamp_key = "@timestamp"
+index = "thanos{{.supervillain}}"
+[sinks.splunk_hec.encoding]
+codec = "json"
+
+[sinks.splunk_hec.buffer]
+when_full = "drop_newest"
+
+[sinks.splunk_hec.request]
+retry_attempts = 17
+`
+
 		splunkSinkTls = splunkDedot + `
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
@@ -187,6 +206,17 @@ key_pass = "junk"
 			},
 		}
 
+		outputCustomIndex = loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeSplunk,
+			Name: "splunk_hec",
+			URL:  "https://splunk-web:8088/endpoint",
+			OutputTypeSpec: loggingv1.OutputTypeSpec{
+				Splunk: &loggingv1.Splunk{
+					Index: "thanos{{.supervillain}}",
+				},
+			},
+		}
+
 		outputWithPassphrase = loggingv1.OutputSpec{
 			Type: loggingv1.OutputTypeSplunk,
 			Name: "splunk_hec",
@@ -273,6 +303,13 @@ key_pass = "junk"
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(splunkSink))
+		})
+
+		It("should provide a valid config with custom index", func() {
+			element := Conf(outputCustomIndex, []string{"pipelineName"}, nil, nil)
+			results, err := g.GenerateConf(element...)
+			Expect(err).To(BeNil())
+			Expect(results).To(EqualTrimLines(splunkSinkCustomIndex))
 		})
 
 		It("should provide a valid config with passphrase", func() {


### PR DESCRIPTION
### Description
This PR adds the ability to change the Splunk's `index` within the `ClusterLogForwarder` for Vector collector.

Example of `ClusterLogForwarder` configuration: 
```
kind: ClusterLogForwarder
apiVersion: logging.openshift.io/v1
metadata:
  name: instance
  namespace: openshift-logging
spec:
  outputs:
    - name: splunk-receiver
      type: splunk
      splunk:
       index: "my_index"
      secret:
        name: splunk-secret
      url: 'http://example-splunk-hec-service:8088'
  pipelines:
    - name: my-logs
      inputRefs:
        - application
        - infrastructure
      outputRefs:
        - splunk-receiver 
```

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
