### PR TITLE
LOG-4792: Collecting `clusterlogging` and `clusterlogforwarder` with inspect

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -49,6 +49,7 @@ cluster_resources+=(clusterrolebindings)
 cluster_resources+=(persistentvolumes)
 cluster_resources+=(clusterversion)
 cluster_resources+=(machineconfigpool)
+cluster_resources+=(customresourcedefinitions)
 
 log "-BEGIN inspecting CRs..." >> "${LOGFILE_PATH}"
 for cr in "${cluster_resources[@]}" ; do
@@ -67,7 +68,6 @@ resources+=(serviceaccounts)
 resources+=(events)
 # clusterlogging is only in the openshift-logging namespace, but it should not impact a lot to run the inspect in the other namespaces
 resources+=(clusterlogging)
-# with multi log forwarder, the clusterlogforwarder can be in custom namespaces, and they are not collected here
 resources+=(clusterlogforwarder)
 
 log "BEGIN inspecting namespaces ..." >> "${LOGFILE_PATH}"

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -65,6 +65,10 @@ resources+=(rolebindings)
 resources+=(configmaps)
 resources+=(serviceaccounts)
 resources+=(events)
+# clusterlogging is only in the openshift-logging namespace, but it should not impact a lot to run the inspect in the other namespaces
+resources+=(clusterlogging)
+# with multi log forwarder, the clusterlogforwarder can be in custom namespaces, and they are not collected here
+resources+=(clusterlogforwarder)
 
 log "BEGIN inspecting namespaces ..." >> "${LOGFILE_PATH}"
 
@@ -121,7 +125,7 @@ if [ "$found_es" != "" ] || [ "$found_lokistack" != "" ] ; then
   if [ "$found" != "" ] ; then
     KUBECACHEDIR=${BASE_COLLECTION_PATH}/cache-dir ${SCRIPT_DIR}/gather_visualization_resources "$BASE_COLLECTION_PATH" >> "${LOGFILE_PATH}" 2>&1
   fi
-  log "BEGIN gathering CLO resources ..." >> "${LOGFILE_PATH}"
+  log "END gathering logstorage resources ..." >> "${LOGFILE_PATH}"
 else
   log "Skipping logstorage inspection.  No Elasticsearch deployment found" >> "${LOGFILE_PATH}" 2>&1
 fi

--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -38,16 +38,12 @@ if [ $NAMESPACE == "openshift-logging" ]; then
   done
 fi
 
-log "Gathering data for 'clusterlogging' and 'clusterlogforwarder' from namespace: $NAMESPACE"
-for r in "clusterlogging" "clusterlogforwarder" ; do
-  names="$(oc -n $NAMESPACE get $r --ignore-not-found -o jsonpath='{.items[*].metadata.name}' | sort -u)"
-  for name in ${names[@]}; do
-    data="$(oc -n $NAMESPACE get $r ${name} --ignore-not-found -o yaml)"
-    if [ "$data" != "" ] ; then
-      echo $data > "${clo_folder}/${r}_${name}.yaml"
-    fi
-  done
-done
+log "Gathering data for 'clusterlogging' and 'clusterlogforwarder' from ${BASE_COLLECTION_PATH}/namespaces/openshift-logging/logging.openshift.io/"
+# As they are already in "namespaces/openshift-logging/logging.openshift.io/" and can be seen with `omc`, maybe not needed to add them here
+cp ${BASE_COLLECTION_PATH}/namespaces/openshift-logging/logging.openshift.io/clusterloggings/instance.yaml ${clo_folder}/clusterlogging_instance.yaml
+# for multi log forwarder feature (for now, only the `clusterlogforwarder` in `openshift-logging` is collected by the `gather` script
+mkdir -p "${clo_folder}/clf"
+cp ${BASE_COLLECTION_PATH}/namespaces/openshift-logging/logging.openshift.io/clusterlogforwarders/*.yaml ${clo_folder}/clf/
 
 log "Gathering 'secrets' from logging namespace: $NAMESPACE"
 oc -n $NAMESPACE get secrets -o yaml > ${clo_folder}/secrets.yaml 2>&1


### PR DESCRIPTION
### Description
Get the `clusterlogging` and `clusterlogforwarder` with the `oc adm inspect` command to avoid the issue reported in [LOG-4792](https://issues.redhat.com//browse/LOG-4792).
Getting also the `customresourcedefinitions` to allow https://github.com/gmeghnag/omc/  to work with above (and other) resources (on testing, it adds only few MB to the full must-gather size for ~200 `customresourcedefinitions`).

I'm not sure if `clusterlogging` and `clusterlogforwarder` should be copied to the `clo` directory. Copying it for now for compatibility with current behavior:
https://github.com/oarribas/cluster-logging-operator/blob/oarribas-cl-and-clo/must-gather/collection-scripts/gather_cluster_logging_operator_resources#L42

/cc @periklis 


Not sure how to use the cherry pick feature to include this in 5.8.z (and if possible also in 5.7.z).


### Links
- JIRA: https://issues.redhat.com/browse/LOG-4792