### PR TITLE
LOG-4779: Deploy collector as a deployment instead of daemonset

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder.go
+++ b/apis/logging/v1/cluster_log_forwarder.go
@@ -12,6 +12,7 @@ const (
 	InputNameApplication    = "application"    // Non-infrastructure container logs.
 	InputNameInfrastructure = "infrastructure" // Infrastructure containers and system logs.
 	InputNameAudit          = "audit"          // System audit logs.
+	InputNameReceiver       = "receiver"       // Receiver to receive logs from non-cluster sources.
 )
 
 var ReservedInputNames = sets.NewString(InputNameApplication, InputNameInfrastructure, InputNameAudit)

--- a/internal/collector/deployment.go
+++ b/internal/collector/deployment.go
@@ -16,8 +16,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ReconcileDaemonset reconciles a daemonset specifically for the collector defined by the factory
-func (f *Factory) ReconcileDaemonset(er record.EventRecorder, k8sClient client.Client, namespace string, owner metav1.OwnerReference) error {
+// ReconcileDeployment reconciles a deployment specifically for the collector defined by the factory
+func (f *Factory) ReconcileDeployment(er record.EventRecorder, k8sClient client.Client, namespace string, owner metav1.OwnerReference) error {
 	trustedCABundle, trustHash := GetTrustedCABundle(k8sClient, namespace, f.ResourceNames.CaTrustBundle)
 	f.TrustedCAHash = trustHash
 	tlsProfile, _ := tls.FetchAPIServerTlsProfile(k8sClient)
@@ -29,16 +29,16 @@ func (f *Factory) ReconcileDaemonset(er record.EventRecorder, k8sClient client.C
 		}
 	}
 
-	desired := f.NewDaemonSet(namespace, f.ResourceNames.DaemonSetName(), trustedCABundle, tls.GetClusterTLSProfileSpec(tlsProfile), receiverInputs)
+	desired := f.NewDeployment(namespace, f.ResourceNames.DaemonSetName(), trustedCABundle, tls.GetClusterTLSProfileSpec(tlsProfile), receiverInputs)
 	utils.AddOwnerRefToObject(desired, owner)
-	return reconcile.DaemonSet(er, k8sClient, desired)
+	return reconcile.Deployment(er, k8sClient, desired)
 }
 
-func Remove(k8sClient client.Client, namespace, name string) (err error) {
-	log.V(3).Info("Removing collector", "namespace", namespace, "name", name)
-	ds := runtime.NewDaemonSet(namespace, name)
+func RemoveDeployment(k8sClient client.Client, namespace, name string) (err error) {
+	log.V(3).Info("Removing collector deployment", "namespace", namespace, "name", name)
+	ds := runtime.NewDeployment(namespace, name)
 	if err = k8sClient.Delete(context.TODO(), ds); err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("Failure deleting daemonset %s/%s: %v", namespace, name, err)
+		return fmt.Errorf("failure deleting deployment %s/%s: %v", namespace, name, err)
 	}
 	return nil
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -98,6 +98,8 @@ const (
 	CollectorMonitorJobLabel    = "monitor-collector"
 	CollectorServiceAccountName = "logcollector"
 	CollectorTrustedCAName      = "collector-trusted-ca-bundle"
+	CollectorDeploymentKind     = "collector-deployment-kind"
+	DeploymentType              = "deployment"
 
 	FluentdImageEnvVar            = "RELATED_IMAGE_FLUENTD"
 	VectorImageEnvVar             = "RELATED_IMAGE_VECTOR"

--- a/internal/constants/features.go
+++ b/internal/constants/features.go
@@ -21,4 +21,9 @@ const (
 	// AnnotationPreviewKorrel8rConsole enables preview features in the console that use Korrel8r.
 	// Korrel8r must also be installed and running in the cluster for these features to work.
 	AnnotationPreviewKorrel8rConsole = "logging.openshift.io/preview-korrel8r-console"
+
+	// AnnotationEnableCollectorAsDeployment is to enable deploying the collector as a deployment
+	// instead of a daemonset to support the HCP use case of using the collector for collecting
+	// audit logs via a webhook.
+	AnnotationEnableCollectorAsDeployment = "logging.openshift.io/dev-preview-enable-collector-as-deployment"
 )

--- a/internal/factory/deployment.go
+++ b/internal/factory/deployment.go
@@ -1,0 +1,42 @@
+package factory
+
+import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+)
+
+// NewDeployment stubs an instance of a deployment
+func NewDeployment(namespace, deploymentName, loggingComponent, component, impl string, podSpec core.PodSpec, visitors ...func(o runtime.Object)) *apps.Deployment {
+	selectors := map[string]string{
+		"provider":                        "openshift",
+		"component":                       component,
+		"logging-infra":                   loggingComponent,
+		constants.CollectorDeploymentKind: constants.DeploymentType,
+	}
+	labels := map[string]string{
+		"implementation": impl,
+	}
+
+	for k, v := range selectors {
+		labels[k] = v
+	}
+
+	annotations := map[string]string{
+		"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+	}
+
+	// Number of replicas for the deployment
+	replicas := int32(2)
+
+	dpl := runtime.NewDeployment(namespace, deploymentName, visitors...)
+	utils.AddLabels(dpl, labels)
+	runtime.NewDeploymentBuilder(dpl).WithTemplateAnnotations(annotations).
+		WithTemplateLabels(dpl.Labels).
+		WithSelector(selectors).
+		WithPodSpec(podSpec).
+		WithReplicas(&replicas)
+	return dpl
+}

--- a/internal/factory/deployment_test.go
+++ b/internal/factory/deployment_test.go
@@ -1,0 +1,48 @@
+package factory
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+)
+
+var _ = Describe("#NewDeployment", func() {
+
+	var (
+		deployment  *apps.Deployment
+		expSelector = map[string]string{
+			"provider":                        "openshift",
+			"component":                       "thecomponent",
+			"logging-infra":                   "thecomponent",
+			constants.CollectorDeploymentKind: constants.DeploymentType,
+		}
+		expLabels = map[string]string{
+			"provider":                           "openshift",
+			"component":                          "thecomponent",
+			"logging-infra":                      "thecomponent",
+			"pod-security.kubernetes.io/enforce": "privileged",
+			"security.openshift.io/scc.podSecurityLabelSync": "false",
+			"implementation":                  "collectorImpl",
+			constants.CollectorDeploymentKind: constants.DeploymentType,
+		}
+	)
+
+	BeforeEach(func() {
+		deployment = NewDeployment("thenamespace", "thename", "thecomponent", "thecomponent", "collectorImpl", core.PodSpec{})
+	})
+
+	It("should leave the MinReadySeconds as the default", func() {
+		Expect(deployment.Spec.MinReadySeconds).ToNot(Equal(0), "Exp. the MinReadySeconds to be the default")
+	})
+
+	It("should only include the provider, component, logging-infra, and collector-deployment-kind in the selector", func() {
+		Expect(deployment.Spec.Selector.MatchLabels).To(Equal(expSelector), "Exp. the selector to only include: provider, component, logging-infra, and collector-deployment-kind")
+	})
+
+	It("should include the collector implementation in the labels only", func() {
+		Expect(deployment.Labels).To(Equal(expLabels))
+		Expect(deployment.Spec.Template.Labels).To(Equal(expLabels))
+	})
+})

--- a/internal/factory/resource_names.go
+++ b/internal/factory/resource_names.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"fmt"
+
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 
 	"github.com/openshift/cluster-logging-operator/internal/constants"
@@ -21,6 +22,11 @@ type ForwarderResourceNames struct {
 
 func (f *ForwarderResourceNames) DaemonSetName() string {
 	return f.CommonName
+}
+
+// GenerateInputServiceName addresses HTTP input service name uniqueness by concatenating the common name with the input service name
+func (f *ForwarderResourceNames) GenerateInputServiceName(serviceName string) string {
+	return fmt.Sprintf("%s-%s", f.CommonName, serviceName)
 }
 
 // GenerateResourceNames is a factory for naming of objects based on ClusterLogForwarder namespace and name

--- a/internal/generator/fluentd/conf.go
+++ b/internal/generator/fluentd/conf.go
@@ -2,12 +2,13 @@ package fluentd
 
 import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	corev1 "k8s.io/api/core/v1"
 )
 
 //nolint:govet // using declarative style
-func Conf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, name string, op framework.Options) []framework.Section {
+func Conf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, name string, resNames *factory.ForwarderResourceNames, op framework.Options) []framework.Section {
 	return []framework.Section{
 		{
 			Header(op),

--- a/internal/generator/fluentd/fluent_conf_test.go
+++ b/internal/generator/fluentd/fluent_conf_test.go
@@ -2,11 +2,13 @@ package fluentd
 
 import (
 	_ "embed"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/helpers/security"
 	"github.com/openshift/cluster-logging-operator/internal/generator/utils"
@@ -72,6 +74,8 @@ var _ = Describe("Generating fluentd config", func() {
 				Data: secretData,
 			},
 		}
+
+		resNames = &factory.ForwarderResourceNames{CommonName: constants.CollectorName}
 	)
 
 	BeforeEach(func() {
@@ -207,7 +211,7 @@ var _ = Describe("Generating fluentd config", func() {
 				Data: secretData,
 			},
 		}
-		c := framework.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, op))
+		c := framework.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, resNames, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())
 
@@ -286,7 +290,7 @@ var _ = Describe("Generating fluentd config", func() {
 				Data: secretData,
 			},
 		}
-		c := framework.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, op))
+		c := framework.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, resNames, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(ExpectedPodLabelsConf))
@@ -366,7 +370,7 @@ var _ = Describe("Generating fluentd config", func() {
 				Data: secretData,
 			},
 		}
-		c := framework.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, op))
+		c := framework.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, resNames, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(ExpectedPodLabelsNSConf))
@@ -389,14 +393,14 @@ var _ = Describe("Generating fluentd config", func() {
 				},
 			},
 		}
-		c := framework.MergeSections(Conf(nil, nil, forwarder, constants.OpenshiftNS, constants.SingletonName, op))
+		c := framework.MergeSections(Conf(nil, nil, forwarder, constants.OpenshiftNS, constants.SingletonName, resNames, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(ExpectedExcludeConf))
 	})
 
 	It("should produce well formed fluent.conf", func() {
-		c := framework.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, op))
+		c := framework.MergeSections(Conf(nil, secrets, forwarder, constants.OpenshiftNS, constants.SingletonName, resNames, op))
 		results, err := g.GenerateConf(c...)
 		Expect(err).To(BeNil())
 		Expect(results).To(EqualTrimLines(ExpectedWellFormedConf))
@@ -479,7 +483,7 @@ var _ = Describe("Generating fluentd config", func() {
 			var spec logging.ClusterLogForwarderSpec
 			Expect(yaml.Unmarshal([]byte(yamlSpec), &spec)).To(Succeed())
 			g := framework.MakeGenerator()
-			s := Conf(nil, security.NoSecrets, &spec, constants.OpenshiftNS, constants.SingletonName, op)
+			s := Conf(nil, security.NoSecrets, &spec, constants.OpenshiftNS, constants.SingletonName, resNames, op)
 			gotFluentdConf, err := g.GenerateConf(framework.MergeSections(s)...)
 			Expect(err).To(Succeed())
 			Expect(gotFluentdConf).To(EqualTrimLines(wantFluentdConf))

--- a/internal/generator/forwarder/generator.go
+++ b/internal/generator/forwarder/generator.go
@@ -3,6 +3,8 @@ package forwarder
 import (
 	"errors"
 	"fmt"
+
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/conf"
 
@@ -28,7 +30,7 @@ var (
 
 type ConfigGenerator struct {
 	g      framework.Generator
-	conf   func(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, forwarderName string, op framework.Options) []framework.Section
+	conf   func(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, forwarderName string, resNames *factory.ForwarderResourceNames, op framework.Options) []framework.Section
 	format func(conf string) string
 }
 
@@ -49,8 +51,8 @@ func New(collectorType logging.LogCollectionType) *ConfigGenerator {
 	return g
 }
 
-func (cg *ConfigGenerator) GenerateConf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, forwarderName string, op framework.Options) (string, error) {
-	sections := cg.conf(clspec, secrets, clfspec, namespace, forwarderName, op)
+func (cg *ConfigGenerator) GenerateConf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, forwarderName string, resNames *factory.ForwarderResourceNames, op framework.Options) (string, error) {
+	sections := cg.conf(clspec, secrets, clfspec, namespace, forwarderName, resNames, op)
 	conf, err := cg.g.GenerateConf(framework.MergeSections(sections)...)
 	return cg.format(conf), err
 }

--- a/internal/generator/utils/logging.go
+++ b/internal/generator/utils/logging.go
@@ -23,6 +23,9 @@ func GatherSources(forwarder *logging.ClusterLogForwarderSpec, op framework.Opti
 			if spec.Audit != nil {
 				types.Insert(logging.InputNameAudit)
 			}
+			if spec.Receiver != nil {
+				types.Insert(logging.InputNameReceiver)
+			}
 		}
 	}
 	return *types

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -1,0 +1,520 @@
+expire_metrics_secs = 60
+data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
+
+[api]
+enabled = true
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+# Logs from host audit
+[sources.input_audit_host]
+type = "file"
+include = ["/var/log/audit/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+[transforms.input_audit_host_viaq]
+type = "remap"
+inputs = ["input_audit_host"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".linux-audit.log"
+
+  match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
+  envelop = {}
+  envelop |= {"type": match1.type}
+
+  match2, err = parse_regex(.message, r'msg=audit\((?P<ts_record>[^ ]+)\):')
+  if err == null {
+    sp, err = split(match2.ts_record,":")
+    if err == null && length(sp) == 2 {
+        ts = parse_timestamp(sp[0],"%s.%3f") ?? ""
+        envelop |= {"record_id": sp[1]}
+        . |= {"audit.linux" : envelop}
+        . |= {"@timestamp" : format_timestamp(ts,"%+") ?? ""}
+    }
+  } else {
+    log("could not parse host audit msg. err=" + err, rate_limit_secs: 0)
+  }
+
+  .level = "default"
+'''
+
+# Logs from kubernetes audit
+[sources.input_audit_kube]
+type = "file"
+include = ["/var/log/kube-apiserver/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+[transforms.input_audit_kube_viaq]
+type = "remap"
+inputs = ["input_audit_kube"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".k8s-audit.log"
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+  .k8s_audit_level = .level
+'''
+
+# Logs from openshift audit
+[sources.input_audit_openshift]
+type = "file"
+include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+[transforms.input_audit_openshift_viaq]
+type = "remap"
+inputs = ["input_audit_openshift"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".openshift-audit.log"
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+  .openshift_audit_level = .level
+'''
+
+# Logs from ovn audit
+[sources.input_audit_ovn]
+type = "file"
+include = ["/var/log/ovn/acl-audit-log.log"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+[transforms.input_audit_ovn_viaq]
+type = "remap"
+inputs = ["input_audit_ovn"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".ovn-audit.log"
+  if !exists(.level) {
+    .level = "default"
+    if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {
+      .level = "warn"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    } else if match!(.message, r'Notice|NOTICE|^N[0-9]+|level=notice|Value:notice|"level":"notice"|<notice>') {
+      .level = "notice"
+    } else if match!(.message, r'Alert|ALERT|^A[0-9]+|level=alert|Value:alert|"level":"alert"|<alert>') {
+      .level = "alert"
+    } else if match!(.message, r'Emergency|EMERGENCY|^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"|<emergency>') {
+      .level = "emergency"
+    } else if match!(.message, r'(?i)\b(?:info)\b|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    }
+  }
+'''
+
+# Set log_type
+[transforms.input_audit_viaq_logtype]
+type = "remap"
+inputs = ["input_audit_host_viaq","input_audit_kube_viaq","input_audit_openshift_viaq","input_audit_ovn_viaq"]
+source = '''
+  .log_type = "audit"
+  .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+# Logs from containers (including openshift containers)
+[sources.input_infrastructure_container]
+type = "kubernetes_logs"
+max_read_bytes = 3145728
+glob_minimum_cooldown_ms = 15000
+auto_partial_merge = true
+include_paths_glob_patterns = ["/var/log/pods/default_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log", "/var/log/pods/kube*_*/*/*.log"]
+exclude_paths_glob_patterns = ["/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]
+pod_annotation_fields.pod_labels = "kubernetes.labels"
+pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
+namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
+
+[transforms.input_infrastructure_container_viaq]
+type = "remap"
+inputs = ["input_infrastructure_container"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+   if !exists(.level) {
+    .level = "default"
+    if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {
+      .level = "warn"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    } else if match!(.message, r'Notice|NOTICE|^N[0-9]+|level=notice|Value:notice|"level":"notice"|<notice>') {
+      .level = "notice"
+    } else if match!(.message, r'Alert|ALERT|^A[0-9]+|level=alert|Value:alert|"level":"alert"|<alert>') {
+      .level = "alert"
+    } else if match!(.message, r'Emergency|EMERGENCY|^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"|<emergency>') {
+      .level = "emergency"
+    } else if match!(.message, r'(?i)\b(?:info)\b|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    }
+  }
+  pod_name = string!(.kubernetes.pod_name)
+  if starts_with(pod_name, "eventrouter-") {
+    parsed, err = parse_json(.message)
+    if err != null {
+      log("Unable to process EventRouter log: " + err, level: "info")
+    } else {
+      ., err = merge(.,parsed)
+      if err == null && exists(.event) && is_object(.event) {
+          if exists(.verb) {
+            .event.verb = .verb
+            del(.verb)
+          }
+          .kubernetes.event = del(.event)
+          .message = del(.kubernetes.event.message)
+          set!(., ["@timestamp"], .kubernetes.event.metadata.creationTimestamp)
+          del(.kubernetes.event.metadata.creationTimestamp)
+		  . = compact(., nullish: true)
+      } else {
+        log("Unable to merge EventRouter log message into record: " + err, level: "info")
+      }
+    }
+  }
+  del(.source_type)
+  del(.stream)
+  del(.kubernetes.pod_ips)
+  del(.kubernetes.node_labels)
+  del(.timestamp_end)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+[sources.input_infrastructure_journal]
+type = "journald"
+journal_directory = "/var/log/journal"
+
+[transforms.input_infrastructure_journal_drop]
+type = "filter"
+inputs = ["input_infrastructure_journal"]
+condition = ".PRIORITY != \"7\" && .PRIORITY != 7"
+
+[transforms.input_infrastructure_journal_viaq]
+type = "remap"
+inputs = ["input_infrastructure_journal_drop"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".journal.system"
+
+  del(.source_type)
+  del(._CPU_USAGE_NSEC)
+  del(.__REALTIME_TIMESTAMP)
+  del(.__MONOTONIC_TIMESTAMP)
+  del(._SOURCE_REALTIME_TIMESTAMP)
+  del(.JOB_RESULT)
+  del(.JOB_TYPE)
+  del(.TIMESTAMP_BOOTTIME)
+  del(.TIMESTAMP_MONOTONIC)
+
+  if .PRIORITY == "8" || .PRIORITY == 8 {
+    .level = "trace"
+  } else {
+  	priority = to_int!(.PRIORITY)
+  	.level, err = to_syslog_level(priority)
+	if err != null {
+	  log("Unable to determine level from PRIORITY: " + err, level: "error")
+	  log(., level: "error")
+	  .level = "unknown"
+	} else {
+	  del(.PRIORITY)
+	}
+  }
+
+  .hostname = del(.host)
+
+  # systemd’s kernel-specific metadata.
+  # .systemd.k = {}
+  if exists(.KERNEL_DEVICE) { .systemd.k.KERNEL_DEVICE = del(.KERNEL_DEVICE) }
+  if exists(.KERNEL_SUBSYSTEM) { .systemd.k.KERNEL_SUBSYSTEM = del(.KERNEL_SUBSYSTEM) }
+  if exists(.UDEV_DEVLINK) { .systemd.k.UDEV_DEVLINK = del(.UDEV_DEVLINK) }
+  if exists(.UDEV_DEVNODE) { .systemd.k.UDEV_DEVNODE = del(.UDEV_DEVNODE) }
+  if exists(.UDEV_SYSNAME) { .systemd.k.UDEV_SYSNAME = del(.UDEV_SYSNAME) }
+
+  # trusted journal fields, fields that are implicitly added by the journal and cannot be altered by client code.
+  .systemd.t = {}
+  if exists(._AUDIT_LOGINUID) { .systemd.t.AUDIT_LOGINUID = del(._AUDIT_LOGINUID) }
+  if exists(._BOOT_ID) { .systemd.t.BOOT_ID = del(._BOOT_ID) }
+  if exists(._AUDIT_SESSION) { .systemd.t.AUDIT_SESSION = del(._AUDIT_SESSION) }
+  if exists(._CAP_EFFECTIVE) { .systemd.t.CAP_EFFECTIVE = del(._CAP_EFFECTIVE) }
+  if exists(._CMDLINE) { .systemd.t.CMDLINE = del(._CMDLINE) }
+  if exists(._COMM) { .systemd.t.COMM = del(._COMM) }
+  if exists(._EXE) { .systemd.t.EXE = del(._EXE) }
+  if exists(._GID) { .systemd.t.GID = del(._GID) }
+  if exists(._HOSTNAME) { .systemd.t.HOSTNAME = .hostname }
+  if exists(._LINE_BREAK) { .systemd.t.LINE_BREAK = del(._LINE_BREAK) }
+  if exists(._MACHINE_ID) { .systemd.t.MACHINE_ID = del(._MACHINE_ID) }
+  if exists(._PID) { .systemd.t.PID = del(._PID) }
+  if exists(._SELINUX_CONTEXT) { .systemd.t.SELINUX_CONTEXT = del(._SELINUX_CONTEXT) }
+  if exists(._SOURCE_REALTIME_TIMESTAMP) { .systemd.t.SOURCE_REALTIME_TIMESTAMP = del(._SOURCE_REALTIME_TIMESTAMP) }
+  if exists(._STREAM_ID) { .systemd.t.STREAM_ID = ._STREAM_ID }
+  if exists(._SYSTEMD_CGROUP) { .systemd.t.SYSTEMD_CGROUP = del(._SYSTEMD_CGROUP) }
+  if exists(._SYSTEMD_INVOCATION_ID) {.systemd.t.SYSTEMD_INVOCATION_ID = ._SYSTEMD_INVOCATION_ID}
+  if exists(._SYSTEMD_OWNER_UID) { .systemd.t.SYSTEMD_OWNER_UID = del(._SYSTEMD_OWNER_UID) }
+  if exists(._SYSTEMD_SESSION) { .systemd.t.SYSTEMD_SESSION = del(._SYSTEMD_SESSION) }
+  if exists(._SYSTEMD_SLICE) { .systemd.t.SYSTEMD_SLICE = del(._SYSTEMD_SLICE) }
+  if exists(._SYSTEMD_UNIT) { .systemd.t.SYSTEMD_UNIT = del(._SYSTEMD_UNIT) }
+  if exists(._SYSTEMD_USER_UNIT) { .systemd.t.SYSTEMD_USER_UNIT = del(._SYSTEMD_USER_UNIT) }
+  if exists(._TRANSPORT) { .systemd.t.TRANSPORT = del(._TRANSPORT) }
+  if exists(._UID) { .systemd.t.UID = del(._UID) }
+
+  # fields that are directly passed from clients and stored in the journal.
+  .systemd.u = {}
+  if exists(.CODE_FILE) { .systemd.u.CODE_FILE = del(.CODE_FILE) }
+  if exists(.CODE_FUNC) { .systemd.u.CODE_FUNCTION = del(.CODE_FUNC) }
+  if exists(.CODE_LINE) { .systemd.u.CODE_LINE = del(.CODE_LINE) }
+  if exists(.ERRNO) { .systemd.u.ERRNO = del(.ERRNO) }
+  if exists(.MESSAGE_ID) { .systemd.u.MESSAGE_ID = del(.MESSAGE_ID) }
+  if exists(.SYSLOG_FACILITY) { .systemd.u.SYSLOG_FACILITY = del(.SYSLOG_FACILITY) }
+  if exists(.SYSLOG_IDENTIFIER) { .systemd.u.SYSLOG_IDENTIFIER = del(.SYSLOG_IDENTIFIER) }
+  if exists(.SYSLOG_PID) { .systemd.u.SYSLOG_PID = del(.SYSLOG_PID) }
+  if exists(.RESULT) { .systemd.u.RESULT = del(.RESULT) }
+  if exists(.UNIT) { .systemd.u.UNIT = del(.UNIT) }
+
+  .time = format_timestamp!(.timestamp, format: "%FT%T%:z")
+
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+# Set log_type
+[transforms.input_infrastructure_viaq_logtype]
+type = "remap"
+inputs = ["input_infrastructure_container_viaq","input_infrastructure_journal_viaq"]
+source = '''
+  .log_type = "infrastructure"
+'''
+
+[sources.input_myreceiver]
+type = "http_server"
+address = "[::]:7777"
+decoding.codec = "json"
+
+[sources.input_myreceiver.tls]
+enabled = true
+key_file = "/etc/collector/receiver/collector-myreceiver/tls.key"
+crt_file = "/etc/collector/receiver/collector-myreceiver/tls.crt"
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
+
+[transforms.input_myreceiver_split]
+type = "remap"
+inputs = ["input_myreceiver"]
+source = '''
+  if exists(.items) && is_array(.items) {. = unnest!(.items)} else {.}
+'''
+
+[transforms.input_myreceiver_items]
+type = "remap"
+inputs = ["input_myreceiver_split"]
+source = '''
+  if exists(.items) {. = .items} else {.}
+'''
+
+[transforms.input_myreceiver_viaq]
+type = "remap"
+inputs = ["input_myreceiver_items"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+  .tag = ".k8s-audit.log"
+  . = merge(., parse_json!(string!(.message))) ?? .
+  del(.message)
+  .k8s_audit_level = .level
+'''
+
+# Set log_type
+[transforms.input_myreceiver_viaq_logtype]
+type = "remap"
+inputs = ["input_myreceiver_viaq"]
+source = '''
+    .log_type = "audit"
+    .hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+    ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+# Logs from containers (including openshift containers)
+[sources.input_mytestapp_container]
+type = "kubernetes_logs"
+max_read_bytes = 3145728
+glob_minimum_cooldown_ms = 15000
+auto_partial_merge = true
+include_paths_glob_patterns = ["/var/log/pods/test-ns_*/*/*.log"]
+exclude_paths_glob_patterns = ["/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp"]
+pod_annotation_fields.pod_labels = "kubernetes.labels"
+pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
+pod_annotation_fields.pod_annotations = "kubernetes.annotations"
+pod_annotation_fields.pod_uid = "kubernetes.pod_id"
+pod_annotation_fields.pod_node_name = "hostname"
+namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
+rotate_wait_ms = 5000
+
+[transforms.input_mytestapp_container_viaq]
+type = "remap"
+inputs = ["input_mytestapp_container"]
+source = '''
+  .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
+   if !exists(.level) {
+    .level = "default"
+    if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {
+      .level = "warn"
+    } else if match!(.message, r'Error|ERROR|^E[0-9]+|level=error|Value:error|"level":"error"|<error>') {
+      .level = "error"
+    } else if match!(.message, r'Critical|CRITICAL|^C[0-9]+|level=critical|Value:critical|"level":"critical"|<critical>') {
+      .level = "critical"
+    } else if match!(.message, r'Debug|DEBUG|^D[0-9]+|level=debug|Value:debug|"level":"debug"|<debug>') {
+      .level = "debug"
+    } else if match!(.message, r'Notice|NOTICE|^N[0-9]+|level=notice|Value:notice|"level":"notice"|<notice>') {
+      .level = "notice"
+    } else if match!(.message, r'Alert|ALERT|^A[0-9]+|level=alert|Value:alert|"level":"alert"|<alert>') {
+      .level = "alert"
+    } else if match!(.message, r'Emergency|EMERGENCY|^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"|<emergency>') {
+      .level = "emergency"
+    } else if match!(.message, r'(?i)\b(?:info)\b|^I[0-9]+|level=info|Value:info|"level":"info"|<info>') {
+      .level = "info"
+    }
+  }
+  pod_name = string!(.kubernetes.pod_name)
+  if starts_with(pod_name, "eventrouter-") {
+    parsed, err = parse_json(.message)
+    if err != null {
+      log("Unable to process EventRouter log: " + err, level: "info")
+    } else {
+      ., err = merge(.,parsed)
+      if err == null && exists(.event) && is_object(.event) {
+          if exists(.verb) {
+            .event.verb = .verb
+            del(.verb)
+          }
+          .kubernetes.event = del(.event)
+          .message = del(.kubernetes.event.message)
+          set!(., ["@timestamp"], .kubernetes.event.metadata.creationTimestamp)
+          del(.kubernetes.event.metadata.creationTimestamp)
+		  . = compact(., nullish: true)
+      } else {
+        log("Unable to merge EventRouter log message into record: " + err, level: "info")
+      }
+    }
+  }
+  del(.source_type)
+  del(.stream)
+  del(.kubernetes.pod_ips)
+  del(.kubernetes.node_labels)
+  del(.timestamp_end)
+  ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}
+'''
+
+# Set log_type
+[transforms.input_mytestapp_viaq_logtype]
+type = "remap"
+inputs = ["input_mytestapp_container_viaq"]
+source = '''
+  .log_type = "application"
+'''
+
+[transforms.pipeline_pipeline_openshiftlabels_0]
+type = "remap"
+inputs = ["input_mytestapp_viaq_logtype","input_infrastructure_viaq_logtype","input_audit_viaq_logtype","input_myreceiver_viaq_logtype"]
+source = '''
+  .openshift.labels = {"key1":"value1","key2":"value2"}
+'''
+
+[transforms.output_kafka_receiver_dedot]
+type = "lua"
+inputs = ["pipeline_pipeline_openshiftlabels_0"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+    function init()
+        count = 0
+    end
+    function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+		dedot(event.log.kubernetes.namespace_labels)
+        dedot(event.log.kubernetes.labels)
+        emit(event)
+    end
+
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "[./]", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+'''
+
+# Kafka config
+[sinks.output_kafka_receiver]
+type = "kafka"
+inputs = ["output_kafka_receiver_dedot"]
+bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
+topic = "topic"
+
+[sinks.output_kafka_receiver.encoding]
+codec = "json"
+timestamp_format = "rfc3339"
+
+[sinks.output_kafka_receiver.buffer]
+when_full = "drop_newest"
+
+[sinks.output_kafka_receiver.tls]
+enabled = true
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
+key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
+crt_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.crt"
+ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"
+
+[transforms.add_nodename_to_metric]
+type = "remap"
+inputs = ["internal_metrics"]
+source = '''
+.tags.hostname = get_env_var!("VECTOR_SELF_NODE_NAME")
+'''
+
+[sinks.prometheus_output]
+type = "prometheus_exporter"
+inputs = ["add_nodename_to_metric"]
+address = "[::]:24231"
+default_namespace = "collector"
+
+[sinks.prometheus_output.tls]
+enabled = true
+key_file = "/etc/collector/metrics/tls.key"
+crt_file = "/etc/collector/metrics/tls.crt"
+min_tls_version = "VersionTLS12"
+ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"

--- a/internal/generator/vector/conf/conf.go
+++ b/internal/generator/vector/conf/conf.go
@@ -1,7 +1,10 @@
 package conf
 
 import (
+	"sort"
+
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/filter"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
@@ -11,7 +14,6 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/pipeline"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/source"
 	corev1 "k8s.io/api/core/v1"
-	"sort"
 )
 
 // Design of next generation conf generation:
@@ -54,13 +56,13 @@ import (
 */
 
 //nolint:govet // using declarative style
-func Conf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, forwarderName string, op framework.Options) []framework.Section {
+func Conf(clspec *logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec *logging.ClusterLogForwarderSpec, namespace, forwarderName string, resNames *factory.ForwarderResourceNames, op framework.Options) []framework.Section {
 
 	// Init inputs, outputs, pipelines
 	inputMap := map[string]*input.Input{}
 	inputCompMap := map[string]helpers.InputComponent{}
 	for _, i := range clfspec.Inputs {
-		a := input.NewInput(i, namespace, op)
+		a := input.NewInput(i, namespace, resNames, op)
 		inputMap[i.Name] = a
 		inputCompMap[i.Name] = a
 	}

--- a/internal/generator/vector/input/adapter.go
+++ b/internal/generator/vector/input/adapter.go
@@ -2,6 +2,7 @@ package input
 
 import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 )
 
@@ -11,8 +12,8 @@ type Input struct {
 	elements []framework.Element
 }
 
-func NewInput(spec logging.InputSpec, collectorNS string, op framework.Options) *Input {
-	elements, ids := NewViaQ(spec, collectorNS, op)
+func NewInput(spec logging.InputSpec, collectorNS string, resNames *factory.ForwarderResourceNames, op framework.Options) *Input {
+	elements, ids := NewViaQ(spec, collectorNS, resNames, op)
 	return &Input{
 		ids:      ids,
 		elements: elements,

--- a/internal/generator/vector/input/receiver.go
+++ b/internal/generator/vector/input/receiver.go
@@ -2,25 +2,26 @@ package input
 
 import (
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	generator "github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	vector "github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/source"
 )
 
-func NewViaqReceiverSource(spec logging.InputSpec, op generator.Options) ([]generator.Element, []string) {
+func NewViaqReceiverSource(spec logging.InputSpec, resNames *factory.ForwarderResourceNames, op generator.Options) ([]generator.Element, []string) {
 	base := helpers.MakeInputID(spec.Name)
 	var el []generator.Element
 	var id string
 	switch {
 	case logging.IsSyslogReceiver(&spec):
-		el = append(el, source.NewSyslogSource(base, spec, op))
+		el = append(el, source.NewSyslogSource(base, resNames.GenerateInputServiceName(spec.Name), spec, op))
 		dropID := helpers.MakeID(base, "drop", "debug")
 		el = append(el, vector.DropJournalDebugLogs(base, dropID)...)
 		id = helpers.MakeID(base, "journal", "viaq")
 		el = append(el, vector.JournalLogs(dropID, id)...)
 	case logging.IsAuditHttpReceiver(&spec):
-		el = []generator.Element{source.NewHttpSource(base, spec, op)}
+		el = []generator.Element{source.NewHttpSource(base, resNames.GenerateInputServiceName(spec.Name), spec, op)}
 		id = helpers.MakeID(base, "viaq")
 		el = append(el, vector.NormalizeK8sAuditLogs(helpers.MakeID(base, "items"), id)...)
 	}

--- a/internal/generator/vector/input/viaq.go
+++ b/internal/generator/vector/input/viaq.go
@@ -2,15 +2,17 @@ package input
 
 import (
 	"fmt"
+	"strings"
+
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/source"
 	"github.com/openshift/cluster-logging-operator/internal/utils/sets"
-	"strings"
 )
 
 const (
@@ -39,7 +41,7 @@ var (
 
 // NewViaQ creates an input adapter to generate config for ViaQ sources to collect logs excluding the
 // collector container logs from the namespace where the collector is deployed
-func NewViaQ(input logging.InputSpec, collectorNS string, op framework.Options) ([]framework.Element, []string) {
+func NewViaQ(input logging.InputSpec, collectorNS string, resNames *factory.ForwarderResourceNames, op framework.Options) ([]framework.Element, []string) {
 	els := []framework.Element{}
 	ids := []string{}
 	switch {
@@ -105,7 +107,7 @@ func NewViaQ(input logging.InputSpec, collectorNS string, op framework.Options) 
 				ids = append(ids, cids...)
 			}
 		} else if input.Receiver != nil {
-			els, ids = NewViaqReceiverSource(input, op)
+			els, ids = NewViaqReceiverSource(input, resNames, op)
 		}
 	}
 	els, ids = addLogType(input, els, ids)
@@ -125,6 +127,7 @@ func addLogType(spec logging.InputSpec, els []framework.Element, ids []string) (
 
 	if logType != "" {
 		id := helpers.MakeInputID(spec.Name, "viaq", "logtype")
+
 		remap := elements.Remap{
 			Desc:        `Set log_type`,
 			ComponentID: id,

--- a/internal/generator/vector/input/viaq_receiver_http_audit.toml
+++ b/internal/generator/vector/input/viaq_receiver_http_audit.toml
@@ -5,8 +5,8 @@ decoding.codec = "json"
 
 [sources.input_myreceiver.tls]
 enabled = true
-key_file = "/etc/collector/receiver/myreceiver/tls.key"
-crt_file = "/etc/collector/receiver/myreceiver/tls.crt"
+key_file = "/etc/collector/receiver/collector-myreceiver/tls.key"
+crt_file = "/etc/collector/receiver/collector-myreceiver/tls.crt"
 
 [transforms.input_myreceiver_split]
 type = "remap"

--- a/internal/generator/vector/input/viaq_receiver_syslog.toml
+++ b/internal/generator/vector/input/viaq_receiver_syslog.toml
@@ -5,8 +5,8 @@ mode = "tcp"
 
 [sources.input_myreceiver.tls]
 enabled = true
-key_file = "/etc/collector/receiver/myreceiver/tls.key"
-crt_file = "/etc/collector/receiver/myreceiver/tls.crt"
+key_file = "/etc/collector/receiver/collector-myreceiver/tls.key"
+crt_file = "/etc/collector/receiver/collector-myreceiver/tls.crt"
 
 [transforms.input_myreceiver_drop_debug]
 type = "filter"

--- a/internal/generator/vector/input/viaq_test.go
+++ b/internal/generator/vector/input/viaq_test.go
@@ -2,13 +2,16 @@ package input
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("inputs", func() {
@@ -17,7 +20,13 @@ var _ = Describe("inputs", func() {
 		if err != nil {
 			Fail(fmt.Sprintf("Error reading the file %q with exp config: %v", expFile, err))
 		}
-		conf, _ := NewViaQ(input, constants.OpenshiftNS, framework.NoOptions)
+		clf := logging.ClusterLogForwarder{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      constants.SingletonName,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+		conf, _ := NewViaQ(input, constants.OpenshiftNS, factory.GenerateResourceNames(clf), framework.NoOptions)
 		Expect(string(exp)).To(EqualConfigFrom(conf))
 	},
 		Entry("with an application input should generate a VIAQ container source", logging.InputSpec{

--- a/internal/generator/vector/pipeline/adapter_test.go
+++ b/internal/generator/vector/pipeline/adapter_test.go
@@ -2,9 +2,13 @@ package pipeline_test
 
 import (
 	"fmt"
+	"sort"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/filter"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/input"
@@ -12,7 +16,6 @@ import (
 	. "github.com/openshift/cluster-logging-operator/internal/generator/vector/pipeline"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
-	"sort"
 )
 
 type FakeInputAdapter struct {
@@ -42,7 +45,7 @@ var _ = Describe("pipeline/adapter.go", func() {
 				InputRefs:  []string{"audit-in"},
 				FilterRefs: []string{"my-audit"},
 			}, map[string]helpers.InputComponent{
-				"audit-in": input.NewInput(logging.InputSpec{Name: "audit-in", Application: &logging.Application{}}, "", nil),
+				"audit-in": input.NewInput(logging.InputSpec{Name: "audit-in", Application: &logging.Application{}}, "", &factory.ForwarderResourceNames{CommonName: constants.CollectorName}, nil),
 			}, map[string]*output.Output{},
 				map[string]*filter.InternalFilterSpec{
 					"my-audit": {

--- a/internal/generator/vector/source/http_receiver.go
+++ b/internal/generator/vector/source/http_receiver.go
@@ -1,15 +1,16 @@
 package source
 
 import (
+	"strings"
+
 	configv1 "github.com/openshift/api/config/v1"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/tls"
-	"strings"
 )
 
-func NewHttpSource(id string, input logging.InputSpec, op framework.Options) framework.Element {
+func NewHttpSource(id, inputName string, input logging.InputSpec, op framework.Options) framework.Element {
 	var minTlsVersion, cipherSuites string
 	if _, ok := op[framework.ClusterTLSProfileSpec]; ok {
 		tlsProfileSpec := op[framework.ClusterTLSProfileSpec].(configv1.TLSProfileSpec)
@@ -18,7 +19,7 @@ func NewHttpSource(id string, input logging.InputSpec, op framework.Options) fra
 	}
 	return HttpReceiver{
 		ID:            id,
-		InputName:     input.Name,
+		InputName:     inputName,
 		ListenAddress: helpers.ListenOnAllLocalInterfacesAddress(),
 		ListenPort:    input.Receiver.HTTP.Port,
 		Format:        input.Receiver.HTTP.Format,

--- a/internal/generator/vector/source/syslog_receiver.go
+++ b/internal/generator/vector/source/syslog_receiver.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/tls"
 )
 
-func NewSyslogSource(id string, input logging.InputSpec, op framework.Options) framework.Element {
+func NewSyslogSource(id, inputName string, input logging.InputSpec, op framework.Options) framework.Element {
 	var minTlsVersion, cipherSuites string
 	if _, ok := op[framework.ClusterTLSProfileSpec]; ok {
 		tlsProfileSpec := op[framework.ClusterTLSProfileSpec].(configv1.TLSProfileSpec)
@@ -19,7 +19,7 @@ func NewSyslogSource(id string, input logging.InputSpec, op framework.Options) f
 	}
 	return SyslogReceiver{
 		ID:            id,
-		InputName:     input.Name,
+		InputName:     inputName,
 		ListenAddress: helpers.ListenOnAllLocalInterfacesAddress(),
 		ListenPort:    input.Receiver.Syslog.Port,
 		TlsMinVersion: minTlsVersion,

--- a/internal/k8shandler/clusterloggingrequest.go
+++ b/internal/k8shandler/clusterloggingrequest.go
@@ -2,9 +2,12 @@ package k8shandler
 
 import (
 	"context"
+	"strings"
+
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	generatorUtils "github.com/openshift/cluster-logging-operator/internal/generator/utils"
 	"github.com/openshift/cluster-logging-operator/internal/k8s/loader"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
-	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/factory"
@@ -40,6 +43,9 @@ type ClusterLoggingRequest struct {
 
 	// Owner of collector resources
 	ResourceOwner metav1.OwnerReference
+
+	// Determine the collector deployment strategy; Daemonset || Deployment
+	isDaemonset bool
 }
 
 func NewClusterLoggingRequest(cl *logging.ClusterLogging, forwarder *logging.ClusterLogForwarder, requestClient client.Client, reader client.Reader, r record.EventRecorder, clusterVersion, clusterID string, resourceNames *factory.ForwarderResourceNames) ClusterLoggingRequest {
@@ -53,12 +59,23 @@ func NewClusterLoggingRequest(cl *logging.ClusterLogging, forwarder *logging.Clu
 		ClusterID:      clusterID,
 		ResourceNames:  resourceNames,
 		ResourceOwner:  utils.AsOwner(forwarder),
+		isDaemonset:    true,
 	}
 
 	// Owner is always the ClusterLogging instance for legacy ClusterLogging
 	if cl.Namespace == constants.OpenshiftNS && cl.Name == constants.SingletonName {
 		request.ResourceOwner = utils.AsOwner(cl)
 	}
+
+	// Collector is not a daemonset if the only input source is an HTTP receiver
+	// Enabled through an annotation
+	if _, ok := request.Forwarder.Annotations[constants.AnnotationEnableCollectorAsDeployment]; ok {
+		inputs := generatorUtils.GatherSources(&forwarder.Spec, framework.NoOptions)
+		if inputs.Len() == 1 && inputs.Has(logging.InputNameReceiver) {
+			request.isDaemonset = false
+		}
+	}
+
 	return request
 }
 

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -1,8 +1,9 @@
 package k8shandler
 
 import (
-	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"strings"
+
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 
 	"github.com/openshift/cluster-logging-operator/internal/tls"
 
@@ -46,7 +47,7 @@ func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config s
 	op[framework.ClusterTLSProfileSpec] = tls.GetClusterTLSProfileSpec(tlsProfile)
 	EvaluateAnnotationsForEnabledCapabilities(clusterRequest.Forwarder, op)
 	g := forwardergenerator.New(clusterRequest.Cluster.Spec.Collection.Type)
-	generatedConfig, err := g.GenerateConf(clusterRequest.Cluster.Spec.Collection, clusterRequest.OutputSecrets, &clusterRequest.Forwarder.Spec, clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, op)
+	generatedConfig, err := g.GenerateConf(clusterRequest.Cluster.Spec.Collection, clusterRequest.OutputSecrets, &clusterRequest.Forwarder.Spec, clusterRequest.Forwarder.Namespace, clusterRequest.Forwarder.Name, clusterRequest.ResourceNames, op)
 
 	if err != nil {
 		log.Error(err, "Unable to generate log configuration")

--- a/internal/network/service.go
+++ b/internal/network/service.go
@@ -38,7 +38,7 @@ func ReconcileService(er record.EventRecorder, k8sClient client.Client, namespac
 	return reconcile.Service(er, k8sClient, desired)
 }
 
-func ReconcileInputService(er record.EventRecorder, k8sClient client.Client, namespace, name, instance, certSecretName string, port int32, targetPort int32, receiverType string, owner metav1.OwnerReference, visitors func(o runtime.Object)) error {
+func ReconcileInputService(er record.EventRecorder, k8sClient client.Client, namespace, name, instance, certSecretName string, port int32, targetPort int32, receiverType string, isDaemonset bool, owner metav1.OwnerReference, visitors func(o runtime.Object)) error {
 	desired := factory.NewService(
 		name,
 		namespace,
@@ -51,10 +51,15 @@ func ReconcileInputService(er record.EventRecorder, k8sClient client.Client, nam
 					Type:   intstr.Int,
 					IntVal: targetPort,
 				},
+				Protocol: v1.ProtocolTCP,
 			},
 		},
 		visitors,
 	)
+
+	if !isDaemonset {
+		desired.Spec.Selector[constants.CollectorDeploymentKind] = constants.DeploymentType
+	}
 
 	desired.Annotations = map[string]string{
 		constants.AnnotationServingCertSecretName: certSecretName,

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -3,6 +3,8 @@ package forwarder
 import (
 	"errors"
 	"fmt"
+
+	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/migrations"
 
@@ -45,6 +47,7 @@ func Generate(collectionType logging.LogCollectionType, clfYaml string, includeD
 			},
 			Spec: logging.ClusterLoggingSpec{},
 		},
+		ResourceNames: factory.GenerateResourceNames(*forwarder),
 	}
 
 	if client != nil {
@@ -74,5 +77,5 @@ func Generate(collectionType logging.LogCollectionType, clfYaml string, includeD
 	if configGenerator == nil {
 		return "", errors.New("unsupported collector implementation")
 	}
-	return configGenerator.GenerateConf(&clspec, clRequest.OutputSecrets, &forwarder.Spec, clRequest.Cluster.Namespace, forwarder.Name, op)
+	return configGenerator.GenerateConf(&clspec, clRequest.OutputSecrets, &forwarder.Spec, clRequest.Cluster.Namespace, forwarder.Name, clRequest.ResourceNames, op)
 }

--- a/internal/reconcile/daemon_sets.go
+++ b/internal/reconcile/daemon_sets.go
@@ -6,7 +6,6 @@ import (
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
-	util "github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/daemonsets"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -33,8 +32,8 @@ func DaemonSet(er record.EventRecorder, k8Client client.Client, desired *apps.Da
 		}
 		same := false
 
-		if same, updateReason = daemonsets.AreSame(current, desired); same && util.HasSameOwner(current.OwnerReferences, desired.OwnerReferences) {
-			log.V(3).Info("DaemonSet are the same skipping update")
+		if same, updateReason = daemonsets.AreSame(current, desired); same {
+			log.V(3).Info("DaemonSets are the same skipping update", "daemonsetName", current.Name)
 			return nil
 		}
 		reason = constants.EventReasonUpdateObject

--- a/internal/reconcile/deployment.go
+++ b/internal/reconcile/deployment.go
@@ -6,52 +6,50 @@ import (
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
-	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/services"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/deployments"
+	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Service reconciles a Service to the desired spec returning an error
+// Deployment reconciles a Deployment to the desired spec returning an error
 // if there is an issue creating or updating to the desired state
-func Service(er record.EventRecorder, k8Client client.Client, desired *corev1.Service) error {
+func Deployment(er record.EventRecorder, k8Client client.Client, desired *apps.Deployment) error {
 	reason := constants.EventReasonGetObject
 	updateReason := ""
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		current := &corev1.Service{}
+		current := &apps.Deployment{}
 		key := client.ObjectKeyFromObject(desired)
 		if err := k8Client.Get(context.TODO(), key, current); err != nil {
 			if errors.IsNotFound(err) {
 				reason = constants.EventReasonCreateObject
 				return k8Client.Create(context.TODO(), desired)
 			}
-			return fmt.Errorf("failed to get %v Service: %w", key, err)
+			return fmt.Errorf("failed to get %v Deployment: %w", key, err)
 		}
 		same := false
 
-		if same, updateReason = services.AreSame(current, desired); same {
-			log.V(3).Info("Service is the same skipping update")
+		if same, updateReason = deployments.AreSame(current, desired); same {
+			log.V(3).Info("Deployments are the same skipping update", "deploymentName", current.Name)
 			return nil
 		}
-
 		reason = constants.EventReasonUpdateObject
-		//Explicitly copying because services are immutable
 		current.Labels = desired.Labels
-		current.Spec.Selector = desired.Spec.Selector
-		current.Spec.Ports = desired.Spec.Ports
+		current.Spec = desired.Spec
 		current.OwnerReferences = desired.OwnerReferences
 		return k8Client.Update(context.TODO(), current)
 	})
 
-	eventType := corev1.EventTypeNormal
-	msg := fmt.Sprintf("%s Service %s/%s", reason, desired.Namespace, desired.Name)
+	eventType := v1.EventTypeNormal
+	msg := fmt.Sprintf("%s Deployment %s/%s", reason, desired.Namespace, desired.Name)
 	if updateReason != "" {
 		msg = fmt.Sprintf("%s because of change in %s.", msg, updateReason)
 	}
 	if retryErr != nil {
-		eventType = corev1.EventTypeWarning
+		eventType = v1.EventTypeWarning
 		msg = fmt.Sprintf("Unable to %s: %v", msg, retryErr)
 	}
 	er.Event(desired, eventType, reason, msg)

--- a/internal/runtime/core.go
+++ b/internal/runtime/core.go
@@ -60,3 +60,10 @@ func NewDaemonSet(namespace, name string, visitors ...func(o runtime.Object)) *a
 	Initialize(ds, namespace, name, visitors...)
 	return ds
 }
+
+// NewDeployment returns a deployment
+func NewDeployment(namespace, name string, visitors ...func(o runtime.Object)) *appsv1.Deployment {
+	dpl := &appsv1.Deployment{}
+	Initialize(dpl, namespace, name, visitors...)
+	return dpl
+}

--- a/internal/runtime/deployment.go
+++ b/internal/runtime/deployment.go
@@ -1,0 +1,49 @@
+package runtime
+
+import (
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DeploymentBuilder struct {
+	Deployment *apps.Deployment
+}
+
+func NewDeploymentBuilder(ds *apps.Deployment) *DeploymentBuilder {
+	return &DeploymentBuilder{
+		Deployment: ds,
+	}
+}
+
+func (builder *DeploymentBuilder) WithTemplateAnnotations(annotations map[string]string) *DeploymentBuilder {
+	builder.Deployment.Spec.Template.Annotations = annotations
+	return builder
+}
+
+func (builder *DeploymentBuilder) WithSelector(selector map[string]string) *DeploymentBuilder {
+	builder.Deployment.Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: selector,
+	}
+	return builder
+}
+
+func (builder *DeploymentBuilder) WithTemplateLabels(labels map[string]string) *DeploymentBuilder {
+	builder.Deployment.Spec.Template.Labels = labels
+	return builder
+}
+
+func (builder *DeploymentBuilder) WithUpdateStrategy(updateStrategy apps.DeploymentStrategy) *DeploymentBuilder {
+	builder.Deployment.Spec.Strategy = updateStrategy
+	return builder
+}
+
+func (builder *DeploymentBuilder) WithPodSpec(podSpec core.PodSpec) *DeploymentBuilder {
+	builder.Deployment.Spec.Template.Spec = podSpec
+	return builder
+}
+
+func (builder *DeploymentBuilder) WithReplicas(replicas *int32) *DeploymentBuilder {
+	builder.Deployment.Spec.Replicas = replicas
+	return builder
+}

--- a/internal/utils/comparators/deployments/comparator.go
+++ b/internal/utils/comparators/deployments/comparator.go
@@ -1,4 +1,4 @@
-package daemonsets
+package deployments
 
 import (
 	"reflect"
@@ -8,24 +8,24 @@ import (
 	apps "k8s.io/api/apps/v1"
 )
 
-// AreSame compares daemonset for equality and return true equal otherwise false
-func AreSame(current *apps.DaemonSet, desired *apps.DaemonSet) (bool, string) {
+// AreSame compares deployments for equality and return true equal otherwise false
+func AreSame(current *apps.Deployment, desired *apps.Deployment) (bool, string) {
 
-	// Check pod spec
+	// Check pod specs
 	if same, resource := pod.AreSame(&current.Spec.Template.Spec, &desired.Spec.Template.Spec, current.Name); !same {
-		log.V(3).Info("Daemonset pod spec change", "name", current.Name)
+		log.V(3).Info("Deployment pod spec change", "name", current.Name)
 		return false, resource
 	}
 
 	// Check labels
 	if !reflect.DeepEqual(current.Labels, desired.Labels) {
-		log.V(3).Info("Daemonset labels change", "name", current.Name)
+		log.V(3).Info("Deployment labels change", "name", current.Name)
 		return false, "labels"
 	}
 
 	// Check ownership
 	if !reflect.DeepEqual(current.GetOwnerReferences(), desired.GetOwnerReferences()) {
-		log.V(3).Info("Daemonset ownership change", "name", current.Name)
+		log.V(3).Info("Deployment ownership change", "name", current.Name)
 		return false, "ownerReference"
 	}
 

--- a/internal/utils/comparators/deployments/comparator_test.go
+++ b/internal/utils/comparators/deployments/comparator_test.go
@@ -1,4 +1,4 @@
-package daemonsets_test
+package deployments_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -7,17 +7,17 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/daemonsets"
+	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/deployments"
 )
 
-var _ = Describe("daemonset#AreSame", func() {
+var _ = Describe("deployments#AreSame", func() {
 
 	var (
-		current, desired *apps.DaemonSet
+		current, desired *apps.Deployment
 	)
 
 	BeforeEach(func() {
-		current = &apps.DaemonSet{
+		current = &apps.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					"foo": "bar",
@@ -29,7 +29,7 @@ var _ = Describe("daemonset#AreSame", func() {
 					},
 				},
 			},
-			Spec: apps.DaemonSetSpec{
+			Spec: apps.DeploymentSpec{
 				Template: v1.PodTemplateSpec{
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
@@ -45,17 +45,17 @@ var _ = Describe("daemonset#AreSame", func() {
 		desired = current.DeepCopy()
 
 	})
-	Context("when evaluating daemonSetSpec", func() {
+	Context("when evaluating deploymentSpec", func() {
 
 		It("should recognize the specs are different", func() {
 			container := v1.Container{}
 			desired.Spec.Template.Spec.Containers = append(desired.Spec.Template.Spec.Containers, container)
-			ok, _ := daemonsets.AreSame(current, desired)
+			ok, _ := deployments.AreSame(current, desired)
 			Expect(ok).To(BeFalse())
 		})
 
 		It("should recognize the specs are same", func() {
-			ok, _ := daemonsets.AreSame(current, desired)
+			ok, _ := deployments.AreSame(current, desired)
 			Expect(ok).To(BeTrue())
 		})
 	})
@@ -64,12 +64,12 @@ var _ = Describe("daemonset#AreSame", func() {
 
 		It("should recognize the labels are different", func() {
 			desired.Labels = map[string]string{"foo": "baz"}
-			ok, _ := daemonsets.AreSame(current, desired)
+			ok, _ := deployments.AreSame(current, desired)
 			Expect(ok).To(BeFalse())
 		})
 
 		It("should recognize labels are same", func() {
-			ok, _ := daemonsets.AreSame(current, desired)
+			ok, _ := deployments.AreSame(current, desired)
 			Expect(ok).To(BeTrue())
 		})
 	})
@@ -83,12 +83,12 @@ var _ = Describe("daemonset#AreSame", func() {
 					Name: "Baz",
 				},
 			}
-			ok, _ := daemonsets.AreSame(current, desired)
+			ok, _ := deployments.AreSame(current, desired)
 			Expect(ok).To(BeFalse())
 		})
 
 		It("should recognize ownerRefs are same", func() {
-			ok, _ := daemonsets.AreSame(current, desired)
+			ok, _ := deployments.AreSame(current, desired)
 			Expect(ok).To(BeTrue())
 		})
 	})

--- a/internal/utils/comparators/deployments/suite_test.go
+++ b/internal/utils/comparators/deployments/suite_test.go
@@ -1,4 +1,4 @@
-package daemonsets_test
+package deployments_test
 
 import (
 	"testing"
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Daemonsets Comparator Suite")
+	RunSpecs(t, "Deployments Comparator Suite")
 }

--- a/internal/utils/comparators/pod/comparator.go
+++ b/internal/utils/comparators/pod/comparator.go
@@ -1,0 +1,76 @@
+package pod
+
+import (
+	"reflect"
+
+	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// AreSame compares pods for equality and return true equal otherwise false
+func AreSame(current *corev1.PodSpec, desired *corev1.PodSpec, name string) (bool, string) {
+
+	if !utils.AreMapsSame(current.NodeSelector, desired.NodeSelector) {
+		log.V(3).Info("nodeSelector change", "name", name)
+		return false, "nodeSelector"
+	}
+
+	if !utils.AreTolerationsSame(current.Tolerations, desired.Tolerations) {
+		log.V(3).Info("tolerations change", "name", name)
+		return false, "tolerations"
+	}
+
+	if !utils.PodVolumeEquivalent(current.Volumes, current.Volumes) {
+		log.V(3).Info("volumes changed", "name", name)
+		return false, "volumes"
+	}
+
+	if len(current.Containers) != len(desired.Containers) {
+		log.V(3).Info("number of containers changed", "name", name)
+		return false, "numberOfContainers"
+	}
+
+	if utils.AreResourcesDifferent(current, desired) {
+		log.V(3).Info("resource(s) change", "name", name)
+		return false, "resources"
+	}
+
+	for i, container := range current.Containers {
+		if !utils.EnvValueEqual(container.Env, desired.Containers[i].Env) {
+			log.V(3).Info("container EnvVar change found, updating ", "name", name)
+			log.V(3).Info("envvars -", "current", container.Env, "desired", desired.Containers[i].Env)
+			container.Env = desired.Containers[i].Env
+			return false, "environment"
+		}
+
+		if !reflect.DeepEqual(container.VolumeMounts, desired.Containers[i].VolumeMounts) {
+			log.V(3).Info("%q container volumeMounts change", "name", name)
+			return false, "volumeMounts"
+		}
+
+		// Check pod image
+		for _, des := range desired.Containers {
+			// Only compare the images of containers with the same name
+			if container.Name == des.Name {
+				if container.Image != des.Image {
+					return false, "podImage"
+				}
+			}
+		}
+	}
+
+	if len(current.InitContainers) != len(desired.InitContainers) {
+		log.V(3).Info("number of init containers changed", "name", name)
+		return false, "initContainers"
+	}
+
+	for i, container := range current.InitContainers {
+		if container.Image != desired.InitContainers[i].Image {
+			log.V(3).Info("init container image is different from desired", "name", name, "CurrentContainerName", container.Name, "DesiredContainerName", desired.InitContainers[i].Name)
+			return false, "initContainerImage"
+		}
+	}
+
+	return true, ""
+}

--- a/internal/utils/comparators/pod/comparator_test.go
+++ b/internal/utils/comparators/pod/comparator_test.go
@@ -1,0 +1,60 @@
+package pod_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/utils/comparators/pod"
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("pod#AreSame", func() {
+
+	var (
+		current, desired *v1.PodSpec
+	)
+
+	BeforeEach(func() {
+		current = &v1.PodSpec{
+			Containers: []v1.Container{
+				{},
+			},
+			InitContainers: []v1.Container{
+				{},
+			},
+		}
+		desired = current.DeepCopy()
+	})
+
+	Context("when evaluating containers", func() {
+
+		It("should recognize the numbers are different", func() {
+			container := v1.Container{}
+			desired.Containers = append(desired.Containers, container)
+			ok, _ := pod.AreSame(current, desired, "")
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should recognize different images", func() {
+			desired.Containers[0].Image = "bar"
+			ok, _ := pod.AreSame(current, desired, "")
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Context("when evaluating init containers", func() {
+
+		It("should recognize the numbers are different", func() {
+			container := v1.Container{}
+			desired.InitContainers = append(desired.InitContainers, container)
+			ok, _ := pod.AreSame(current, desired, "")
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should recognize different images", func() {
+			desired.InitContainers[0].Image = "bar"
+			ok, _ := pod.AreSame(current, desired, "")
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+})

--- a/internal/utils/comparators/pod/suite_test.go
+++ b/internal/utils/comparators/pod/suite_test.go
@@ -1,4 +1,4 @@
-package daemonsets_test
+package pod_test
 
 import (
 	"testing"
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Daemonsets Comparator Suite")
+	RunSpecs(t, "Pod Comparator Suite")
 }

--- a/internal/utils/resources.go
+++ b/internal/utils/resources.go
@@ -1,12 +1,7 @@
 package utils
 
 import (
-	"errors"
-	"reflect"
-
 	log "github.com/ViaQ/logerr/v2/log/static"
-	apps "k8s.io/api/apps/v1"
-	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -42,37 +37,14 @@ func AreResourcesSame(current, desired *v1.ResourceRequirements) bool {
 	return true
 }
 
-func AreResourcesDifferent(current, desired interface{}) bool {
+func AreResourcesDifferent(current, desired *v1.PodSpec) bool {
 
-	var currentContainers []v1.Container
-	var desiredContainers []v1.Container
-
-	currentType := reflect.TypeOf(current)
-	desiredType := reflect.TypeOf(desired)
-
-	if currentType != desiredType {
-		log.Error(errors.New("Attempting to compare resources for different types"), "",
-			"current", currentType, "desired", desiredType)
+	if current == nil || desired == nil {
 		return false
 	}
 
-	switch currentType {
-	case reflect.TypeOf(&apps.Deployment{}):
-		currentContainers = current.(*apps.Deployment).Spec.Template.Spec.Containers
-		desiredContainers = desired.(*apps.Deployment).Spec.Template.Spec.Containers
-
-	case reflect.TypeOf(&apps.DaemonSet{}):
-		currentContainers = current.(*apps.DaemonSet).Spec.Template.Spec.Containers
-		desiredContainers = desired.(*apps.DaemonSet).Spec.Template.Spec.Containers
-
-	case reflect.TypeOf(&batch.CronJob{}):
-		currentContainers = current.(*batch.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers
-		desiredContainers = desired.(*batch.CronJob).Spec.JobTemplate.Spec.Template.Spec.Containers
-
-	default:
-		log.Info("Attempting to check resources for unmatched type", "current", currentType)
-		return false
-	}
+	currentContainers := current.Containers
+	desiredContainers := desired.Containers
 
 	changed := false
 

--- a/internal/utils/resources_test.go
+++ b/internal/utils/resources_test.go
@@ -5,9 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -59,64 +57,38 @@ var _ = Describe("#AreResourcesSame", func() {
 var _ = Describe("#AreResourcesDifferent", func() {
 
 	var (
-		ds1 = &apps.DaemonSet{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "DaemonSet",
-				APIVersion: apps.SchemeGroupVersion.String(),
-			},
-			Spec: apps.DaemonSetSpec{
-				Template: v1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test1",
-					},
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
-							{
-								Name:  "test-container",
-								Image: "test-image",
-								Resources: v1.ResourceRequirements{
-									Requests: v1.ResourceList{
-										v1.ResourceCPU:    requestCPU,
-										v1.ResourceMemory: resource.MustParse("50Gi"),
-									},
-									Limits: v1.ResourceList{
-										v1.ResourceCPU:    resource.MustParse("100m"),
-										v1.ResourceMemory: requestMemory,
-									},
-								},
-							},
+		pod1 = &v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    requestCPU,
+							v1.ResourceMemory: resource.MustParse("50Gi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("100m"),
+							v1.ResourceMemory: requestMemory,
 						},
 					},
 				},
 			},
 		}
 
-		ds2 = &apps.DaemonSet{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "DaemonSet",
-				APIVersion: apps.SchemeGroupVersion.String(),
-			},
-			Spec: apps.DaemonSetSpec{
-				Template: v1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test2",
-					},
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
-							{
-								Name:  "test-container",
-								Image: "test-image",
-								Resources: v1.ResourceRequirements{
-									Requests: v1.ResourceList{
-										v1.ResourceCPU:    requestCPU,
-										v1.ResourceMemory: requestMemory,
-									},
-									Limits: v1.ResourceList{
-										v1.ResourceCPU:    requestCPU,
-										v1.ResourceMemory: requestMemory,
-									},
-								},
-							},
+		pod2 = &v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    requestCPU,
+							v1.ResourceMemory: requestMemory,
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    requestCPU,
+							v1.ResourceMemory: requestMemory,
 						},
 					},
 				},
@@ -130,18 +102,18 @@ var _ = Describe("#AreResourcesDifferent", func() {
 
 	// Comparing daemonset to nil type will be false
 	It("should be false when one is nil and the other is not", func() {
-		Expect(AreResourcesDifferent(nil, ds2)).To(BeFalse())
-		Expect(AreResourcesDifferent(ds1, nil)).To(BeFalse())
+		Expect(AreResourcesDifferent(nil, pod2)).To(BeFalse())
+		Expect(AreResourcesDifferent(pod1, nil)).To(BeFalse())
 	})
 	It("should be true when daemonset resources are different", func() {
-		left := ds1
-		right := ds2
+		left := pod1
+		right := pod2
 		Expect(AreResourcesDifferent(left, right)).To(BeTrue())
 		Expect(AreResourcesDifferent(right, left)).To(BeTrue())
 	})
 	It("should be false when limits and requests are the same", func() {
-		left := ds1
-		right := ds1
+		left := pod1
+		right := pod1
 		Expect(AreResourcesDifferent(left, right)).To(BeFalse())
 		Expect(AreResourcesDifferent(right, left)).To(BeFalse())
 	})

--- a/test/e2e/collection/collector_as_deployment_test.go
+++ b/test/e2e/collection/collector_as_deployment_test.go
@@ -1,0 +1,183 @@
+package collection
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
+	"github.com/openshift/cluster-logging-operator/test/helpers"
+	testruntime "github.com/openshift/cluster-logging-operator/test/runtime"
+	apps "k8s.io/api/apps/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test collector deployment type", func() {
+	const (
+		fluentConf = `
+<system>
+  log_level info
+</system>
+<source>
+  @type http
+  port 24224
+  bind 0.0.0.0
+  body_size_limit 32m
+  keepalive_timeout 10s
+  # Headers are capitalized, and added with prefix "HTTP_"
+  add_http_headers true
+  add_remote_addr true
+  <parse>
+    @type json
+  </parse>
+  <transport tls>
+	  ca_path /etc/fluentd/secrets/ca-bundle.crt
+	  cert_path /etc/fluentd/secrets/tls.crt
+	  private_key_path /etc/fluentd/secrets/tls.key
+  </transport>
+</source>
+
+<match logs.app>
+  @type file
+  append true
+  path /tmp/app.logs
+  symlink_path /tmp/app-logs
+</match>
+<match logs.infra>
+  @type file
+  append true
+  path /tmp/infra.logs
+  symlink_path /tmp/infra-logs
+</match>
+<match logs.audit>
+  @type file
+  append true
+  path /tmp/audit.logs
+  symlink_path /tmp/audit-logs
+</match>
+<match **>
+	@type stdout
+</match>
+`
+		receiverPort = 8080
+		receiverName = "http-audit"
+	)
+	var (
+		err                  error
+		wd, _                = os.Getwd()
+		rootDir              = fmt.Sprintf("%s/../../../../", wd)
+		forwarder            *loggingv1.ClusterLogForwarder
+		deploymentAnnotation = map[string]string{constants.AnnotationEnableCollectorAsDeployment: "true"}
+		fluentDeployment     *apps.Deployment
+		logGenNS             string
+		headers              = map[string]string{"h1": "v1", "h2": "v2"}
+		e2e                  = framework.NewE2ETestFramework()
+		fwdSpec              = loggingv1.ClusterLogForwarderSpec{
+			Inputs: []loggingv1.InputSpec{
+				{
+					Name: receiverName,
+					Receiver: &loggingv1.ReceiverSpec{
+						Type: loggingv1.ReceiverTypeHttp,
+						ReceiverTypeSpec: &loggingv1.ReceiverTypeSpec{
+							HTTP: &loggingv1.HTTPReceiver{
+								Format: loggingv1.FormatKubeAPIAudit,
+								Port:   receiverPort,
+							},
+						},
+					},
+				},
+			},
+			Outputs: []loggingv1.OutputSpec{
+				{
+					Name: "httpout-audit",
+					Type: loggingv1.OutputTypeHttp,
+					URL:  "https://fluent-receiver.openshift-logging.svc:24224/logs/audit",
+					OutputTypeSpec: loggingv1.OutputTypeSpec{
+						Http: &loggingv1.Http{
+							Headers: headers,
+							Method:  "POST",
+						},
+					},
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: "fluent-receiver",
+					},
+					TLS: &loggingv1.OutputTLSSpec{
+						InsecureSkipVerify: true,
+					},
+				},
+			},
+			Pipelines: []loggingv1.PipelineSpec{
+				{
+					Name:       "input-receiver-logs",
+					OutputRefs: []string{"httpout-audit"},
+					InputRefs:  []string{"http-audit"},
+				},
+			},
+		}
+	)
+
+	Describe("with vector collector", func() {
+		BeforeEach(func() {
+			cr := helpers.NewClusterLogging(helpers.ComponentTypeCollectorVector)
+			if err = e2e.CreateClusterLogging(cr); err != nil {
+				Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+			}
+			forwarder = testruntime.NewClusterLogForwarder()
+			forwarder.Spec = fwdSpec
+			httpReceiverServiceName := fmt.Sprintf("%s-%s", constants.CollectorName, receiverName)
+			httpReceiverEndpoint := fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", httpReceiverServiceName, constants.OpenshiftNS, receiverPort)
+			if logGenNS, err = e2e.DeployCURLLogGenerator(httpReceiverEndpoint); err != nil {
+				Fail(fmt.Sprintf("unable to deploy log generator %v.", err))
+			}
+		})
+
+		It("collector should be a deployment when annotated and http receiver is the only input", func() {
+			fluentDeployment, err = e2e.DeployFluentdReceiverWithConf(rootDir, true, fluentConf)
+			Expect(err).To(BeNil())
+			forwarder.Annotations = deploymentAnnotation
+			if err := e2e.CreateClusterLogForwarder(forwarder); err != nil {
+				Fail(fmt.Sprintf("Unable to create an instance of logforwarder: %v", err))
+			}
+			components := []helpers.LogComponentType{helpers.ComponentTypeCollectorDeployment}
+			for _, component := range components {
+				if err := e2e.WaitFor(component); err != nil {
+					Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
+				}
+			}
+
+			logStore := e2e.LogStores[fluentDeployment.GetName()]
+			has, err := logStore.HasAuditLogs(framework.DefaultWaitForLogsTimeout)
+			Expect(err).To(BeNil())
+			Expect(has).To(BeTrue())
+
+			collectedLogs, err := logStore.RetrieveLogs()
+			Expect(err).To(BeNil())
+			auditLogsStr, ok := collectedLogs["audit"]
+			fmt.Printf("---- %s\n", auditLogsStr)
+			Expect(ok).To(BeTrue())
+			auditLogs := map[string]interface{}{}
+			err = json.Unmarshal([]byte(auditLogsStr), &auditLogs)
+			Expect(err).To(BeNil(), auditLogsStr)
+			for k, v := range headers {
+				// Headers are capitalized, and sent with prefix "HTTP_"
+				headerVal, ok := auditLogs[fmt.Sprintf("HTTP_%s", strings.ToUpper(k))]
+				Expect(ok).To(BeTrue())
+				Expect(headerVal).To(Equal(v))
+			}
+			message, ok := auditLogs["log_message"]
+			Expect(ok).To(BeTrue())
+			Expect(message).To(Not(BeEmpty()))
+		})
+
+		AfterEach(func() {
+			e2e.Cleanup()
+			e2e.WaitForCleanupCompletion(logGenNS, []string{"test"})
+		})
+	})
+
+})

--- a/test/framework/e2e/wait.go
+++ b/test/framework/e2e/wait.go
@@ -3,6 +3,10 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	clolog "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/test/helpers"
@@ -10,9 +14,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"strconv"
-	"strings"
-	"time"
 )
 
 func (tc *E2ETestFramework) WaitFor(component helpers.LogComponentType) error {
@@ -24,6 +25,8 @@ func (tc *E2ETestFramework) WaitFor(component helpers.LogComponentType) error {
 		return tc.waitForFluentDaemonSet(defaultRetryInterval, defaultTimeout)
 	case helpers.ComponentTypeStore:
 		return tc.waitForElasticsearchPods(defaultRetryInterval, defaultTimeout)
+	case helpers.ComponentTypeCollectorDeployment:
+		return tc.waitForDeployment(constants.OpenshiftNS, constants.CollectorName, defaultRetryInterval, defaultTimeout)
 	}
 	return fmt.Errorf("Unable to waitfor unrecognized component: %v", component)
 }

--- a/test/helpers/clusterlogging.go
+++ b/test/helpers/clusterlogging.go
@@ -14,11 +14,12 @@ import (
 type LogComponentType string
 
 const (
-	ComponentTypeStore            LogComponentType = "LogStore"
-	ComponentTypeVisualization    LogComponentType = "Visualization"
-	ComponentTypeCollector        LogComponentType = "collector"
-	ComponentTypeCollectorFluentd LogComponentType = "collector-fluentd"
-	ComponentTypeCollectorVector  LogComponentType = "collector-vector"
+	ComponentTypeStore               LogComponentType = "LogStore"
+	ComponentTypeVisualization       LogComponentType = "Visualization"
+	ComponentTypeCollector           LogComponentType = "collector"
+	ComponentTypeCollectorFluentd    LogComponentType = "collector-fluentd"
+	ComponentTypeCollectorVector     LogComponentType = "collector-vector"
+	ComponentTypeCollectorDeployment LogComponentType = "collector-deployment"
 )
 
 func NewClusterLogging(componentTypes ...LogComponentType) *cl.ClusterLogging {


### PR DESCRIPTION
### Description
This is the ported version of the PR originally for `release-5.8` (https://github.com/openshift/cluster-logging-operator/pull/2240) to `master` (release-5.9).

Added an `E2E` test.

#### Description from PR#2240
This PR deals with the scenario in which a user wishes to specify the collector as an HTTP receiver as the sole input option.

Originally the collector was deployed as a `daemonset`. However, with this change, when all pipelines specified in the `ClusterLogForwarder` (CLF) reference an 'HTTP' receiver as their sole input reference, the collector will be deployed as a `deployment`.

This addresses the following:

The HCP usecase that utilizes one collector per NS for collecting audit logs via a webhook
Saves deployment resources
Collector does not need to mount the host file system given it only receives logs via the receiver

#### Extra
This also fixes a bug when defining `HTTP` input receivers in multi-CLF. Multiple CLFs with the same `HTTP` input receiver name will endlessly reconcile the same service because the names are the same. The fix for this was the make HTTP input service names unique with the format of `<CLF-NAME>-<input.Name>`.
Related Jira: https://issues.redhat.com/browse/LOG-5009

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- Github Old PR: https://github.com/openshift/cluster-logging-operator/pull/2240
- JIRA: https://issues.redhat.com/browse/LOG-4779
