### PR TITLE
LOG-4559: fix writing to default lokistack with Fluentd collector

### DIFF
--- a/internal/generator/fluentd/output/loki/loki_conf_test.go
+++ b/internal/generator/fluentd/output/loki/loki_conf_test.go
@@ -1,6 +1,7 @@
 package loki
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
 	"sort"
 	"testing"
 
@@ -294,6 +295,74 @@ var _ = Describe("[internal][generator][fluentd][output][loki] #Conf", func() {
     <buffer>
       @type file
       path '/var/lib/fluentd/loki_receiver'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+</label>
+`,
+		}),
+		Entry("in same cluster (default loki)", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type: logging.OutputTypeLoki,
+						Name: lokistack.FormatOutputNameFromInput(logging.InputNameApplication),
+						URL:  "http://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application",
+					},
+				},
+			},
+			ExpectedConf: `
+<label @DEFAULT_LOKI_APPS>
+  #dedot namespace_labels and rebuild message field if present
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_, _dummy3_
+  </filter>
+  
+ <filter **>
+    @type record_modifier
+    <record>
+      _kubernetes_container_name ${record.dig("kubernetes","container_name")}
+      _kubernetes_host "#{ENV['NODE_NAME']}"
+      _kubernetes_namespace_name ${record.dig("kubernetes","namespace_name")}
+      _kubernetes_pod_name ${record.dig("kubernetes","pod_name")}
+      _log_type ${record.dig("log_type")}
+    </record>
+  </filter>
+  
+  <match **>
+    @type loki
+    @id default_loki_apps
+    line_format json
+    url http://lokistack-dev-gateway-http.openshift-logging.svc:8080/api/logs/v1/application
+    ca_cert /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+    bearer_token_file /var/run/secrets/kubernetes.io/serviceaccount/token
+    <label>
+      kubernetes_container_name _kubernetes_container_name
+      kubernetes_host _kubernetes_host
+      kubernetes_namespace_name _kubernetes_namespace_name
+      kubernetes_pod_name _kubernetes_pod_name
+      log_type _log_type
+    </label>
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/default_loki_apps'
       flush_mode interval
       flush_interval 1s
       flush_thread_count 2


### PR DESCRIPTION
### Description
This PR fixes writing to the default LokiStack `Fluentd` collector, by set CA from `logcollector` `ServiceAccount`
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @jcantrill <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4559
- Enhancement proposal:
