### PR TITLE
LOG-4575: Vector not releasing deleted file handles

### DIFF
--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -108,6 +108,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -565,6 +566,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -1201,6 +1203,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -1921,6 +1924,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -29,5 +29,6 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 {{end}}`
 }

--- a/internal/generator/vector/sources_test.go
+++ b/internal/generator/vector/sources_test.go
@@ -43,6 +43,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 `,
 		}),
 		Entry("Only Infrastructure", helpers.ConfGenerateTest{
@@ -71,6 +72,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"
@@ -147,6 +149,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
 
 [sources.raw_journal_logs]
 type = "journald"


### PR DESCRIPTION
### Description
For the kubernetes_logs vector source, override the (very large) default for the newly introduced rotate_wait_ms variable.

This is a manual cherrypick of https://github.com/openshift/cluster-logging-operator/pull/2185

/cc @cahartma 
/assign @jcantrill 

### Links
- Depending on PR(s): https://github.com/openshift/cluster-logging-operator/pull/2185
- JIRA: https://issues.redhat.com/browse/LOG-4575

