### PR TITLE
LOG-5035: fix deleting collector procedure in case removing CLF instance

### DIFF
--- a/controllers/forwarding/forwarding_controller.go
+++ b/controllers/forwarding/forwarding_controller.go
@@ -2,10 +2,10 @@ package forwarding
 
 import (
 	"context"
+	"github.com/openshift/cluster-logging-operator/internal/collector"
 	"strings"
 	"time"
 
-	"github.com/openshift/cluster-logging-operator/internal/collector"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -88,8 +88,17 @@ func (r *ReconcileForwarder) Reconcile(ctx context.Context, request ctrl.Request
 	if err != nil {
 		log.V(3).Info("clusterlogforwarder-controller Error getting instance. It will be retried if other then 'NotFound'", "error", err.Error())
 		if validationerrors.MustUndeployCollector(err) {
-			name := factory.GenerateResourceNames(instance).DaemonSetName()
-			if deleteErr := collector.Remove(r.Client, instance.Namespace, name); deleteErr != nil {
+			daemonSetName := ""
+			if errors.IsNotFound(err) {
+				daemonSetName = request.NamespacedName.Name
+				// legacy deployment
+				if request.NamespacedName.Namespace == constants.OpenshiftNS && request.NamespacedName.Name == constants.SingletonName {
+					daemonSetName = constants.CollectorName
+				}
+			} else {
+				daemonSetName = factory.GenerateResourceNames(instance).DaemonSetName()
+			}
+			if deleteErr := collector.Remove(r.Client, request.NamespacedName.Namespace, daemonSetName); deleteErr != nil {
 				log.V(0).Error(deleteErr, "Unable to remove collector deployment")
 			}
 		}


### PR DESCRIPTION
### Description
This PR addressing to fixing issue with reconciling (deleting) collector in case removing `ClusterLogForwarding` instance. 
Since the CLF instance is already removed, we can't take `instance.Namespace`  and `instance.Name`, so added logic to take this values from other source.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5035
- Enhancement proposal:
