### PR TITLE
LOG-4604: Add infrastructure annotations

### DIFF
--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -121,6 +121,16 @@ metadata:
     createdAt: "2024-01-03T18:36:22Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing your aggregated logging stack.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=5.7.0-0 <5.9.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-logging

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -9,6 +9,16 @@ metadata:
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing your aggregated logging stack.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "true"
+    features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=5.7.0-0 <5.9.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-logging


### PR DESCRIPTION
### Description
This PR:
* adds infrastructure annotations

@cahartma is it correct that we can claim aws token support?  We can use the tokens as provided by the CloudCredentialsOperator?

@syedriko is it correct we can claim FIPS compliance based upon the following definition? 
```
Whether the opperator accepts the [FIPS-140](https://issues.redhat.com/browse/FIPS-140) configuration of the underlying platform and works on nodes that are booted into FIPS mode. In this mode, the operator and any workloads it manages (operands) are solely calling the RHEL cryptographic library submitted for [FIPS-140](https://issues.redhat.com/browse/FIPS-140) validation.
```

### Links
* https://issues.redhat.com/browse/LOG-4604
