### PR TITLE
LOG-4612: Service/secret is not deleted when the inputs.receiver.http is removed

### DIFF
--- a/internal/collector/daemonset.go
+++ b/internal/collector/daemonset.go
@@ -16,10 +16,18 @@ import (
 )
 
 // ReconcileDaemonset reconciles a daemonset specifically for the collector defined by the factory
-func (f *Factory) ReconcileDaemonset(er record.EventRecorder, k8sClient client.Client, namespace string, owner metav1.OwnerReference, httpInputs []string) error {
+func (f *Factory) ReconcileDaemonset(er record.EventRecorder, k8sClient client.Client, namespace string, owner metav1.OwnerReference) error {
 	trustedCABundle, trustHash := GetTrustedCABundle(k8sClient, namespace, f.ResourceNames.CaTrustBundle)
 	f.TrustedCAHash = trustHash
 	tlsProfile, _ := tls.FetchAPIServerTlsProfile(k8sClient)
+
+	var httpInputs []string
+	for _, input := range f.ForwarderSpec.Inputs {
+		if input.Receiver != nil && input.Receiver.HTTP != nil {
+			httpInputs = append(httpInputs, input.Name)
+		}
+	}
+
 	desired := f.NewDaemonSet(namespace, f.ResourceNames.DaemonSetName(), trustedCABundle, tls.GetClusterTLSProfileSpec(tlsProfile), httpInputs)
 	utils.AddOwnerRefToObject(desired, owner)
 	return reconcile.DaemonSet(er, k8sClient, desired)

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -123,7 +123,8 @@ const (
 	ClusterLogging         = "cluster-logging"
 	ClusterLoggingOperator = "cluster-logging-operator"
 	// Commonly-used label names.
-	LabelApp = "app"
+	LabelApp       = "app"
+	LabelComponent = "component"
 
 	EventReasonReconcilingLoggingCR = "ReconcilingLoggingCR"
 	EventReasonCreateObject         = "CreateObject"
@@ -137,7 +138,8 @@ const (
 	OptimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
 	OTELSchema             = "opentelemetry"
 
-	HTTPReceiverPort = 8443
+	HTTPReceiverPort      = 8443
+	LabelHTTPInputService = "http-input-service"
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}

--- a/internal/k8shandler/service.go
+++ b/internal/k8shandler/service.go
@@ -1,9 +1,12 @@
 package k8shandler
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/factory"
@@ -39,4 +42,14 @@ func (clusterRequest *ClusterLoggingRequest) RemoveInputService(serviceName stri
 	}
 
 	return nil
+}
+
+// GetServiceList returns a list of services based on a key/value label
+func (clusterRequest *ClusterLoggingRequest) GetServiceList(key, val, namespace string) (*core.ServiceList, error) {
+	labelSelector, _ := labels.Parse(fmt.Sprintf("%s=%s", key, val))
+	httpServices := core.ServiceList{}
+	if err := clusterRequest.Client.List(context.TODO(), &httpServices, &client.ListOptions{LabelSelector: labelSelector, Namespace: namespace}); err != nil {
+		return nil, fmt.Errorf("failure listing services with label: %s,  %v", fmt.Sprintf("%s=%s", key, val), err)
+	}
+	return &httpServices, nil
 }

--- a/internal/network/service.go
+++ b/internal/network/service.go
@@ -60,6 +60,8 @@ func ReconcileInputService(er record.EventRecorder, k8sClient client.Client, nam
 		constants.AnnotationServingCertSecretName: certSecretName,
 	}
 
+	desired.Labels[constants.LabelComponent] = constants.LabelHTTPInputService
+
 	utils.AddOwnerRefToObject(desired, owner)
 	return reconcile.Service(er, k8sClient, desired)
 }


### PR DESCRIPTION
### Description
This PR addresses removing stale `HTTP` input services when the `ClusterLogForwarder` (CLF) is modified. 

Originally when the `inputs.receiver.http` was removed from the CLF and updated, NOT deleted and recreated, any previously defined `HTTP` input services were not garbage collected. 

The approach was to label all `HTTP` input services with `http-input-service` and upon CLF reconciliation, check if the service is defined in the CLF as well as if the reconciling CLF owns the specific service. If the service is not defined, remove it.

/cc @syedriko @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4612
