### PR TITLE
LOG-4929: do not allow to choose protocol for syslog receiver

### DIFF
--- a/apis/logging/v1/input_receiver_types.go
+++ b/apis/logging/v1/input_receiver_types.go
@@ -54,10 +54,4 @@ type SyslogReceiver struct {
 	// +kubebuilder:validation:Maximum:=65535
 	// +optional
 	Port int32 `json:"port"`
-
-	// The protocol of the connection the Receiver will listen on: tcp or upd
-	// +kubebuilder:validation:Enum=tcp;udp
-	// +kubebuilder:default:=tcp
-	// +optional
-	Protocol string `json:"protocol"`
 }

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -418,14 +418,6 @@ spec:
                               maximum: 65535
                               minimum: 1024
                               type: integer
-                            protocol:
-                              default: tcp
-                              description: 'The protocol of the connection the Receiver
-                                will listen on: tcp or upd'
-                              enum:
-                              - tcp
-                              - udp
-                              type: string
                           type: object
                         type:
                           description: Type of Receiver plugin.

--- a/internal/generator/vector/input/viaq_test.go
+++ b/internal/generator/vector/input/viaq_test.go
@@ -90,7 +90,6 @@ var _ = Describe("inputs", func() {
 				ReceiverTypeSpec: &logging.ReceiverTypeSpec{
 					Syslog: &logging.SyslogReceiver{
 						Port:     12345,
-						Protocol: "tcp",
 					},
 				},
 			},

--- a/internal/generator/vector/source/syslog_receiver.go
+++ b/internal/generator/vector/source/syslog_receiver.go
@@ -22,7 +22,6 @@ func NewSyslogSource(id string, input logging.InputSpec, op framework.Options) f
 		InputName:     input.Name,
 		ListenAddress: helpers.ListenOnAllLocalInterfacesAddress(),
 		ListenPort:    input.Receiver.Syslog.Port,
-		Protocol:      input.Receiver.Syslog.Protocol,
 		TlsMinVersion: minTlsVersion,
 		CipherSuites:  cipherSuites,
 	}
@@ -33,7 +32,6 @@ type SyslogReceiver struct {
 	InputName     string
 	ListenAddress string
 	ListenPort    int32
-	Protocol      string
 	TlsMinVersion string
 	CipherSuites  string
 }
@@ -48,7 +46,7 @@ func (i SyslogReceiver) Template() string {
 [sources.{{.ID}}]
 type = "syslog"
 address = "{{.ListenAddress}}:{{.ListenPort}}"
-mode = "{{.Protocol}}"
+mode = "tcp"
 
 [sources.{{.ID}}.tls]
 enabled = true

--- a/internal/validations/clusterlogforwarder/inputs/validate.go
+++ b/internal/validations/clusterlogforwarder/inputs/validate.go
@@ -65,8 +65,6 @@ func Verify(inputs []loggingv1.InputSpec, status *loggingv1.ClusterLogForwarderS
 			badInput("invalid port specified for Syslog receiver")
 		case loggingv1.IsHttpReceiver(&input) && input.Receiver.HTTP.Format != loggingv1.FormatKubeAPIAudit:
 			badInput("invalid format specified for HTTP receiver")
-		case loggingv1.IsSyslogReceiver(&input) && input.Receiver.Syslog.Protocol != "tcp" && input.Receiver.Syslog.Protocol != "udp":
-			badInput("invalid protocol specified for Syslog receiver")
 		default:
 			status.Inputs.Set(input.Name, conditions.CondReady)
 		}

--- a/internal/validations/clusterlogforwarder/inputs/validate_test.go
+++ b/internal/validations/clusterlogforwarder/inputs/validate_test.go
@@ -276,14 +276,13 @@ var _ = Describe("#Validate", func() {
 				)
 			}
 
-			checkPortAndSyslogProtocol := func(port int32, protocol string, expectedErrMsg string) {
+			checkSyslogPort := func(port int32, expectedErrMsg string) {
 				checkReceiver(
 					&loggingv1.ReceiverSpec{
 						Type: loggingv1.ReceiverTypeSyslog,
 						ReceiverTypeSpec: &loggingv1.ReceiverTypeSpec{
 							Syslog: &loggingv1.SyslogReceiver{
 								Port:     port,
-								Protocol: protocol,
 							},
 						},
 					},
@@ -334,11 +333,10 @@ var _ = Describe("#Validate", func() {
 			}
 			checkPortAndHTTPFormat(8080, `no_such_format`, `invalid format specified for HTTP receiver`)
 			for _, port := range []int32{-1, 53, 80_000} {
-				checkPortAndSyslogProtocol(port, "tcp", `invalid port specified for Syslog receiver`)
+				checkSyslogPort(port, `invalid port specified for Syslog receiver`)
 			}
 			checkReceiverMismatchTypeHttp(`mismatched Type specified for receiver, specified HTTP and have Syslog`)
 			checkReceiverMismatchTypeSyslog(`mismatched Type specified for receiver, specified Syslog and have HTTP`)
-			checkPortAndSyslogProtocol(10514, "http", `invalid protocol specified for Syslog receiver`)
 			checkReceiverType("wrong-receiver", `invalid Type specified for receiver`)
 			checkReceiver(&loggingv1.ReceiverSpec{}, `invalid ReceiverTypeSpec specified for receiver`, map[string]bool{constants.VectorName: true})
 			checkReceiver(&loggingv1.ReceiverSpec{}, `ReceiverSpecs are only supported for the vector log collector`, map[string]bool{})

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account_test.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account_test.go
@@ -200,7 +200,6 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder permissio
 							ReceiverTypeSpec: &loggingv1.ReceiverTypeSpec{
 								Syslog: &loggingv1.SyslogReceiver{
 									Port:     10514,
-									Protocol: "tcp",
 								},
 							},
 						},


### PR DESCRIPTION
### Description
QA found an issue when udp was selected and tls was automatically applied. tls cannot work on udp protocol, so this was causing confusion. After a conversation, we decided that the udp protocol case is not required at the moment because OpenStack (the first user of the syslog receiver) will always send the logs via tls-encrypted tcp.

This PR removes the option to configure a protocol for the syslog receiver, as it will always use tcp.

/cc @jcantrill 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4929
