### PR TITLE
LOG-4823: Explicitly specify vector config file as /etc/vector/vector.toml

### DIFF
--- a/internal/collector/vector/run_script.go
+++ b/internal/collector/vector/run_script.go
@@ -9,6 +9,5 @@ VECTOR_DATA_DIR=%s
 echo "Creating the directory used for persisting Vector state $VECTOR_DATA_DIR"
 mkdir -p $VECTOR_DATA_DIR
 echo "Starting Vector process..."
-exec "/usr/bin/vector"
-
+exec /usr/bin/vector -c /etc/vector/vector.toml
 `


### PR DESCRIPTION
### Description
In preparation for upstream vector v0.34.0, explicitly specify vector config file as /etc/vector/vector.toml. The default config file from v0.34.0 on is /etc/vector/vector.yaml.

/cc @jcantrill 
/assign @cahartma 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4823

