### PR TITLE
Remove raw secrets from must-gather and update dir structure

### DIFF
--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -36,14 +36,14 @@ Example must-gather for cluster-logging output:
 ```
 ├── cluster-logging
 │  ├── clo
-│  │  ├── cluster-logging-operator-74dd5994f-6ttgt
-│  │  ├── clusterlogforwarder_cr
-│  │  ├── cr
-│  │  ├── csv
-│  │  ├── deployment
-│  │  └── logforwarding_cr
-│  ├── collector
-│  │  ├── fluentd-2tr64
+│  │  ├── [nampespace_name]       ## including openshift-logging
+│  │  │  ├── cluster-logging-operator-74dd5994f-6ttgt
+│  │  │  ├── cr
+│  │  │  ├── csv
+│  │  │  └── deployment
+│  ├── collectors
+│  │  ├── [nampespace_name]       ## including openshift-logging
+│  │  ├── collector-2tr64
 │  ├── eo
 │  │  ├── csv
 │  │  ├── deployment
@@ -85,7 +85,7 @@ Example must-gather for cluster-logging output:
 ├── event-filter.html
 ├── gather-debug.log
 └── namespaces
-   ├── openshift-logging
+   ├── [namespace_name]       ## including openshift-logging
    │  ├── apps
    │  │  ├── daemonsets.yaml
    │  │  ├── deployments.yaml
@@ -94,6 +94,11 @@ Example must-gather for cluster-logging output:
    │  ├── batch
    │  │  ├── cronjobs.yaml
    │  │  └── jobs.yaml
+   │  ├── logging.openshift.io/
+   │  │  ├── clusterloggings
+   │  │  │  ├── [instance_name.yaml]
+   │  │  ├── clusterlogforwarders
+   │  │  │  └── [clf_name.yaml]   
    │  ├── core
    │  │  ├── configmaps.yaml
    │  │  ├── endpoints.yaml
@@ -135,28 +140,27 @@ Example must-gather for cluster-logging output:
    │  │  │           ├── previous.insecure.log
    │  │  │           └── previous.log
    │  │  ├── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
-   │  │  ├── elasticsearch-delete-app-1596030300-bpgcx
-   │  │  │  ├── elasticsearch-delete-app-1596030300-bpgcx.yaml
+   │  │  │  └── elasticsearch
+   │  │  │     └── elasticsearch
+   │  │  │        └── logs
+   │  │  │           ├── current.log
+   │  │  │           ├── previous.insecure.log
+   │  │  │           └── previous.log   
+   │  │  ├── elasticsearch-im-app-1596030300-bpgcx
    │  │  │  └── indexmanagement
    │  │  │     └── indexmanagement
    │  │  │        └── logs
    │  │  │           ├── current.log
    │  │  │           ├── previous.insecure.log
    │  │  │           └── previous.log
-   │  │  ├── fluentd-2tr64
-   │  │  │  ├── fluentd
-   │  │  │  │  └── fluentd
+   │  │  ├── colletor-2tr64
+   │  │  │  ├── collector
+   │  │  │  │  └── collector
    │  │  │  │     └── logs
    │  │  │  │        ├── current.log
    │  │  │  │        ├── previous.insecure.log
    │  │  │  │        └── previous.log
-   │  │  │  ├── fluentd-2tr64.yaml
-   │  │  │  └── fluentd-init
-   │  │  │     └── fluentd-init
-   │  │  │        └── logs
-   │  │  │           ├── current.log
-   │  │  │           ├── previous.insecure.log
-   │  │  │           └── previous.log
+   │  │  │  └── collector-2tr64.yaml
    │  │  ├── kibana-9d69668d4-2rkvz
    │  │  │  ├── kibana
    │  │  │  │  └── kibana
@@ -176,3 +180,10 @@ Example must-gather for cluster-logging output:
    └── openshift-operators-redhat
       ├── ...
 ```
+
+### Moved resources
+With the support of [multi log-forwarder feature](https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/log-forwarding.html#log-forwarding-implementations-multi-clf_log-forwarding) in Cluster Logging v5.8, CLO resources have moved from `cluster-logging/clo/` to individual namespaces under `cluster-logging/clo/[namespace_name]`.
+
+The `clusterlogging` and `clusterlogforwarder` resources are no longer collected in `cluster-logging/clo` and have moved to `namespaces/[namespace_name]/logging.openshift.io/`. This directory structure allows tools like [`omc`](https://github.com/gmeghnag/omc/) to work with those resources in a similar way to `oc` commands on a cluster.
+
+The `deployments`, `daemonsets` and `secrets` are also found under `namespaces/[namespace_name]/` and can also be seen using the [`omc`](https://github.com/gmeghnag/omc/) tool.

--- a/must-gather/collection-scripts/common
+++ b/must-gather/collection-scripts/common
@@ -14,16 +14,16 @@ get_env() {
   local pod=$1
   local env_file=$2/$pod
   local ns=${3:-$NAMESPACE}
-  local pattern=${4:-"Dockerfile-*logging*"}
+  local pattern=${4:-"Dockerfile-.*logging*"}
   echo ---- Env for $pod
   containers=$(oc -n $ns get po $pod -o jsonpath='{.spec.containers[*].name}')
   for container in $containers
   do
-    dockerfile=$(oc -n $ns exec $pod -c $container -- find /root/buildinfo -name $pattern)
+    dockerfile=$(oc -n $ns exec $pod -c $container -- ls /root/buildinfo | grep $pattern)
     if [ -n "$dockerfile" ]
     then
       echo Image info: $dockerfile > $env_file
-      oc -n $ns exec $pod -c $container -- grep -o "\"build-date\"=\"[^[:blank:]]*\"" $dockerfile >> $env_file || echo "---- Unable to get build date"
+      oc -n $ns exec $pod -c $container -- grep -o "\"build-date\"=\"[^[:blank:]]*\"" /root/buildinfo/$dockerfile >> $env_file || echo "---- Unable to get build date"
     fi
     echo -- Environment Variables >> $env_file
     oc -n $ns exec $pod -c $container -- env | sort >> $env_file

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -53,6 +53,7 @@ cluster_resources+=(clusterrolebindings)
 cluster_resources+=(persistentvolumes)
 cluster_resources+=(clusterversion)
 cluster_resources+=(machineconfigpool)
+cluster_resources+=(customresourcedefinitions)
 
 log "-BEGIN inspecting CRs..." >> "${LOGFILE_PATH}"
 for cr in "${cluster_resources[@]}" ; do
@@ -70,12 +71,14 @@ resources+=(rolebindings)
 resources+=(configmaps)
 resources+=(serviceaccounts)
 resources+=(events)
+resources+=(clusterlogging)
+resources+=(clusterlogforwarder)
 
 log "BEGIN inspecting namespaces ..." >> "${LOGFILE_PATH}"
 
 for namespace in "${cluster_resources[@]}" ; do
   # grab all our namespaces -- openshift-logging, openshift-operator-lifecycle-manager, openshift-operators-redhat
-  # should also include any mulit-forwarder namespaces found above
+  # should also include any multi-forwarder namespaces found above
   if [[ $namespace == ns/* ]]; then
     ns=${namespace#ns/}  # remove "ns/" prefix
     for resource in "${resources[@]}" ; do
@@ -125,6 +128,7 @@ if [ "$found_es" != "" ] || [ "$found_lokistack" != "" ] ; then
   fi
 
   if [ "$found_lokistack" != "" ] ; then
+    log "BEGIN gathering lokistack resources ..." >> "${LOGFILE_PATH}"
     ${SCRIPT_DIR}/gather_logstore_resources "$BASE_COLLECTION_PATH" "lokistack" >> "${LOGFILE_PATH}" 2>&1 &
     pids+=($!)
   fi
@@ -133,9 +137,9 @@ if [ "$found_es" != "" ] || [ "$found_lokistack" != "" ] ; then
   if [ "$found" != "" ] ; then
     KUBECACHEDIR=${BASE_COLLECTION_PATH}/cache-dir ${SCRIPT_DIR}/gather_visualization_resources "$BASE_COLLECTION_PATH" >> "${LOGFILE_PATH}" 2>&1
   fi
-  log "BEGIN gathering CLO resources ..." >> "${LOGFILE_PATH}"
+  log "END gathering logstorage resources ..." >> "${LOGFILE_PATH}"
 else
-  log "Skipping logstorage inspection.  No Elasticsearch deployment found" >> "${LOGFILE_PATH}" 2>&1
+  log "Skipping logstorage inspection.  No deployment found" >> "${LOGFILE_PATH}" 2>&1
 fi
 
 # Check if PID array has any values, if so, wait for them to finish

--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -27,7 +27,7 @@ if [ $NAMESPACE == "openshift-logging" ]; then
   pods=$(oc -n $NAMESPACE get pods -l name=cluster-logging-operator -o jsonpath='{.items[*].metadata.name}')
   for pod in $pods
   do
-      get_env $pod $clo_folder $NAMESPACE "Dockerfile-*operator*"
+      get_env $pod $clo_folder $NAMESPACE "Dockerfile-.*operator*"
   done
 
   oc -n $NAMESPACE get deployment cluster-logging-operator -o yaml --cache-dir=${KUBECACHEDIR} > $clo_folder/deployment
@@ -37,20 +37,6 @@ if [ $NAMESPACE == "openshift-logging" ]; then
     oc -n $NAMESPACE get "${csv}" -o yaml --cache-dir=${KUBECACHEDIR} > ${clo_folder}/"${csv}.yaml"
   done
 fi
-
-log "Gathering data for 'clusterlogging' and 'clusterlogforwarder' from namespace: $NAMESPACE"
-for r in "clusterlogging" "clusterlogforwarder" ; do
-  names="$(oc -n $NAMESPACE get $r --ignore-not-found -o jsonpath='{.items[*].metadata.name}' | sort -u)"
-  for name in ${names[@]}; do
-    data="$(oc -n $NAMESPACE get $r ${name} --ignore-not-found -o yaml)"
-    if [ "$data" != "" ] ; then
-      echo "${data}" > "${clo_folder}/${r}_${name}.yaml"
-    fi
-  done
-done
-
-log "Gathering 'secrets' from logging namespace: $NAMESPACE"
-oc -n $NAMESPACE get secrets -o yaml > ${clo_folder}/secrets.yaml 2>&1
 
 log "Gathering any 'vector.toml' from logging namespace: $NAMESPACE"
 secret_names=$(oc -n $NAMESPACE get secrets -o custom-columns=:.metadata.name | grep -e '-config')

--- a/must-gather/collection-scripts/gather_elasticsearch_operator_resources
+++ b/must-gather/collection-scripts/gather_elasticsearch_operator_resources
@@ -24,7 +24,7 @@ mkdir -p "$eo_folder"
 pods=$(oc -n $NAMESPACE get pods -l name=elasticsearch-operator -o jsonpath='{.items[*].metadata.name}')
 for pod in $pods
 do
-    get_env $pod $eo_folder $NAMESPACE "Dockerfile-*operator*"
+    get_env $pod $eo_folder $NAMESPACE "Dockerfile-.*operator*"
 done
 
 oc -n $LOGGING_NS --cache-dir=${KUBECACHEDIR} exec -c elasticsearch \


### PR DESCRIPTION
### Description
For [LOG-4817](https://issues.redhat.com/browse/LOG-4817) the best solution is to remove this file from the 'oc get' under '/cluster-logging/clo' directory.   There is already a list of sanitized secrets listed under each namespace.   
The other changes are from PR 2257 below, are aligning docs and directory structure to be used with the 'omc' tool.

/cc @vparfonov @Clee2691 
/assign @jcantrill 


### Links
- https://github.com/openshift/cluster-logging-operator/pull/2257
