### PR TITLE
LOG-4574: Input permission validation failure with an HTTP receiver as input in a multiple-CLF

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
@@ -116,6 +116,9 @@ func gatherPipelineInputs(clf loggingv1.ClusterLogForwarder) sets.String {
 		if inputRefs.Has(input.Name) && input.Application != nil {
 			inputTypes.Insert(loggingv1.InputNameApplication)
 		}
+		if input.Receiver != nil && input.Receiver.HTTP != nil {
+			inputTypes.Insert(loggingv1.InputNameAudit)
+		}
 	}
 
 	return *inputTypes


### PR DESCRIPTION
### Description
Fix for CLF with an HTTP receiver validation failure, now HTTP receivers are treated as audit log sources.

/cc @Clee2691 
/assign @jcantrill 


### Links
- JIRA: https://issues.redhat.com/browse/LOG-4574

