### PR TITLE
LOG-4844: Custom Tenant Spike

### DIFF
--- a/docs/features/logforwarding/custom-tenants/custom-tenant-support.adoc
+++ b/docs/features/logforwarding/custom-tenants/custom-tenant-support.adoc
@@ -1,0 +1,246 @@
+= Configuring Custom Tenants
+
+Most of the outputs supported have some concept of a `tenant` and can currently be configured with custom values. For example `Kafka` has `topics`, `CloudWatch` has `log_groups`, and `ElasticSearch` has `indices`. This document provides guidance on configuring the tenant for supported outputs.
+
+== CloudWatch
+CloudWatch's tenant can be configured by setting how logs are grouped together along with an optional prefix. Configure using the `groupBy` & `groupPrefix` fields.
+
+* Logs can be grouped by the following:
+. `namespaceName`
+. `namespaceUUID`
+. `logType`
+
+=== Example
+
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+spec:
+  outputs:
+   - name: cw 
+     type: cloudwatch 
+     cloudwatch:
+       groupBy: logType <1>
+       groupPrefix: <group prefix> <2> 
+       region: us-east-2
+----
+<1> Specify the `groupBy` type here.
+<2> Specify an optional prefix to add to the tenant.
+
+=== References
+
+. See the link:https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/configuring-log-forwarding.html#cluster-logging-collector-log-forward-cloudwatch_configuring-log-forwarding[forwarding to CloudWatch section] on the official documentation.
+
+== Elasticsearch
+Elasticsearch's default behavior is to send logs to indices defined by their `log_type` and appended by `-write`.
+
+  Example: `application` logs will be sent to the index `app-write`.
+
+ElasticSearch's index can be configured if `parse: json` is enabled.
+
+* Configure using the `structuredTypeKey & structuredTypeName` fields.
+
+=== Example
+
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+spec:
+  outputs:
+    - name: external-es
+      type: elasticsearch
+      elasticsearch: 
+        structuredTypeKey: kubernetes.namespace_name <1>
+        structuredTypeName: myParsedMessages <2>
+  pipelines:
+    - name: parsed-app-logs
+      inputRefs:
+        - application
+      outputRefs:
+        - external-es
+      parse: json <3>
+
+----
+<1> Specify the `structuredTypeKey` here.
+<2> Specify the `structuredTypeName` here.
+<3> Parse JSON must be enabled.
+
+NOTE: Both or one of `structuredTypeKey` and/or `structuredTypeName` must be specified. If both are specified, the `structureTypeName` will be used as fallback if the field defined by the `structuredTypeKey` is not present in the log record.
+
+=== References
+
+. See the link:../outputs/elasticsearch-forwarding.adoc[custom index configuration section] of the internal Elasticsearch forwarding documentation.
+
+. See also the link:https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/cluster-logging-enabling-json-logging.html#cluster-logging-configuration-of-json-log-data-for-default-elasticsearch_cluster-logging-enabling-json-logging[configuring JSON log data for Elasticsearch] on the offical documention.
+
+== Google Cloud Logging
+Google Cloud Logging can be configured with a custom tenant by setting the `logId` field.
+
+=== Example
+
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+spec:
+  outputs:
+    - name: gcp-1
+      type: googleCloudLogging
+      secret:
+        name: gcp-secret
+      googleCloudLogging:
+        projectId : openshift-gce-devel
+        logId : app-gcp <1>
+----
+<1> Specify the `logId` here.
+
+=== References
+
+. See the link:../outputs/google-cloud-forwarding.adoc[internal forwarding doc] for Google Cloud Logging.
+
+. See also the link:https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/configuring-log-forwarding.html#cluster-logging-collector-log-forward-gcp_configuring-log-forwarding[forwarding logs to GCL section] on the official documentation.
+
+== HTTP
+A `header` can be added to the HTTP output as a tenant label.
+
+=== Example
+
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+spec:
+  outputs:
+    - name: httpout-app
+      type: http
+      url: <HTTP-URL>
+      http:
+        headers: 
+          h1: v1
+          tenant: myAppLogs <1>
+        method: POST
+----
+<1> Specify the `header` here.
+
+=== References
+
+. See the link:../outputs/send-logs-to-fluentd-http.adoc[internal forwarding doc] for Vector HTTP.
+
+. See also the link:https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/configuring-log-forwarding.html#logging-http-forward_configuring-log-forwarding[forwarding logs to HTTP section] on the offical documentation.
+
+== Kafka
+Kafka's tenant can be configured by setting the `topic` either through the `topic` field or at the end of the URL.
+
+=== Examples
+
+.Topic Field: cluster-log-forwarder.yaml
+[source,yaml]
+----
+spec:
+  outputs:
+     - name: app-logs 
+       type: kafka
+       kafka:
+         topic: app-topic <1>
+----
+<1> Specify the `topic` here.
+
+.Topic in URL: cluster-log-forwarder.yaml
+[source,yaml]
+----
+spec:
+  outputs:
+     - name: app-logs 
+       type: kafka 
+       url: tls://kafka.example.devlab.com:9093/app-topic <1>
+----
+<1> Specify the `topic` here.
+
+=== References
+
+. See the link:https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/configuring-log-forwarding.html#cluster-logging-collector-log-forward-kafka_configuring-log-forwarding[forwarding to Kafka section] on the official documentation.
+
+== Loki
+Loki's tenant can be configured through the `tenantKey` field.
+
+=== Example
+
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+spec:
+  outputs:
+     - name: loki-insecure 
+       type: "loki" 
+       url: http://loki.insecure.com:3100 
+       loki:
+         tenantKey: kubernetes.namespace_name <1>
+----
+<1> Specify the `tenantKey` here.
+
+=== References
+
+. See the link:https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/configuring-log-forwarding.html#cluster-logging-collector-log-forward-loki_configuring-log-forwarding[forwarding logs to Loki section] on the official documentation.
+
+== Splunk
+Splunk's index can be configured by either setting an `IndexKey` or `IndexName`. +
+
+. `IndexKey`: Dynamic index extraction of logs.
+* If the field referenced by the `IndexKey` is not present, the log will be sent to Splunks default index
+
+. `IndexName`: Static index values. +
+
+NOTE: If `IndexKey/IndexName` is not defined, logs will be sent to Splunk's default index.
+
+=== Example
+
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+spec:
+  outputs:
+    - name: splunk-receiver
+      type: splunk
+      splunk:
+        indexKey: "kubernetes.namespace_name" <1>
+      url: 'http://example-splunk-hec-service:8088'
+----
+<1> Specify one of `indexKey` or `indexName` not both.
+
+=== References
+
+. See the link:../outputs/splunk-forwarding.adoc[customizing Splunk's index section] of the internal Splunk forwarding documentation.
+
+. See also the link:https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/configuring-log-forwarding.html#logging-forward-splunk_configuring-log-forwarding[Splunk forwarding section] on the official documentation.
+
+== Syslog
+Syslog uses a combination of `facility & severity` to group logs. A possible way to define a tenant is to configure the `tag`.
+
+=== Example
+
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+spec:
+  outputs:
+    - name: syslogout
+      syslog:
+        addLogSource: true
+        tag: mytag <1>
+      type: syslog
+      url: tls://syslog-receiver.openshift-logging.svc:24224
+----
+<1> Specify the `tag` here.
+
+=== References
+
+. See link:https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/configuring-log-forwarding.html#cluster-logging-collector-log-forward-examples-syslog-log-source[adding log source information to message output] for Syslog on the official documentation.
+
+== Outputs Without Customizable Tenants
+
+=== Lokistack (non default)
+Tenant customization not currently supported.
+
+=== Default (Elasticsearch/LokiStack)
+Tenant customization is not allowed.
+
+=== Fluent Forward
+FluentD only/ not applicable

--- a/docs/features/logforwarding/outputs/elasticsearch-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/elasticsearch-forwarding.adoc
@@ -1,6 +1,6 @@
-=== Steps to forward to Elasticsearch
+= Forwarding To Elasticsearch
 
-
+== Steps to forward to Elasticsearch
 . Create a ClusterLogging instance with collection `type: vector`:
 +
 ----
@@ -54,3 +54,71 @@ spec:
 +
 <1> Forwarding to an external Elasticsearch of version 8.x or greater requires the `version` field to be specified otherwise this can be omitted. The `version` field is nested under `elasticsearch`.
 <2> For a `https` prefix, specify the name of the secret required by the endpoint for TLS communication. If the certificate is signed by `custom root ca`, it must have key: `ca-bundle.crt`. If you want to enable Mutual Transport Layer Security (mTLS) between collector and elasticsearch, the secret must have keys of: `tls.crt`, `tls.key` that point to the respective certificates that they represent. Otherwise, for `http` and `https` prefixes, you can specify a secret that contains a username and password.
+
+== Custom Index Configuration
+
+https://docs.openshift.com/container-platform/4.12/logging/log_collection_forwarding/cluster-logging-enabling-json-logging.html[Official Cluster Logging Operator Documentation on JSON Parsing]
+
+A custom index can be configured for elasticsearch through by utilizing `JSON` parsing and is supported for logs of type `application`. This is defined through the `structuredTypeKey` and `structuredTypeName` fields in the `ClusterLogForwarder`. 
+
+=== Steps To Configure a Custom Index
+
+. Create a `ClusterLogging` instance with collection `type: vector`:
++
+----
+ oc apply -f cluster-logging.yaml
+----
++
+.cluster-logging.yaml
+[source,yaml]
+----
+kind: ClusterLogging
+apiVersion: logging.openshift.io/v1
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  collection:
+    type: vector
+----
+
+. Create a `ClusterLogForwarder` instance to `Elasticsearch`.
+* Specify a `structuredTypeKey` and an alternative `structuredTypeName` of the index to send structured messages to.
+* Add `json: parse` to the pipeline.
++
+----
+ oc apply -f cluster-log-forwarder.yaml
+----
++
+.cluster-log-forwarder.yaml
+[source,yaml]
+----
+kind: ClusterLogForwarder
+apiVersion: logging.openshift.io/v1
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  outputs:
+    - name: external-es
+      type: elasticsearch
+      elasticsearch: 
+        structuredTypeKey: kubernetes.namespace_name <1>
+        structuredTypeName: myParsedMessages <2>
+      url: 'https://<ES_URL>:9200'
+  pipelines:
+    - name: parsed-app-logs
+      inputRefs:
+        - application
+      outputRefs:
+        - external-es
+      parse: json <3>
+----
++
+<1> The `structuredTypeKey` is the field of the log record used to construct an index name.
+<2> The `structuredTypeName` is a static value used to construct an index name.
+<3> `parse: json` must be added to the pipeline
+
+*Note*: The Elasticsearch index for structured records is formed by prepending "app-" to the key or name and appending "-write".
+
+Application logs that have their messages successfully parsed will be sent to the index defined by the `structuredTypeKey`. If the `structuredTypeKey` is not available in the log record, then the `structuredTypeName` will be used as the index instead.


### PR DESCRIPTION
### Description
This PR adds information on supporting custom tenants along with an example for `Elasticsearch` using `json` parsing to defined a custom index.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-4844
