### PR TITLE
LOG-4577: Resources created after enabling receiver.http are not cleaned up after CLF is deleted

### DIFF
--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -88,7 +88,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 		return err
 	}
 
-	if err := factory.ReconcileInputServices(clusterRequest.EventRecorder, clusterRequest.Client, clusterRequest.Forwarder.Namespace, clusterRequest.ResourceNames.CommonName, constants.CollectorName, clusterRequest.ResourceOwner, factory.CommonLabelInitializer); err != nil {
+	if err := factory.ReconcileInputServices(clusterRequest.EventRecorder, clusterRequest.Client, clusterRequest.Forwarder.Namespace, clusterRequest.ResourceNames.CommonName, constants.CollectorName, utils.AsOwner(clusterRequest.Forwarder), factory.CommonLabelInitializer); err != nil {
 		log.Error(err, "collector.ReconcileInputServices")
 		return err
 	}


### PR DESCRIPTION
### Description
Make CLF the owner of the Services and Secrets associated with HTTP receivers so they are GC'd once the CLF defining the corresponding HTTP receivers is deleted.

/cc @Clee2691 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4577
