### PR TITLE
LOG-5047: Fix Vector collector crash for invalid splunk.IndexKey symbols

### DIFF
--- a/internal/validations/clusterlogforwarder/outputs/splunk.go
+++ b/internal/validations/clusterlogforwarder/outputs/splunk.go
@@ -1,0 +1,46 @@
+package outputs
+
+import (
+	log "github.com/ViaQ/logerr/v2/log/static"
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/status"
+	"github.com/openshift/cluster-logging-operator/internal/validations/clusterlogforwarder/conditions"
+	"k8s.io/api/core/v1"
+	"regexp"
+)
+
+const pattern = `^([a-zA-Z0-9_]+|"(?:\\.|[^"\\])*")(?:\.([a-zA-Z0-9_]+|"(?:\\.|[^"\\])*"))*$`
+
+func VerifySplunk(name string, splunk *loggingv1.Splunk) (bool, status.Condition) {
+	if splunk != nil {
+		if splunk.IndexKey != "" && splunk.IndexName != "" {
+			log.V(3).Info("verifyOutputsFailed", "reason", "splunk output allows only one of indexKey or indexName, not both.")
+			return false, conditions.CondInvalid("output %q: Only one of indexKey or indexName can be set, not both.", name)
+		}
+
+		if splunk.IndexKey != "" && !isIndexKeyMatch(splunk.IndexKey) {
+			return false, conditions.CondInvalid("output %q: IndexKey can only contain letters, numbers, and underscores (a-zA-Z0-9_). "+
+				"Segments that contain characters outside of this range must be quoted.", name)
+		}
+	}
+	return true, conditions.CondReady
+}
+
+func VerifySecretKeysForSplunk(output *loggingv1.OutputSpec, conds loggingv1.NamedConditions, secret *v1.Secret) bool {
+	fail := func(c status.Condition) bool {
+		conds.Set(output.Name, c)
+		return false
+	}
+
+	if len(secret.Data[constants.SplunkHECTokenKey]) > 0 {
+		return true
+	} else {
+		return fail(conditions.CondMissing("A non-empty " + constants.SplunkHECTokenKey + " entry is required"))
+	}
+}
+
+func isIndexKeyMatch(indexKey string) bool {
+	reg := regexp.MustCompile(pattern)
+	return reg.MatchString(indexKey)
+}

--- a/internal/validations/clusterlogforwarder/outputs/splunk_test.go
+++ b/internal/validations/clusterlogforwarder/outputs/splunk_test.go
@@ -1,0 +1,89 @@
+package outputs
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/status"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var _ = Describe("Validate Splunk:", func() {
+
+	Context("when validating Output Type", func() {
+
+		It("should be valid", func() {
+			splunk := &loggingv1.Splunk{
+				IndexKey: "kubernetes.labels.test_logging",
+			}
+			valid, st := VerifySplunk("splunk", splunk)
+			Expect(valid).To(BeTrue())
+			Expect(map[string]status.Condition{"splunk": st}).To(HaveCondition("Ready", true, "", ""))
+		})
+
+		It("should fail if no IndexKey and ", func() {
+			splunk := &loggingv1.Splunk{
+				IndexKey:  "kubernetes.labels.test_logging",
+				IndexName: "application",
+			}
+			valid, st := VerifySplunk("splunk", splunk)
+			Expect(valid).To(BeFalse())
+			Expect(map[string]status.Condition{"azureMonitor": st}).To(HaveCondition("Ready", false, loggingv1.ReasonInvalid, "output \"splunk\": Only one of indexKey or indexName can be set, not both."))
+		})
+
+		It("should fail if IndexKey bad format: not allowed symbols", func() {
+			splunk := &loggingv1.Splunk{
+				IndexKey: "kubernetes.labels.test:logging",
+			}
+			valid, st := VerifySplunk("splunk", splunk)
+			Expect(valid).To(BeFalse())
+			Expect(map[string]status.Condition{"splunk": st}).To(HaveCondition("Ready", false, loggingv1.ReasonInvalid, "output \"splunk\": IndexKey can only contain letters, numbers, and underscores \\(a-zA-Z0-9_\\). Segments that contain characters outside of this range must be quoted."))
+		})
+	})
+
+	Context("when validating secret for Splunk", func() {
+
+		It("should fail for secret that are missing hecToken", func() {
+			secret := runtime.NewSecret("namespace", "mysec", map[string][]byte{
+				"foo": {'b', 'a', 'r'},
+			})
+			Expect(VerifySecretKeysForSplunk(&loggingv1.OutputSpec{}, loggingv1.NamedConditions{}, secret)).To(BeFalse())
+		})
+
+		It("should fail for secret that has empty hecToken", func() {
+			secret := runtime.NewSecret("namespace", "mysec", map[string][]byte{
+				constants.SplunkHECTokenKey: nil,
+			})
+			Expect(VerifySecretKeysForSplunk(&loggingv1.OutputSpec{}, loggingv1.NamedConditions{}, secret)).To(BeFalse())
+		})
+
+		It("should pass for secrets with not empty hecToken", func() {
+			secret := runtime.NewSecret("namespace", "mysec", map[string][]byte{
+				constants.SplunkHECTokenKey: {'k', 'e', 'y'},
+			})
+			Expect(VerifySecretKeysForSplunk(&loggingv1.OutputSpec{}, loggingv1.NamedConditions{}, secret)).To(BeTrue())
+		})
+	})
+})
+
+func TestValidateIndexKeyMatch(t *testing.T) {
+	inputs := map[string]bool{
+		"kubernetes.labels.test-logging":     false,
+		"kubernetes.labels.test:logging":     false,
+		"kubernetes.labels.test/logging":     false,
+		"kubernetes.labels.test_logging":     true,
+		"kubernetes.labels.\"test-logging\"": true,
+		"kubernetes.labels.\"test/logging\"": true,
+		"kubernetes.labels.\"test:logging\"": true,
+		"example.string.test":                true,
+	}
+
+	for key, must := range inputs {
+		match := isIndexKeyMatch(key)
+		assert.Equal(t, match, must, "isIndexKeyMatch('%s') = %v, must be: %v", key, match, must)
+	}
+}

--- a/internal/validations/clusterlogforwarder/outputs/suite_test.go
+++ b/internal/validations/clusterlogforwarder/outputs/suite_test.go
@@ -1,0 +1,13 @@
+package outputs
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][validations][clusterlogforwarder][outputs] Suite")
+}

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	urlhelper "github.com/openshift/cluster-logging-operator/internal/generator/url"
+	"github.com/openshift/cluster-logging-operator/internal/validations/clusterlogforwarder/outputs"
 	"strings"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
@@ -215,11 +216,12 @@ func verifyOutputs(namespace string, clfClient client.Client, spec *loggingv1.Cl
 			status.Outputs.Set(output.Name,
 				conditions.CondInvalid("output %q: Exactly one of billingAccountId, folderId, organizationId, or projectId must be set.",
 					output.Name))
-		case output.Type == loggingv1.OutputTypeSplunk && output.Splunk != nil && (output.Splunk.IndexKey != "" && output.Splunk.IndexName != ""):
-			log.V(3).Info("verifyOutputsFailed", "reason", "splunk output allows only one of indexKey or indexName, not both.")
-			status.Outputs.Set(output.Name,
-				conditions.CondInvalid("output %q: Only one of indexKey or indexName can be set, not both.",
-					output.Name))
+		case output.Type == loggingv1.OutputTypeSplunk:
+			valid, con := outputs.VerifySplunk(output.Name, output.Splunk)
+			if !valid {
+				log.V(3).Info("verifyOutputs failed", "reason", con.Reason, "output name", output.Name)
+			}
+			status.Outputs.Set(output.Name, con)
 		case output.HasPolicy() && output.GetMaxRecordsPerSecond() < 0:
 			status.Outputs.Set(output.Name, conditions.CondInvalid("output %q: Output cannot have negative limit threshold", output.Name))
 		case !outputRefs.Has(output.Name):
@@ -349,7 +351,7 @@ func verifyOutputSecret(namespace string, clfClient client.Client, output *loggi
 			return false
 		}
 	case loggingv1.OutputTypeSplunk:
-		if !verifySecretKeysForSplunk(output, conds, secret) {
+		if !outputs.VerifySecretKeysForSplunk(output, conds, secret) {
 			return false
 		}
 	}
@@ -411,19 +413,6 @@ func verifySecretKeysForCloudwatch(output *loggingv1.OutputSpec, conds loggingv1
 		return fail(conditions.CondMissing("auth keys: " + constants.AWSAccessKeyID + " and " + constants.AWSSecretAccessKey + " are required"))
 	}
 	return true
-}
-
-func verifySecretKeysForSplunk(output *loggingv1.OutputSpec, conds loggingv1.NamedConditions, secret *corev1.Secret) bool {
-	fail := func(c status.Condition) bool {
-		conds.Set(output.Name, c)
-		return false
-	}
-
-	if len(secret.Data[constants.SplunkHECTokenKey]) > 0 {
-		return true
-	} else {
-		return fail(conditions.CondMissing("A non-empty " + constants.SplunkHECTokenKey + " entry is required"))
-	}
 }
 
 func readClusterName(clfClient client.Client) (string, error) {


### PR DESCRIPTION
### Description
This PR addressing to fix collector crashes when the `splunk.IndexKey` parameter contains symbols not allowed by Vector's template syntax, which adheres to VRL path expressions. 
Implements stricter validation for `splunk.IndexKey` to ensure it conforms to VRL path rules:

- only alphanumeric characters and underscores `(a-zA-Z0-9_)` are allowed.
- segments containing other characters must be quoted (e.g., `kubernetes.labels."test-logging"`).

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5047
- Enhancement proposal:
