### PR TITLE
LOG-4608: [httpserver] Connection refused on IPv6 cluster

### DIFF
--- a/internal/generator/vector/metrics.go
+++ b/internal/generator/vector/metrics.go
@@ -1,27 +1,11 @@
 package vector
 
-import (
-	"golang.org/x/sys/unix"
-)
-
 const (
-	InternalMetricsSourceName = "internal_metrics"
-	PrometheusOutputSinkName  = "prometheus_output"
-
+	InternalMetricsSourceName        = "internal_metrics"
+	PrometheusOutputSinkName         = "prometheus_output"
+	PrometheusExporterListenPort     = `24231`
 	AddNodenameToMetricTransformName = "add_nodename_to_metric"
 )
-
-var PrometheusExporterAddress string
-
-func init() {
-	if fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_STREAM, unix.IPPROTO_IP); err != nil {
-		PrometheusExporterAddress = `0.0.0.0`
-	} else {
-		unix.Close(fd)
-		PrometheusExporterAddress = `[::]`
-	}
-	PrometheusExporterAddress += `:24231`
-}
 
 type InternalMetrics struct {
 	ID                string

--- a/internal/generator/vector/outputs.go
+++ b/internal/generator/vector/outputs.go
@@ -2,6 +2,7 @@ package vector
 
 import (
 	"fmt"
+
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -116,7 +117,7 @@ func PrometheusOutput(id string, inputs []string, minTlsVersion string, cipherSu
 	return PrometheusExporter{
 		ID:            id,
 		Inputs:        helpers.MakeInputs(inputs...),
-		Address:       PrometheusExporterAddress,
+		Address:       helpers.ListenOnAllLocalInterfacesAddress() + `:` + PrometheusExporterListenPort,
 		TlsMinVersion: minTlsVersion,
 		CipherSuites:  cipherSuites,
 	}

--- a/internal/generator/vector/sources.go
+++ b/internal/generator/vector/sources.go
@@ -8,6 +8,7 @@ import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/source"
 	"github.com/openshift/cluster-logging-operator/internal/tls"
 )
@@ -137,7 +138,8 @@ func HttpSources(spec *logging.ClusterLogForwarderSpec, op generator.Options) []
 			}
 			el = append(el, HttpReceiver{
 				ID:            input.Name,
-				Port:          listenPort,
+				ListenAddress: helpers.ListenOnAllLocalInterfacesAddress(),
+				ListenPort:    listenPort,
 				Format:        input.Receiver.HTTP.Format,
 				TlsMinVersion: minTlsVersion,
 				CipherSuites:  cipherSuites,
@@ -149,7 +151,8 @@ func HttpSources(spec *logging.ClusterLogForwarderSpec, op generator.Options) []
 
 type HttpReceiver struct {
 	ID            string
-	Port          int32
+	ListenAddress string
+	ListenPort    int32
 	Format        string
 	TlsMinVersion string
 	CipherSuites  string
@@ -164,7 +167,7 @@ func (i HttpReceiver) Template() string {
 {{define "` + i.Name() + `" -}}
 [sources.{{.ID}}]
 type = "http_server"
-address = "0.0.0.0:{{.Port}}"
+address = "{{.ListenAddress}}:{{.ListenPort}}"
 decoding.codec = "json"
 
 [sources.{{.ID}}.tls]


### PR DESCRIPTION
### Description
Detect the correct "listen on all local interfaces" address and use it for HTTP receivers and Prometheus metrics. Further development of https://github.com/openshift/cluster-logging-operator/pull/2200.

/cc @xperimental 
/assign @alanconway 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4608