### PR TITLE
LOG-4706: Fluentd CrashLoopBackOff on single stack IPv6 and dual stack clusters

### DIFF
--- a/internal/collector/fluentd/run_script.go
+++ b/internal/collector/fluentd/run_script.go
@@ -45,7 +45,7 @@ ruby <<EOF
 		isIPV6 |= ipaddr.ipv6?
 	  end
 	end
-	return "[::]" if isIPV6
+	return "::" if isIPV6
 	return "0.0.0.0" if isIPV4
 	return "invalid-ip"
   end


### PR DESCRIPTION
### Description
This PR addresses the issue with collector pods crashing due to `Fluentd` binding an IPv6 address that include brackets (`[::]`) for `prometheus` monitoring. `Fluentd v1.14.6` worked with the mentioned IPv6 address but `Fluentd v5.8.0` changed the way IPv6 addresses are handled.

/cc @syedriko @cahartma 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4706

