### PR TITLE
LOG-4962: fix outputs with no secret adding bearer token

### DIFF
--- a/internal/generator/vector/helpers/secrets.go
+++ b/internal/generator/vector/helpers/secrets.go
@@ -4,6 +4,7 @@ import (
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -12,10 +13,10 @@ func GetOutputSecret(o logging.OutputSpec, secrets map[string]*corev1.Secret) *c
 		log.V(9).Info("Using secret configured in output: " + o.Name)
 		return s
 	}
-	if s := secrets[constants.LogCollectorToken]; s != nil {
-		log.V(9).Info("Using secret configured in " + constants.LogCollectorToken)
-		return s
+	if o.Type == logging.OutputTypeLoki && lokistack.DefaultLokiOutputNames.Has(o.Name) {
+		log.V(9).Info("Default lokiStack, using collector token", "output", o.Name, "secret", constants.LogCollectorToken)
+		return secrets[constants.LogCollectorToken]
 	}
-	log.V(9).Info("No Secret found in " + constants.LogCollectorToken)
+	log.V(9).Info("No Secret found for output", "output", o.Name)
 	return nil
 }

--- a/internal/generator/vector/helpers/secrets_test.go
+++ b/internal/generator/vector/helpers/secrets_test.go
@@ -1,0 +1,40 @@
+package helpers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/logstore/lokistack"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("helpers", func() {
+	const outputName = "anOutput"
+	var (
+		legacyToken = &corev1.Secret{}
+		aSecret     = &corev1.Secret{}
+	)
+	var _ = DescribeTable("#GetOutputSecret", func(o logging.OutputSpec, expSecret *corev1.Secret) {
+		secrets := map[string]*corev1.Secret{
+			constants.LogCollectorToken: legacyToken,
+			outputName:                  aSecret,
+		}
+		Expect(GetOutputSecret(o, secrets)).To(Equal(expSecret))
+	},
+		Entry("should return the secret when found in all output secrets", logging.OutputSpec{
+			Name: outputName,
+			Type: logging.OutputTypeSplunk,
+		}, aSecret),
+		Entry("should return nil when not found in all output secrets", logging.OutputSpec{
+			Name: "nameNotFoune",
+			Type: logging.OutputTypeSplunk,
+		}, nil),
+		Entry("should return the legacy token secret when output is default lokiStack", logging.OutputSpec{
+			Name: lokistack.FormatOutputNameFromInput(logging.InputNameApplication),
+			Type: logging.OutputTypeLoki,
+		}, legacyToken),
+	)
+
+})

--- a/internal/generator/vector/helpers/suite_test.go
+++ b/internal/generator/vector/helpers/suite_test.go
@@ -1,0 +1,13 @@
+package helpers
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][generator][vector][helpers]")
+}


### PR DESCRIPTION
### Description
This PR:
* fixes the case where outputs which define no secret still generate config with the legacy token secret
* Adds a function for secret special handling of generated default loki outputs

### Links
* https://issues.redhat.com/browse/LOG-4962
* forward port of #2307 

cc @xperimental @Clee2691 