### PR TITLE
LOG-3949: Vector not releasing deleted file handles

### DIFF
--- a/internal/generator/vector/conf_test/complex.toml
+++ b/internal/generator/vector/conf_test/complex.toml
@@ -16,6 +16,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"

--- a/internal/generator/vector/conf_test/complex_custom_data_dir.toml
+++ b/internal/generator/vector/conf_test/complex_custom_data_dir.toml
@@ -17,6 +17,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"

--- a/internal/generator/vector/conf_test/complex_es_no_ver.toml
+++ b/internal/generator/vector/conf_test/complex_es_no_ver.toml
@@ -16,6 +16,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"

--- a/internal/generator/vector/conf_test/complex_es_v6.toml
+++ b/internal/generator/vector/conf_test/complex_es_v6.toml
@@ -16,6 +16,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"

--- a/internal/generator/vector/conf_test/complex_otel.toml
+++ b/internal/generator/vector/conf_test/complex_otel.toml
@@ -16,6 +16,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"

--- a/internal/generator/vector/conf_test/es_pipeline_w_spaces.toml
+++ b/internal/generator/vector/conf_test/es_pipeline_w_spaces.toml
@@ -16,6 +16,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -29,5 +29,6 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 {{end}}`
 }

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -43,6 +43,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 `,
 		}),
 		Entry("Only Infrastructure", helpers.ConfGenerateTest{
@@ -71,6 +72,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -147,6 +149,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"


### PR DESCRIPTION
### Description

For the kubernetes_logs vector source, override the (very large) default for the newly introduced rotate_wait_ms variable.

/cc @cahartma 
/assign @jcantrill 

- PRs: https://github.com/ViaQ/vector/pull/154 // needs this to merge first
- JIRA: https://issues.redhat.com/browse/LOG-3949
