### PR TITLE
LOG-5021: add validation if no secret for CloudWatch and Splunk outputs

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -358,9 +358,14 @@ func verifyOutputSecret(namespace string, clfClient client.Client, output *loggi
 		conds.Set(output.Name, c)
 		return false
 	}
+
 	if output.Secret == nil {
+		if output.Type == loggingv1.OutputTypeCloudwatch || output.Type == loggingv1.OutputTypeSplunk {
+			return fail(CondMissing("secret must be provided for %s output", output.Type))
+		}
 		return true
 	}
+
 	if output.Secret.Name == "" {
 		conds.Set(output.Name, CondInvalid("secret has empty name"))
 		return false


### PR DESCRIPTION
### Description
This PR add's:

- validation if no secret for CloudWatch and Splunk outputs CLF status will report about invalid state
- few tests for checking validation code for Splunk output 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5021
- Enhancement proposal:
