### PR TITLE
LOG-4846: Adjust CLO to include the korrel8r proxy in the logging view plugin

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -140,6 +140,9 @@ const (
 
 	HTTPReceiverPort      = 8443
 	LabelHTTPInputService = "http-input-service"
+
+	Korrel8rName      = "korrel8r"
+	Korrel8rNamespace = "korrel8r"
 )
 
 var ReconcileForGlobalProxyList = []string{CollectorTrustedCAName}

--- a/internal/constants/features.go
+++ b/internal/constants/features.go
@@ -17,4 +17,8 @@ const (
 	// without switching the default `logStore` to LokiStack. The value should be the
 	// LokiStack resource name representing the target store for the migration.
 	AnnotationOCPConsoleMigrationTarget = "logging.openshift.io/force-enable-ocp-console-target"
+
+	// AnnotationPreviewKorrel8rConsole enables preview features in the console that use Korrel8r.
+	// Korrel8r must also be installed and running in the cluster for these features to work.
+	AnnotationPreviewKorrel8rConsole = "logging.openshift.io/preview-korrel8r-console"
 )

--- a/internal/visualization/console/config.go
+++ b/internal/visualization/console/config.go
@@ -13,12 +13,15 @@ const Name = "logging-view-plugin"
 // Config is the configuration struct for the logging console plugin Reconciler.
 // Construct with NewConfig to set default values.
 type Config struct {
-	Owner       client.Object // Owning object - the ClusterLogging instance
-	Name        string        // Name for the consoleplugin and related objects
-	Image       string        // Image for the logging view service.
-	LokiService string        // Name of the LokiStack gateway service.
-	LokiPort    int32         // Port of the LokiStack gateway service.
-	Features    []string      // The features enabled for the plugin
+	Owner             client.Object // Owning object - the ClusterLogging instance
+	Name              string        // Name for the consoleplugin and related objects
+	Image             string        // Image for the logging view service.
+	LokiService       string        // Name of the LokiStack gateway service.
+	LokiPort          int32         // Port of the LokiStack gateway service.
+	Korrel8rName      string        // Name of the Korrel8r service.
+	Korrel8rNamespace string        // Namespace of korrel8r service.
+	Korrel8rPort      int32         // Port of the Korrel8r service.
+	Features          []string      // The features enabled for the plugin
 }
 
 func (cf *Config) Namespace() string        { return cf.Owner.GetNamespace() }
@@ -27,13 +30,16 @@ func (cf *Config) defaultMode() *int32      { return utils.GetPtr[int32](420) }
 func (cf *Config) pluginBackendPort() int32 { return 9443 }
 
 // NewConfig returns a config with default settings.
-func NewConfig(owner client.Object, lokiService string, features []string) Config {
+func NewConfig(owner client.Object, lokiService, korrel8rName, korrel8rNS string, features []string) Config {
 	return Config{
-		Owner:       owner,
-		Name:        Name,
-		Image:       utils.GetComponentImage(constants.ConsolePluginName),
-		LokiService: lokiService,
-		LokiPort:    8080,
-		Features:    features,
+		Owner:             owner,
+		Name:              Name,
+		Image:             utils.GetComponentImage(constants.ConsolePluginName),
+		LokiService:       lokiService,
+		LokiPort:          8080,
+		Korrel8rName:      korrel8rName,
+		Korrel8rNamespace: korrel8rNS,
+		Korrel8rPort:      8443,
+		Features:          features,
 	}
 }

--- a/internal/visualization/console/reconciler.go
+++ b/internal/visualization/console/reconciler.go
@@ -161,16 +161,30 @@ func (r *Reconciler) mutateConsolePlugin() error {
 			BasePath:  "/",
 			Port:      r.pluginBackendPort(),
 		},
-		Proxy: []consolev1alpha1.ConsolePluginProxy{{
-			Type:      "Service",
-			Alias:     "backend",
-			Authorize: true,
-			Service: consolev1alpha1.ConsolePluginProxyServiceConfig{
-				Name:      r.LokiService,
-				Namespace: r.Namespace(),
-				Port:      r.LokiPort,
+		Proxy: []consolev1alpha1.ConsolePluginProxy{
+			{
+				Type:      "Service",
+				Alias:     "backend",
+				Authorize: true,
+				Service: consolev1alpha1.ConsolePluginProxyServiceConfig{
+					Name:      r.LokiService,
+					Namespace: r.Namespace(),
+					Port:      r.LokiPort,
+				},
 			},
-		}},
+		},
+	}
+	if r.Korrel8rName != "" && r.Korrel8rNamespace != "" {
+		o.Spec.Proxy = append(o.Spec.Proxy, consolev1alpha1.ConsolePluginProxy{
+			Type:      "Service",
+			Alias:     r.Korrel8rName,
+			Authorize: false,
+			Service: consolev1alpha1.ConsolePluginProxyServiceConfig{
+				Name:      r.Korrel8rName,
+				Namespace: r.Korrel8rNamespace,
+				Port:      8443,
+			},
+		})
 	}
 	r.mutateCommon(o)
 	return nil

--- a/test/e2e/consoleplugin/smoke_test/consoleplugin_test.go
+++ b/test/e2e/consoleplugin/smoke_test/consoleplugin_test.go
@@ -53,7 +53,7 @@ var _ = Describe("[ConsolePlugin]", func() {
 		c = client.NewTest()
 		r = console.NewReconciler(
 			c.ControllerRuntimeClient(),
-			console.NewConfig(testruntime.NewClusterLogging(), "lokiService", []string{}), nil)
+			console.NewConfig(testruntime.NewClusterLogging(), "lokiService", "korrel8r", "korrel8r", []string{}), nil)
 		cleanup() // Clear out objects left behind by previous tests.
 	})
 


### PR DESCRIPTION
Korrel8r proxy is enabled whenever Loki view is.
Points to fixed service korrel8r in namespace korrel8r.

Keeping it simple, the role of enabling korrel8r will likely move out of CLO,
and become part of the new observability operator in future.