### PR TITLE
LOG-3651: [Vector] Add ability to change the Splunk's index within the ClusterLogForwarder

### DIFF
--- a/apis/logging/v1/output_types.go
+++ b/apis/logging/v1/output_types.go
@@ -276,6 +276,21 @@ type Splunk struct {
 	// Should be a valid JSON object
 	// +optional
 	Fields []string `json:"fields,omitempty"`
+
+	// IndexKey is a meta-data key field to use to send events to.
+	// For example: 'IndexKey: kubernetes.namespace_name` will use the kubernetes
+	// namespace as the index.
+	// If the IndexKey is not found, the default index defined within Splunk is used.
+	// Only one of IndexKey or IndexName can be defined.
+	// If IndexKey && IndexName are not specified, the default index defined within Splunk is used.
+	// +optional
+	IndexKey string `json:"indexKey,omitempty"`
+
+	// IndexName is the name of the index to send events to.
+	// Only one of IndexKey or IndexName can be defined.
+	// If IndexKey && IndexName are not specified, the default index defined within Splunk is used.
+	// +optional
+	IndexName string `json:"indexName,omitempty"`
 }
 
 // Http provided configuration for sending json encoded logs to a generic http endpoint.

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -699,6 +699,21 @@ spec:
                           items:
                             type: string
                           type: array
+                        indexKey:
+                          description: 'IndexKey is a meta-data key field to use to
+                            send events to. For example: ''IndexKey: kubernetes.namespace_name`
+                            will use the kubernetes namespace as the index. If the
+                            IndexKey is not found, the default index defined within
+                            Splunk is used. Only one of IndexKey or IndexName can
+                            be defined. If IndexKey && IndexName are not specified,
+                            the default index defined within Splunk is used.'
+                          type: string
+                        indexName:
+                          description: IndexName is the name of the index to send
+                            events to. Only one of IndexKey or IndexName can be defined.
+                            If IndexKey && IndexName are not specified, the default
+                            index defined within Splunk is used.
+                          type: string
                       type: object
                     syslog:
                       description: Syslog provides optional extra properties for output

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -700,6 +700,21 @@ spec:
                           items:
                             type: string
                           type: array
+                        indexKey:
+                          description: 'IndexKey is a meta-data key field to use to
+                            send events to. For example: ''IndexKey: kubernetes.namespace_name`
+                            will use the kubernetes namespace as the index. If the
+                            IndexKey is not found, the default index defined within
+                            Splunk is used. Only one of IndexKey or IndexName can
+                            be defined. If IndexKey && IndexName are not specified,
+                            the default index defined within Splunk is used.'
+                          type: string
+                        indexName:
+                          description: IndexName is the name of the index to send
+                            events to. Only one of IndexKey or IndexName can be defined.
+                            If IndexKey && IndexName are not specified, the default
+                            index defined within Splunk is used.
+                          type: string
                       type: object
                     syslog:
                       description: Syslog provides optional extra properties for output

--- a/docs/features/logforwarding/outputs/splunk-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/splunk-forwarding.adoc
@@ -56,4 +56,71 @@ spec:
       outputRefs:
         - splunk-receiver
 ----
+
+=== Customizing Splunk Index
+
+To customize the index where you send events to in Splunk, you need to configure it in your log forwarding configuration (If not specified, the default index defined within Splunk is used.):
+
+. Specifying `indexKey`:
 +
+----
+oc apply -f cluster-log-forwarder.yaml
+----
++
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+kind: ClusterLogForwarder
+apiVersion: logging.openshift.io/v1
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  outputs:
+    - name: splunk-receiver
+      type: splunk
+      splunk:
+       indexKey: "kubernetes.namespace_name"
+      secret:
+        name: splunk-secret
+      url: 'http://example-splunk-hec-service:8088'
+  pipelines:
+    - name: my-logs
+      inputRefs:
+        - application
+        - infrastructure
+      outputRefs:
+        - splunk-receiver
+----
++
+. Specifying `indexName`:
+----
+oc apply -f cluster-log-forwarder.yaml
+----
+
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+kind: ClusterLogForwarder
+apiVersion: logging.openshift.io/v1
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  outputs:
+    - name: splunk-receiver
+      type: splunk
+      splunk:
+       indexName: "testIndex"
+      secret:
+        name: splunk-secret
+      url: 'http://example-splunk-hec-service:8088'
+  pipelines:
+    - name: my-logs
+      inputRefs:
+        - application
+        - infrastructure
+      outputRefs:
+        - splunk-receiver
+----
+NOTE:  Only one of _indexKey_ or _indexName_ can be used at once, not both at the same time.

--- a/test/framework/functional/cluster_log_forwarder.go
+++ b/test/framework/functional/cluster_log_forwarder.go
@@ -95,6 +95,10 @@ func (p *PipelineBuilder) ToCloudwatchOutput() *ClusterLogForwarderBuilder {
 	return p.ToOutputWithVisitor(func(output *logging.OutputSpec) {}, logging.OutputTypeCloudwatch)
 }
 
+func (p *PipelineBuilder) ToSplunkOutput() *ClusterLogForwarderBuilder {
+	return p.ToOutputWithVisitor(func(output *logging.OutputSpec) {}, logging.OutputTypeSplunk)
+}
+
 func (p *PipelineBuilder) ToKafkaOutput(visitors ...func(output *logging.OutputSpec)) *ClusterLogForwarderBuilder {
 	kafkaVisitor := func(output *logging.OutputSpec) {
 		output.Type = logging.OutputTypeKafka
@@ -199,6 +203,18 @@ func (p *PipelineBuilder) ToOutputWithVisitor(visit OutputSpecVisitor, outputNam
 						},
 						Method: "POST",
 					},
+				},
+			}
+		case logging.OutputTypeSplunk:
+			output = &logging.OutputSpec{
+				Name: logging.OutputTypeSplunk,
+				Type: logging.OutputTypeSplunk,
+				URL:  "http://localhost:8088",
+				OutputTypeSpec: logging.OutputTypeSpec{
+					Splunk: &logging.Splunk{},
+				},
+				Secret: &logging.OutputSecretSpec{
+					Name: "splunk-secret",
 				},
 			}
 		default:

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -3,13 +3,14 @@ package functional
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/migrations/clusterlogforwarder"
 	"net"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/internal/migrations/clusterlogforwarder"
 
 	"github.com/openshift/cluster-logging-operator/internal/collector"
 	"github.com/openshift/cluster-logging-operator/test"
@@ -395,6 +396,10 @@ func (f *CollectorFunctionalFramework) addOutputContainers(b *runtime.PodBuilder
 			}
 		case logging.OutputTypeHttp:
 			if err := f.AddFluentdHttpOutput(b, output); err != nil {
+				return err
+			}
+		case logging.OutputTypeSplunk:
+			if err := f.AddSplunkOutput(b, output); err != nil {
 				return err
 			}
 		}

--- a/test/framework/functional/output_splunk.go
+++ b/test/framework/functional/output_splunk.go
@@ -1,0 +1,161 @@
+package functional
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"text/template"
+
+	log "github.com/ViaQ/logerr/v2/log/static"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
+	"github.com/openshift/cluster-logging-operator/test/helpers/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	SplunkImage        = "quay.io/openshift-logging/splunk:9.0.0"
+	SplunkHecPort      = 8088
+	SplunkIndexName    = "fooIndex"
+	SplunkIndexKeyName = "log_type"
+	SplunkDefaultIndex = "main"
+)
+
+var (
+	HecToken      = rand.Word(16)
+	AdminPassword = rand.Word(16)
+
+	configTemplateName = "splunkserver"
+	ConfigTemplate     = fmt.Sprintf(`
+splunk:
+  hec:
+    ssl: false
+    token: "{{ string .Token }}"
+  password: "{{ string .Password }}"
+  idxc_secret: "{{ string .IdxcSecret }}"
+  shc_secret: "{{ string .SHCSecret }}"
+  conf:
+    - key: indexes
+      value:
+        directory: /opt/splunk/etc/system/local/
+        content:
+          %s:
+            homePath: $SPLUNK_DB/%s/db
+            coldPath: $SPLUNK_DB/%s/colddb
+            thawedPath: $SPLUNK_DB/%s/thaweddb
+          %s:
+            homePath: $SPLUNK_DB/%s/db
+            coldPath: $SPLUNK_DB/%s/colddb
+            thawedPath: $SPLUNK_DB/%s/thaweddb
+`, SplunkIndexName, SplunkIndexName, SplunkIndexName, SplunkIndexName, logging.InputNameApplication, logging.InputNameApplication, logging.InputNameApplication, logging.InputNameApplication)
+	SplunkEndpointHTTP = fmt.Sprintf("http://localhost:%d", SplunkHecPort)
+)
+
+func (f *CollectorFunctionalFramework) AddSplunkOutput(b *runtime.PodBuilder, output logging.OutputSpec) error {
+	data, err := GenerateConfigmapData()
+	if err != nil {
+		return err
+	}
+	config := runtime.NewConfigMap(b.Pod.Namespace, logging.OutputTypeSplunk, data)
+	log.V(2).Info("Creating configmap", "namespace", config.Namespace, "name", config.Name)
+	if err := f.Test.Client.Create(config); err != nil {
+		return err
+	}
+	cb := b.AddContainer(logging.OutputTypeSplunk, SplunkImage).
+		AddContainerPort("http-splunkweb", 8000).
+		AddContainerPort("http-hec", SplunkHecPort).
+		AddContainerPort("https-splunkd", 8089).
+		AddContainerPort("tcp-s2s", 9097).
+		AddEnvVar("SPLUNK_DECLARATIVE_ADMIN_PASSWORD", "true").
+		AddEnvVar("SPLUNK_DEFAULTS_URL", "/mnt/splunk-secrets/default.yml").
+		AddEnvVar("SPLUNK_DECLARATIVE_ADMIN_PASSWORD", "true").
+		AddEnvVar("SPLUNK_HOME_OWNERSHIP_ENFORCEMENT", "false").
+		AddEnvVar("SPLUNK_ROLE", "splunk_standalone").
+		AddEnvVar("SPLUNK_START_ARGS", "--accept-license").
+		AddVolumeMount(config.Name, "/mnt/splunk-secrets", "", true).
+		AddVolumeMount("optvar", "/opt/splunk/var", "", false).
+		AddVolumeMount("optetc", "/opt/splunk/etc", "", false).
+		WithPrivilege()
+
+	cb.End()
+	b.AddConfigMapVolume(config.Name, config.Name)
+	b.AddEmptyDirVolume("optvar")
+	b.AddEmptyDirVolume("optetc")
+	return nil
+}
+
+func GenerateConfigmapData() (data map[string]string, err error) {
+	b := &bytes.Buffer{}
+	t := template.Must(
+		template.New(configTemplateName).
+			Funcs(template.FuncMap{
+				"string": func(arg []byte) string {
+					return string(arg)
+				},
+			}).
+			Parse(ConfigTemplate),
+	)
+	if err = t.Execute(b,
+		struct {
+			Token        []byte
+			Password     []byte
+			Pass4SymmKey []byte
+			IdxcSecret   []byte
+			SHCSecret    []byte
+		}{
+			Token:        HecToken,
+			Password:     AdminPassword,
+			Pass4SymmKey: []byte("o4a9itWyG1YECvxpyVV9faUO"),
+			IdxcSecret:   []byte("5oPyAqIlod4sxH1Xk7fZpNe4"),
+			SHCSecret:    []byte("77mwFNOSUzmQLG9EGa2ZVEFq"),
+		},
+	); err != nil {
+		log.V(3).Error(err, "Error executing template")
+		return data, err
+	}
+	data = map[string]string{
+		"default.yml": b.String(),
+	}
+
+	return data, nil
+}
+
+func (f *CollectorFunctionalFramework) ReadLogsByTypeFromSplunk(namespace, name, logType string) (results []string, err error) {
+	var output string
+	cmd := fmt.Sprintf(`/opt/splunk/bin/splunk search log_type=%s -auth "admin:%s"`, logType, AdminPassword)
+	err = wait.PollUntilContextTimeout(context.TODO(), defaultRetryInterval, f.GetMaxReadDuration(), true, func(cxt context.Context) (done bool, err error) {
+		output, err = oc.Exec().WithNamespace(namespace).Pod(name).Container(logging.OutputTypeSplunk).WithCmd("/bin/sh", "-c", cmd).Run()
+		if output == "" || err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	results = strings.Split(output, "\n")
+	return results, nil
+}
+
+func (f *CollectorFunctionalFramework) ReadAppLogsByIndexFromSplunk(namespace, name, index string) (results []string, err error) {
+	var output string
+	cmd := fmt.Sprintf(`/opt/splunk/bin/splunk search index=%s -auth "admin:%s"`, index, AdminPassword)
+	err = wait.PollUntilContextTimeout(context.TODO(), defaultRetryInterval, f.GetMaxReadDuration(), true, func(cxt context.Context) (done bool, err error) {
+		output, err = oc.Exec().WithNamespace(namespace).Pod(name).Container(logging.OutputTypeSplunk).WithCmd("/bin/sh", "-c", cmd).Run()
+		if output == "" || err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	results = strings.Split(output, "\n")
+	return results, nil
+}

--- a/test/functional/outputs/splunk/forward_to_splunk_test.go
+++ b/test/functional/outputs/splunk/forward_to_splunk_test.go
@@ -1,0 +1,181 @@
+// go:build !fluentd
+
+package splunk
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Forwarding to Splunk", func() {
+	var (
+		framework *functional.CollectorFunctionalFramework
+		secret    *v1.Secret
+	)
+	BeforeEach(func() {
+		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
+		secret = runtime.NewSecret(framework.Namespace, "splunk-secret",
+			map[string][]byte{
+				"hecToken": []byte(string(functional.HecToken)),
+			},
+		)
+	})
+
+	AfterEach(func() {
+		framework.Cleanup()
+	})
+
+	It("should accept application logs", func() {
+
+		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+			FromInput(logging.InputNameApplication).
+			ToSplunkOutput()
+		framework.Secrets = append(framework.Secrets, secret)
+		Expect(framework.Deploy()).To(BeNil())
+
+		// Wait for splunk to be ready
+		time.Sleep(45 * time.Second)
+
+		// Write app logs
+		timestamp := "2020-11-04T18:13:59.061892+00:00"
+		applicationLogLine := functional.NewCRIOLogMessage(timestamp, "This is my test message", false)
+		Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 2)).To(BeNil())
+
+		// Read app logs
+		logs, err := framework.ReadLogsByTypeFromSplunk(framework.Namespace, framework.Name, logging.InputNameApplication)
+		Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+		Expect(logs).ToNot(BeEmpty())
+
+		// Parse the logs
+		var appLogs []types.ApplicationLog
+		jsonString := fmt.Sprintf("[%s]", strings.Join(logs, ","))
+		err = types.ParseLogsFrom(jsonString, &appLogs, false)
+		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+		outputTestLog := appLogs[0]
+		Expect(outputTestLog.LogType).To(Equal(logging.InputNameApplication))
+	})
+
+	Context("with custom indexes", func() {
+		withIndexName := func(spec *logging.OutputSpec) {
+			spec.Splunk = &logging.Splunk{
+				IndexName: functional.SplunkIndexName,
+			}
+		}
+
+		withIndexKey := func(spec *logging.OutputSpec) {
+			spec.Splunk = &logging.Splunk{
+				IndexKey: "log_type",
+			}
+		}
+
+		withFakeIndexKey := func(spec *logging.OutputSpec) {
+			spec.Splunk = &logging.Splunk{
+				IndexKey: "kubernetes.foo_key",
+			}
+		}
+
+		It("should send logs to spec'd indexName in Splunk", func() {
+
+			functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(logging.InputNameApplication).
+				ToOutputWithVisitor(withIndexName, logging.OutputTypeSplunk)
+			framework.Secrets = append(framework.Secrets, secret)
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Wait for splunk to be ready
+			time.Sleep(45 * time.Second)
+
+			// Write app logs
+			timestamp := "2020-11-04T18:13:59.061892+00:00"
+			applicationLogLine := functional.NewCRIOLogMessage(timestamp, "This is my test message", false)
+			Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 2)).To(BeNil())
+
+			// Read app logs
+			logs, err := framework.ReadAppLogsByIndexFromSplunk(framework.Namespace, framework.Name, functional.SplunkIndexName)
+			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+			Expect(logs).ToNot(BeEmpty())
+
+			// Parse the logs
+			var appLogs []types.ApplicationLog
+			jsonString := fmt.Sprintf("[%s]", strings.Join(logs, ","))
+			err = types.ParseLogsFrom(jsonString, &appLogs, false)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+			outputTestLog := appLogs[0]
+			Expect(outputTestLog.LogType).To(Equal(logging.InputNameApplication))
+		})
+
+		It("should send logs to spec'd indexKey in Splunk", func() {
+
+			functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(logging.InputNameApplication).
+				ToOutputWithVisitor(withIndexKey, logging.OutputTypeSplunk)
+			framework.Secrets = append(framework.Secrets, secret)
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Wait for splunk to be ready
+			time.Sleep(45 * time.Second)
+
+			// Write app logs
+			timestamp := "2020-11-04T18:13:59.061892+00:00"
+			applicationLogLine := functional.NewCRIOLogMessage(timestamp, "This is my test message", false)
+			Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 2)).To(BeNil())
+
+			// Read app logs from index = "application"
+			logs, err := framework.ReadAppLogsByIndexFromSplunk(framework.Namespace, framework.Name, logging.InputNameApplication)
+			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+			Expect(logs).ToNot(BeEmpty())
+
+			// Parse the logs
+			var appLogs []types.ApplicationLog
+			jsonString := fmt.Sprintf("[%s]", strings.Join(logs, ","))
+			err = types.ParseLogsFrom(jsonString, &appLogs, false)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+			outputTestLog := appLogs[0]
+			Expect(outputTestLog.LogType).To(Equal(logging.InputNameApplication))
+		})
+
+		It("should send logs to default index if spec'd indexKey is not available", func() {
+
+			functional.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(logging.InputNameApplication).
+				ToOutputWithVisitor(withFakeIndexKey, logging.OutputTypeSplunk)
+			framework.Secrets = append(framework.Secrets, secret)
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Wait for splunk to be ready
+			time.Sleep(45 * time.Second)
+
+			// Write app logs
+			timestamp := "2020-11-04T18:13:59.061892+00:00"
+			applicationLogLine := functional.NewCRIOLogMessage(timestamp, "This is my test message", false)
+			Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 2)).To(BeNil())
+
+			// Read app logs from default index in splunk. Without config, default is "main"
+			logs, err := framework.ReadAppLogsByIndexFromSplunk(framework.Namespace, framework.Name, functional.SplunkDefaultIndex)
+			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+			Expect(logs).ToNot(BeEmpty())
+
+			// Parse the logs
+			var appLogs []types.ApplicationLog
+			jsonString := fmt.Sprintf("[%s]", strings.Join(logs, ","))
+			err = types.ParseLogsFrom(jsonString, &appLogs, false)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+			outputTestLog := appLogs[0]
+			Expect(outputTestLog.LogType).To(Equal(logging.InputNameApplication))
+		})
+	})
+})

--- a/test/functional/outputs/splunk/suite_test.go
+++ b/test/functional/outputs/splunk/suite_test.go
@@ -1,0 +1,13 @@
+package splunk
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFunctionalOutputSplunk(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[Functional][Outputs][Splunk] Suite")
+}


### PR DESCRIPTION
### Description
This PR adds the ability for users to configure `vector` to define an `index` for the `Splunk` output dynamically using a `meta-data` key such as `kubernetes.namespace_name` or a single static value such as `my-index`.

They are captured in new fields on the `ClusterLogForwarder` when specifying the Splunk output, named `indexKey` and `indexName`. Only one of the fields can be defined at once.

/cc @vparfonov @cahartma 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-3651

