### PR TITLE
Catch nil ptr exceptions with enabled Forwarder and empty Collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ run:
 	WATCH_NAMESPACE=$(NAMESPACE) \
 	KUBERNETES_CONFIG=$(KUBECONFIG) \
 	WORKING_DIR=$(CURDIR)/tmp \
-	$(RUN_CMD) main.go
+	$(RUN_CMD) cmd/main.go
 
 .PHONY: run-debug
 run-debug:

--- a/internal/controller/forwarding/forwarding_controller.go
+++ b/internal/controller/forwarding/forwarding_controller.go
@@ -83,7 +83,7 @@ func (r *ReconcileForwarder) Reconcile(ctx context.Context, request ctrl.Request
 	// Fetch the ClusterLogForwarder instance
 	instance, err, status := loader.FetchClusterLogForwarder(r.Client, request.NamespacedName.Namespace, request.NamespacedName.Name, true, func() logging.ClusterLogging { return *cl })
 	if status != nil {
-		instance.Status = *status
+		instance.Status.Synchronize(status)
 	}
 	if err != nil {
 		log.V(3).Info("clusterlogforwarder-controller Error getting instance. It will be retried if other then 'NotFound'", "error", err.Error())

--- a/internal/k8s/loader/load.go
+++ b/internal/k8s/loader/load.go
@@ -64,7 +64,8 @@ func FetchClusterLogForwarder(k8sClient client.Client, namespace, name string, i
 	forwarder.Spec, extras, migrationMessages = migrations.MigrateClusterLogForwarder(namespace, name, forwarder.Spec, fetchClusterLogging().Spec.LogStore, extras, internalLogStoreSecret, saTokenSecret)
 	setMigrationStatusConditions(&forwarder.Status, migrationMessages)
 
-	extras[constants.ClusterLoggingAvailable] = (fetchClusterLogging().Name != "")
+	clusterLogging := fetchClusterLogging()
+	extras[constants.ClusterLoggingAvailable] = (clusterLogging.Name != "" && clusterLogging.Spec.Collection != nil)
 	extras[constants.VectorName] = false
 	if fetchClusterLogging().Spec.Collection != nil {
 		extras[constants.VectorName] = fetchClusterLogging().Spec.Collection.Type == logging.LogCollectionTypeVector

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -1,6 +1,7 @@
 package k8shandler
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
@@ -41,6 +42,9 @@ func EvaluateAnnotationsForEnabledCapabilities(forwarder *logging.ClusterLogForw
 }
 
 func (clusterRequest *ClusterLoggingRequest) generateCollectorConfig() (config string, err error) {
+	if clusterRequest.Cluster.Spec.Collection == nil {
+		return "", fmt.Errorf("unable to generate collector config, spec.collection must be set but is empty")
+	}
 
 	op := framework.Options{}
 	tlsProfile, _ := tls.FetchAPIServerTlsProfile(clusterRequest.Client)

--- a/internal/validations/clusterlogforwarder/validate_clusterlogging_dependency.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogging_dependency.go
@@ -7,9 +7,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	ValidateClusterLoggingDependencyMSG = "is dependent on a ClusterLogging instance with a valid spec.collector configuration"
+)
+
 func ValidateClusterLoggingDependency(clf loggingv1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *loggingv1.ClusterLogForwarderStatus) {
 	if clf.Name == constants.SingletonName && clf.Namespace == constants.OpenshiftNS && !extras[constants.ClusterLoggingAvailable] {
-		return errors.NewValidationError("ClusterLogForwarder '%s/%s' is dependent on a ClusterLogging instance", constants.OpenshiftNS, constants.SingletonName), nil
+		return errors.NewValidationError("ClusterLogForwarder '%s/%s' %s", constants.OpenshiftNS, constants.SingletonName, ValidateClusterLoggingDependencyMSG), nil
 	}
 	return nil, nil
 }

--- a/test/client/clf.go
+++ b/test/client/clf.go
@@ -2,9 +2,12 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	clfvalidation "github.com/openshift/cluster-logging-operator/internal/validations/clusterlogforwarder"
 	"github.com/openshift/cluster-logging-operator/test"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -19,4 +22,26 @@ func ClusterLogForwarderReady(e watch.Event) (bool, error) {
 	default:
 		return false, nil
 	}
+}
+
+// ClusterLogForwarderValidationFailure expects condition type "Validation" to be set on the ClusterLogForwarder
+// resource. If no such condition can be found, it returns false, and a nil error (so that c.WaitFor can wait until
+// the condition is set, or time out if the condition is never set). If the condition is set, we expect its message
+// to match clfvalidation.ValidateClusterLoggingDependencyMSG and we expect it to be "True". We also expect the "Ready"
+// condition to be "False". In that case, we return true and no error. In case of the contrary, we return false and an
+// error.
+func ClusterLogForwarderValidationFailure(e watch.Event) (bool, error) {
+	clf := e.Object.(*loggingv1.ClusterLogForwarder)
+	cond := clf.Status.Conditions
+
+	validationCondition := cond.GetCondition(loggingv1.ValidationCondition)
+	if validationCondition == nil {
+		return false, nil
+	}
+
+	if strings.Contains(validationCondition.Message, clfvalidation.ValidateClusterLoggingDependencyMSG) &&
+		validationCondition.Status == v1.ConditionTrue && cond.IsFalseFor(loggingv1.ConditionReady) {
+		return true, nil
+	}
+	return false, fmt.Errorf("ClusterLogForwarder unexpected condition: %v", test.YAMLString(clf.Status))
 }

--- a/test/e2e/logforwarding/miscellaneous/forward_miscellaneous_test.go
+++ b/test/e2e/logforwarding/miscellaneous/forward_miscellaneous_test.go
@@ -1,0 +1,69 @@
+package miscellaneous
+
+import (
+	"testing"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	"github.com/openshift/cluster-logging-operator/test/client"
+	"github.com/openshift/cluster-logging-operator/test/framework/e2e"
+	"github.com/openshift/cluster-logging-operator/test/runtime"
+)
+
+const miscellaneousReceiverName = "miscellaneous-receiver"
+
+var spec = loggingv1.ClusterLogForwarderSpec{
+	Outputs: []loggingv1.OutputSpec{{
+		Name: miscellaneousReceiverName,
+		Type: loggingv1.OutputTypeLoki,
+		URL:  "http://127.0.0.1:3100",
+	}},
+	Pipelines: []loggingv1.PipelineSpec{
+		{
+			Name:       "test-app",
+			InputRefs:  []string{loggingv1.InputNameApplication},
+			OutputRefs: []string{miscellaneousReceiverName},
+			Labels:     map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		{
+			Name:       "test-audit",
+			InputRefs:  []string{loggingv1.InputNameAudit},
+			OutputRefs: []string{miscellaneousReceiverName},
+		},
+		{
+			Name:       "test-infra",
+			InputRefs:  []string{loggingv1.InputNameInfrastructure},
+			OutputRefs: []string{miscellaneousReceiverName},
+		},
+	},
+}
+
+// TestLogForwardingWithEmptyCollection tests for issue https://github.com/openshift/cluster-logging-operator/issues/2312.
+// It creates a CL with cl.Spec.Collection set to nil. This would trigger a nil pointer exception without a
+// fix in place.
+func TestLogForwardingWithEmptyCollection(t *testing.T) {
+	// First, make sure that the Operator can handle a nil cl.Spec.Collection.
+	// https://github.com/openshift/cluster-logging-operator/issues/2312
+	t.Log("TestLogForwardingWithEmptyCollection: Test handling an empty ClusterLogging Spec.Condition")
+	cl := runtime.NewClusterLogging()
+	cl.Spec.Collection = nil
+	clf := runtime.NewClusterLogForwarder()
+	clf.Spec = spec
+
+	c := client.ForTest(t)
+	framework := e2e.NewE2ETestFramework()
+	defer framework.Cleanup()
+	framework.AddCleanup(func() error { return c.Delete(cl) })
+	framework.AddCleanup(func() error { return c.Delete(clf) })
+	var g errgroup.Group
+	e2e.RecreateClClfAsync(&g, c, cl, clf)
+
+	// We now expect to see a validation error.
+	require.NoError(t, g.Wait())
+	require.NoError(t, c.WaitFor(clf, client.ClusterLogForwarderValidationFailure))
+	require.NoError(t, framework.WaitFor(helpers.ComponentTypeCollector))
+}

--- a/test/matchers/condition.go
+++ b/test/matchers/condition.go
@@ -4,7 +4,9 @@ import (
 	//"fmt"
 	"github.com/onsi/gomega/types"
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/status"
 	corev1 "k8s.io/api/core/v1"
+
 	//"k8s.io/utils/diff"
 	//"reflect"
 	. "github.com/onsi/gomega"
@@ -32,4 +34,27 @@ func matchCondition(t logging.ConditionType, s bool, r logging.ConditionReason, 
 
 func HaveCondition(t logging.ConditionType, s bool, r logging.ConditionReason, messageRegex string) types.GomegaMatcher {
 	return ContainElement(matchCondition(t, s, r, messageRegex))
+}
+
+func equalCondition(expected status.Condition) types.GomegaMatcher {
+	fields := Fields{
+		"Type":               Equal(expected.Type),
+		"Status":             Equal(expected.Status),
+		"Reason":             Equal(expected.Reason),
+		"Message":            Equal(expected.Message),
+		"LastTransitionTime": MatchLastTransitionTime(expected.LastTransitionTime),
+	}
+	return MatchFields(IgnoreExtras, fields)
+}
+
+// MatchConditions compares 2 conditions slices.
+// For LastTransitionTime, 2 conditions are considered equal either if both timestamps are identical. Or, if
+// expected[..].LastTransitionTime.Time is time 0 UTC, it will check if actual[..].LastTransitionTime has a time stamp
+// within the last 5 minutes.
+func MatchConditions(expected status.Conditions) types.GomegaMatcher {
+	var conditionMatchers []interface{}
+	for _, condition := range expected {
+		conditionMatchers = append(conditionMatchers, equalCondition(condition))
+	}
+	return ConsistOf(conditionMatchers...)
 }

--- a/test/matchers/lasttransitiontime.go
+++ b/test/matchers/lasttransitiontime.go
@@ -1,0 +1,52 @@
+package matchers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type LastTransitionTimeMatcher struct {
+	expected metav1.Time
+}
+
+func MatchLastTransitionTime(expected metav1.Time) types.GomegaMatcher {
+	return &LastTransitionTimeMatcher{
+		expected: expected,
+	}
+}
+
+// Match returns success either if both timestamps are identical. If expected.Time is time 0 UTC, it will check if
+// actual.Time has a time stamp within the last 5 minutes.
+func (m *LastTransitionTimeMatcher) Match(a interface{}) (success bool, err error) {
+	expected := m.expected
+	actual, ok := a.(metav1.Time)
+	if !ok {
+		return false, fmt.Errorf("Matcher expects metav1.Time")
+	}
+	if expected.Time == time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC) {
+		if actual.Time.Before(time.Now().Add(time.Minute * time.Duration(-5))) {
+			return false, nil
+		}
+		return true, nil
+	}
+	return actual == expected, nil
+}
+
+func (m *LastTransitionTimeMatcher) FailureMessage(actual interface{}) (message string) {
+	if m.expected.Time == time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC) {
+		return fmt.Sprintf("Expected LastTransitionTime not be within the last 5 minutes, time now: %s, got: %s",
+			time.Now(), actual)
+	}
+	return fmt.Sprintf("Expected\n\t%s\nto equal \n\t%s", actual, m.expected)
+}
+
+func (m *LastTransitionTimeMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	if m.expected.Time == time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC) {
+		return fmt.Sprintf("Expected LastTransitionTime to be within the last 5 minutes, time now: %s, got: %s",
+			time.Now(), actual)
+	}
+	return fmt.Sprintf("Expected\n\t%#v\nnot to match \n\t%#v", actual, m.expected)
+}


### PR DESCRIPTION
When the Forwarder is enabled, make sure that
clusterLogging.Spec.Collection is non nil to avoid nil pointer exceptions from occurring.

Fixes https://github.com/openshift/cluster-logging-operator/issues/2312
Fixes https://github.com/openshift/cluster-logging-operator/issues/2314
Fixes https://github.com/openshift/cluster-logging-operator/issues/2315

### Description


### Links
* https://issues.redhat.com/browse/LOG-5006
* https://issues.redhat.com/browse/LOG-5007
