### PR TITLE
LOG-4536: add request and buffer settings to address memory consumption

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -294,7 +294,7 @@ type Http struct {
 
 	// Timeout specifies the Http request timeout in seconds. If not set, 10secs is used.
 	// +optional
-	Timeout string `json:"timeout,omitempty"`
+	Timeout int `json:"timeout,omitempty"`
 
 	// Method specifies the Http method to be used for sending logs. If not set, 'POST' is used.
 	// +kubebuilder:validation:Enum:=GET;HEAD;POST;PUT;DELETE;OPTIONS;TRACE;PATCH

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -241,7 +241,7 @@ spec:
                         timeout:
                           description: Timeout specifies the Http request timeout
                             in seconds. If not set, 10secs is used.
-                          type: string
+                          type: integer
                       type: object
                     kafka:
                       description: 'Kafka provides optional extra properties for `type:

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -237,7 +237,7 @@ spec:
                         timeout:
                           description: Timeout specifies the Http request timeout
                             in seconds. If not set, 10secs is used.
-                          type: string
+                          type: integer
                       type: object
                     kafka:
                       description: 'Kafka provides optional extra properties for `type:

--- a/internal/generator/fluentd/output/http/http_test.go
+++ b/internal/generator/fluentd/output/http/http_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Generate fluentd config", func() {
 						Name: "http-receiver",
 						URL:  "https://my-logstore.com/logs/app-logs",
 						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
-							Timeout: "50",
+							Timeout: 50,
 							Headers: map[string]string{
 								"k1": "v1",
 								"k2": "v2",
@@ -170,7 +170,7 @@ var _ = Describe("Generate fluentd config", func() {
 						Name: "http-receiver",
 						URL:  "https://my-logstore.com/logs/app-logs",
 						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
-							Timeout: "50",
+							Timeout: 50,
 							Headers: map[string]string{
 								"k1": "v1",
 								"k2": "v2",
@@ -253,7 +253,7 @@ var _ = Describe("Generate fluentd config", func() {
 						Name: "http-receiver",
 						URL:  "https://my-logstore.com/logs/app-logs",
 						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
-							Timeout: "50",
+							Timeout: 50,
 							Headers: map[string]string{
 								"Content-Type": "application/json",
 								"k1":           "v1",

--- a/internal/generator/helpers/optional_pair.go
+++ b/internal/generator/helpers/optional_pair.go
@@ -1,0 +1,29 @@
+package helpers
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type OptionalPair struct {
+	key   string
+	Value interface{}
+}
+
+func NewOptionalPair(key string, value interface{}) OptionalPair {
+	return OptionalPair{
+		key,
+		value,
+	}
+}
+
+func (op OptionalPair) String() string {
+	if op.Value == nil {
+		return ""
+	}
+	format := "%s = %v"
+	if reflect.TypeOf(op.Value).Kind() == reflect.String {
+		format = "%s = %q"
+	}
+	return fmt.Sprintf(format, op.key, op.Value)
+}

--- a/internal/generator/helpers/optional_pair_test.go
+++ b/internal/generator/helpers/optional_pair_test.go
@@ -1,0 +1,34 @@
+package helpers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OptionalPair", func() {
+	Context("#Template", func() {
+		var (
+			pair OptionalPair
+		)
+		It("should return an empty template when the value is nil", func() {
+			pair = NewOptionalPair("abc", nil)
+			Expect(pair.String()).To(BeEmpty())
+		})
+		It("should return a formatted string config when value is a string", func() {
+			pair = NewOptionalPair("abc", "xyz")
+			Expect(pair.String()).To(Equal(`abc = "xyz"`))
+		})
+		It("should return a formatted numerical config when value is an int", func() {
+			pair = NewOptionalPair("abc", 123)
+			Expect(pair.String()).To(Equal(`abc = 123`))
+		})
+		It("should return a formatted bool config when value is bool", func() {
+			pair = NewOptionalPair("abc", true)
+			Expect(pair.String()).To(Equal(`abc = true`))
+		})
+		It("should return a formatted false bool config when value is bool", func() {
+			pair = NewOptionalPair("abc", false)
+			Expect(pair.String()).To(Equal(`abc = false`))
+		})
+	})
+})

--- a/internal/generator/helpers/suite_test.go
+++ b/internal/generator/helpers/suite_test.go
@@ -1,0 +1,13 @@
+package helpers
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][generator][helpers] Suite")
+}

--- a/internal/generator/utils/utils.go
+++ b/internal/generator/utils/utils.go
@@ -7,6 +7,9 @@ import (
 )
 
 func ToHeaderStr(h map[string]string, formatStr string) string {
+	if len(h) == 0 {
+		return ""
+	}
 	sortedKeys := make([]string, len(h))
 	i := 0
 	for k := range h {

--- a/internal/generator/vector/conf_test.go
+++ b/internal/generator/vector/conf_test.go
@@ -43,15 +43,6 @@ var _ = Describe("Testing Complete Config Generation", func() {
 				constants.PreviewTLSSecurityProfile: "",
 				generator.ClusterTLSProfileSpec:     tls.GetClusterTLSProfileSpec(nil),
 			},
-			CLSpec: logging.CollectionSpec{
-				Fluentd: &logging.FluentdForwarderSpec{
-					Buffer: &logging.FluentdBufferSpec{
-						ChunkLimitSize: "8m",
-						TotalLimitSize: "800000000",
-						OverflowAction: "throw_exception",
-					},
-				},
-			},
 			CLFSpec: logging.ClusterLogForwarderSpec{
 				Inputs: []logging.InputSpec{
 					{
@@ -472,6 +463,9 @@ topic = "topic"
 [sinks.kafka_receiver.encoding]
 codec = "json"
 timestamp_format = "rfc3339"
+
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
 
 [sinks.kafka_receiver.tls]
 enabled = true
@@ -971,9 +965,15 @@ endpoints = ["https://es-1.svc.messaging.cluster.local:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 
 [sinks.es_1.tls]
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
@@ -1083,9 +1083,15 @@ endpoints = ["https://es-2.svc.messaging.cluster.local:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.es_2.buffer]
+when_full = "drop_newest"
+
+[sinks.es_2.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 
 [sinks.es_2.tls]
 key_file = "/var/run/ocp-collector/secrets/es-2/tls.key"
@@ -1607,9 +1613,15 @@ endpoints = ["https://elasticsearch:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.default.buffer]
+when_full = "drop_newest"
+
+[sinks.default.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 
 [sinks.default.tls]
 key_file = "/var/run/ocp-collector/secrets/collector/tls.key"
@@ -1724,9 +1736,15 @@ endpoints = ["https://es-1.svc.messaging.cluster.local:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 
 [sinks.es_1.tls]
 min_tls_version = "VersionTLS12"
@@ -1842,9 +1860,15 @@ endpoints = ["https://es-2.svc.messaging.cluster.local:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v8"
+
+[sinks.es_2.buffer]
+when_full = "drop_newest"
+
+[sinks.es_2.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 
 [sinks.es_2.tls]
 min_tls_version = "VersionTLS12"
@@ -2329,9 +2353,15 @@ endpoints = ["https://es-1.svc.messaging.cluster.local:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 
 [sinks.es_1.tls]
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"

--- a/internal/generator/vector/elements/keyval.go
+++ b/internal/generator/vector/elements/keyval.go
@@ -13,6 +13,9 @@ func (kv KeyVal) Name() string {
 }
 
 func (kv KeyVal) Template() string {
+	if kv.Val == "" {
+		return `{{define "` + kv.Name() + `" -}}{{end -}}`
+	}
 	return `{{define "` + kv.Name() + `" -}}
 {{.Key}} = {{.Val}}
 {{end -}}`

--- a/internal/generator/vector/output/buffer.go
+++ b/internal/generator/vector/output/buffer.go
@@ -1,0 +1,24 @@
+package output
+
+type Buffer struct {
+	ComponentID string
+	WhenFull    string
+}
+
+func NewBuffer(id string) Buffer {
+	return Buffer{
+		ComponentID: id,
+		WhenFull:    "drop_newest",
+	}
+}
+
+func (b Buffer) Name() string {
+	return "buffer"
+}
+
+func (b Buffer) Template() string {
+	return `{{define "` + b.Name() + `" -}}
+[sinks.{{.ComponentID}}.buffer]
+when_full = "{{.WhenFull}}"
+{{end}}`
+}

--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -2,6 +2,7 @@ package cloudwatch
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output"
 	"regexp"
 	"strings"
 
@@ -62,7 +63,6 @@ group_name = "{{"{{ group_name }}"}}"
 stream_name = "{{"{{ stream_name }}"}}"
 {{compose_one .SecurityConfig}}
 encoding.codec = "json"
-request.concurrency = 2
 healthcheck.enabled = false
 {{compose_one .EndpointConfig}}
 {{- end}}
@@ -70,29 +70,33 @@ healthcheck.enabled = false
 }
 
 func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
-	outputName := helpers.FormatComponentID(o.Name)
-	componentID := fmt.Sprintf("%s_%s", outputName, "normalize_group_and_streams")
-	dedottedID := normalize.ID(outputName, "dedot")
+	id := helpers.FormatComponentID(o.Name)
+	componentID := fmt.Sprintf("%s_%s", id, "normalize_group_and_streams")
+	dedottedID := normalize.ID(id, "dedot")
 	if genhelper.IsDebugOutput(op) {
 		return []Element{
 			NormalizeGroupAndStreamName(LogGroupNameField(o), LogGroupPrefix(o), componentID, inputs),
-			Debug(outputName, helpers.MakeInputs([]string{componentID}...)),
+			Debug(id, helpers.MakeInputs([]string{componentID}...)),
 		}
 	}
+	request := output.NewRequest(id)
+	request.Concurrency.Value = 2
 	return MergeElements(
 		[]Element{
 			NormalizeGroupAndStreamName(LogGroupNameField(o), LogGroupPrefix(o), componentID, inputs),
 			normalize.DedotLabels(dedottedID, []string{componentID}),
-			OutputConf(o, []string{dedottedID}, secret, op, o.Cloudwatch.Region),
+			OutputConf(id, o, []string{dedottedID}, secret, op, o.Cloudwatch.Region),
+			output.NewBuffer(id),
+			request,
 		},
 		TLSConf(o, secret, op),
 	)
 }
 
-func OutputConf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options, region string) Element {
+func OutputConf(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options, region string) Element {
 	return CloudWatch{
 		Desc:           "Cloudwatch Logs",
-		ComponentID:    helpers.FormatComponentID(o.Name),
+		ComponentID:    id,
 		Inputs:         helpers.MakeInputs(inputs...),
 		Region:         region,
 		SecurityConfig: SecurityConfig(secret),

--- a/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
@@ -104,8 +104,15 @@ stream_name = "{{ stream_name }}"
 auth.access_key_id = "` + keyId + `"
 auth.secret_access_key = "` + keySecret + `"
 encoding.codec = "json"
-request.concurrency = 2
 healthcheck.enabled = false
+`
+
+	cwBufferAndRequest = `
+[sinks.cw.buffer]
+when_full = "drop_newest"
+[sinks.cw.request]
+retry_attempts = 17
+concurrency = 2
 `
 	cwSinkRole = `
 # Cloudwatch Logs
@@ -118,7 +125,6 @@ group_name = "{{ group_name }}"
 stream_name = "{{ stream_name }}"
 # role_arn and identity token set via env vars
 encoding.codec = "json"
-request.concurrency = 2
 healthcheck.enabled = false
 `
 	cwSinkKeyIdTLS = `
@@ -133,8 +139,12 @@ stream_name = "{{ stream_name }}"
 auth.access_key_id = "` + keyId + `"
 auth.secret_access_key = "` + keySecret + `"
 encoding.codec = "json"
-request.concurrency = 2
 healthcheck.enabled = false
+[sinks.cw.buffer]
+when_full = "drop_newest"
+[sinks.cw.request]
+retry_attempts = 17
+concurrency = 2
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -154,8 +164,12 @@ stream_name = "{{ stream_name }}"
 auth.access_key_id = "` + keyId + `"
 auth.secret_access_key = "` + keySecret + `"
 encoding.codec = "json"
-request.concurrency = 2
 healthcheck.enabled = false
+[sinks.cw.buffer]
+when_full = "drop_newest"
+[sinks.cw.request]
+retry_attempts = 17
+concurrency = 2
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -173,8 +187,12 @@ stream_name = "{{ stream_name }}"
 auth.access_key_id = "` + keyId + `"
 auth.secret_access_key = "` + keySecret + `"
 encoding.codec = "json"
-request.concurrency = 2
 healthcheck.enabled = false
+[sinks.cw.buffer]
+when_full = "drop_newest"
+[sinks.cw.request]
+retry_attempts = 17
+concurrency = 2
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -195,8 +213,12 @@ group_name = "{{ group_name }}"
 stream_name = "{{ stream_name }}"
 # role_arn and identity token set via env vars
 encoding.codec = "json"
-request.concurrency = 2
 healthcheck.enabled = false
+[sinks.cw.buffer]
+when_full = "drop_newest"
+[sinks.cw.request]
+retry_attempts = 17
+concurrency = 2
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -215,8 +237,12 @@ group_name = "{{ group_name }}"
 stream_name = "{{ stream_name }}"
 # role_arn and identity token set via env vars
 encoding.codec = "json"
-request.concurrency = 2
 healthcheck.enabled = false
+[sinks.cw.buffer]
+when_full = "drop_newest"
+[sinks.cw.request]
+retry_attempts = 17
+concurrency = 2
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -237,8 +263,12 @@ group_name = "{{ group_name }}"
 stream_name = "{{ stream_name }}"
 # role_arn and identity token set via env vars
 encoding.codec = "json"
-request.concurrency = 2
 healthcheck.enabled = false
+[sinks.cw.buffer]
+when_full = "drop_newest"
+[sinks.cw.request]
+retry_attempts = 17
+concurrency = 2
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -257,8 +287,12 @@ group_name = "{{ group_name }}"
 stream_name = "{{ stream_name }}"
 # role_arn and identity token set via env vars
 encoding.codec = "json"
-request.concurrency = 2
 healthcheck.enabled = false
+[sinks.cw.buffer]
+when_full = "drop_newest"
+[sinks.cw.request]
+retry_attempts = 17
+concurrency = 2
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -349,6 +383,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 ` + dedotted + `
 
 ` + cwSinkKeyId + `
+` + cwBufferAndRequest + `
 `
 				element := Conf(output, pipelineName, secrets[output.Secret.Name], nil)
 				results, err := g.GenerateConf(element...)
@@ -383,6 +418,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 ` + dedotted + `
 
 ` + cwSinkKeyId + `
+` + cwBufferAndRequest + `
 `
 				element := Conf(output, pipelineName, secrets[output.Secret.Name], nil)
 				results, err := g.GenerateConf(element...)
@@ -417,6 +453,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 ` + dedotted + `
 
 ` + cwSinkKeyId + `
+` + cwBufferAndRequest + `
 `
 				element := Conf(output, pipelineName, secrets[output.Secret.Name], nil)
 				results, err := g.GenerateConf(element...)
@@ -458,6 +495,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 ` + dedotted + `
 
 ` + cwSinkKeyId + `
+` + cwBufferAndRequest + `
 `
 				element := Conf(output, pipelineName, secrets[output.Secret.Name], nil)
 				results, err := g.GenerateConf(element...)
@@ -494,9 +532,9 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 ` + dedotted + `
 
 ` + cwSinkKeyId + `
-endpoint = "` + endpoint + `"
+endpoint = "` + endpoint + `"` + `
 tls.verify_certificate = false
-`
+` + cwBufferAndRequest
 			element := Conf(output, pipelineName, secrets[output.Secret.Name], nil)
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
@@ -682,6 +720,8 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
 ` + dedotted + `
 
 ` + cwSinkRole + `
+` + cwBufferAndRequest + `
+
 `
 				element := Conf(output, pipelineName, secrets[output.Secret.Name], nil)
 				results, err := g.GenerateConf(element...)
@@ -800,6 +840,7 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
 ` + dedotted + `
 
 ` + cwSinkRole + `
+` + cwBufferAndRequest + `
 `
 				element := Conf(output, pipelineName, secrets[output.Secret.Name], nil)
 				results, err := g.GenerateConf(element...)

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -150,9 +150,14 @@ endpoints = ["https://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 
 # Basic Auth Config
 [sinks.es_1.auth]
@@ -287,9 +292,14 @@ endpoints = ["https://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 
 [sinks.es_1.tls]
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
@@ -413,9 +423,14 @@ endpoints = ["http://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 `,
 		}),
 		Entry("with multiple pipelines for elastic-search", helpers.ConfGenerateTest{
@@ -576,9 +591,14 @@ endpoints = ["https://es-1.svc.messaging.cluster.local:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 
 [sinks.es_1.tls]
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
@@ -688,9 +708,14 @@ endpoints = ["https://es-2.svc.messaging.cluster.local:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.es_2.buffer]
+when_full = "drop_newest"
+[sinks.es_2.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 
 [sinks.es_2.tls]
 key_file = "/var/run/ocp-collector/secrets/es-2/tls.key"
@@ -832,9 +857,14 @@ endpoints = ["http://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 `,
 		}),
 		Entry("with StructuredTypeName", helpers.ConfGenerateTest{
@@ -967,9 +997,13 @@ endpoints = ["http://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 `,
 		}),
 		Entry("with both StructuredTypeKey and StructuredTypeName", helpers.ConfGenerateTest{
@@ -1108,9 +1142,13 @@ endpoints = ["http://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 `,
 		}),
 		Entry("with StructuredTypeKey, StructuredTypeName, container annotations enabled", helpers.ConfGenerateTest{
@@ -1262,9 +1300,13 @@ endpoints = ["http://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 `,
 		}),
 		Entry("without an Elasticsearch version", helpers.ConfGenerateTest{
@@ -1383,9 +1425,13 @@ endpoints = ["http://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 `,
 		}),
 		Entry("with an Elasticsearch version less than our default", helpers.ConfGenerateTest{
@@ -1513,9 +1559,13 @@ endpoints = ["http://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v5"
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 `,
 		}),
 		Entry("with our default Elasticsearch version", helpers.ConfGenerateTest{
@@ -1643,9 +1693,13 @@ endpoints = ["http://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v6"
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 `,
 		}),
 		Entry("with Elasticsearch version 7", helpers.ConfGenerateTest{
@@ -1773,9 +1827,13 @@ endpoints = ["http://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v7"
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 `,
 		}),
 		Entry("with an Elasticsearch version greater than latest version", helpers.ConfGenerateTest{
@@ -1903,9 +1961,13 @@ endpoints = ["http://es.svc.infra.cluster:9200"]
 bulk.index = "{{ write_index }}"
 bulk.action = "create"
 encoding.except_fields = ["write_index"]
-request.timeout_secs = 2147483648
 id_key = "_id"
 api_version = "v9"
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
 `,
 		}),
 	)

--- a/internal/generator/vector/output/gcl/gcl_test.go
+++ b/internal/generator/vector/output/gcl/gcl_test.go
@@ -109,10 +109,13 @@ credentials_path = "/var/run/ocp-collector/secrets/junk/google-application-crede
 log_id = "vector-1"
 severity_key = "level"
 
-
 [sinks.gcl_1.resource]
 type = "k8s_node"
 node_name = "{{hostname}}"
+[sinks.gcl_1.buffer]
+when_full = "drop_newest"
+[sinks.gcl_1.request]
+retry_attempts = 17
 `,
 		}),
 		Entry("with TLS config with default minTLSVersion & ciphers", helpers.ConfGenerateTest{
@@ -207,10 +210,14 @@ credentials_path = "/var/run/ocp-collector/secrets/junk/google-application-crede
 log_id = "vector-1"
 severity_key = "level"
 
-
 [sinks.gcl_tls.resource]
 type = "k8s_node"
 node_name = "{{hostname}}"
+
+[sinks.gcl_tls.buffer]
+when_full = "drop_newest"
+[sinks.gcl_tls.request]
+retry_attempts = 17
 
 [sinks.gcl_tls.tls]
 min_tls_version = "` + defaultTLS + `"
@@ -315,6 +322,11 @@ severity_key = "level"
 [sinks.gcl_tls.resource]
 type = "k8s_node"
 node_name = "{{hostname}}"
+
+[sinks.gcl_tls.buffer]
+when_full = "drop_newest"
+[sinks.gcl_tls.request]
+retry_attempts = 17
 
 [sinks.gcl_tls.tls]
 min_tls_version = "` + defaultTLS + `"

--- a/internal/generator/vector/output/http/http_test.go
+++ b/internal/generator/vector/output/http/http_test.go
@@ -116,7 +116,11 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
+[sinks.http_receiver.buffer]
+when_full = "drop_newest"
+
 [sinks.http_receiver.request]
+retry_attempts = 17
 timeout_secs = 10
 headers = {"h1"="v1","h2"="v2"}
 
@@ -221,7 +225,11 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
+[sinks.http_receiver.buffer]
+when_full = "drop_newest"
+
 [sinks.http_receiver.request]
+retry_attempts = 17
 timeout_secs = 10
 headers = {"h1"="v1","h2"="v2"}
 
@@ -239,7 +247,7 @@ token = "token-for-custom-http"
 						Name: "http-receiver",
 						URL:  "https://my-logstore.com",
 						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
-							Timeout: "50",
+							Timeout: 50,
 							Headers: map[string]string{
 								"k1": "v1",
 								"k2": "v2",
@@ -323,7 +331,11 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
+[sinks.http_receiver.buffer]
+when_full = "drop_newest"
+
 [sinks.http_receiver.request]
+retry_attempts = 17
 timeout_secs = 50
 headers = {"k1"="v1","k2"="v2"}
 
@@ -341,7 +353,7 @@ token = "token-for-custom-http"
 						Name: "http-receiver",
 						URL:  "https://my-logstore.com",
 						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
-							Timeout: "50",
+							Timeout: 50,
 							Headers: map[string]string{
 								"k1": "v1",
 								"k2": "v2",
@@ -421,11 +433,14 @@ type = "http"
 inputs = ["http_receiver_dedot"]
 uri = "https://my-logstore.com"
 method = "post"
-
 [sinks.http_receiver.encoding]
 codec = "json"
 
+[sinks.http_receiver.buffer]
+when_full = "drop_newest"
+
 [sinks.http_receiver.request]
+retry_attempts = 17
 timeout_secs = 50
 headers = {"k1"="v1","k2"="v2"}
 
@@ -443,7 +458,7 @@ token = "token-for-custom-http"
 						Name: "http-receiver",
 						URL:  "https://my-logstore.com",
 						OutputTypeSpec: v1.OutputTypeSpec{Http: &v1.Http{
-							Timeout: "50",
+							Timeout: 50,
 							Headers: map[string]string{
 								"k1": "v1",
 								"k2": "v2",
@@ -533,7 +548,11 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
+[sinks.http_receiver.buffer]
+when_full = "drop_newest"
+
 [sinks.http_receiver.request]
+retry_attempts = 17
 timeout_secs = 50
 headers = {"k1"="v1","k2"="v2"}
 

--- a/internal/generator/vector/output/kafka/kafka_test.go
+++ b/internal/generator/vector/output/kafka/kafka_test.go
@@ -107,6 +107,8 @@ topic = "build_complete"
 codec = "json"
 timestamp_format = "rfc3339"
 
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
 
 # SASL Config
 [sinks.kafka_receiver.sasl]
@@ -204,6 +206,9 @@ topic = "build_complete"
 [sinks.kafka_receiver.encoding]
 codec = "json"
 timestamp_format = "rfc3339"
+
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
 
 [sinks.kafka_receiver.tls]
 enabled = true
@@ -308,6 +313,9 @@ topic = "build_complete"
 codec = "json"
 timestamp_format = "rfc3339"
 
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
+
 [sinks.kafka_receiver.tls]
 enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
@@ -403,6 +411,9 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
+
 [sinks.kafka_receiver.tls]
 enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
@@ -497,6 +508,9 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
+
 [sinks.kafka_receiver.tls]
 enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
@@ -589,6 +603,9 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
+
 [sinks.kafka_receiver.librdkafka_options]
 "enable.ssl.certificate.verification" = "false"
 [sinks.kafka_receiver.tls]
@@ -678,6 +695,9 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
+
 [sinks.kafka_receiver.tls]
 enabled = true
 key_pass = "junk"
@@ -753,6 +773,9 @@ topic = "topic"
 [sinks.kafka_receiver.encoding]
 codec = "json"
 timestamp_format = "rfc3339"
+
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
 `,
 		}),
 		Entry("with plain TLS - no secret", helpers.ConfGenerateTest{
@@ -825,6 +848,9 @@ topic = "topic"
 [sinks.kafka_receiver.encoding]
 codec = "json"
 timestamp_format = "rfc3339"
+
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
 `,
 		}),
 		Entry("without security", helpers.ConfGenerateTest{
@@ -897,6 +923,9 @@ topic = "topic"
 [sinks.kafka_receiver.encoding]
 codec = "json"
 timestamp_format = "rfc3339"
+
+[sinks.kafka_receiver.buffer]
+when_full = "drop_newest"
 `,
 		}),
 	)

--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -2,6 +2,7 @@ package loki
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output"
 	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
@@ -107,20 +108,22 @@ func (l LokiLabels) Template() string {
 }
 
 func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
+	id := vectorhelpers.FormatComponentID(o.Name)
 	if genhelper.IsDebugOutput(op) {
 		return []Element{
-			Debug(vectorhelpers.FormatComponentID(o.Name), vectorhelpers.MakeInputs(inputs...)),
+			Debug(id, vectorhelpers.MakeInputs(inputs...)),
 		}
 	}
-	outputName := helpers.FormatComponentID(o.Name)
-	componentID := fmt.Sprintf("%s_%s", outputName, "remap")
-	dedottedID := normalize.ID(outputName, "dedot")
+	componentID := fmt.Sprintf("%s_%s", id, "remap")
+	dedottedID := normalize.ID(id, "dedot")
 	return MergeElements(
 		[]Element{
 			CleanupFields(componentID, inputs),
 			normalize.DedotLabels(dedottedID, []string{componentID}),
 			Output(o, []string{dedottedID}),
 			Encoding(o),
+			output.NewBuffer(id),
+			output.NewRequest(id),
 			Labels(o),
 		},
 		TLSConf(o, secret, op),

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -140,6 +140,11 @@ healthcheck.enabled = false
 [sinks.loki_receiver.encoding]
 codec = "json"
 
+[sinks.loki_receiver.buffer]
+when_full = "drop_newest"
+[sinks.loki_receiver.request]
+retry_attempts = 17
+
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
@@ -244,6 +249,11 @@ healthcheck.enabled = false
 [sinks.loki_receiver.encoding]
 codec = "json"
 
+[sinks.loki_receiver.buffer]
+when_full = "drop_newest"
+[sinks.loki_receiver.request]
+retry_attempts = 17
+
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
@@ -347,6 +357,11 @@ tenant_id = "{{foo.bar.baz}}"
 [sinks.loki_receiver.encoding]
 codec = "json"
 
+[sinks.loki_receiver.buffer]
+when_full = "drop_newest"
+[sinks.loki_receiver.request]
+retry_attempts = 17
+
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
@@ -447,6 +462,11 @@ healthcheck.enabled = false
 
 [sinks.loki_receiver.encoding]
 codec = "json"
+
+[sinks.loki_receiver.buffer]
+when_full = "drop_newest"
+[sinks.loki_receiver.request]
+retry_attempts = 17
 
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
@@ -550,6 +570,11 @@ healthcheck.enabled = false
 [sinks.loki_receiver.encoding]
 codec = "json"
 
+[sinks.loki_receiver.buffer]
+when_full = "drop_newest"
+[sinks.loki_receiver.request]
+retry_attempts = 17
+
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
@@ -641,6 +666,11 @@ healthcheck.enabled = false
 
 [sinks.loki_receiver.encoding]
 codec = "json"
+
+[sinks.loki_receiver.buffer]
+when_full = "drop_newest"
+[sinks.loki_receiver.request]
+retry_attempts = 17
 
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
@@ -742,12 +772,19 @@ out_of_order_action = "accept"
 healthcheck.enabled = false
 [sinks.loki_receiver.encoding]
 codec = "json"
+
+[sinks.loki_receiver.buffer]
+when_full = "drop_newest"
+[sinks.loki_receiver.request]
+retry_attempts = 17
+
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+
 [sinks.loki_receiver.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -849,6 +886,11 @@ healthcheck.enabled = false
 
 [sinks.loki_receiver.encoding]
 codec = "json"
+
+[sinks.loki_receiver.buffer]
+when_full = "drop_newest"
+[sinks.loki_receiver.request]
+retry_attempts = 17
 
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"

--- a/internal/generator/vector/output/request.go
+++ b/internal/generator/vector/output/request.go
@@ -1,0 +1,49 @@
+package output
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/utils"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
+)
+
+type Request struct {
+	ComponentID   string
+	RetryAttempts int
+	Concurrency   helpers.OptionalPair
+	TimeoutSecs   helpers.OptionalPair
+	headers       map[string]string
+}
+
+// NewRequest section for an output
+// Ref: LOG-4536 for RetryAttempts default
+func NewRequest(id string) *Request {
+	return &Request{
+		ComponentID:   id,
+		RetryAttempts: 17,
+		Concurrency:   helpers.NewOptionalPair("concurrency", nil),
+		TimeoutSecs:   helpers.NewOptionalPair("timeout_secs", nil),
+	}
+}
+
+func (r *Request) Name() string {
+	return "request"
+}
+
+func (r *Request) Template() string {
+	return `{{define "` + r.Name() + `" -}}
+[sinks.{{.ComponentID}}.request]
+retry_attempts = {{.RetryAttempts}}
+{{ .Concurrency -}}
+{{ .TimeoutSecs }}
+{{kv .Headers }}
+{{end}}
+`
+}
+
+func (r *Request) Headers() elements.KeyVal {
+	return elements.KV("headers", utils.ToHeaderStr(r.headers, "%q=%q"))
+}
+
+func (r *Request) SetHeaders(headers map[string]string) {
+	r.headers = headers
+}

--- a/internal/generator/vector/output/splunk/splunk_test.go
+++ b/internal/generator/vector/output/splunk/splunk_test.go
@@ -76,6 +76,10 @@ default_token = "` + hecToken + `"
 timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
+[sinks.splunk_hec.buffer]
+when_full = "drop_newest"
+[sinks.splunk_hec.request]
+retry_attempts = 17
 `
 		splunkSinkTls = splunkDedot + `
 [sinks.splunk_hec]
@@ -87,6 +91,10 @@ default_token = "` + hecToken + `"
 timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
+[sinks.splunk_hec.buffer]
+when_full = "drop_newest"
+[sinks.splunk_hec.request]
+retry_attempts = 17
 [sinks.splunk_hec.tls]
 key_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.crt"
@@ -102,6 +110,10 @@ default_token = "` + hecToken + `"
 timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
+[sinks.splunk_hec.buffer]
+when_full = "drop_newest"
+[sinks.splunk_hec.request]
+retry_attempts = 17
 [sinks.splunk_hec.tls]
 verify_certificate = false
 verify_hostname = false
@@ -119,6 +131,10 @@ default_token = ""
 timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
+[sinks.splunk_hec.buffer]
+when_full = "drop_newest"
+[sinks.splunk_hec.request]
+retry_attempts = 17
 [sinks.splunk_hec.tls]
 verify_certificate = false
 verify_hostname = false
@@ -134,7 +150,10 @@ timestamp_key = "@timestamp"
 
 [sinks.splunk_hec.encoding]
 codec = "json"
-
+[sinks.splunk_hec.buffer]
+when_full = "drop_newest"
+[sinks.splunk_hec.request]
+retry_attempts = 17
 [sinks.splunk_hec.tls]
 key_pass = "junk"
 `

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -85,9 +85,10 @@ severity = "{{.Severity}}"
 }
 
 func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
+	id := vectorhelpers.FormatComponentID(o.Name)
 	if genhelper.IsDebugOutput(op) {
 		return []Element{
-			Debug(vectorhelpers.FormatComponentID(o.Name), vectorhelpers.MakeInputs(inputs...)),
+			Debug(id, vectorhelpers.MakeInputs(inputs...)),
 		}
 	}
 	u, _ := url.Parse(o.URL)

--- a/internal/generator/vector/outputs_test.go
+++ b/internal/generator/vector/outputs_test.go
@@ -106,6 +106,11 @@ healthcheck.enabled = false
 [sinks.default_loki_apps.encoding]
 codec = "json"
 
+[sinks.default_loki_apps.buffer]
+when_full = "drop_newest"
+[sinks.default_loki_apps.request]
+retry_attempts = 17
+
 [sinks.default_loki_apps.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"


### PR DESCRIPTION
### Description
* Adds buffer and request settings to all outputs for vector in order to achieve some parity to prior releases
* Modifies http api timeout to be an int instead of string of an int

### Links
* https://issues.redhat.com/browse/LOG-4536
* backport of #2203 