### PR TITLE
LOG-4848: Enable TLS on tcp connections for rsyslog server

### DIFF
--- a/internal/generator/vector/input/viaq_receiver_http_audit.toml
+++ b/internal/generator/vector/input/viaq_receiver_http_audit.toml
@@ -5,8 +5,8 @@ decoding.codec = "json"
 
 [sources.input_myreceiver.tls]
 enabled = true
-key_file = "/etc/collector/receiver/input_myreceiver/tls.key"
-crt_file = "/etc/collector/receiver/input_myreceiver/tls.crt"
+key_file = "/etc/collector/receiver/myreceiver/tls.key"
+crt_file = "/etc/collector/receiver/myreceiver/tls.crt"
 
 [transforms.input_myreceiver_split]
 type = "remap"

--- a/internal/generator/vector/input/viaq_receiver_syslog.toml
+++ b/internal/generator/vector/input/viaq_receiver_syslog.toml
@@ -3,6 +3,11 @@ type = "syslog"
 address = "[::]:12345"
 mode = "tcp"
 
+[sources.input_myreceiver.tls]
+enabled = true
+key_file = "/etc/collector/receiver/myreceiver/tls.key"
+crt_file = "/etc/collector/receiver/myreceiver/tls.crt"
+
 [transforms.input_myreceiver_drop_debug]
 type = "filter"
 inputs = ["input_myreceiver"]

--- a/internal/generator/vector/source/http_receiver.go
+++ b/internal/generator/vector/source/http_receiver.go
@@ -28,6 +28,7 @@ func NewHttpSource(id string, input logging.InputSpec, op framework.Options) fra
 	}
 	return HttpReceiver{
 		ID:            id,
+		InputName:     input.Name,
 		ListenAddress: helpers.ListenOnAllLocalInterfacesAddress(),
 		ListenPort:    input.Receiver.HTTP.Port,
 		Format:        input.Receiver.HTTP.Format,
@@ -38,6 +39,7 @@ func NewHttpSource(id string, input logging.InputSpec, op framework.Options) fra
 
 type HttpReceiver struct {
 	ID            string
+	InputName     string
 	ListenAddress string
 	ListenPort    int32
 	Format        string
@@ -59,8 +61,8 @@ decoding.codec = "json"
 
 [sources.{{.ID}}.tls]
 enabled = true
-key_file = "/etc/collector/receiver/{{.ID}}/tls.key"
-crt_file = "/etc/collector/receiver/{{.ID}}/tls.crt"
+key_file = "/etc/collector/receiver/{{.InputName}}/tls.key"
+crt_file = "/etc/collector/receiver/{{.InputName}}/tls.crt"
 {{- if ne .TlsMinVersion "" }}
 min_tls_version = "{{ .TlsMinVersion }}"
 {{- end }}


### PR DESCRIPTION
### Description
This change enables TLS on the Vector aggregator Syslog source using the the same secret key names and meanings as all the other TLS  outputs we support.

/cc @syedriko 
/assign @jcantrill

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4848
