### PR TITLE
LOG-4741: cluster-logging-operator reconciling dozens of times

### DIFF
--- a/controllers/clusterlogging/clusterlogging_controller.go
+++ b/controllers/clusterlogging/clusterlogging_controller.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"strings"
@@ -166,7 +168,7 @@ func (r *ReconcileClusterLogging) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&appsv1.Deployment{}).
-		Owns(&appsv1.DaemonSet{}).
+		Owns(&appsv1.DaemonSet{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&monitoringv1.ServiceMonitor{}).
 		Watches(&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {

--- a/controllers/forwarding/forwarding_controller.go
+++ b/controllers/forwarding/forwarding_controller.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -182,7 +184,7 @@ func (r *ReconcileForwarder) SetupWithManager(mgr ctrl.Manager) error {
 	return controllerBuilder.
 		For(&logging.ClusterLogForwarder{}).
 		Owns(&corev1.ConfigMap{}).
-		Owns(&appsv1.DaemonSet{}).
+		Owns(&appsv1.DaemonSet{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&appsv1.Deployment{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).


### PR DESCRIPTION
### Description
This PR attempts to fix the `cluster logging operator` from reconciling dozens of times after a `ClusterLogForwarder` (CLF) was defined. After applying a CLF YAML, the resulting created daemonset's status was updating many time resulting in dozens of reconcile requests to the CLF. The proposed change is to ignore the daemonset's status changes and only reconcile on spec changes.

/cc @jlarriba @syedriko @cahartma 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4741

