### PR TITLE
LOG-4591: The http service endpoints can not be selected

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -223,7 +223,7 @@ func (f *Factory) NewCollectorContainer(secretNames []string, clusterID string, 
 	return &collector
 }
 
-func (f *Factory) ReconcileInputServices(er record.EventRecorder, k8sClient client.Client, namespace, name, selectorComponent string, owner metav1.OwnerReference, visitors func(o runtime.Object)) error {
+func (f *Factory) ReconcileInputServices(er record.EventRecorder, k8sClient client.Client, namespace, selectorComponent string, owner metav1.OwnerReference, visitors func(o runtime.Object)) error {
 	if f.CollectorType != logging.LogCollectionTypeVector {
 		return nil
 	}
@@ -238,7 +238,7 @@ func (f *Factory) ReconcileInputServices(er record.EventRecorder, k8sClient clie
 			if targetPort == 0 {
 				targetPort = input.Receiver.HTTP.ReceiverPort.Port
 			}
-			if err := network.ReconcileInputService(er, k8sClient, namespace, serviceName, selectorComponent, selectorComponent, input.Name, input.Receiver.HTTP.ReceiverPort.Port, targetPort, owner, visitors); err != nil {
+			if err := network.ReconcileInputService(er, k8sClient, namespace, serviceName, selectorComponent, input.Name, input.Receiver.HTTP.ReceiverPort.Port, targetPort, owner, visitors); err != nil {
 				return err
 			}
 		}

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -88,7 +88,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 		return err
 	}
 
-	if err := factory.ReconcileInputServices(clusterRequest.EventRecorder, clusterRequest.Client, clusterRequest.Forwarder.Namespace, clusterRequest.ResourceNames.CommonName, constants.CollectorName, utils.AsOwner(clusterRequest.Forwarder), factory.CommonLabelInitializer); err != nil {
+	if err := factory.ReconcileInputServices(clusterRequest.EventRecorder, clusterRequest.Client, clusterRequest.Forwarder.Namespace, clusterRequest.ResourceNames.CommonName, utils.AsOwner(clusterRequest.Forwarder), factory.CommonLabelInitializer); err != nil {
 		log.Error(err, "collector.ReconcileInputServices")
 		return err
 	}

--- a/internal/network/service.go
+++ b/internal/network/service.go
@@ -38,11 +38,11 @@ func ReconcileService(er record.EventRecorder, k8sClient client.Client, namespac
 	return reconcile.Service(er, k8sClient, desired)
 }
 
-func ReconcileInputService(er record.EventRecorder, k8sClient client.Client, namespace, name, component, instance, certSecretName string, port int32, targetPort int32, owner metav1.OwnerReference, visitors func(o runtime.Object)) error {
+func ReconcileInputService(er record.EventRecorder, k8sClient client.Client, namespace, name, instance, certSecretName string, port int32, targetPort int32, owner metav1.OwnerReference, visitors func(o runtime.Object)) error {
 	desired := factory.NewService(
 		name,
 		namespace,
-		component,
+		constants.CollectorName,
 		instance,
 		[]v1.ServicePort{
 			{


### PR DESCRIPTION
### Description

This PR corrects how the  "app.kubernetes.io/instance" label in the service selector is assigned for the service fronting the HTTP receiver in non-default CLFs.

/cc @Clee2691 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4591