### PR TITLE
LOG-4813: Add matcher to help test conf generation

### DIFF
--- a/internal/generator/framework/generator.go
+++ b/internal/generator/framework/generator.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"bytes"
+	log "github.com/ViaQ/logerr/v2/log/static"
 	"sort"
 	"strings"
 	"text/template"
@@ -85,6 +86,7 @@ func (g Generator) generate(es []Element) (string, error) {
 		t = template.Must(t.Parse(e.Template()))
 		err := t.ExecuteTemplate(b, e.Name(), e)
 		if err != nil {
+			log.V(0).Error(err, "Error in conf generation")
 			return "error in conf generation", err
 		}
 		if i < len(es)-1 {

--- a/test/matchers/diff.go
+++ b/test/matchers/diff.go
@@ -39,7 +39,7 @@ type lineMatcher struct {
 }
 
 func (m *lineMatcher) Match(actual interface{}) (success bool, err error) {
-	m.diff = cmp.Diff(m.normalize(actual.(string)), m.normalize(m.expected.(string)))
+	m.diff = cmp.Diff(normalize(actual.(string), m.trim), normalize(m.expected.(string), m.trim))
 	return m.diff == "", nil
 }
 
@@ -51,10 +51,10 @@ func (m *lineMatcher) NegatedFailureMessage(actual interface{}) (message string)
 	return ("Expected differences but none found.")
 }
 
-func (m *lineMatcher) normalize(in string) []string {
+func normalize(in string, trim bool) []string {
 	out := []string{}
 	for _, line := range strings.Split(in, "\n") {
-		if m.trim {
+		if trim {
 			line = strings.TrimSpace(line)
 		}
 		if line != "" {

--- a/test/matchers/generator_element.go
+++ b/test/matchers/generator_element.go
@@ -1,0 +1,80 @@
+package matchers
+
+import (
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/onsi/gomega/types"
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"reflect"
+	"strings"
+)
+
+type GeneratorElementMatcher struct {
+	expected interface{}
+	diff     string
+	err      error
+}
+
+func EqualConfigFrom(expected interface{}) types.GomegaMatcher {
+	return &GeneratorElementMatcher{
+		expected: expected,
+	}
+}
+
+func (m *GeneratorElementMatcher) Match(actual interface{}) (bool, error) {
+	if actType := reflect.TypeOf(actual); actType.Kind() != reflect.String {
+		return false, fmt.Errorf("The 'actual' type is expected to be a string but is: %s", actType.Name())
+	}
+	conf, err := generateConf(m.expected)
+	m.err = err
+	if err != nil {
+		return false, err
+	}
+	nactual := normalize(actual.(string), true)
+	nexpected := normalize(conf, true)
+	m.diff = cmp.Diff(strings.Join(nactual, "\n"), strings.Join(nexpected, "\n"))
+	return m.diff == "", nil
+}
+
+func (m *GeneratorElementMatcher) FailureMessage(actual interface{}) (message string) {
+	if m.err != nil {
+		return fmt.Sprintf("Error generating 'expected' conf: %v", m.err)
+	}
+	return fmt.Sprintf("Expected element to produce a config from 'elements' but got this diff: %s", m.diff)
+}
+
+func (m *GeneratorElementMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	if m.err != nil {
+		return fmt.Sprintf("Error generating 'expected' conf: %v", m.err)
+	}
+	return fmt.Sprintf("Expected element to not produce config from 'elements' but got this diff: %s", m.diff)
+}
+
+func generateConf(expected interface{}) (string, error) {
+	var els []framework.Element
+	expType := reflect.TypeOf(expected)
+	switch {
+	case expType.Kind() == reflect.Slice && expType.Elem().Name() == "Section":
+		sections := expected.([]framework.Section)
+		for _, v := range sections {
+			els = append(els, v.Elements...)
+		}
+	case expType.Kind() == reflect.Slice && expType.Elem().Name() == "Element":
+		elements := expected.([]framework.Element)
+		els = elements
+	case expType.Implements(generatorElementType):
+		if el, ok := expected.(framework.Element); ok {
+			els = []framework.Element{el}
+		} else {
+			return "", fmt.Errorf("Matcher unable to cast 'expected' type %q to a generator.Element", expType.Name())
+		}
+	default:
+		return "", fmt.Errorf("Matcher does not support 'expected' kind %q or element type: %q", expType.Kind(), expType.Name())
+	}
+	g := framework.MakeGenerator()
+	return g.GenerateConf(els...)
+}
+
+var (
+	generatorElementType = reflect.TypeOf((*framework.Element)(nil)).Elem()
+)

--- a/test/matchers/generator_element_test.go
+++ b/test/matchers/generator_element_test.go
@@ -1,0 +1,55 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	"strings"
+)
+
+const FakeConfiguration = "fake-configuration"
+
+type FakeElement struct{}
+
+func (f FakeElement) Name() string {
+	return "fake-element"
+}
+func (f FakeElement) Template() string {
+	return `{{define "` + f.Name() + `" -}}
+fake-configuration
+{{- end}}
+`
+}
+
+var _ = Describe("Generator Element matcher", func() {
+
+	Context("when verifying an array of Sections", func() {
+
+		It("should match when elements generate the same config", func() {
+			Expect(FakeConfiguration).To(EqualConfigFrom([]framework.Section{
+				{Elements: []framework.Element{&FakeElement{}}},
+			}))
+		})
+
+	})
+	Context("when verifying a slice of Elements", func() {
+		It("should match the generated config from a slice of pointer elements", func() {
+			exp := []string{FakeConfiguration, FakeConfiguration, FakeConfiguration}
+			Expect(strings.Join(exp, "\n")).To(EqualConfigFrom([]framework.Element{&FakeElement{}, &FakeElement{}, &FakeElement{}}))
+		})
+		It("should match the generated config from a slice of struct elements", func() {
+			exp := []string{FakeConfiguration, FakeConfiguration, FakeConfiguration}
+			Expect(strings.Join(exp, "\n")).To(EqualConfigFrom([]framework.Element{FakeElement{}, FakeElement{}, FakeElement{}}))
+		})
+	})
+	Context("when verifying an Element", func() {
+		It("should match when a pointer element generates the same config", func() {
+			Expect(FakeConfiguration).To(EqualConfigFrom(&FakeElement{}))
+		})
+		It("should match when a struct element generates the same config", func() {
+			Expect(FakeConfiguration).To(EqualConfigFrom(FakeElement{}))
+		})
+	})
+
+})


### PR DESCRIPTION
### Description
This PR:

* adds test matchers to assist in testing conf generation and to make it possible for assertions to be consistent across the test base

### Links
* https://issues.redhat.com/browse/LOG-4813


cc @cahartma @syedriko 
