### PR TITLE
LOG-5021: add validation if no secret for Cloudwatch and Splunk output

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -319,7 +319,7 @@ func verifyOutputSecret(namespace string, clfClient client.Client, output *loggi
 
 	if output.Secret == nil {
 		if output.Type == loggingv1.OutputTypeCloudwatch || output.Type == loggingv1.OutputTypeSplunk {
-			return fail(CondMissing("secret must be provided for %s output", output.Type))
+			return fail(conditions.CondMissing("secret must be provided for %s output", output.Type))
 		}
 		return true
 	}

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -316,9 +316,14 @@ func verifyOutputSecret(namespace string, clfClient client.Client, output *loggi
 		conds.Set(output.Name, c)
 		return false
 	}
+
 	if output.Secret == nil {
+		if output.Type == loggingv1.OutputTypeCloudwatch || output.Type == loggingv1.OutputTypeSplunk {
+			return fail(CondMissing("secret must be provided for %s output", output.Type))
+		}
 		return true
 	}
+
 	if output.Secret.Name == "" {
 		conds.Set(output.Name, conditions.CondInvalid("secret has empty name"))
 		return false

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
@@ -579,9 +579,15 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 			var (
 				forwarderSpec    = loggingv1.ClusterLogForwarderSpec{}
 				splunkOutputName = "splunk-index"
+				splunkSecret     *corev1.Secret
 			)
+
 			BeforeEach(func() {
+				splunkSecret = runtime.NewSecret(constants.OpenshiftNS, "mysecret", map[string][]byte{
+					constants.SplunkHECTokenKey: {'t', 'o', 'k', 'e', 'n'},
+				})
 				forwarderSpec.Pipelines = []loggingv1.PipelineSpec{{OutputRefs: []string{splunkOutputName}}}
+				client = fake.NewFakeClient(splunkSecret) //nolint
 			})
 
 			It("should pass if only IndexKey is spec'd", func() {
@@ -595,6 +601,7 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 								IndexKey: "kubernetes.namespace_name",
 							},
 						},
+						Secret: &loggingv1.OutputSecretSpec{Name: splunkSecret.Name},
 					},
 				}
 				verifyOutputs(namespace, client, &forwarderSpec, clfStatus, extras)
@@ -613,6 +620,7 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 								IndexName: "custom-index",
 							},
 						},
+						Secret: &loggingv1.OutputSecretSpec{Name: splunkSecret.Name},
 					},
 				}
 				verifyOutputs(namespace, client, &forwarderSpec, clfStatus, extras)
@@ -627,6 +635,7 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 						Type:           loggingv1.OutputTypeSplunk,
 						URL:            "https://splunk-web:8088/endpoint",
 						OutputTypeSpec: loggingv1.OutputTypeSpec{},
+						Secret:         &loggingv1.OutputSecretSpec{Name: splunkSecret.Name},
 					},
 				}
 				verifyOutputs(namespace, client, &forwarderSpec, clfStatus, extras)
@@ -646,6 +655,7 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 								IndexName: "custom-index",
 							},
 						},
+						Secret: &loggingv1.OutputSecretSpec{Name: splunkSecret.Name},
 					},
 				}
 				verifyOutputs(namespace, client, &forwarderSpec, clfStatus, extras)

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
@@ -38,14 +38,16 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 	})
 
 	Context("output specs", func() {
+		const secretName = "mytestsecret"
 		var (
-			client        client.Client
-			namespace     = constants.OpenshiftNS
-			extras        map[string]bool
-			clfStatus     *loggingv1.ClusterLogForwarderStatus
-			output        loggingv1.OutputSpec
-			otherOutput   loggingv1.OutputSpec
-			forwarderSpec *loggingv1.ClusterLogForwarderSpec
+			client           client.Client
+			namespace        = constants.OpenshiftNS
+			extras           map[string]bool
+			clfStatus        *loggingv1.ClusterLogForwarderStatus
+			output           loggingv1.OutputSpec
+			otherOutput      loggingv1.OutputSpec
+			forwarderSpec    *loggingv1.ClusterLogForwarderSpec
+			cloudWatchSecret *corev1.Secret
 		)
 
 		BeforeEach(func() {
@@ -54,6 +56,11 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 			)).Build()
 			clfStatus = &loggingv1.ClusterLogForwarderStatus{}
 			extras = map[string]bool{}
+
+			cloudWatchSecret = runtime.NewSecret(constants.OpenshiftNS, secretName, map[string][]byte{
+				constants.AWSSecretAccessKey: {0, 1, 2},
+				constants.AWSAccessKeyID:     {0, 1, 2},
+			})
 
 			output = loggingv1.OutputSpec{
 				Name: "myOutput",
@@ -220,10 +227,14 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 		})
 
 		It("should fail Cloudwatch output without OutputTypeSpec", func() {
+			client = fake.NewFakeClient(cloudWatchSecret) //nolint
 			forwarderSpec.Outputs = []loggingv1.OutputSpec{
 				{
 					Name: "cw",
 					Type: loggingv1.OutputTypeCloudwatch,
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: secretName,
+					},
 				},
 			}
 			verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
@@ -231,6 +242,7 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 		})
 
 		It("should allow specific outputs that do not require URL", func() {
+			client = fake.NewFakeClient(cloudWatchSecret) //nolint
 			forwarderSpec.Pipelines = []loggingv1.PipelineSpec{{OutputRefs: []string{"aCloudwatch"}}}
 			forwarderSpec.Outputs = []loggingv1.OutputSpec{
 				{
@@ -238,6 +250,9 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 					Type: loggingv1.OutputTypeCloudwatch,
 					OutputTypeSpec: loggingv1.OutputTypeSpec{
 						Cloudwatch: &loggingv1.Cloudwatch{},
+					},
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: secretName,
 					},
 				},
 			}
@@ -304,7 +319,7 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 						APIVersion: corev1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "mytestsecret",
+						Name:      secretName,
 						Namespace: constants.OpenshiftNS,
 					},
 					Data: map[string][]byte{},
@@ -332,7 +347,23 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 					Expect(clfStatus.Outputs["aName"]).To(HaveCondition("Ready", false, "MissingResource", missingMessage))
 				})
 
-				It("should fail outputs with secrets that is missing aws_secret_access_id", func() {
+				It("should fail outputs without secrets", func() {
+					client = fake.NewFakeClient(secret) //nolint
+					output = loggingv1.OutputSpec{
+						Name: "aName",
+						Type: loggingv1.OutputTypeCloudwatch,
+						OutputTypeSpec: loggingv1.OutputTypeSpec{
+							Cloudwatch: &loggingv1.Cloudwatch{},
+						},
+					}
+					forwarderSpec = &loggingv1.ClusterLogForwarderSpec{}
+					forwarderSpec.Pipelines = []loggingv1.PipelineSpec{{OutputRefs: []string{output.Name}}}
+					forwarderSpec.Outputs = []loggingv1.OutputSpec{output}
+					verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
+					Expect(clfStatus.Outputs["aName"]).To(HaveCondition("Ready", false, "MissingResource", "secret must be provided for cloudwatch output"))
+				})
+
+				It("should fail outputs without secrets that is missing aws_secret_access_id", func() {
 					secret.Data[constants.AWSSecretAccessKey] = []byte{0, 1, 2}
 					client = fake.NewFakeClient(secret) //nolint
 					verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
@@ -394,6 +425,68 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 					verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
 					stsMessage := "auth keys: a 'role_arn' or 'credentials' key is required containing a valid arn value"
 					Expect(clfStatus.Outputs["aName"]).To(HaveCondition("Ready", false, "MissingResource", stsMessage))
+				})
+			})
+
+			Context("for writing to Splunk", func() {
+				BeforeEach(func() {
+					output = loggingv1.OutputSpec{
+						Name: "aName",
+						Type: loggingv1.OutputTypeSplunk,
+						URL:  "https://splunk-web:8088/endpoint",
+						OutputTypeSpec: loggingv1.OutputTypeSpec{
+							Splunk: &loggingv1.Splunk{},
+						},
+						Secret: &loggingv1.OutputSecretSpec{Name: secret.Name},
+					}
+					forwarderSpec.Pipelines = []loggingv1.PipelineSpec{{OutputRefs: []string{output.Name}}}
+					forwarderSpec.Outputs = []loggingv1.OutputSpec{output}
+				})
+
+				It("should fail outputs with secrets that is missing hecToken", func() {
+					client = fake.NewFakeClient(secret) //nolint
+					verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
+					Expect(clfStatus.Outputs["aName"]).To(HaveCondition("Ready", false, "MissingResource", "A non-empty hecToken entry is required"))
+				})
+
+				It("should fail outputs without secrets", func() {
+					client = fake.NewFakeClient(secret) //nolint
+					output = loggingv1.OutputSpec{
+						Name: "aName",
+						URL:  "https://splunk-web:8088/endpoint",
+						Type: loggingv1.OutputTypeSplunk,
+						OutputTypeSpec: loggingv1.OutputTypeSpec{
+							Splunk: &loggingv1.Splunk{},
+						},
+					}
+					forwarderSpec = &loggingv1.ClusterLogForwarderSpec{}
+					forwarderSpec.Pipelines = []loggingv1.PipelineSpec{{OutputRefs: []string{output.Name}}}
+					forwarderSpec.Outputs = []loggingv1.OutputSpec{output}
+					verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
+					Expect(clfStatus.Outputs["aName"]).To(HaveCondition("Ready", false, "MissingResource", "secret must be provided for splunk output"))
+				})
+
+				It("should fail outputs with secrets that have empty hecToken", func() {
+					secret.Data[constants.SplunkHECTokenKey] = []byte{}
+					client = fake.NewFakeClient(secret) //nolint
+					verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
+					Expect(clfStatus.Outputs["aName"]).To(HaveCondition("Ready", false, "MissingResource", "A non-empty hecToken entry is required"))
+				})
+
+				It("should pass outputs with secrets that have hecToken", func() {
+					secret.Data[constants.SplunkHECTokenKey] = []byte{0, 1, 2}
+					client = fake.NewFakeClient(secret) //nolint
+					verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
+					Expect(forwarderSpec.Outputs).To(HaveLen(len(forwarderSpec.Outputs)))
+					Expect(clfStatus.Outputs["aName"]).To(HaveCondition("Ready", true, "", ""))
+				})
+
+				It("should fail outputs without URL", func() {
+					forwarderSpec.Outputs[0].URL = ""
+					secret.Data[constants.SplunkHECTokenKey] = []byte{0, 1, 2}
+					client = fake.NewFakeClient(secret) //nolint
+					verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
+					Expect(clfStatus.Outputs["aName"]).To(HaveCondition("Ready", false, "Invalid", "URL is required for output type splunk"))
 				})
 			})
 


### PR DESCRIPTION
### Description
This PR add's:

- validation if no secret for CloudWatch and Splunk outputs CLF status will report about invalid state
- few tests for checking validation code for Splunk output

manual cherry-pick for #2324  

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com//browse/LOG-5021
- Enhancement proposal:
