### PR TITLE
LOG-5053: make  spec.inputs[0].receiver.type optional to prevent failing on update to the CLO 5.9

### DIFF
--- a/apis/logging/v1/input_receiver_types.go
+++ b/apis/logging/v1/input_receiver_types.go
@@ -16,9 +16,8 @@ const (
 type ReceiverSpec struct {
 
 	// Type of Receiver plugin.
-	//
 	// +kubebuilder:validation:Enum:=http;syslog
-	// +required
+	// +optional
 	Type string `json:"type"`
 
 	// The ReceiverTypeSpec that handles particular parameters

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -424,8 +424,6 @@ spec:
                           - http
                           - syslog
                           type: string
-                      required:
-                      - type
                       type: object
                   required:
                   - name

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -425,8 +425,6 @@ spec:
                           - http
                           - syslog
                           type: string
-                      required:
-                      - type
                       type: object
                   required:
                   - name

--- a/internal/migrations/clusterlogforwarder/migrate_inputs.go
+++ b/internal/migrations/clusterlogforwarder/migrate_inputs.go
@@ -6,6 +6,19 @@ import (
 )
 
 func MigrateInputs(namespace, name string, spec loggingv1.ClusterLogForwarderSpec, logStore *loggingv1.LogStoreSpec, extras map[string]bool, logstoreSecretName, saTokenSecret string) (loggingv1.ClusterLogForwarderSpec, map[string]bool, []loggingv1.Condition) {
+	for i, input := range spec.Inputs {
+		if input.Receiver != nil {
+			if input.Receiver.HTTP != nil && input.Receiver.Type == "" {
+				input.Receiver.Type = loggingv1.ReceiverTypeHttp
+				spec.Inputs[i] = input
+			}
+			if input.Receiver.Syslog != nil && input.Receiver.Type == "" {
+				input.Receiver.Type = loggingv1.ReceiverTypeSyslog
+				spec.Inputs[i] = input
+			}
+		}
+	}
+
 	inputs := map[string]loggingv1.InputSpec{}
 	for _, p := range spec.Pipelines {
 		for _, i := range p.InputRefs {

--- a/internal/migrations/clusterlogforwarder/migrate_inputs_test.go
+++ b/internal/migrations/clusterlogforwarder/migrate_inputs_test.go
@@ -54,4 +54,128 @@ var _ = Describe("migrateInputs", func() {
 		})
 	})
 
+	Context("for input receiver types", func() {
+		var (
+			http = &logging.HTTPReceiver{
+				Port:   8080,
+				Format: logging.FormatKubeAPIAudit,
+			}
+			syslog = &logging.SyslogReceiver{
+				Port: 8080,
+			}
+		)
+
+		It("should set 'http' receiver type HTTPReceiver declared", func() {
+			spec := logging.ClusterLogForwarderSpec{
+				Inputs: []logging.InputSpec{
+					{
+						Name: "my-custom-input",
+						Receiver: &logging.ReceiverSpec{
+							ReceiverTypeSpec: &logging.ReceiverTypeSpec{
+								HTTP: http,
+							},
+						},
+					},
+				},
+			}
+			extras := map[string]bool{}
+			result, _, _ := MigrateInputs("", "", spec, nil, extras, "", "")
+			Expect(result.Inputs).To(HaveLen(1))
+			Expect(result.Inputs[0]).To(Equal(logging.InputSpec{
+				Name: "my-custom-input",
+				Receiver: &logging.ReceiverSpec{
+					Type: logging.ReceiverTypeHttp,
+					ReceiverTypeSpec: &logging.ReceiverTypeSpec{
+						HTTP: http,
+					},
+				},
+			}))
+		})
+
+		It("should do nothing if receiver type declared as 'http'", func() {
+			spec := logging.ClusterLogForwarderSpec{
+				Inputs: []logging.InputSpec{
+					{
+						Name: "my-custom-input",
+						Receiver: &logging.ReceiverSpec{
+							Type: logging.ReceiverTypeHttp,
+							ReceiverTypeSpec: &logging.ReceiverTypeSpec{
+								HTTP: http,
+							},
+						},
+					},
+				},
+			}
+			extras := map[string]bool{}
+			result, _, _ := MigrateInputs("", "", spec, nil, extras, "", "")
+			Expect(result.Inputs).To(HaveLen(1))
+			Expect(result.Inputs[0]).To(Equal(logging.InputSpec{
+				Name: "my-custom-input",
+				Receiver: &logging.ReceiverSpec{
+					Type: logging.ReceiverTypeHttp,
+					ReceiverTypeSpec: &logging.ReceiverTypeSpec{
+						HTTP: http,
+					},
+				},
+			}))
+			Expect(extras).To(BeEmpty())
+		})
+
+		It("should set 'syslog' receiver type SyslogReceiver declared", func() {
+			spec := logging.ClusterLogForwarderSpec{
+				Inputs: []logging.InputSpec{
+					{
+						Name: "my-custom-input",
+						Receiver: &logging.ReceiverSpec{
+							ReceiverTypeSpec: &logging.ReceiverTypeSpec{
+								Syslog: syslog,
+							},
+						},
+					},
+				},
+			}
+			extras := map[string]bool{}
+			result, _, _ := MigrateInputs("", "", spec, nil, extras, "", "")
+			Expect(result.Inputs).To(HaveLen(1))
+			Expect(result.Inputs[0]).To(Equal(logging.InputSpec{
+				Name: "my-custom-input",
+				Receiver: &logging.ReceiverSpec{
+					Type: logging.ReceiverTypeSyslog,
+					ReceiverTypeSpec: &logging.ReceiverTypeSpec{
+						Syslog: syslog,
+					},
+				},
+			}))
+		})
+
+		It("should do nothing if receiver type declared as 'syslog'", func() {
+			spec := logging.ClusterLogForwarderSpec{
+				Inputs: []logging.InputSpec{
+					{
+						Name: "my-custom-input",
+						Receiver: &logging.ReceiverSpec{
+							Type: logging.ReceiverTypeSyslog,
+							ReceiverTypeSpec: &logging.ReceiverTypeSpec{
+								Syslog: syslog,
+							},
+						},
+					},
+				},
+			}
+			extras := map[string]bool{}
+			result, _, _ := MigrateInputs("", "", spec, nil, extras, "", "")
+			Expect(result.Inputs).To(HaveLen(1))
+			Expect(result.Inputs[0]).To(Equal(logging.InputSpec{
+				Name: "my-custom-input",
+				Receiver: &logging.ReceiverSpec{
+					Type: logging.ReceiverTypeSyslog,
+					ReceiverTypeSpec: &logging.ReceiverTypeSpec{
+						Syslog: syslog,
+					},
+				},
+			}))
+			Expect(extras).To(BeEmpty())
+		})
+
+	})
 })


### PR DESCRIPTION
### Description
This PR makes `spec.inputs[0].receiver.type` an optional field instead of a required one. This change is necessary to prevent potential failures during updates from version 5.8.x to version 5.9. Additionally, it introduces a migration feature that sets `receiver.type` according to the given configuration if it is not already set, allowing for `http` or `syslog` configurations.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5053
- Enhancement proposal:
