### PR TITLE
LOG-4589: vector fails to start on a node with IPv6 disabled

### DIFF
--- a/internal/generator/vector/metrics.go
+++ b/internal/generator/vector/metrics.go
@@ -1,12 +1,27 @@
 package vector
 
+import (
+	"golang.org/x/sys/unix"
+)
+
 const (
 	InternalMetricsSourceName = "internal_metrics"
 	PrometheusOutputSinkName  = "prometheus_output"
-	PrometheusExporterAddress = "[::]:24231"
 
 	AddNodenameToMetricTransformName = "add_nodename_to_metric"
 )
+
+var PrometheusExporterAddress string
+
+func init() {
+	if fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_STREAM, unix.IPPROTO_IP); err != nil {
+		PrometheusExporterAddress = `0.0.0.0`
+	} else {
+		unix.Close(fd)
+		PrometheusExporterAddress = `[::]`
+	}
+	PrometheusExporterAddress += `:24231`
+}
 
 type InternalMetrics struct {
 	ID                string


### PR DESCRIPTION
### Description

A cherry-pick of https://github.com/openshift/cluster-logging-operator/pull/2200 onto the release-5.7 branch.

/cc @cahartma 
/assign @jcantrill 

### Links
- Depending on PR(s): https://github.com/openshift/cluster-logging-operator/pull/2200
- JIRA: https://issues.redhat.com/browse/LOG-4593
