### PR TITLE
LOG-4963: fix outputs to allows specifying insecureSkipVerify without

### DIFF
--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -112,8 +112,8 @@ spec:
                         included, the response body is removed. - RequestResponse:
                         All data is included: metadata, request body and response
                         body. Note the response body can be very large. For example
-                        the a command like `oc list -A pods` generates a response
-                        body containing the YAML description of every pod in the cluster.
+                        the a command like `oc get -A pods` generates a response body
+                        containing the YAML description of every pod in the cluster.
                         \n # Extensions \n The following features are extensions to
                         the standard [Kube Audit Policy] \n ## Wildcards \n Names
                         of users, groups, namespaces, and resources can have a leading

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -113,8 +113,8 @@ spec:
                         included, the response body is removed. - RequestResponse:
                         All data is included: metadata, request body and response
                         body. Note the response body can be very large. For example
-                        the a command like `oc list -A pods` generates a response
-                        body containing the YAML description of every pod in the cluster.
+                        the a command like `oc get -A pods` generates a response body
+                        containing the YAML description of every pod in the cluster.
                         \n # Extensions \n The following features are extensions to
                         the standard [Kube Audit Policy] \n ## Wildcards \n Names
                         of users, groups, namespaces, and resources can have a leading

--- a/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/fluentd/output/elasticsearch/elasticsearch.go
@@ -141,7 +141,7 @@ func SecurityConfig(o logging.OutputSpec, secret *corev1.Secret) []Element {
 	isHttps := url.IsTLSScheme(u.Scheme)
 	isSSLVerify := !(o.TLS != nil && o.TLS.InsecureSkipVerify)
 	esTls := EsTLS{
-		security.TLS(isHttps),
+		TLS(isHttps),
 		isSSLVerify,
 	}
 	conf := append([]Element{}, esTls)

--- a/internal/generator/fluentd/output/elasticsearch/tls.go
+++ b/internal/generator/fluentd/output/elasticsearch/tls.go
@@ -1,11 +1,8 @@
 package elasticsearch
 
-import (
-	"github.com/openshift/cluster-logging-operator/internal/generator/helpers/security"
-)
-
+type TLS bool
 type EsTLS struct {
-	security.TLS
+	TLS
 	SSLVerify bool
 }
 

--- a/internal/generator/fluentd/output/syslog/tls.go
+++ b/internal/generator/fluentd/output/syslog/tls.go
@@ -5,7 +5,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/helpers/security"
 )
 
-type TLS security.TLS
+type TLS bool
 
 func (t TLS) Name() string {
 	return "syslogTLSTemplate"

--- a/internal/generator/helpers/security/security.go
+++ b/internal/generator/helpers/security/security.go
@@ -8,8 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type TLS bool
-
 type HostnameVerify bool
 
 type TLSCertKey struct {

--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -86,7 +86,7 @@ func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret
 			common.NewBuffer(id),
 			request,
 		},
-		TLSConf(id, o, secret, op),
+		common.TLS(id, o, secret, op),
 	)
 }
 
@@ -113,16 +113,6 @@ func SecurityConfig(secret *corev1.Secret) Element {
 		KeyID:     strings.TrimSpace(common.GetFromSecret(secret, constants.AWSAccessKeyID)),
 		KeySecret: strings.TrimSpace(common.GetFromSecret(secret, constants.AWSSecretAccessKey)),
 	}
-}
-
-func TLSConf(id string, o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
-		if tlsConf := common.GenerateTLSConfWithID(id, o, secret, op, false); tlsConf != nil {
-			tlsConf.NeedsEnabled = false
-			return []Element{tlsConf}
-		}
-	}
-	return []Element{}
 }
 
 func EndpointConfig(o logging.OutputSpec) Element {

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -186,7 +186,8 @@ func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret
 			common.NewBuffer(id),
 			request,
 		},
-		TLSConf(id, o, secret, op),
+
+		common.TLS(id, o, secret, op),
 		BasicAuth(id, o, secret),
 	)
 
@@ -208,17 +209,8 @@ func Output(id string, o logging.OutputSpec, inputs []string, secret *corev1.Sec
 	return es
 }
 
-func TLSConf(id string, o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
-		if tlsConf := common.GenerateTLSConfWithID(id, o, secret, op, false); tlsConf != nil {
-			tlsConf.NeedsEnabled = false
-			return []Element{tlsConf}
-		}
-	}
-	return []Element{}
-}
-
 func BasicAuth(id string, o logging.OutputSpec, secret *corev1.Secret) []Element {
+
 	conf := []Element{}
 
 	if o.Secret != nil {

--- a/internal/generator/vector/output/gcl/gcl.go
+++ b/internal/generator/vector/output/gcl/gcl.go
@@ -91,18 +91,8 @@ func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret
 			common.NewBuffer(id),
 			common.NewRequest(id),
 		},
-		TLSConf(id, o, secret, op),
+		common.TLS(id, o, secret, op),
 	)
-}
-
-func TLSConf(id string, o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
-		if tlsConf := common.GenerateTLSConfWithID(id, o, secret, op, false); tlsConf != nil {
-			tlsConf.NeedsEnabled = false
-			return []Element{tlsConf}
-		}
-	}
-	return []Element{}
 }
 
 func setInput(gcl *GoogleCloudLogging, inputs []string) Element {

--- a/internal/generator/vector/output/http/http.go
+++ b/internal/generator/vector/output/http/http.go
@@ -130,7 +130,7 @@ func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret
 			common.NewBuffer(id),
 			Request(id, o),
 		},
-		TLSConf(id, o, secret, op),
+		common.TLS(id, o, secret, op),
 		BasicAuth(id, o, secret),
 		BearerTokenAuth(id, o, secret),
 	)
@@ -188,16 +188,6 @@ func Encoding(id string) Element {
 		ComponentID: id,
 		Codec:       httpEncodingJson,
 	}
-}
-
-func TLSConf(id string, o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
-		if tlsConf := common.GenerateTLSConfWithID(id, o, secret, op, false); tlsConf != nil {
-			tlsConf.NeedsEnabled = false
-			return []Element{tlsConf}
-		}
-	}
-	return []Element{}
 }
 
 func BasicAuth(id string, o logging.OutputSpec, secret *corev1.Secret) []Element {

--- a/internal/generator/vector/output/kafka/kafka.go
+++ b/internal/generator/vector/output/kafka/kafka.go
@@ -142,7 +142,7 @@ timestamp_format = "rfc3339"
 }
 
 func TLSConf(id string, o logging.OutputSpec, secret *corev1.Secret, op Options, genTLSConf bool) []Element {
-	if o.Secret != nil {
+	if o.Secret != nil || (o.TLS != nil && o.TLS.InsecureSkipVerify) {
 		conf := []Element{}
 
 		if tlsConf := common.GenerateTLSConfWithID(id, o, secret, op, genTLSConf); tlsConf != nil {

--- a/internal/generator/vector/output/splunk/splunk.go
+++ b/internal/generator/vector/output/splunk/splunk.go
@@ -88,7 +88,7 @@ func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret
 			common.NewBuffer(id),
 			common.NewRequest(id),
 		},
-		TLSConf(id, o, secret, op),
+		common.TLS(id, o, secret, op),
 	)
 }
 
@@ -165,12 +165,4 @@ func Encoding(id string, o logging.OutputSpec) Element {
 		Codec:        splunkEncodingJson,
 		ExceptFields: AddSplunkEncodeExceptFields(o.Splunk),
 	}
-}
-
-func TLSConf(id string, o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if tlsConf := common.GenerateTLSConfWithID(id, o, secret, op, false); tlsConf != nil {
-		tlsConf.NeedsEnabled = false
-		return []Element{tlsConf}
-	}
-	return []Element{}
 }

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -136,7 +136,7 @@ func Encoding(id string, o logging.OutputSpec) Element {
 }
 
 func TLSConf(id string, o logging.OutputSpec, secret *corev1.Secret, op Options) []Element {
-	if o.Secret != nil {
+	if o.Secret != nil || (o.TLS != nil && o.TLS.InsecureSkipVerify) {
 		if tlsConf := common.GenerateTLSConfWithID(id, o, secret, op, false); tlsConf != nil {
 			return []Element{tlsConf}
 		}


### PR DESCRIPTION
### Description
This PR:
* fixes output config to allow configuration of tls.insecureSkipVerify without requiring a secret
* Refactors tls config to common function where possible

### Links
* https://issues.redhat.com/browse/LOG-4963
* Forward port of #2308 