### PR TITLE
Sort labels in LabelSelectorFrom as expected in test

### DIFF
--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -5,6 +5,7 @@ import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -159,12 +160,18 @@ func collapseWildcards(entry string) string {
 }
 
 func LabelSelectorFrom(selector *logging.LabelSelector) string {
-	matchLabels := []string{}
 	if selector == nil {
 		return ""
 	}
-	for k, v := range selector.MatchLabels {
-		matchLabels = append(matchLabels, fmt.Sprintf("%s=%s", k, v))
+
+	matchLabels := make([]string, 0, len(selector.MatchLabels))
+	for k := range selector.MatchLabels {
+		matchLabels = append(matchLabels, k)
+	}
+	sort.Strings(matchLabels)
+
+	for i, k := range matchLabels {
+		matchLabels[i] = fmt.Sprintf("%s=%s", k, selector.MatchLabels[k])
 	}
 	return strings.Join(matchLabels, ",")
 }


### PR DESCRIPTION
### Description

The [unit test](https://github.com/openshift/cluster-logging-operator/blob/6c69c486d3bd1ebb12828ba6b6af0ca1082497a7/internal/generator/vector/source/kubernetes_logs_test.go#L72) for `LabelSelectorFrom` expects the labels to be sorted by key. The underlying data structure is a `map[string]string` which does not sort the keys, so the result of the test depends on chance. This PR changes the implementation of `LabelSelectorFrom` to explicitly sort the map keys before creating the selector.
