### PR TITLE
LOG-5002: input.receiver.syslog should be an optional field

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder.go
+++ b/apis/logging/v1/cluster_log_forwarder.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/utils/sets"
 )
 
@@ -196,19 +197,42 @@ func (output *OutputSpec) GetMaxRecordsPerSecond() int64 {
 	return output.Limit.MaxRecordsPerSecond
 }
 
-func IsAuditHttpReceiver(input *InputSpec) bool {
-	return input.Receiver != nil &&
-		input.Receiver.HTTP != nil &&
-		input.Receiver.Type == ReceiverTypeHttp &&
-		input.Receiver.HTTP.Format == FormatKubeAPIAudit
+func (receiver *ReceiverSpec) IsAuditHttpReceiver() bool {
+	return receiver != nil &&
+		receiver.Type == ReceiverTypeHttp &&
+		receiver.GetHTTPFormat() == FormatKubeAPIAudit
 }
 
-func IsHttpReceiver(input *InputSpec) bool {
-	return input.Receiver != nil &&
-		input.Receiver.Type == ReceiverTypeHttp
+func (receiver *ReceiverSpec) IsHttpReceiver() bool {
+	return receiver != nil &&
+		receiver.Type == ReceiverTypeHttp
 }
 
-func IsSyslogReceiver(input *InputSpec) bool {
-	return input.Receiver != nil &&
-		input.Receiver.Type == ReceiverTypeSyslog
+func (receiver *ReceiverSpec) IsSyslogReceiver() bool {
+	return receiver != nil &&
+		receiver.Type == ReceiverTypeSyslog
+}
+
+func (receiver *ReceiverSpec) GetSyslogPort() (ret int32) {
+	ret = constants.SyslogReceiverPort
+	if receiver != nil && receiver.ReceiverTypeSpec != nil && receiver.Syslog != nil && receiver.Syslog.Port != 0 {
+		ret = receiver.Syslog.Port
+	}
+	return
+}
+
+func (receiver *ReceiverSpec) GetHTTPPort() (ret int32) {
+	ret = constants.HTTPReceiverPort
+	if receiver != nil && receiver.ReceiverTypeSpec != nil && receiver.HTTP != nil && receiver.HTTP.Port != 0 {
+		ret = receiver.HTTP.Port
+	}
+	return
+}
+
+func (receiver *ReceiverSpec) GetHTTPFormat() (ret string) {
+	ret = constants.HTTPFormat
+	if receiver != nil && receiver.ReceiverTypeSpec != nil && receiver.HTTP != nil && receiver.HTTP.Format != FormatKubeAPIAudit {
+		ret = receiver.HTTP.Format
+	}
+	return
 }

--- a/apis/logging/v1/input_receiver_types.go
+++ b/apis/logging/v1/input_receiver_types.go
@@ -22,7 +22,8 @@ type ReceiverSpec struct {
 	Type string `json:"type"`
 
 	// The ReceiverTypeSpec that handles particular parameters
-	*ReceiverTypeSpec `json:",inline"`
+	// +optional
+	*ReceiverTypeSpec `json:",inline,omitempty"`
 }
 
 type ReceiverTypeSpec struct {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -249,12 +249,12 @@ func (f *Factory) ReconcileInputServices(er record.EventRecorder, k8sClient clie
 	for _, input := range f.ForwarderSpec.Inputs {
 		var listenPort int32
 		serviceName := f.ResourceNames.GenerateInputServiceName(input.Name)
-		if input.Receiver != nil && input.Receiver.ReceiverTypeSpec != nil {
-			if logging.IsHttpReceiver(&input) {
-				listenPort = input.Receiver.HTTP.Port
+		if input.Receiver != nil {
+			if input.Receiver.IsHttpReceiver() {
+				listenPort = input.Receiver.GetHTTPPort()
 			}
-			if logging.IsSyslogReceiver(&input) {
-				listenPort = input.Receiver.Syslog.Port
+			if input.Receiver.IsSyslogReceiver() {
+				listenPort = input.Receiver.GetSyslogPort()
 			}
 			if err := network.ReconcileInputService(er, k8sClient, namespace, serviceName, selectorComponent, serviceName, listenPort, listenPort, input.Receiver.Type, f.isDaemonset, owner, visitors); err != nil {
 				return err

--- a/internal/collector/daemonset.go
+++ b/internal/collector/daemonset.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
-	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/tls"
@@ -24,7 +23,7 @@ func (f *Factory) ReconcileDaemonset(er record.EventRecorder, k8sClient client.C
 
 	var receiverInputs []string
 	for _, input := range f.ForwarderSpec.Inputs {
-		if logging.IsHttpReceiver(&input) || logging.IsSyslogReceiver(&input) {
+		if input.Receiver != nil {
 			receiverInputs = append(receiverInputs, f.ResourceNames.GenerateInputServiceName(input.Name))
 		}
 	}

--- a/internal/collector/deployment.go
+++ b/internal/collector/deployment.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
-	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/tls"
@@ -24,7 +23,7 @@ func (f *Factory) ReconcileDeployment(er record.EventRecorder, k8sClient client.
 
 	var receiverInputs []string
 	for _, input := range f.ForwarderSpec.Inputs {
-		if logging.IsHttpReceiver(&input) || logging.IsSyslogReceiver(&input) {
+		if input.Receiver != nil {
 			receiverInputs = append(receiverInputs, f.ResourceNames.GenerateInputServiceName(input.Name))
 		}
 	}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -144,6 +144,10 @@ const (
 	OptimisticLockErrorMsg = "the object has been modified; please apply your changes to the latest version and try again"
 	OTELSchema             = "opentelemetry"
 
+	HTTPReceiverPort   = 8443
+	HTTPFormat         = "kubeAPIAudit"
+	SyslogReceiverPort = 10514
+
 	LabelHTTPInputService   = "http-input-service"
 	LabelSyslogInputService = "syslog-input-service"
 

--- a/internal/generator/vector/input/receiver.go
+++ b/internal/generator/vector/input/receiver.go
@@ -14,13 +14,13 @@ func NewViaqReceiverSource(spec logging.InputSpec, resNames *factory.ForwarderRe
 	var el []generator.Element
 	var id string
 	switch {
-	case logging.IsSyslogReceiver(&spec):
+	case spec.Receiver.IsSyslogReceiver():
 		el = append(el, source.NewSyslogSource(base, resNames.GenerateInputServiceName(spec.Name), spec, op))
 		dropID := helpers.MakeID(base, "drop", "debug")
 		el = append(el, vector.DropJournalDebugLogs(base, dropID)...)
 		id = helpers.MakeID(base, "journal", "viaq")
 		el = append(el, vector.JournalLogs(dropID, id)...)
-	case logging.IsAuditHttpReceiver(&spec):
+	case spec.Receiver.IsAuditHttpReceiver():
 		el = []generator.Element{source.NewHttpSource(base, resNames.GenerateInputServiceName(spec.Name), spec, op)}
 		id = helpers.MakeID(base, "viaq")
 		el = append(el, vector.NormalizeK8sAuditLogs(helpers.MakeID(base, "items"), id)...)

--- a/internal/generator/vector/input/viaq.go
+++ b/internal/generator/vector/input/viaq.go
@@ -126,9 +126,9 @@ func addLogType(spec logging.InputSpec, els []framework.Element, ids []string) (
 	switch {
 	case spec.Application != nil:
 		logType = logging.InputNameApplication
-	case spec.Infrastructure != nil || logging.IsSyslogReceiver(&spec):
+	case spec.Infrastructure != nil || spec.Receiver.IsSyslogReceiver():
 		logType = logging.InputNameInfrastructure
-	case spec.Audit != nil || logging.IsAuditHttpReceiver(&spec):
+	case spec.Audit != nil || spec.Receiver.IsAuditHttpReceiver():
 		logType = logging.InputNameAudit
 	}
 

--- a/internal/generator/vector/source/http_receiver.go
+++ b/internal/generator/vector/source/http_receiver.go
@@ -21,8 +21,8 @@ func NewHttpSource(id, inputName string, input logging.InputSpec, op framework.O
 		ID:            id,
 		InputName:     inputName,
 		ListenAddress: helpers.ListenOnAllLocalInterfacesAddress(),
-		ListenPort:    input.Receiver.HTTP.Port,
-		Format:        input.Receiver.HTTP.Format,
+		ListenPort:    input.Receiver.GetHTTPPort(),
+		Format:        input.Receiver.GetHTTPFormat(),
 		TlsMinVersion: minTlsVersion,
 		CipherSuites:  cipherSuites,
 	}

--- a/internal/generator/vector/source/syslog_receiver.go
+++ b/internal/generator/vector/source/syslog_receiver.go
@@ -21,7 +21,7 @@ func NewSyslogSource(id, inputName string, input logging.InputSpec, op framework
 		ID:            id,
 		InputName:     inputName,
 		ListenAddress: helpers.ListenOnAllLocalInterfacesAddress(),
-		ListenPort:    input.Receiver.Syslog.Port,
+		ListenPort:    input.Receiver.GetSyslogPort(),
 		TlsMinVersion: minTlsVersion,
 		CipherSuites:  cipherSuites,
 	}

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -220,7 +220,7 @@ func (clusterRequest *ClusterLoggingRequest) RemoveInputServices(currOwner []met
 	// Collect defined http inputs
 	httpInputs := sets.NewString()
 	for _, input := range clusterRequest.Forwarder.Spec.Inputs {
-		if logging.IsHttpReceiver(&input) {
+		if input.Receiver.IsHttpReceiver() {
 			httpInputs.Insert(clusterRequest.ResourceNames.GenerateInputServiceName(input.Name))
 		}
 	}
@@ -243,7 +243,7 @@ func (clusterRequest *ClusterLoggingRequest) RemoveInputServices(currOwner []met
 	// Collect defined syslog inputs
 	syslogInputs := sets.NewString()
 	for _, input := range clusterRequest.Forwarder.Spec.Inputs {
-		if logging.IsSyslogReceiver(&input) {
+		if input.Receiver.IsSyslogReceiver() {
 			syslogInputs.Insert(clusterRequest.ResourceNames.GenerateInputServiceName(input.Name))
 		}
 	}

--- a/internal/logstore/lokistack/logstore_lokistack.go
+++ b/internal/logstore/lokistack/logstore_lokistack.go
@@ -251,10 +251,10 @@ func getInputTypeFromName(spec loggingv1.ClusterLogForwarderSpec, inputName stri
 			if input.Application != nil {
 				return loggingv1.InputNameApplication
 			}
-			if input.Infrastructure != nil || loggingv1.IsSyslogReceiver(&input) {
+			if input.Infrastructure != nil || input.Receiver.IsSyslogReceiver() {
 				return loggingv1.InputNameInfrastructure
 			}
-			if input.Audit != nil || loggingv1.IsAuditHttpReceiver(&input) {
+			if input.Audit != nil || input.Receiver.IsAuditHttpReceiver() {
 				return loggingv1.InputNameAudit
 			}
 		}

--- a/internal/validations/clusterlogforwarder/inputs/validate_test.go
+++ b/internal/validations/clusterlogforwarder/inputs/validate_test.go
@@ -338,7 +338,6 @@ var _ = Describe("#Validate", func() {
 			checkReceiverMismatchTypeHttp(`mismatched Type specified for receiver, specified HTTP and have Syslog`)
 			checkReceiverMismatchTypeSyslog(`mismatched Type specified for receiver, specified Syslog and have HTTP`)
 			checkReceiverType("wrong-receiver", `invalid Type specified for receiver`)
-			checkReceiver(&loggingv1.ReceiverSpec{}, `invalid ReceiverTypeSpec specified for receiver`, map[string]bool{constants.VectorName: true})
 			checkReceiver(&loggingv1.ReceiverSpec{}, `ReceiverSpecs are only supported for the vector log collector`, map[string]bool{})
 		})
 	})


### PR DESCRIPTION
### Description
This is a change mandated by concision in the yaml, as we had a lot of "syslog" mandatory definitions. Due to the limitations on kubebuilder:default (it does not work on fields whose "parent" is empty), we had to go back to the original "GetPort()" funcs.

The change was requested for syslog receiver, but the necessary changes were also implemented in http receiver, as it would not have made any sense to have "syslog" optional but "http" mandatory.

I have also used this change to assign the IsSyslogReceiver, IsHttpReceiver and IsAuditHttpReceiver funcs to the Receiver struct, as it they "belong" naturally to a Receiver.

/cc @jcantrill @anpingli 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5002
