### PR TITLE
WIP:LOG-4508: don't propagate Fluentd Pod status if it's empty

### DIFF
--- a/apis/logging/v1/clusterlogging_types.go
+++ b/apis/logging/v1/clusterlogging_types.go
@@ -86,8 +86,9 @@ type ClusterLoggingStatus struct {
 
 	// Deprecated.
 	// +optional
+	// +nullable
 	// +deprecated
-	Collection CollectionStatus `json:"collection"`
+	Collection CollectionStatus `json:"collection,omitempty"`
 
 	// +optional
 	Curation CurationStatus `json:"curation"`
@@ -598,7 +599,6 @@ type FluentdCollectorStatus struct {
 	// +optional
 	Nodes map[string]string `json:"nodes,omitempty"`
 	// +optional
-	//+operator-sdk:csv:customresourcedefinitions:type=status,displayName="Fluentd status",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podStatuses"}
 	Pods PodStateMap `json:"pods,omitempty"`
 	// +optional
 	Conditions map[string]ClusterConditions `json:"clusterCondition,omitempty"`

--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -326,11 +326,6 @@ spec:
         path: visualization.tolerations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Toleration
-      statusDescriptors:
-      - displayName: Fluentd status
-        path: collection.logs.fluentdStatus.pods
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v1
   description: |-
     # Red Hat OpenShift Logging

--- a/bundle/manifests/logging.openshift.io_clusterloggings.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterloggings.yaml
@@ -1031,6 +1031,7 @@ spec:
             properties:
               collection:
                 description: Deprecated.
+                nullable: true
                 properties:
                   logs:
                     properties:

--- a/config/crd/bases/logging.openshift.io_clusterloggings.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterloggings.yaml
@@ -1027,6 +1027,7 @@ spec:
             properties:
               collection:
                 description: Deprecated.
+                nullable: true
                 properties:
                   logs:
                     properties:

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -241,11 +241,6 @@ spec:
         path: visualization.tolerations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Toleration
-      statusDescriptors:
-      - displayName: Fluentd status
-        path: collection.logs.fluentdStatus.pods
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v1
   description: |-
     # Red Hat OpenShift Logging


### PR DESCRIPTION
### Description
This pull request addresses the processing of the `Fluentd` Collector pod status by making the following change:
- adds a `+nullable` annotation to the `CollectionStatus` field to prevent propagation if it is empty

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4508
- Enhancement proposal:
