### PR TITLE
LOG-4441: set invalid condition when using parse json with without setting structuredTypeKey or structuredTypeName

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_json_parsing_to_elasticsearch.go
+++ b/internal/validations/clusterlogforwarder/validate_json_parsing_to_elasticsearch.go
@@ -1,6 +1,7 @@
 package clusterlogforwarder
 
 import (
+	"fmt"
 	"github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/validations/errors"
@@ -23,7 +24,11 @@ func validateJsonParsingToElasticsearch(clf v1.ClusterLogForwarder, k8sClient cl
 					case clf.Spec.OutputDefaults != nil && clf.Spec.OutputDefaults.Elasticsearch != nil && (clf.Spec.OutputDefaults.Elasticsearch.StructuredTypeName != "" || clf.Spec.OutputDefaults.Elasticsearch.StructuredTypeKey != ""):
 						continue
 					default:
-						return errors.NewValidationError("structuredTypeKey or structuredTypeName must be defined for Elasticsearch output named %q when JSON parsing is enabled on pipeline %q that references it", name, pipeline.Name), nil
+						status := &loggingv1.ClusterLogForwarderStatus{}
+						msg := fmt.Sprintf("structuredTypeKey or structuredTypeName must be defined for Elasticsearch output named %q when JSON parsing is enabled on pipeline %q that references it", name, pipeline.Name)
+						status.Conditions.SetCondition(CondInvalid(msg))
+						return errors.NewValidationError(msg), status
+
 					}
 				}
 			}

--- a/internal/validations/clusterlogforwarder/validate_json_parsing_to_elasticsearch_test.go
+++ b/internal/validations/clusterlogforwarder/validate_json_parsing_to_elasticsearch_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -43,7 +44,12 @@ var _ = Describe("[internal][validations] ClusterLogForwarder", func() {
 	Context("#validateJsonParsingToElasticsearch", func() {
 
 		It("should fail validation when the pipeline includes Elasticsearch and structuredTypeKey or structuredTypeName is missing", func() {
-			Expect(validateJsonParsingToElasticsearch(*clf, k8sClient, extras)).To(Not(Succeed()))
+			err, status := validateJsonParsingToElasticsearch(*clf, k8sClient, extras)
+			Expect(err).To(Not(BeNil()))
+			Expect(status).To(Not(BeNil()))
+			Expect(len(status.Conditions)).To(Equal(1))
+			Expect(status.Conditions[0].Status).To(Equal(corev1.ConditionFalse))
+			Expect(status.Conditions[0].Reason).To(Equal(v1.ReasonInvalid))
 		})
 		It("should pass validation when the pipeline includes Elasticsearch and structuredTypeName is spec'd", func() {
 			es.StructuredTypeName = "foo"


### PR DESCRIPTION
### Description
Set invalid condition when using parse `json` with without setting `structuredTypeKey` or `structuredTypeName`
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4441
- Enhancement proposal:
