### PR TITLE
LOG-4786: Label 'openshift.sequence' is missing when forwarding logs over syslog with vector

### DIFF
--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -11,6 +11,7 @@ import (
 	genhelper "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 	. "github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	vectorhelpers "github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/security"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -86,6 +87,7 @@ severity = "{{.Severity}}"
 
 func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
 	id := vectorhelpers.FormatComponentID(o.Name)
+	dedottedID := normalize.ID(id, "dedot")
 	if genhelper.IsDebugOutput(op) {
 		return []Element{
 			Debug(id, vectorhelpers.MakeInputs(inputs...)),
@@ -94,7 +96,8 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 	u, _ := url.Parse(o.URL)
 	return MergeElements(
 		[]Element{
-			Output(o, inputs, secret, op, u.Scheme, u.Host),
+			normalize.DedotLabels(dedottedID, inputs),
+			Output(o, []string{dedottedID}, secret, op, u.Scheme, u.Host),
 			Encoding(o),
 		},
 		TLSConf(o, secret, op),

--- a/internal/generator/vector/output/syslog/syslog_test.go
+++ b/internal/generator/vector/output/syslog/syslog_test.go
@@ -14,9 +14,57 @@ import (
 var _ = Describe("vector syslog clf output", func() {
 	const (
 		xyzDefaults = `
+[transforms.syslog_xyz_dedot]
+type = "lua"
+inputs = ["pipelineName"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+	function init()
+		count = 0
+	end
+	function process(event, emit)
+		count = count + 1
+		event.log.openshift.sequence = count
+		if event.log.kubernetes == nil then
+			emit(event)
+			return
+		end
+		if event.log.kubernetes.labels == nil then
+			emit(event)
+			return
+		end
+		dedot(event.log.kubernetes.namespace_labels)
+		dedot(event.log.kubernetes.labels)
+		emit(event)
+	end
+
+	function dedot(map)
+		if map == nil then
+			return
+		end
+		local new_map = {}
+		local changed_keys = {}
+		for k, v in pairs(map) do
+			local dedotted = string.gsub(k, "[./]", "_")
+			if dedotted ~= k then
+				new_map[dedotted] = v
+				changed_keys[k] = true
+			end
+		end
+		for k in pairs(changed_keys) do
+			map[k] = nil
+		end
+		for k, v in pairs(new_map) do
+			map[k] = v
+		end
+	end
+'''
+
 [transforms.syslog_xyz_json]
 type = "remap"
-inputs = ["pipelineName"]
+inputs = ["syslog_xyz_dedot"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
 '''
@@ -34,9 +82,57 @@ facility = "user"
 severity = "informational"
 `
 		tcpDefaults = `
+[transforms.syslog_tcp_dedot]
+type = "lua"
+inputs = ["pipelineName"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+	function init()
+		count = 0
+	end
+	function process(event, emit)
+		count = count + 1
+		event.log.openshift.sequence = count
+		if event.log.kubernetes == nil then
+			emit(event)
+			return
+		end
+		if event.log.kubernetes.labels == nil then
+			emit(event)
+			return
+		end
+		dedot(event.log.kubernetes.namespace_labels)
+		dedot(event.log.kubernetes.labels)
+		emit(event)
+	end
+
+	function dedot(map)
+		if map == nil then
+			return
+		end
+		local new_map = {}
+		local changed_keys = {}
+		for k, v in pairs(map) do
+			local dedotted = string.gsub(k, "[./]", "_")
+			if dedotted ~= k then
+				new_map[dedotted] = v
+				changed_keys[k] = true
+			end
+		end
+		for k in pairs(changed_keys) do
+			map[k] = nil
+		end
+		for k, v in pairs(new_map) do
+			map[k] = v
+		end
+	end
+'''
+
 [transforms.syslog_tcp_json]
 type = "remap"
-inputs = ["pipelineName"]
+inputs = ["syslog_tcp_dedot"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
 '''
@@ -54,9 +150,57 @@ facility = "user"
 severity = "informational"
 `
 		udpEverySetting = `
+[transforms.syslog_udp_dedot]
+type = "lua"
+inputs = ["pipelineName"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+	function init()
+		count = 0
+	end
+	function process(event, emit)
+		count = count + 1
+		event.log.openshift.sequence = count
+		if event.log.kubernetes == nil then
+			emit(event)
+			return
+		end
+		if event.log.kubernetes.labels == nil then
+			emit(event)
+			return
+		end
+		dedot(event.log.kubernetes.namespace_labels)
+		dedot(event.log.kubernetes.labels)
+		emit(event)
+	end
+
+	function dedot(map)
+		if map == nil then
+			return
+		end
+		local new_map = {}
+		local changed_keys = {}
+		for k, v in pairs(map) do
+			local dedotted = string.gsub(k, "[./]", "_")
+			if dedotted ~= k then
+				new_map[dedotted] = v
+				changed_keys[k] = true
+			end
+		end
+		for k in pairs(changed_keys) do
+			map[k] = nil
+		end
+		for k, v in pairs(new_map) do
+			map[k] = v
+		end
+	end
+'''
+
 [transforms.syslog_udp_json]
 type = "remap"
-inputs = ["pipelineName"]
+inputs = ["syslog_udp_dedot"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
 '''
@@ -80,9 +224,57 @@ add_log_source = true
 `
 
 		tlsWithLogRecordReferences = `
+[transforms.syslog_tls_dedot]
+type = "lua"
+inputs = ["pipelineName"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+	function init()
+		count = 0
+	end
+	function process(event, emit)
+		count = count + 1
+		event.log.openshift.sequence = count
+		if event.log.kubernetes == nil then
+			emit(event)
+			return
+		end
+		if event.log.kubernetes.labels == nil then
+			emit(event)
+			return
+		end
+		dedot(event.log.kubernetes.namespace_labels)
+		dedot(event.log.kubernetes.labels)
+		emit(event)
+	end
+
+	function dedot(map)
+		if map == nil then
+			return
+		end
+		local new_map = {}
+		local changed_keys = {}
+		for k, v in pairs(map) do
+			local dedotted = string.gsub(k, "[./]", "_")
+			if dedotted ~= k then
+				new_map[dedotted] = v
+				changed_keys[k] = true
+			end
+		end
+		for k in pairs(changed_keys) do
+			map[k] = nil
+		end
+		for k, v in pairs(new_map) do
+			map[k] = v
+		end
+	end
+'''
+
 [transforms.syslog_tls_json]
 type = "remap"
-inputs = ["pipelineName"]
+inputs = ["syslog_tls_dedot"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
 '''


### PR DESCRIPTION
### Description

For vector forwarding to a syslog destination, generate the dedot transform that adds openshift.sequence to the log message.

/cc @cahartma 
/assign @jcantrill 

/cherry-pick release-5.8

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4786

