### PR TITLE
LOG-4607: fix install mode to only AllNamespaces

### DIFF
--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -118,7 +118,7 @@ metadata:
     certified: "false"
     console.openshift.io/plugins: '["logging-view-plugin"]'
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2023-10-10T13:03:29Z"
+    createdAt: "2023-10-11T17:54:55Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing your aggregated logging stack.
     olm.skipRange: '>=5.6.0-0 <5.8.0'
@@ -618,11 +618,11 @@ spec:
         serviceAccountName: cluster-logging-operator
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
   - supported: true
     type: AllNamespaces

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -307,11 +307,11 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
   - supported: true
     type: AllNamespaces


### PR DESCRIPTION
### Description
This PR modifies the manifest to only allow install mode of "all namespaces"

### Links
* https://issues.redhat.com/browse/LOG-4607