### PR TITLE
LOG-4537: Collector pods stuck in ContainerCreating state when receiver.http is enabled in CLF

### DIFF
--- a/internal/k8s/loader/load.go
+++ b/internal/k8s/loader/load.go
@@ -63,6 +63,7 @@ func FetchClusterLogForwarder(k8sClient client.Client, namespace, name string, i
 	forwarder.Spec, extras = migrations.MigrateClusterLogForwarderSpec(namespace, name, forwarder.Spec, fetchClusterLogging().Spec.LogStore, extras, internalLogStoreSecret, saTokenSecret)
 
 	extras[constants.ClusterLoggingAvailable] = (fetchClusterLogging().Name != "")
+	extras[constants.VectorName] = (fetchClusterLogging().Spec.Collection.Type == logging.LogCollectionTypeVector)
 	if err, status = clusterlogforwarder.Validate(forwarder, k8sClient, extras); err != nil {
 		return forwarder, err, status
 	}


### PR DESCRIPTION
### Description

Added a CLF validation step to prevent deployment of HTTP Receivers with fluentd. The following diagnostic is produced:

```
$ oc -n openshift-logging get clf/instance -oyaml
apiVersion: logging.openshift.io/v1
kind: ClusterLogForwarder
status:
  inputs:
    http-input:
    - lastTransitionTime: "2023-09-25T21:56:15Z"
      message: ReceiverSpecs are only supported for the vector log collector
      reason: Invalid
      status: "False"
      type: Ready
```

/cc @cahartma 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4537

