### PR TITLE
LOG-4963: fix outputs to allows specifying insecureSkipVerify without

### DIFF
--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -88,7 +88,7 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 			output.NewBuffer(id),
 			request,
 		},
-		TLSConf(o, secret, op),
+		security.TLS(o, secret, op),
 	)
 }
 
@@ -115,16 +115,6 @@ func SecurityConfig(secret *corev1.Secret) Element {
 		KeyID:     strings.TrimSpace(security.GetFromSecret(secret, constants.AWSAccessKeyID)),
 		KeySecret: strings.TrimSpace(security.GetFromSecret(secret, constants.AWSSecretAccessKey)),
 	}
-}
-
-func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
-			tlsConf.NeedsEnabled = false
-			return []Element{tlsConf}
-		}
-	}
-	return []Element{}
 }
 
 func EndpointConfig(o logging.OutputSpec) Element {

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -236,7 +236,7 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 			output.NewBuffer(id),
 			request,
 		},
-		TLSConf(o, secret, op),
+		security.TLS(o, secret, op),
 		BasicAuth(o, secret),
 	)
 
@@ -256,16 +256,6 @@ func Output(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Opt
 		es.Version = logging.DefaultESVersion
 	}
 	return es
-}
-
-func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
-			tlsConf.NeedsEnabled = false
-			return []Element{tlsConf}
-		}
-	}
-	return []Element{}
 }
 
 func BasicAuth(o logging.OutputSpec, secret *corev1.Secret) []Element {

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -436,6 +436,140 @@ retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),
+		Entry("without secret and TLS.insecureSkipVerify=true", helpers.ConfGenerateTest{
+			CLFSpec: logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					{
+						Type:   logging.OutputTypeElasticsearch,
+						Name:   "es-1",
+						URL:    "https://es.svc.infra.cluster:9200",
+						Secret: nil,
+						TLS: &logging.OutputTLSSpec{
+							InsecureSkipVerify: true,
+						},
+					},
+				},
+			},
+			Secrets: security.NoSecrets,
+			ExpectedConf: `
+# Set Elasticsearch index
+[transforms.es_1_add_es_index]
+type = "remap"
+inputs = ["application"]
+source = '''
+  index = "default"
+  if (.log_type == "application"){
+    index = "app"
+  }
+  if (.log_type == "infrastructure"){
+    index = "infra"
+  }
+  if (.log_type == "audit"){
+    index = "audit"
+  }
+  .write_index = index + "-write"
+  ._id = encode_base64(uuid_v4())
+  del(.file)
+  del(.tag)
+  del(.source_type)
+'''
+
+[transforms.es_1_dedot_and_flatten]
+type = "lua"
+inputs = ["es_1_add_es_index"]
+version = "2"
+hooks.init = "init"
+hooks.process = "process"
+source = '''
+    function init()
+        count = 0
+    end
+    function process(event, emit)
+        count = count + 1
+        event.log.openshift.sequence = count
+        if event.log.kubernetes == nil then
+            emit(event)
+            return
+        end
+        if event.log.kubernetes.labels == nil then
+            emit(event)
+            return
+        end
+        dedot(event.log.kubernetes.namespace_labels)
+        dedot(event.log.kubernetes.labels)
+        flatten_labels(event)
+        prune_labels(event)
+        emit(event)
+    end
+	
+    function dedot(map)
+        if map == nil then
+            return
+        end
+        local new_map = {}
+        local changed_keys = {}
+        for k, v in pairs(map) do
+            local dedotted = string.gsub(k, "[./]", "_")
+            if dedotted ~= k then
+                new_map[dedotted] = v
+                changed_keys[k] = true
+            end
+        end
+        for k in pairs(changed_keys) do
+            map[k] = nil
+        end
+        for k, v in pairs(new_map) do
+            map[k] = v
+        end
+    end
+
+    function flatten_labels(event)
+        -- create "flat_labels" key
+        event.log.kubernetes.flat_labels = {}
+        i = 1
+        -- flatten the labels
+        for k,v in pairs(event.log.kubernetes.labels) do
+          event.log.kubernetes.flat_labels[i] = k.."="..v
+          i=i+1
+        end
+    end 
+
+	function prune_labels(event)
+		local exclusions = {"app_kubernetes_io_name", "app_kubernetes_io_instance", "app_kubernetes_io_version", "app_kubernetes_io_component", "app_kubernetes_io_part-of", "app_kubernetes_io_managed-by", "app_kubernetes_io_created-by"}
+		local keys = {}
+		for k,v in pairs(event.log.kubernetes.labels) do
+			for index, e in pairs(exclusions) do
+				if k == e then
+					keys[k] = v
+				end
+			end
+		end
+		event.log.kubernetes.labels = keys
+	end
+'''
+
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["es_1_dedot_and_flatten"]
+endpoints = ["https://es.svc.infra.cluster:9200"]
+bulk.index = "{{ write_index }}"
+bulk.action = "create"
+encoding.except_fields = ["write_index"]
+id_key = "_id"
+api_version = "v6"
+
+[sinks.es_1.buffer]
+when_full = "drop_newest"
+
+[sinks.es_1.request]
+retry_attempts = 17
+timeout_secs = 2147483648
+
+[sinks.es_1.tls]
+verify_certificate = false
+verify_hostname = false
+`,
+		}),
 		Entry("with multiple pipelines for elastic-search", helpers.ConfGenerateTest{
 			CLSpec: logging.CollectionSpec{},
 			CLFSpec: logging.ClusterLogForwarderSpec{

--- a/internal/generator/vector/output/gcl/gcl.go
+++ b/internal/generator/vector/output/gcl/gcl.go
@@ -89,18 +89,8 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 			output.NewBuffer(id),
 			output.NewRequest(id),
 		},
-		TLSConf(o, secret, op),
+		security.TLS(o, secret, op),
 	)
-}
-
-func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
-			tlsConf.NeedsEnabled = false
-			return []Element{tlsConf}
-		}
-	}
-	return []Element{}
 }
 
 func setInput(gcl *GoogleCloudLogging, inputs []string) Element {

--- a/internal/generator/vector/output/http/http.go
+++ b/internal/generator/vector/output/http/http.go
@@ -129,7 +129,7 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 			output.NewBuffer(id),
 			Request(o),
 		},
-		TLSConf(o, secret, op),
+		security.TLS(o, secret, op),
 		BasicAuth(o, secret),
 		BearerTokenAuth(o, secret),
 	)
@@ -200,16 +200,6 @@ func Encoding(o logging.OutputSpec) Element {
 		ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
 		Codec:       httpEncodingJson,
 	}
-}
-
-func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
-		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
-			tlsConf.NeedsEnabled = false
-			return []Element{tlsConf}
-		}
-	}
-	return []Element{}
 }
 
 func BasicAuth(o logging.OutputSpec, secret *corev1.Secret) []Element {

--- a/internal/generator/vector/output/kafka/kafka.go
+++ b/internal/generator/vector/output/kafka/kafka.go
@@ -144,7 +144,7 @@ timestamp_format = "rfc3339"
 }
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options, genTLSConf bool) []Element {
-	if o.Secret != nil {
+	if o.Secret != nil || (o.TLS != nil && o.TLS.InsecureSkipVerify) {
 		conf := []Element{}
 
 		if tlsConf := security.GenerateTLSConf(o, secret, op, genTLSConf); tlsConf != nil {

--- a/internal/generator/vector/output/security/security.go
+++ b/internal/generator/vector/output/security/security.go
@@ -15,8 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type TLS bool
-
 type UserNamePass struct {
 	Username string
 	Password string
@@ -32,6 +30,16 @@ type Passphrase struct {
 
 type BearerToken struct {
 	Token string
+}
+
+func TLS(o logging.OutputSpec, secret *corev1.Secret, op generator.Options) []generator.Element {
+	if o.Secret != nil || (o.TLS != nil && o.TLS.InsecureSkipVerify) {
+		if tlsConf := GenerateTLSConf(o, secret, op, false); tlsConf != nil {
+			tlsConf.NeedsEnabled = false
+			return []generator.Element{tlsConf}
+		}
+	}
+	return []generator.Element{}
 }
 
 type TLSConf struct {
@@ -67,13 +75,13 @@ func (conf *TLSConf) SetTLSProfileFromOptions(op generator.Options) {
 
 func addTLSSettings(o logging.OutputSpec, secret *corev1.Secret, conf *TLSConf) bool {
 	addTLS := false
-	if o.Name == logging.OutputNameDefault || HasTLSCertAndKey(secret) {
+	if o.Secret != nil && (o.Name == logging.OutputNameDefault || HasTLSCertAndKey(secret)) {
 		addTLS = true
 		conf.CertPath = SecretPath(o.Secret.Name, constants.ClientCertKey)
 		conf.KeyPath = SecretPath(o.Secret.Name, constants.ClientPrivateKey)
 	}
 
-	if o.Name == logging.OutputNameDefault || HasCABundle(secret) {
+	if o.Secret != nil && (o.Name == logging.OutputNameDefault || HasCABundle(secret)) {
 		addTLS = true
 		conf.CAFilePath = SecretPath(o.Secret.Name, constants.TrustedCABundleKey)
 	}

--- a/internal/generator/vector/output/splunk/splunk.go
+++ b/internal/generator/vector/output/splunk/splunk.go
@@ -77,7 +77,7 @@ func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Optio
 			output.NewBuffer(id),
 			output.NewRequest(id),
 		},
-		TLSConf(o, secret, op),
+		security.TLS(o, secret, op),
 	)
 }
 
@@ -95,12 +95,4 @@ func Encoding(o logging.OutputSpec) Element {
 		ComponentID: strings.ToLower(vectorhelpers.Replacer.Replace(o.Name)),
 		Codec:       splunkEncodingJson,
 	}
-}
-
-func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
-		tlsConf.NeedsEnabled = false
-		return []Element{tlsConf}
-	}
-	return []Element{}
 }

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -133,7 +133,7 @@ func Encoding(o logging.OutputSpec) Element {
 }
 
 func TLSConf(o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
+	if o.Secret != nil || (o.TLS != nil && o.TLS.InsecureSkipVerify) {
 		if tlsConf := security.GenerateTLSConf(o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}


### PR DESCRIPTION
### Description
This PR:
* fixes output config to allow configuration of tls.insecureSkipVerify without requiring a secret
* Refactors tls config to common function where possible

### Links
* https://issues.redhat.com/browse/LOG-4963
