### PR TITLE
LOG-5034: Remove required field from install on STS and ROSA

### DIFF
--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -128,7 +128,7 @@ metadata:
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "true"
-    features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=5.7.0-0 <5.9.0'
@@ -664,6 +664,8 @@ spec:
     url: https://www.elastic.co/
   - name: Fluentd
     url: https://www.fluentd.org/
+  - name: Vector
+    url: https://vector.dev/
   - name: Documentation
     url: https://github.com/openshift/cluster-logging-operator/blob/master/README.adoc
   - name: Red Hat OpenShift Logging Operator

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "true"
-    features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=5.7.0-0 <5.9.0'
@@ -353,6 +353,8 @@ spec:
     url: https://www.elastic.co/
   - name: Fluentd
     url: https://www.fluentd.org/
+  - name: Vector
+    url: https://vector.dev/
   - name: Documentation
     url: https://github.com/openshift/cluster-logging-operator/blob/master/README.adoc
   - name: Red Hat OpenShift Logging Operator


### PR DESCRIPTION
### Description
[LOG-5034](https://issues.redhat.com//browse/LOG-5034) was created to remove the annotation which creates a required "role_arn" at install of our logging operator.   This will remove us from the "token enabled" list in the operator hub, but the resulting required field is more confusing than not being included in the list. 
This can be backported once verified.
Ultimately, we need to come up with a better solution to the epic requiring this "role_arn at install" feature.  re:  https://issues.redhat.com/browse/LOG-4154

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- https://issues.redhat.com/browse/LOG-5034
- https://issues.redhat.com/browse/LOG-4154
