### PR TITLE
LOG-4383: resolve conflict between outputs and pipelines name

### DIFF
--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -2765,6 +2765,1147 @@ var _ = Describe("Generating fluentd config", func() {
 	})
 
 	It("should produce well formed fluent.conf", func() {
+		forwarder = &logging.ClusterLogForwarderSpec{
+			Outputs: []logging.OutputSpec{
+				{
+					Type:   logging.OutputTypeElasticsearch,
+					Name:   "infra-es",
+					URL:    "https://es.svc.infra.cluster:9999",
+					Secret: &logging.OutputSecretSpec{Name: "my-infra-secret"},
+				},
+				{
+					Type:   logging.OutputTypeElasticsearch,
+					Name:   "apps-es-1",
+					URL:    "https://es.svc.messaging.cluster.local:9654",
+					Secret: &logging.OutputSecretSpec{Name: "my-es-secret"},
+				},
+				{
+					Type: logging.OutputTypeElasticsearch,
+					Name: "apps-es-46",
+					URL:  "https://es.svc.messaging.cluster.local2:9654",
+					Secret: &logging.OutputSecretSpec{
+						Name: "my-other-secret",
+					},
+				},
+				{
+					Type: logging.OutputTypeElasticsearch,
+					Name: "audit-es",
+					URL:  "https://es.svc.audit.cluster:9654",
+					Secret: &logging.OutputSecretSpec{
+						Name: "my-audit-secret",
+					},
+				},
+			},
+			Pipelines: []logging.PipelineSpec{
+				{
+					Name:       "infra-es",
+					InputRefs:  []string{logging.InputNameInfrastructure},
+					OutputRefs: []string{"infra-es"},
+				},
+				{
+					Name:       "apps-es-46",
+					InputRefs:  []string{logging.InputNameApplication},
+					OutputRefs: []string{"apps-es-1", "apps-es-46"},
+				},
+				{
+					Name:       "audit-pipeline",
+					InputRefs:  []string{logging.InputNameAudit},
+					OutputRefs: []string{"audit-es"},
+				},
+			},
+		}
+		secret = corev1.Secret{
+			Data: map[string][]byte{
+				"tls.key":       []byte(""),
+				"tls.crt":       []byte(""),
+				"ca-bundle.crt": []byte(""),
+			},
+		}
+		secrets = map[string]*corev1.Secret{
+			"infra-es":   &secret,
+			"apps-es-1":  &secret,
+			"apps-es-46": &secret,
+			"audit-es":   &secret,
+		}
+		c := generator.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, op))
+		results, err := g.GenerateConf(c...)
+		Expect(err).To(BeNil())
+		Expect(results).To(EqualTrimLines(`
+## CLO GENERATED CONFIGURATION ###
+# This file is a copy of the fluentd configuration entrypoint
+# which should normally be supplied in a configmap.
+
+<system>
+  log_level "#{ENV['LOG_LEVEL'] || 'warn'}"
+</system>
+
+# Prometheus Monitoring
+<source>
+  @type prometheus
+  bind "#{ENV['PROM_BIND_IP']}"
+  <transport tls>
+    cert_path /etc/collector/metrics/tls.crt
+    private_key_path /etc/collector/metrics/tls.key
+    min_version TLS1_2
+    max_version TLS1_3
+    ciphers TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+  </transport>
+</source>
+
+<source>
+  @type prometheus_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
+
+# excluding prometheus_tail_monitor
+# since it leaks namespace/pod info
+# via file paths
+
+# tail_monitor plugin which publishes log_collected_bytes_total
+<source>
+  @type collected_tail_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
+
+# This is considered experimental by the repo
+<source>
+  @type prometheus_output_monitor
+  <labels>
+    hostname ${hostname}
+  </labels>
+</source>
+
+# Logs from linux journal
+<source>
+  @type systemd
+  @id systemd-input
+  @label @INGRESS
+  path '/var/log/journal'
+  <storage>
+    @type local
+    persistent true
+    # NOTE: if this does not end in .json, fluentd will think it
+    # is the name of a directory - see fluentd storage_local.rb
+    path '/var/lib/fluentd/pos/journal_pos.json'
+  </storage>
+  matches "#{ENV['JOURNAL_FILTERS_JSON'] || '[]'}"
+  tag journal
+  read_from_head "#{if (val = ENV.fetch('JOURNAL_READ_FROM_HEAD','')) && (val.length > 0); val; else 'false'; end}"
+</source>
+
+# Logs from containers (including openshift containers)
+<source>
+  @type tail
+  @id container-input
+  path "/var/log/pods/*/*/*.log"
+  exclude_path ["/var/log/pods/openshift-logging_collector-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]
+  pos_file "/var/lib/fluentd/pos/es-containers.log.pos"
+  follow_inodes true
+  refresh_interval 5
+  rotate_wait 5
+  tag kubernetes.*
+  read_from_head "true"
+  skip_refresh_on_startup true
+  @label @CONCAT
+  <parse>
+    @type regexp
+    expression /^(?<@timestamp>[^\s]+) (?<stream>stdout|stderr) (?<logtag>[F|P]) (?<message>.*)$/
+    time_key '@timestamp'
+    keep_time_key true
+  </parse>
+</source>
+
+# linux audit logs
+<source>
+  @type tail
+  @id audit-input
+  @label @INGRESS
+  path "/var/log/audit/audit.log"
+  pos_file "/var/lib/fluentd/pos/audit.log.pos"
+  follow_inodes true
+  tag linux-audit.log
+  <parse>
+    @type viaq_host_audit
+  </parse>
+</source>
+
+# k8s audit logs
+<source>
+  @type tail
+  @id k8s-audit-input
+  @label @INGRESS
+  path "/var/log/kube-apiserver/audit.log"
+  pos_file "/var/lib/fluentd/pos/kube-apiserver.audit.log.pos"
+  follow_inodes true
+  tag k8s-audit.log
+  <parse>
+    @type json
+    time_key requestReceivedTimestamp
+    # In case folks want to parse based on the requestReceivedTimestamp key
+    keep_time_key true
+    time_format %Y-%m-%dT%H:%M:%S.%N%z
+  </parse>
+</source>
+
+# Openshift audit logs
+<source>
+  @type tail
+  @id openshift-audit-input
+  @label @INGRESS
+  path /var/log/oauth-apiserver/audit.log,/var/log/openshift-apiserver/audit.log,/var/log/oauth-server/audit.log
+  pos_file /var/lib/fluentd/pos/oauth-apiserver.audit.log
+  follow_inodes true
+  tag openshift-audit.log
+  <parse>
+    @type json
+    time_key requestReceivedTimestamp
+    # In case folks want to parse based on the requestReceivedTimestamp key
+    keep_time_key true
+    time_format %Y-%m-%dT%H:%M:%S.%N%z
+  </parse>
+</source>
+
+# Openshift Virtual Network (OVN) audit logs
+<source>
+  @type tail
+  @id ovn-audit-input
+  @label @INGRESS
+  path "/var/log/ovn/acl-audit-log.log"
+  pos_file "/var/lib/fluentd/pos/acl-audit-log.pos"
+  follow_inodes true
+  tag ovn-audit.log
+  refresh_interval 5
+  rotate_wait 5
+  read_from_head true
+  <parse>
+    @type none
+  </parse>
+</source>
+
+# Concat log lines of container logs, and send to INGRESS pipeline
+<label @CONCAT>
+  <filter kubernetes.**>
+    @type concat
+    key message
+    partial_key logtag
+    partial_value P
+    separator ''
+  </filter>
+  
+  <match kubernetes.**>
+    @type relabel
+    @label @INGRESS
+  </match>
+</label>
+
+# Ingress pipeline
+<label @INGRESS>
+  # Filter out PRIORITY from journal logs
+  <filter journal>
+    @type grep
+    <exclude>
+      key PRIORITY
+      pattern ^7$
+    </exclude>
+  </filter>
+  
+  # Process OVN logs
+  <filter ovn-audit.log**>
+    @type record_modifier
+    <record>
+      @timestamp ${DateTime.parse(record['message'].split('|')[0]).rfc3339(6)}
+      level ${record['message'].split('|')[3].downcase}
+    </record>
+  </filter>
+
+  # Process Kube and OpenShift Audit logs
+  <filter k8s-audit.log openshift-audit.log>
+    @type record_modifier
+    <record>
+      @timestamp ${record['requestReceivedTimestamp']}
+    </record>
+  </filter>
+
+  # Retag Journal logs to specific tags
+  <match journal>
+    @type rewrite_tag_filter
+    # skip to @INGRESS label section
+    @label @INGRESS
+  
+    # see if this is a kibana container for special log handling
+    # looks like this:
+    # k8s_kibana.a67f366_logging-kibana-1-d90e3_logging_26c51a61-2835-11e6-ad29-fa163e4944d5_f0db49a2
+    # we filter these logs through the kibana_transform.conf filter
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_kibana\.
+      tag kubernetes.journal.container.kibana
+    </rule>
+  
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_logging-eventrouter-[^_]+_
+      tag kubernetes.journal.container._default_.kubernetes-event
+    </rule>
+  
+    # mark logs from default namespace for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_default_
+      tag kubernetes.journal.container._default_
+    </rule>
+  
+    # mark logs from kube-* namespaces for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_kube-(.+)_
+      tag kubernetes.journal.container._kube-$1_
+    </rule>
+  
+    # mark logs from openshift-* namespaces for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_openshift-(.+)_
+      tag kubernetes.journal.container._openshift-$1_
+    </rule>
+  
+    # mark logs from openshift namespace for processing as k8s logs but stored as system logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_[^_]+_[^_]+_openshift_
+      tag kubernetes.journal.container._openshift_
+    </rule>
+  
+    # mark fluentd container logs
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_.*fluentd
+      tag kubernetes.journal.container.fluentd
+    </rule>
+  
+    # this is a kubernetes container
+    <rule>
+      key CONTAINER_NAME
+      pattern ^k8s_
+      tag kubernetes.journal.container
+    </rule>
+  
+    # not kubernetes - assume a system log or system container log
+    <rule>
+      key _TRANSPORT
+      pattern .+
+      tag journal.system
+    </rule>
+  </match>
+  
+  # Invoke kubernetes apiserver to get kubernetes metadata
+  <filter kubernetes.**>
+	@id kubernetes-metadata
+    @type kubernetes_metadata
+    kubernetes_url 'https://kubernetes.default.svc'
+	annotation_match ["^containerType\.logging\.openshift\.io\/.*$"]
+    allow_orphans false
+    cache_size '1000'
+    ssl_partial_chain 'true'
+  </filter>
+  
+  # Parse Json fields for container, journal and eventrouter logs
+  <filter kubernetes.var.log.pods.**_eventrouter-**>
+    @type parse_json_field
+    merge_json_log true
+    preserve_json_log true
+    json_fields 'message'
+  </filter>
+  
+  # Fix level field in audit logs
+  <filter k8s-audit.log**>
+    @type record_modifier
+    <record>
+      k8s_audit_level ${record['level']}
+    </record>
+  </filter>
+  
+  <filter openshift-audit.log**>
+    @type record_modifier
+    <record>
+      openshift_audit_level ${record['level']}
+    </record>
+  </filter>
+  
+  # Viaq Data Model
+  <filter **>
+    @type viaq_data_model
+    enable_flatten_labels true
+    enable_prune_empty_fields false
+    default_keep_fields CEE,time,@timestamp,aushape,ci_job,collectd,docker,fedora-ci,file,foreman,geoip,hostname,ipaddr4,ipaddr6,kubernetes,level,message,namespace_name,namespace_uuid,offset,openstack,ovirt,pid,pipeline_metadata,rsyslog,service,systemd,tags,testcase,tlog,viaq_msg_id
+    keep_empty_fields 'message'
+    rename_time true
+    pipeline_type 'collector'
+    process_kubernetes_events false
+    <level>
+      name warn
+      match 'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"'
+    </level>
+    <level>
+      name info
+      match 'Info|INFO|^I[0-9]+|level=info|Value:info|"level":"info"'
+    </level>
+    <level>
+      name error
+      match 'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"'
+    </level>
+    <level>
+      name critical
+      match 'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"'
+    </level>
+    <level>
+      name debug
+      match 'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"'
+    </level>
+    <formatter>
+      tag "journal.system**"
+      type sys_journal
+      remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+    </formatter>
+    <formatter>
+      tag "kubernetes.var.log.pods.**_eventrouter-** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+      type k8s_json_file
+      remove_keys stream
+      process_kubernetes_events 'true'
+    </formatter>
+    <formatter>
+      tag "kubernetes.var.log.pods**"
+      type k8s_json_file
+      remove_keys stream
+    </formatter>
+  </filter>
+  
+  # Generate elasticsearch id
+  <filter **>
+    @type elasticsearch_genid_ext
+    hash_id_key viaq_msg_id
+    alt_key kubernetes.event.metadata.uid
+    alt_tags 'kubernetes.var.log.pods.**_eventrouter-*.** kubernetes.journal.container._default_.kubernetes-event'
+  </filter>
+  
+  # Include Infrastructure logs
+  <match kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** journal.** system.var.log**>
+    @type relabel
+    @label @_INFRASTRUCTURE
+  </match>
+  
+  # Include Application logs
+  <match kubernetes.**>
+    @type relabel
+    @label @_APPLICATION
+  </match>
+  
+  # Include Audit logs
+  <match linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**>
+    @type relabel
+    @label @_AUDIT
+  </match>
+  
+  # Send any remaining unmatched tags to stdout
+  <match **>
+   @type stdout
+  </match>
+</label>
+
+# Sending application source type to pipeline
+<label @_APPLICATION>
+  <filter **>
+    @type record_modifier
+    <record>
+      log_type application
+    </record>
+  </filter>
+  
+  <match **>
+    @type relabel
+    @label @APPS_ES_46
+  </match>
+</label>
+
+# Sending infrastructure source type to pipeline
+<label @_INFRASTRUCTURE>
+  <filter **>
+    @type record_modifier
+    <record>
+      log_type infrastructure
+    </record>
+  </filter>
+  
+  <match **>
+    @type relabel
+    @label @INFRA_ES
+  </match>
+</label>
+
+# Sending audit source type to pipeline
+<label @_AUDIT>
+  <filter **>
+    @type record_modifier
+    <record>
+      log_type audit
+    </record>
+  </filter>
+  
+  <match **>
+    @type relabel
+    @label @AUDIT_PIPELINE
+  </match>
+</label>
+
+# Copying pipeline apps-es-46 to outputs
+<label @APPS_ES_46>
+  <match **>
+    @type copy
+	copy_mode deep
+    <store>
+      @type relabel
+      @label @APPS_ES_1
+    </store>
+    
+    <store>
+      @type relabel
+      @label @OUTPUT_APPS_ES_46
+    </store>
+  </match>
+</label>
+
+# Copying pipeline audit-pipeline to outputs
+<label @AUDIT_PIPELINE>
+  <match **>
+    @type relabel
+    @label @AUDIT_ES
+  </match>
+</label>
+
+# Copying pipeline infra-es to outputs
+<label @INFRA_ES>
+  <match **>
+    @type relabel
+    @label @OUTPUT_INFRA_ES
+  </match>
+</label>
+
+# Ship logs to specific outputs
+<label @OUTPUT_INFRA_ES>
+  #dedot namespace_labels
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_, _dummy3_
+  </filter>
+
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+    enable_openshift_model false
+    enable_prune_empty_fields false
+    rename_time false
+    undefined_dot_replace_char UNUSED
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  <filter **>
+	@type viaq_data_model
+	enable_prune_labels true
+	enable_openshift_model false
+	rename_time false
+	undefined_dot_replace_char UNUSED
+  prune_labels_exclusions app_kubernetes_io_name,app_kubernetes_io_instance,app_kubernetes_io_version,app_kubernetes_io_component,app_kubernetes_io_part-of,app_kubernetes_io_managed-by,app_kubernetes_io_created-by
+  </filter>
+
+  #rebuild message field if present
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    </record>
+    remove_keys _dummy_
+  </filter>
+  
+  #remove structured field if present
+  <filter **>
+	@type record_modifier
+    char_encoding utf-8:utf-8
+	remove_keys structured
+  </filter>
+  
+  <match retry_output_infra_es>
+    @type elasticsearch
+    @id retry_output_infra_es
+    host es.svc.infra.cluster
+    port 9999
+    scheme https
+    ssl_version TLSv1_2
+    client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
+    ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    verify_es_version_at_startup false
+    type_name _doc
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/retry_output_infra_es'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+  
+  <match **>
+    @type elasticsearch
+    @id output_infra_es
+    host es.svc.infra.cluster
+    port 9999
+    scheme https
+    ssl_version TLSv1_2
+    client_key '/var/run/ocp-collector/secrets/my-infra-secret/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/my-infra-secret/tls.crt'
+    ca_file '/var/run/ocp-collector/secrets/my-infra-secret/ca-bundle.crt'
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    verify_es_version_at_startup false
+    type_name _doc
+    retry_tag retry_output_infra_es
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/output_infra_es'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+</label>
+
+<label @APPS_ES_1>
+  #dedot namespace_labels
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_, _dummy3_
+  </filter>
+
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+    enable_openshift_model false
+    enable_prune_empty_fields false
+    rename_time false
+    undefined_dot_replace_char UNUSED
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  <filter **>
+	@type viaq_data_model
+	enable_prune_labels true
+	enable_openshift_model false
+	rename_time false
+	undefined_dot_replace_char UNUSED
+  prune_labels_exclusions app_kubernetes_io_name,app_kubernetes_io_instance,app_kubernetes_io_version,app_kubernetes_io_component,app_kubernetes_io_part-of,app_kubernetes_io_managed-by,app_kubernetes_io_created-by
+  </filter>
+
+  #rebuild message field if present
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    </record>
+    remove_keys _dummy_
+  </filter>
+
+  #remove structured field if present
+  <filter **>
+	@type record_modifier
+    char_encoding utf-8:utf-8
+	remove_keys structured
+  </filter>
+  
+  <match retry_apps_es_1>
+    @type elasticsearch
+    @id retry_apps_es_1
+    host es.svc.messaging.cluster.local
+    port 9654
+    scheme https
+    ssl_version TLSv1_2
+    client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+    ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    verify_es_version_at_startup false
+    type_name _doc
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/retry_apps_es_1'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+  
+  <match **>
+    @type elasticsearch
+    @id apps_es_1
+    host es.svc.messaging.cluster.local
+    port 9654
+    scheme https
+    ssl_version TLSv1_2
+    client_key '/var/run/ocp-collector/secrets/my-es-secret/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/my-es-secret/tls.crt'
+    ca_file '/var/run/ocp-collector/secrets/my-es-secret/ca-bundle.crt'
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    verify_es_version_at_startup false
+    type_name _doc
+    retry_tag retry_apps_es_1
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/apps_es_1'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+</label>
+
+<label @OUTPUT_APPS_ES_46>
+  #dedot namespace_labels
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_, _dummy3_
+  </filter>
+
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+    enable_openshift_model false
+    enable_prune_empty_fields false
+    rename_time false
+    undefined_dot_replace_char UNUSED
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  <filter **>
+	@type viaq_data_model
+	enable_prune_labels true
+	enable_openshift_model false
+	rename_time false
+	undefined_dot_replace_char UNUSED
+  prune_labels_exclusions app_kubernetes_io_name,app_kubernetes_io_instance,app_kubernetes_io_version,app_kubernetes_io_component,app_kubernetes_io_part-of,app_kubernetes_io_managed-by,app_kubernetes_io_created-by
+  </filter>
+
+  #rebuild message field if present
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    </record>
+    remove_keys _dummy_
+  </filter>
+
+  #remove structured field if present
+  <filter **>
+	@type record_modifier
+    char_encoding utf-8:utf-8
+	remove_keys structured
+  </filter>
+  
+  <match retry_output_apps_es_46>
+    @type elasticsearch
+    @id retry_output_apps_es_46
+    host es.svc.messaging.cluster.local2
+    port 9654
+    scheme https
+    ssl_version TLSv1_2
+    client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
+    ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    verify_es_version_at_startup false
+    type_name _doc
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/retry_output_apps_es_46'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+  
+  <match **>
+    @type elasticsearch
+    @id output_apps_es_46
+    host es.svc.messaging.cluster.local2
+    port 9654
+    scheme https
+    ssl_version TLSv1_2
+    client_key '/var/run/ocp-collector/secrets/my-other-secret/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/my-other-secret/tls.crt'
+    ca_file '/var/run/ocp-collector/secrets/my-other-secret/ca-bundle.crt'
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    verify_es_version_at_startup false
+    type_name _doc
+    retry_tag retry_output_apps_es_46
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/output_apps_es_46'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+</label>
+
+<label @AUDIT_ES>
+  #dedot namespace_labels
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${if m=record.dig("kubernetes","namespace_labels");record["kubernetes"]["namespace_labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy2_ ${if m=record.dig("kubernetes","labels");record["kubernetes"]["labels"]={}.tap{|n|m.each{|k,v|n[k.gsub(/[.\/]/,'_')]=v}};end}
+    _dummy3_ ${if m=record.dig("kubernetes","flat_labels");record["kubernetes"]["flat_labels"]=[].tap{|n|m.each_with_index{|s, i|n[i] = s.gsub(/[.\/]/,'_')}};end}
+    </record>
+    remove_keys _dummy_, _dummy2_, _dummy3_
+  </filter>
+
+  # Viaq Data Model
+  <filter **>
+	@type viaq_data_model
+    enable_openshift_model false
+    enable_prune_empty_fields false
+    rename_time false
+    undefined_dot_replace_char UNUSED
+	elasticsearch_index_prefix_field 'viaq_index_name'
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "kubernetes.var.log.pods.openshift_** kubernetes.var.log.pods.openshift-*_** kubernetes.var.log.pods.default_** kubernetes.var.log.pods.kube-*_** var.log.pods.openshift_** var.log.pods.openshift-*_** var.log.pods.default_** var.log.pods.kube-*_** journal.system** system.var.log**"
+	  name_type static
+	  static_index_name infra-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "linux-audit.log** k8s-audit.log** openshift-audit.log** ovn-audit.log**"
+	  name_type static
+	  static_index_name audit-write
+	</elasticsearch_index_name>
+	<elasticsearch_index_name>
+	  enabled 'true'
+	  tag "**"
+	  name_type structured
+	  static_index_name app-write
+	</elasticsearch_index_name>
+  </filter>
+  <filter **>
+	@type viaq_data_model
+	enable_prune_labels true
+	enable_openshift_model false
+	rename_time false
+	undefined_dot_replace_char UNUSED
+  prune_labels_exclusions app_kubernetes_io_name,app_kubernetes_io_instance,app_kubernetes_io_version,app_kubernetes_io_component,app_kubernetes_io_part-of,app_kubernetes_io_managed-by,app_kubernetes_io_created-by
+  </filter>
+
+  #rebuild message field if present
+  <filter **>
+    @type record_modifier
+    <record>
+    _dummy_ ${(require 'json';record['message']=JSON.dump(record['structured']);record.delete('structured')) if record['structured'] and record['viaq_index_name'] == 'app-write'}
+    </record>
+    remove_keys _dummy_
+  </filter>
+
+  #remove structured field if present
+  <filter **>
+	@type record_modifier
+    char_encoding utf-8:utf-8
+	remove_keys structured
+  </filter>
+  
+  <match retry_audit_es>
+    @type elasticsearch
+    @id retry_audit_es
+    host es.svc.audit.cluster
+    port 9654
+    scheme https
+    ssl_version TLSv1_2
+    client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
+    ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    verify_es_version_at_startup false
+    type_name _doc
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/retry_audit_es'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+  
+  <match **>
+    @type elasticsearch
+    @id audit_es
+    host es.svc.audit.cluster
+    port 9654
+    scheme https
+    ssl_version TLSv1_2
+    client_key '/var/run/ocp-collector/secrets/my-audit-secret/tls.key'
+    client_cert '/var/run/ocp-collector/secrets/my-audit-secret/tls.crt'
+    ca_file '/var/run/ocp-collector/secrets/my-audit-secret/ca-bundle.crt'
+    target_index_key viaq_index_name
+    id_key viaq_msg_id
+    remove_keys viaq_index_name
+    verify_es_version_at_startup false
+    type_name _doc
+    retry_tag retry_audit_es
+    http_backend typhoeus
+    write_operation create
+    reload_connections 'true'
+    # https://github.com/uken/fluent-plugin-elasticsearch#reload-after
+    reload_after '200'
+    # https://github.com/uken/fluent-plugin-elasticsearch#sniffer-class-name
+    sniffer_class_name 'Fluent::Plugin::ElasticsearchSimpleSniffer'
+    reload_on_failure false
+    # 2 ^ 31
+    request_timeout 2147483648
+    <buffer>
+      @type file
+      path '/var/lib/fluentd/audit_es'
+      flush_mode interval
+      flush_interval 1s
+      flush_thread_count 2
+      retry_type exponential_backoff
+      retry_wait 1s
+      retry_max_interval 60s
+      retry_timeout 60m
+      queued_chunks_limit_size "#{ENV['BUFFER_QUEUE_LIMIT'] || '32'}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE_PER_BUFFER'] || '8589934592'}"
+      chunk_limit_size "#{ENV['BUFFER_SIZE_LIMIT'] || '8m'}"
+      overflow_action block
+      disable_chunk_backup true
+    </buffer>
+  </match>
+</label>
+`))
+	})
+
+	It("should produce well formed fluent.conf", func() {
 		c := generator.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())

--- a/internal/generator/fluentd/pipeline_to_output.go
+++ b/internal/generator/fluentd/pipeline_to_output.go
@@ -90,14 +90,23 @@ func PipelineToOutputs(spec *logging.ClusterLogForwarderSpec, op Options) []Elem
 		case 0:
 			// should not happen
 		case 1:
+			oname := p.OutputRefs[0]
+			if p.Name == p.OutputRefs[0] {
+				oname = "OUTPUT_" + oname
+			}
 			po.SubElements = append(po.SubElements,
 				Match{
 					MatchTags: "**",
 					MatchElement: Relabel{
-						OutLabel: helpers.LabelName(p.OutputRefs[0]),
+						OutLabel: helpers.LabelName(oname),
 					},
 				})
 		default:
+			for i, o := range p.OutputRefs {
+				if o == p.Name {
+					p.OutputRefs[i] = "OUTPUT_" + o
+				}
+			}
 			po.SubElements = append(po.SubElements,
 				Match{
 					MatchTags: "**",


### PR DESCRIPTION
### Description
This PR addresses the issue where conflicts between output and pipeline names have been occurring due to label generation. The root cause of this problem is that FluentD requires labels to be unique. We will prefix the label with 'OUTPUT_' for labels which conflict with pipeline names. This adjustment ensures that output labels are unique and distinct from pipeline names.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4383
- Enhancement proposal:
