### PR TITLE
[release-5.7] Include clusterversion and machineconfigpool in logging…

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -30,6 +30,8 @@ cluster_resources+=(nodes)
 cluster_resources+=(clusterroles)
 cluster_resources+=(clusterrolebindings)
 cluster_resources+=(persistentvolumes)
+cluster_resources+=(clusterversion)
+cluster_resources+=(machineconfigpool)
 
 log "BEGIN inspecting CRs..." >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 for cr in "${cluster_resources[@]}" ; do


### PR DESCRIPTION
### Description
Manual cherrypick of #2249 for release 5.7

/cc @periklis
/assign @periklis

/cherry-pick release 5.6

### Links

- Github issue: https://github.com/openshift/cluster-logging-operator/issues/935