### PR TITLE
Revert "LOG-4607: fix install mode to only AllNamespaces"

### DIFF
--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -618,11 +618,11 @@ spec:
         serviceAccountName: cluster-logging-operator
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
-  - supported: false
+  - supported: true
     type: MultiNamespace
   - supported: true
     type: AllNamespaces

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -307,11 +307,11 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
-  - supported: false
+  - supported: true
     type: MultiNamespace
   - supported: true
     type: AllNamespaces


### PR DESCRIPTION
This reverts commit b2384abf1c686ba7574c9fe337fcb356ef512ca5.

### Description
This PR reverts the prior change after testing that existing deployments can successfully upgrade to 5.8.  The implications here is existing deployments will need to adjust there operatorgroup to take full advantage of mCLF.  Additionally it may be new deployments must explicitly choose "all namespaces" or will need to edit the operatorgroup in the future if they do not

### Links
* https://issues.redhat.com/browse/LOG-4650
