### PR TITLE
LOG-4893: add validation for checking if provided not secure URL along with TLS configuration

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	urlhelper "github.com/openshift/cluster-logging-operator/internal/generator/url"
 	"strings"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -304,6 +305,10 @@ func verifyOutputURL(output *loggingv1.OutputSpec, conds loggingv1.NamedConditio
 	fail := func(c status.Condition) bool {
 		conds.Set(output.Name, c)
 		return false
+	}
+
+	if u, _ := url.Parse(output.URL); u != nil && output.TLS != nil && !urlhelper.IsTLSScheme(u.Scheme) {
+		return fail(CondInvalid("invalid configuration: provided not secure URL along with TLS configuration"))
 	}
 
 	if output.Type == loggingv1.OutputTypeKafka {

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
@@ -2,6 +2,7 @@ package clusterlogforwarder
 
 import (
 	"fmt"
+	v12 "github.com/openshift/api/config/v1"
 	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/migrations/clusterlogforwarder"
@@ -1408,6 +1409,38 @@ func Test_verifyOutputURL(t *testing.T) {
 				output: &loggingv1.OutputSpec{
 					Name: "test-output",
 					Type: loggingv1.OutputTypeLoki,
+				},
+				conds: loggingv1.NamedConditions{},
+			},
+			want: false,
+		},
+		{
+			name: "should fail with not secure URL  and given TLS config: InsecureSkipVerify",
+			args: args{
+				output: &loggingv1.OutputSpec{
+					Name: "test-output",
+					Type: loggingv1.OutputTypeLoki,
+					URL:  "http://local.svc:514",
+					TLS: &loggingv1.OutputTLSSpec{
+						InsecureSkipVerify: true,
+					},
+				},
+				conds: loggingv1.NamedConditions{},
+			},
+			want: false,
+		},
+		{
+			name: "should fail with not secure URL and given TLS config: TLSSecurityProfile",
+			args: args{
+				output: &loggingv1.OutputSpec{
+					Name: "test-output",
+					Type: loggingv1.OutputTypeLoki,
+					URL:  "http://local.svc:514",
+					TLS: &loggingv1.OutputTLSSpec{
+						TLSSecurityProfile: &v12.TLSSecurityProfile{
+							Type: v12.TLSProfileOldType,
+						},
+					},
 				},
 				conds: loggingv1.NamedConditions{},
 			},


### PR DESCRIPTION
### Description
This PR adds checks for a secure (HTTPS) URL and given TLS configuration. Throwing an error in the status section indicating that the options used are invalid together. The specific error being addressed is: "invalid configuration: provided not secure URL along with TLS configuration."

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4893
- Enhancement proposal:
