### PR TITLE
LOG-4580: Add validation for secret used with the Splunk output in CLF

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -48,6 +48,8 @@ const (
 	AWSRoleSessionEnvVarKey      = "AWS_ROLE_SESSION_NAME"
 	AWSWebIdentityTokenEnvVarKey = "AWS_WEB_IDENTITY_TOKEN_FILE" //nolint:gosec
 
+	SplunkHECTokenKey = `hecToken`
+
 	TokenKey          = "token"
 	LogCollectorToken = "logcollector-token"
 

--- a/internal/generator/vector/output/splunk/splunk.go
+++ b/internal/generator/vector/output/splunk/splunk.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
@@ -82,7 +83,7 @@ func Output(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Opt
 		ComponentID:  strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
 		Inputs:       vectorhelpers.MakeInputs(inputs...),
 		Endpoint:     o.URL,
-		DefaultToken: security.GetFromSecret(secret, "hecToken"),
+		DefaultToken: security.GetFromSecret(secret, constants.SplunkHECTokenKey),
 	}
 }
 

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -369,14 +369,18 @@ func verifyOutputSecret(namespace string, clfClient client.Client, output *loggi
 	if err != nil {
 		return fail(CondMissing("secret %q not found", output.Secret.Name))
 	}
-	verifySecret := verifySecretKeysForTLS
-	if output.Type == loggingv1.OutputTypeCloudwatch {
-		verifySecret = verifySecretKeysForCloudwatch
+
+	switch output.Type {
+	case loggingv1.OutputTypeCloudwatch:
+		if !verifySecretKeysForCloudwatch(output, conds, secret) {
+			return false
+		}
+	case loggingv1.OutputTypeSplunk:
+		if !verifySecretKeysForSplunk(output, conds, secret) {
+			return false
+		}
 	}
-	if !verifySecret(output, conds, secret) {
-		return false
-	}
-	return true
+	return verifySecretKeysForTLS(output, conds, secret)
 }
 
 func getOutputSecret(namespace string, clfClient client.Client, secretName string) (*corev1.Secret, error) {
@@ -394,6 +398,7 @@ func verifySecretKeysForTLS(output *loggingv1.OutputSpec, conds loggingv1.NamedC
 		conds.Set(output.Name, c)
 		return false
 	}
+
 	// Make sure we have secrets for a valid TLS configuration.
 	haveCert := len(secret.Data[constants.ClientCertKey]) > 0
 	haveKey := len(secret.Data[constants.ClientPrivateKey]) > 0
@@ -413,7 +418,6 @@ func verifySecretKeysForTLS(output *loggingv1.OutputSpec, conds loggingv1.NamedC
 }
 
 func verifySecretKeysForCloudwatch(output *loggingv1.OutputSpec, conds loggingv1.NamedConditions, secret *corev1.Secret) bool {
-	log.V(3).Info("V")
 	fail := func(c status.Condition) bool {
 		conds.Set(output.Name, c)
 		return false
@@ -434,6 +438,19 @@ func verifySecretKeysForCloudwatch(output *loggingv1.OutputSpec, conds loggingv1
 		return fail(CondMissing("auth keys: " + constants.AWSAccessKeyID + " and " + constants.AWSSecretAccessKey + " are required"))
 	}
 	return true
+}
+
+func verifySecretKeysForSplunk(output *loggingv1.OutputSpec, conds loggingv1.NamedConditions, secret *corev1.Secret) bool {
+	fail := func(c status.Condition) bool {
+		conds.Set(output.Name, c)
+		return false
+	}
+
+	if len(secret.Data[constants.SplunkHECTokenKey]) > 0 {
+		return true
+	} else {
+		return fail(CondMissing("A non-empty " + constants.SplunkHECTokenKey + " entry is required"))
+	}
 }
 
 func readClusterName(clfClient client.Client) (string, error) {


### PR DESCRIPTION
### Description
Added CLF validation for the hecToken in the Splunk secret

/cc @Clee2691 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4580

