### PR TITLE
LOG-4579: Show FluentD Buffer Usage in metrics dashboard instead of availability

### DIFF
--- a/files/dashboards/fluentd/openshift-logging-dashboard.json
+++ b/files/dashboards/fluentd/openshift-logging-dashboard.json
@@ -1400,7 +1400,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "100 - max by(plugin_id)(fluentd_output_status_buffer_available_space_ratio)",
+              "expr": "100 - min by(plugin_id)(fluentd_output_status_buffer_available_space_ratio)",
               "refId": "A"
             }
           ],
@@ -1408,7 +1408,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "FluentD Buffer Availability",
+          "title": "FluentD Buffer Usage",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
### Description

Backport of #2172 to 5.6

### Links

- JIRA: [LOG-4579](https://issues.redhat.com//browse/LOG-4579)
