### PR TITLE
LOG-4823: Update vector to upstream tag v0.34.1

### DIFF
--- a/test/framework/functional/vector/deploy.go
+++ b/test/framework/functional/vector/deploy.go
@@ -2,9 +2,10 @@ package vector
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/collector/vector"
 	"regexp"
 	"strings"
+
+	"github.com/openshift/cluster-logging-operator/internal/collector/vector"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
@@ -17,7 +18,7 @@ import (
 const entrypointScript = `#!/bin/bash
 mkdir -p %s
 
-/usr/bin/vector
+/usr/bin/vector --config-toml /etc/vector/vector.toml
 `
 
 type VectorCollector struct {


### PR DESCRIPTION
### Description
Fix for upcoming vector v0.34.1, explicitly specify TOML config file because the default config format in the newer vector is now YAML.

/cc @jcantrill 
/assign @cahartma 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4823

