### PR TITLE
LOG-4681: kubeAPIAudit policies don't work on audit logs from auditWebhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ test-unit: test-forwarder-generator
 	RELATED_IMAGE_FLUENTD=$(IMAGE_LOGGING_FLUENTD) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	RELATED_IMAGE_LOGGING_CONSOLE_PLUGIN=$(IMAGE_LOGGING_CONSOLE_PLUGIN) \
-	go test -coverprofile=test.cov -race ./apis/... ./internal/... `go list ./test/... | grep -Ev 'test/(e2e|functional|client|helpers)'`
+	go test -coverprofile=test.cov -race ./apis/... ./internal/... `go list ./test/... | grep -Ev 'test/(e2e|functional|framework|client|helpers)'`
 
 .PHONY: coverage
 coverage: test-unit

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -314,30 +314,14 @@ spec:
                               enum:
                               - kubeAPIAudit
                               type: string
-                            receiverPort:
-                              description: ReceiverPort specifies parameters for the
-                                Service fronting the HTTPReceiver
-                              properties:
-                                name:
-                                  description: Name of the service to create for this
-                                    HTTPReceiver If not specified, defaults to the
-                                    name of the containing ClusterLogForwarder input
-                                  type: string
-                                port:
-                                  description: Port the Service will listen on.
-                                  format: int32
-                                  type: integer
-                                targetPort:
-                                  description: Port the Receiver will listen on. If
-                                    not specified, defaults to the value of Port
-                                  format: int32
-                                  type: integer
-                              required:
-                              - port
-                              type: object
+                            port:
+                              default: 8443
+                              description: Port the Service and the HTTP listener
+                                listen on.
+                              format: int32
+                              type: integer
                           required:
                           - format
-                          - receiverPort
                           type: object
                       type: object
                   required:

--- a/internal/generator/vector/conf_test/complex.toml
+++ b/internal/generator/vector/conf_test/complex.toml
@@ -235,7 +235,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.openshift_audit_logs]
@@ -247,7 +246,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.ovn_audit_logs]

--- a/internal/generator/vector/conf_test/complex_custom_data_dir.toml
+++ b/internal/generator/vector/conf_test/complex_custom_data_dir.toml
@@ -236,7 +236,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.openshift_audit_logs]
@@ -248,7 +247,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.ovn_audit_logs]

--- a/internal/generator/vector/conf_test/complex_es_no_ver.toml
+++ b/internal/generator/vector/conf_test/complex_es_no_ver.toml
@@ -236,7 +236,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.openshift_audit_logs]
@@ -248,7 +247,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.ovn_audit_logs]

--- a/internal/generator/vector/conf_test/complex_es_v6.toml
+++ b/internal/generator/vector/conf_test/complex_es_v6.toml
@@ -235,7 +235,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.openshift_audit_logs]
@@ -247,7 +246,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.ovn_audit_logs]

--- a/internal/generator/vector/conf_test/complex_otel.toml
+++ b/internal/generator/vector/conf_test/complex_otel.toml
@@ -235,7 +235,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.openshift_audit_logs]
@@ -247,7 +246,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.ovn_audit_logs]

--- a/internal/generator/vector/conf_test/es_pipeline_w_spaces.toml
+++ b/internal/generator/vector/conf_test/es_pipeline_w_spaces.toml
@@ -236,7 +236,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.openshift_audit_logs]
@@ -248,7 +247,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.ovn_audit_logs]

--- a/internal/generator/vector/filter/apiaudit/policy.vrl.tmpl
+++ b/internal/generator/vector/filter/apiaudit/policy.vrl.tmpl
@@ -1,5 +1,5 @@
 {{- /*Generate VRL policy from audit.Policy, see Go comment on var policyVRLTemplate.*/ -}}
-if is_object(.) && .kind == "Event" && .apiVersion == "audit.k8s.io/v1" {
+if is_string(.auditID) && is_string(.verb) {
   res = if is_null(.objectRef.resource) { "" } else { string!(.objectRef.resource) }
   sub = if is_null(.objectRef.subresource) { "" } else { string!(.objectRef.subresource) }
   namespace = if is_null(.objectRef.namespace) { "" } else { string!(.objectRef.namespace) }

--- a/internal/generator/vector/normalize.go
+++ b/internal/generator/vector/normalize.go
@@ -174,7 +174,6 @@ func NormalizeK8sAuditLogs(inLabel, outLabel string) []generator.Element {
 				AddK8sAuditTag,
 				ParseAndFlatten,
 				FixK8sAuditLevel,
-				AddDefaultLogLevel,
 			}), "\n"),
 		},
 	}
@@ -190,7 +189,6 @@ func NormalizeOpenshiftAuditLogs(inLabel, outLabel string) []generator.Element {
 				AddOpenAuditTag,
 				ParseAndFlatten,
 				FixOpenshiftAuditLevel,
-				AddDefaultLogLevel,
 			}), "\n"),
 		},
 	}

--- a/internal/generator/vector/normalize_test.go
+++ b/internal/generator/vector/normalize_test.go
@@ -298,7 +298,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .k8s_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.openshift_audit_logs]
@@ -310,7 +309,6 @@ source = '''
   . = merge(., parse_json!(string!(.message))) ?? .
   del(.message)
   .openshift_audit_level = .level
-  .level = "default"
 '''
 
 [transforms.ovn_audit_logs]

--- a/test/framework/e2e/framework.go
+++ b/test/framework/e2e/framework.go
@@ -120,7 +120,7 @@ func (tc *E2ETestFramework) DeployLogGeneratorWithNamespace(namespace string) er
 		opts := metav1.DeleteOptions{}
 		return tc.KubeClient.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, opts)
 	})
-	return client.NewTest().Client.WaitFor(pod, client.PodRunning)
+	return client.Get().WaitFor(pod, client.PodRunning)
 }
 
 func (tc *E2ETestFramework) DeployLogGeneratorWithNamespaceAndLabels(namespace string, labels map[string]string) error {

--- a/test/functional/collection/namespace_filtering_test.go
+++ b/test/functional/collection/namespace_filtering_test.go
@@ -31,6 +31,11 @@ var _ = Describe("[Functional][Collection] Namespace filtering", func() {
 			ToFluentForwardOutput()
 		Expect(instance.Deploy()).To(BeNil())
 	})
+
+	AfterEach(func() {
+		instance.Cleanup()
+	})
+
 	It("should send logs from one namespace only", func() {
 
 		msg := functional.NewFullCRIOLogMessage(functional.CRIOTime(time.Now()), "my message")

--- a/test/functional/filters/apiaudit/vrl/suite_test.go
+++ b/test/functional/filters/apiaudit/vrl/suite_test.go
@@ -136,9 +136,8 @@ func readPolicy(path string) *loggingv1.KubeAPIAudit {
 	return policy
 }
 
+// fillEvent fills event defaults for filter tests.
 func fillEvent(in *Event) {
-	in.GetObjectKind().SetGroupVersionKind(runtime.GroupVersionKind(in))
-	// Force input event to be full RequestResponse
 	if in.Level == "" {
 		in.Level = LevelRequestResponse
 	}
@@ -148,5 +147,11 @@ func fillEvent(in *Event) {
 	}
 	if in.ResponseObject == nil {
 		in.ResponseObject = obj
+	}
+	if in.AuditID == "" {
+		in.AuditID = "0000"
+	}
+	if in.Verb == "" {
+		in.Verb = "create"
 	}
 }

--- a/test/functional/inputs/http/http_input_test.go
+++ b/test/functional/inputs/http/http_input_test.go
@@ -2,6 +2,7 @@
 package http
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -14,14 +15,93 @@ import (
 	testfw "github.com/openshift/cluster-logging-operator/test/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
-	authentication "k8s.io/api/authentication/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 )
 
 const (
 	httpInputName  = `http-source`
 	servicePortNum = 8080
+
+	// eventsString is a sample from the API-server webhook.
+	// It does not include the 'apiVersion' and 'kind' fields in each event.
+	// Use this exact serialization for testing to ensure compatibility with the real API server.
+	// For more see: https://issues.redhat.com/browse/LOG-4681
+	eventsString = `{
+  "apiVersion": "audit.k8s.io/v1",
+  "items": [
+    {
+      "annotations": {
+        "authorization.k8s.io/decision": "allow",
+        "authorization.k8s.io/reason": ""
+      },
+      "auditID": "0c8bc986-b74c-4392-8756-7bdbaf3cc63e",
+      "level": "Metadata",
+      "objectRef": {
+        "apiGroup": "user.openshift.io",
+        "apiVersion": "v1",
+        "resource": "groups"
+      },
+      "requestReceivedTimestamp": "2023-10-18T09:26:15.332127Z",
+      "requestURI": "/apis/user.openshift.io/v1/groups?allowWatchBookmarks=true&resourceVersion=205534&timeout=5m15s&timeoutSeconds=315&watch=true",
+      "responseStatus": {
+        "code": 200,
+        "metadata": {}
+      },
+      "sourceIPs": [
+        "::1"
+      ],
+      "stage": "ResponseComplete",
+      "stageTimestamp": "2023-10-18T09:31:30.332784Z",
+      "user": {
+        "groups": [
+          "system:masters"
+        ],
+        "uid": "e71d8fb7-531f-4b8d-bdba-65abb9c0849b",
+        "username": "system:apiserver"
+      },
+      "userAgent": "oauth-apiserver/v0.0.0 (linux/amd64) kubernetes/$Format",
+      "verb": "watch"
+    },
+    {
+      "annotations": {
+        "authorization.k8s.io/decision": "allow",
+        "authorization.k8s.io/reason": ""
+      },
+      "auditID": "3803e946-cbd2-4fe7-b8c0-57dba6a849d9",
+      "level": "Metadata",
+      "objectRef": {
+        "apiGroup": "user.openshift.io",
+        "apiVersion": "v1",
+        "resource": "groups"
+      },
+      "requestReceivedTimestamp": "2023-10-18T09:31:30.333236Z",
+      "requestURI": "/apis/user.openshift.io/v1/groups?allowWatchBookmarks=true&resourceVersion=207810&timeout=8m15s&timeoutSeconds=495&watch=true",
+      "responseStatus": {
+        "code": 200,
+        "metadata": {}
+      },
+      "sourceIPs": [
+        "::1"
+      ],
+      "stage": "ResponseStarted",
+      "stageTimestamp": "2023-10-18T09:31:30.333626Z",
+      "user": {
+        "groups": [
+          "system:masters"
+        ],
+        "uid": "e71d8fb7-531f-4b8d-bdba-65abb9c0849b",
+        "username": "system:apiserver"
+      },
+      "userAgent": "oauth-apiserver/v0.0.0 (linux/amd64) kubernetes/$Format",
+      "verb": "watch"
+    }
+  ],
+  "kind": "EventList",
+  "metadata": {},
+  "path": "/",
+  "source_type": "http_server",
+  "timestamp": "2023-10-18T09:31:53.359093622Z"
+}`
 )
 
 var _ = Describe("[Functional][Inputs][Http] Functional tests", func() {
@@ -31,39 +111,14 @@ var _ = Describe("[Functional][Inputs][Http] Functional tests", func() {
 		Skip("skip for non-vector")
 	}
 
-	tsF := func(tsStr string) time.Time { ts, _ := time.Parse(time.RFC3339Nano, tsStr); return ts }
-
 	var (
 		framework *functional.CollectorFunctionalFramework
-
-		auditRecord = auditv1.Event{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       `Event`,
-				APIVersion: `audit.k8s.io/v1`,
-			},
-			Level:      `default`,
-			AuditID:    `16dcc977-a39e-467b-af44-921416b7800b`,
-			Stage:      `RequestReceived`,
-			RequestURI: `/apis/rbac.authorization.k8s.io/v1/clusterrolebindings?limit=500\u0026resourceVersion=0`,
-			Verb:       `create`,
-			User: authentication.UserInfo{
-				Username: "foobar",
-				Groups:   []string{"system:masters", "system:authenticated"},
-			},
-			SourceIPs: []string{"::1", "127.0.0.1"},
-			UserAgent: "kube-apiserver/v1.27.3 (linux/amd64) kubernetes/25b4e43",
-			ObjectRef: &auditv1.ObjectReference{
-				Resource:   "clusterrolebindings",
-				APIGroup:   "rbac.authorization.k8s.io",
-				APIVersion: "v1",
-			},
-			StageTimestamp:           metav1.NewMicroTime(tsF(`2022-08-17T20:27:20.570375Z`)),
-			RequestReceivedTimestamp: metav1.NewMicroTime(tsF(`2023-08-24T21:37:38.842649Z`)),
-			Annotations:              map[string]string{"foo": "bar"},
-		}
+		events    auditv1.EventList
 	)
+	eventsBytes := []byte(strings.Replace(eventsString, "\n", "", -1))
 
 	BeforeEach(func() {
+		Expect(json.Unmarshal(eventsBytes, &events)).To(Succeed())
 		Expect(testfw.LogCollectionType).To(Equal(logging.LogCollectionTypeVector))
 		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
 		framework.VisitConfig = func(conf string) string {
@@ -92,7 +147,7 @@ var _ = Describe("[Functional][Inputs][Http] Functional tests", func() {
 					return framework.AddVectorHttpOutput(b, framework.Forwarder.Spec.Outputs[0])
 				}),
 			).To(BeNil())
-			err := framework.WriteAsJsonToHttpInput(httpInputName, auditRecord)
+			err := framework.WriteAsJsonToHttpInput(httpInputName, events.Items[0])
 			Expect(err).To(BeNil(), "Expected no errors writing to HTTP input")
 			raw, err := framework.ReadFileFromWithRetryInterval("http", functional.ApplicationLogFile, time.Second)
 			Expect(err).To(BeNil(), "Expected no errors reading the logs")
@@ -100,7 +155,7 @@ var _ = Describe("[Functional][Inputs][Http] Functional tests", func() {
 			err = types.ParseLogsFrom(utils.ToJsonLogs([]string{raw}), &logs, false)
 			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
 			outputTestLog := logs[0]
-			Expect(outputTestLog).To(FitLogFormatTemplate(auditRecord))
+			Expect(outputTestLog).To(FitLogFormatTemplate(events.Items[0]), "raw string: %q", raw)
 		})
 	})
 
@@ -112,22 +167,49 @@ var _ = Describe("[Functional][Inputs][Http] Functional tests", func() {
 				}),
 			).To(BeNil())
 
-			var logArray = auditv1.EventList{
-				Items: []auditv1.Event{auditRecord, auditRecord},
-			}
-
-			err := framework.WriteAsJsonToHttpInput(httpInputName, logArray)
+			err := framework.WriteToHttpInputWithPortForwarder(httpInputName, eventsBytes)
 			Expect(err).To(BeNil(), "Expected no errors writing to HTTP input")
 			raw, err := framework.ReadFileFromWithRetryInterval("http", functional.ApplicationLogFile, time.Second)
 			Expect(err).To(BeNil(), "Expected no errors reading the logs")
 			lines := strings.Split(strings.TrimSpace(raw), "\n")
-			Expect(len(lines)).To(Equal(len(logArray.Items)), "--- raw lines:\n%v\n...", raw)
-			for _, line := range lines {
+			Expect(len(lines)).To(Equal(len(events.Items)), "--- raw lines:\n%v\n...", raw)
+			for i, line := range lines {
 				var logs []auditv1.Event
 				err = types.ParseLogsFrom(utils.ToJsonLogs([]string{line}), &logs, false)
 				Expect(err).To(BeNil(), "Expected no errors parsing the logs")
-				Expect(logs[0]).To(FitLogFormatTemplate(auditRecord))
+				Expect(logs[0]).To(FitLogFormatTemplate(events.Items[i]))
 			}
+		})
+
+		It("should apply an audit filter", func() {
+			Expect(events.Items[0].Stage).To(Not(Equal(events.Items[1].Stage)))
+			filterName := "auditFilter"
+			framework.Forwarder.Spec.Filters = []logging.FilterSpec{{
+				Name: filterName,
+				Type: logging.FilterKubeAPIAudit,
+				FilterTypeSpec: logging.FilterTypeSpec{KubeAPIAudit: &logging.KubeAPIAudit{
+					OmitStages: []auditv1.Stage{events.Items[0].Stage},
+					Rules:      []auditv1.PolicyRule{{Level: auditv1.LevelMetadata}}, // Skip default rules.
+				}},
+			}}
+			framework.Forwarder.Spec.Pipelines[0].FilterRefs = []string{filterName}
+
+			Expect(framework.DeployWithVisitor(
+				func(b *runtime.PodBuilder) error {
+					return framework.AddVectorHttpOutput(b, framework.Forwarder.Spec.Outputs[0])
+				}),
+			).To(BeNil())
+
+			err := framework.WriteToHttpInputWithPortForwarder(httpInputName, eventsBytes)
+			Expect(err).To(BeNil(), "Expected no errors writing to HTTP input")
+			raw, err := framework.ReadFileFromWithRetryInterval("http", functional.ApplicationLogFile, time.Second)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			lines := strings.Split(strings.TrimSpace(raw), "\n")
+			Expect(lines).To(HaveLen(1))
+			var logs []auditv1.Event
+			err = types.ParseLogsFrom(utils.ToJsonLogs(lines), &logs, false)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+			Expect(logs[0]).To(FitLogFormatTemplate(events.Items[1]))
 		})
 	})
 })

--- a/test/functional/normalization/audit_logs_format_test.go
+++ b/test/functional/normalization/audit_logs_format_test.go
@@ -164,7 +164,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 						Kind:             "Event",
 						Hostname:         framework.Pod.Spec.NodeName,
 						LogType:          "audit",
-						Level:            "default",
+						Level:            "Metadata",
 						Timestamp:        time.Time{},
 						PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
 						OpenshiftLabels: types.OpenshiftMeta{
@@ -186,7 +186,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				outputTestLog := logs[0]
 				Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 				results := strings.Join(raw, " ")
-				Expect(results).To(MatchRegexp("kind.*Event.*level.*default.*k8s_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
+				Expect(results).To(MatchRegexp("kind.*Event.*level.*Metadata.*k8s_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
 
 			})
 			It("should parse openshift audit log format correctly", func() {
@@ -200,7 +200,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 						Kind:             "Event",
 						Hostname:         framework.Pod.Spec.NodeName,
 						LogType:          "audit",
-						Level:            "default",
+						Level:            "Metadata",
 						Timestamp:        time.Time{},
 						PipelineMetadata: functional.TemplateForAnyPipelineMetadata,
 						OpenshiftLabels: types.OpenshiftMeta{
@@ -223,7 +223,7 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				for _, outputTestLog := range logs {
 					Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 					results := strings.Join(raw, " ")
-					Expect(results).To(MatchRegexp("kind.*Event.*level.*default.*openshift_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
+					Expect(results).To(MatchRegexp("kind.*Event.*level.*Metadata.*openshift_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
 				}
 			})
 			It("should parse linux audit log format correctly", func() {


### PR DESCRIPTION
The kubeapi-server webhook serializes audit Events without "apiVersion" or "kind" fields.
The audit filter was using these fields to identify API-audit log records.
Instead check for presence and type of "auditID" and "verb" which are always present.

Other changes:
- Don't overwrite "level" field for API audit events, users will expect this field.
- test/functionl/vector.go make vector the default collector default if no build tags are set.