### PR TITLE
LOG-5041: Add output tuning strategy and config templates

### DIFF
--- a/apis/logging/v1/cluster_log_forwarder_types.go
+++ b/apis/logging/v1/cluster_log_forwarder_types.go
@@ -225,6 +225,11 @@ type OutputSpec struct {
 	Tuning *OutputTuningSpec `json:"tuning,omitempty"`
 }
 
+const (
+	OutputDeliveryModeAtLeastOnce = "AtLeastOnce"
+	OutputDeliveryModeAtMostOnce  = "AtMostOnce"
+)
+
 // OutputTuningSpec tuning parameters for an output
 type OutputTuningSpec struct {
 
@@ -248,19 +253,16 @@ type OutputTuningSpec struct {
 	Compression string `json:"compression,omitempty"`
 
 	// MaxWrite limits the maximum payload in terms of bytes of a single "send" to the output.
-	// The default is set to an efficient value based on the output type.
 	//
 	// +optional
 	MaxWrite *resource.Quantity `json:"maxWrite,omitempty"`
 
-	// MinRetryDuration is the minimum time to wait between attempts to re-connect after a failure.
-	// The default is set to an efficient value based on the output type.
+	// MinRetryDuration is the minimum time to wait between attempts to retry after delivery a failure.
 	//
 	// +optional
 	MinRetryDuration *time.Duration `json:"minRetryDuration,omitempty"`
 
-	// MaxRetryDuration is the maximum time to wait between re-connect attempts after a connection failure.
-	// The default is set to an efficient value based on the output type.
+	// MaxRetryDuration is the maximum time to wait between retry attempts after a delivery failure.
 	//
 	// +optional
 	MaxRetryDuration *time.Duration `json:"maxRetryDuration,omitempty"`

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -1010,9 +1010,7 @@ spec:
                           type: string
                         maxRetryDuration:
                           description: MaxRetryDuration is the maximum time to wait
-                            between re-connect attempts after a connection failure.
-                            The default is set to an efficient value based on the
-                            output type.
+                            between retry attempts after a delivery failure.
                           format: int64
                           type: integer
                         maxWrite:
@@ -1020,14 +1018,12 @@ spec:
                           - type: integer
                           - type: string
                           description: MaxWrite limits the maximum payload in terms
-                            of bytes of a single "send" to the output. The default
-                            is set to an efficient value based on the output type.
+                            of bytes of a single "send" to the output.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         minRetryDuration:
                           description: MinRetryDuration is the minimum time to wait
-                            between attempts to re-connect after a failure. The default
-                            is set to an efficient value based on the output type.
+                            between attempts to retry after delivery a failure.
                           format: int64
                           type: integer
                       type: object

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -1011,9 +1011,7 @@ spec:
                           type: string
                         maxRetryDuration:
                           description: MaxRetryDuration is the maximum time to wait
-                            between re-connect attempts after a connection failure.
-                            The default is set to an efficient value based on the
-                            output type.
+                            between retry attempts after a delivery failure.
                           format: int64
                           type: integer
                         maxWrite:
@@ -1021,14 +1019,12 @@ spec:
                           - type: integer
                           - type: string
                           description: MaxWrite limits the maximum payload in terms
-                            of bytes of a single "send" to the output. The default
-                            is set to an efficient value based on the output type.
+                            of bytes of a single "send" to the output.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         minRetryDuration:
                           description: MinRetryDuration is the minimum time to wait
-                            between attempts to re-connect after a failure. The default
-                            is set to an efficient value based on the output type.
+                            between attempts to retry after delivery a failure.
                           format: int64
                           type: integer
                       type: object

--- a/docs/reference/operator/api.adoc
+++ b/docs/reference/operator/api.adoc
@@ -432,9 +432,9 @@ OutputTuningSpec tuning parameters for an output
 
 |compression|string|  *(optional)* Compression causes data to be compressed before sending over the network.
 |delivery|string|  Delivery mode for log forwarding.
-|maxRetryDuration|Duration|  *(optional)* MaxRetryDuration is the maximum time to wait between re-connect attempts after a connection failure.
+|maxRetryDuration|Duration|  *(optional)* MaxRetryDuration is the maximum time to wait between retry attempts after a delivery failure.
 |maxWrite|object|  *(optional)* MaxWrite limits the maximum payload in terms of bytes of a single &#34;send&#34; to the output.
-|minRetryDuration|Duration|  *(optional)* MinRetryDuration is the minimum time to wait between attempts to re-connect after a failure.
+|minRetryDuration|Duration|  *(optional)* MinRetryDuration is the minimum time to wait between attempts to retry after delivery a failure.
 |======================
 
 === .spec.outputs[].tuning.maxRetryDuration

--- a/internal/generator/vector/output/adapter.go
+++ b/internal/generator/vector/output/adapter.go
@@ -24,7 +24,7 @@ func NewOutput(spec logging.OutputSpec, secrets map[string]*corev1.Secret, op ge
 }
 
 func (o *Output) Elements() []generator.Element {
-	el := New(o.spec, o.inputIDs, o.secrets, o.op)
+	el := New(o.spec, o.inputIDs, o.secrets, o, o.op)
 	return el
 }
 

--- a/internal/generator/vector/output/azuremonitor/azuremonitor.go
+++ b/internal/generator/vector/output/azuremonitor/azuremonitor.go
@@ -45,7 +45,7 @@ shared_key = "{{.SharedKey}}"
 {{end}}`
 }
 
-func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret, op framework.Options) []framework.Element {
+func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret, strategy common.ConfigStrategy, op framework.Options) []framework.Element {
 	dedottedID := vectorhelpers.MakeID(id, "dedot")
 	if genhelper.IsDebugOutput(op) {
 		return []framework.Element{
@@ -56,6 +56,10 @@ func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret
 		[]framework.Element{
 			normalize.DedotLabels(dedottedID, inputs),
 			Output(id, o, []string{dedottedID}, secret, op),
+			common.NewAcknowledgments(id, strategy),
+			common.NewBatch(id, strategy),
+			common.NewBuffer(id, strategy),
+			common.NewRequest(id, strategy),
 		},
 		TLSConf(id, o, secret, op),
 	)

--- a/internal/generator/vector/output/azuremonitor/azuremonitor_test.go
+++ b/internal/generator/vector/output/azuremonitor/azuremonitor_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Generating vector config for Azure Monitor Logs output:", func
 	)
 
 	DescribeTable("should generate valid config", func(outputSpec loggingv1.OutputSpec, secret, expValue string) {
-		conf := New(vectorhelpers.MakeOutputID(outputSpec.Name), outputSpec, []string{"pipelineName"}, secrets[secret], nil)
+		conf := New(vectorhelpers.MakeOutputID(outputSpec.Name), outputSpec, []string{"pipelineName"}, secrets[secret], nil, nil)
 		Expect(expValue).To(EqualConfigFrom(conf))
 	},
 		Entry("for common case", outputCommon, secretName, ExpectedAzureCommonToml),

--- a/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/output_cloudwatch_test.go
@@ -85,11 +85,7 @@ encoding.codec = "json"
 healthcheck.enabled = false
 `
 	cwBufferAndRequest = `
-[sinks.cw.buffer]
-when_full = "drop_newest"
-
 [sinks.cw.request]
-retry_attempts = 17
 concurrency = 2
 `
 	cwSinkRole = `
@@ -105,11 +101,7 @@ stream_name = "{{ stream_name }}"
 encoding.codec = "json"
 healthcheck.enabled = false
 
-[sinks.cw.buffer]
-when_full = "drop_newest"
-
 [sinks.cw.request]
-retry_attempts = 17
 concurrency = 2
 `
 	cwSinkKeyIdTLS = `
@@ -126,11 +118,7 @@ auth.secret_access_key = "` + keySecret + `"
 encoding.codec = "json"
 healthcheck.enabled = false
 
-[sinks.cw.buffer]
-when_full = "drop_newest"
-
 [sinks.cw.request]
-retry_attempts = 17
 concurrency = 2
 
 [sinks.cw.tls]
@@ -154,12 +142,9 @@ auth.secret_access_key = "` + keySecret + `"
 encoding.codec = "json"
 healthcheck.enabled = false
 
-[sinks.cw.buffer]
-when_full = "drop_newest"
-
 [sinks.cw.request]
-retry_attempts = 17
 concurrency = 2
+
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -179,12 +164,9 @@ auth.secret_access_key = "` + keySecret + `"
 encoding.codec = "json"
 healthcheck.enabled = false
 
-[sinks.cw.buffer]
-when_full = "drop_newest"
-
 [sinks.cw.request]
-retry_attempts = 17
 concurrency = 2
+
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -207,12 +189,9 @@ stream_name = "{{ stream_name }}"
 encoding.codec = "json"
 healthcheck.enabled = false
 
-[sinks.cw.buffer]
-when_full = "drop_newest"
-
 [sinks.cw.request]
-retry_attempts = 17
 concurrency = 2
+
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -233,12 +212,9 @@ stream_name = "{{ stream_name }}"
 encoding.codec = "json"
 healthcheck.enabled = false
 
-[sinks.cw.buffer]
-when_full = "drop_newest"
-
 [sinks.cw.request]
-retry_attempts = 17
 concurrency = 2
+
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -261,12 +237,9 @@ stream_name = "{{ stream_name }}"
 encoding.codec = "json"
 healthcheck.enabled = false
 
-[sinks.cw.buffer]
-when_full = "drop_newest"
-
 [sinks.cw.request]
-retry_attempts = 17
 concurrency = 2
+
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -287,12 +260,9 @@ stream_name = "{{ stream_name }}"
 encoding.codec = "json"
 healthcheck.enabled = false
 
-[sinks.cw.buffer]
-when_full = "drop_newest"
-
 [sinks.cw.request]
-retry_attempts = 17
 concurrency = 2
+
 [sinks.cw.tls]
 min_tls_version = "` + defaultTLS + `"
 ciphersuites = "` + defaultCiphers + `"
@@ -385,7 +355,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 ` + cwSinkKeyId + `
 ` + cwBufferAndRequest + `
 `
-				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil)
+				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, nil)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))
@@ -420,7 +390,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 ` + cwSinkKeyId + `
 ` + cwBufferAndRequest + `
 `
-				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil)
+				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, nil)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))
@@ -455,7 +425,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 ` + cwSinkKeyId + `
 ` + cwBufferAndRequest + `
 `
-				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil)
+				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, nil)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))
@@ -497,7 +467,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 ` + cwSinkKeyId + `
 ` + cwBufferAndRequest + `
 `
-				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil)
+				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, nil)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))
@@ -534,7 +504,7 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 ` + cwSinkKeyId + `
 endpoint = "` + endpoint + `"` + cwBufferAndRequest
 
-			element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil)
+			element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, nil)
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(expConf))
@@ -576,7 +546,7 @@ endpoint = "` + endpoint + `"` + cwBufferAndRequest
 
 	` + cwSinkKeyIdTLSNoCerts + `
 	`
-			element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], op)
+			element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, op)
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(expConf))
@@ -604,7 +574,7 @@ endpoint = "` + endpoint + `"` + cwBufferAndRequest
 
 	` + cwSinkKeyIdTLS + `
 	`
-			element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], op)
+			element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, op)
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(expConf))
@@ -636,7 +606,7 @@ endpoint = "` + endpoint + `"` + cwBufferAndRequest
 
 	` + cwSinkKeyIdTLSInsecure + `
 	`
-			element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], op)
+			element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, op)
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(expConf))
@@ -720,7 +690,7 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
 
 ` + cwSinkRole + `
 `
-				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil)
+				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, nil)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))
@@ -758,7 +728,7 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
 
 			` + cwSinkRoleTLS + `
 			`
-				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], op)
+				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, op)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))
@@ -789,7 +759,7 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
 
 			` + cwSinkRoleTLSInsecure + `
 			`
-				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], op)
+				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, op)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))
@@ -838,7 +808,7 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
 
 ` + cwSinkRole + `
 `
-				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil)
+				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, nil)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))
@@ -885,7 +855,7 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
 
 			` + cwSinkRoleTLSCredentials + `
 			`
-				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], op)
+				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, op)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))
@@ -916,7 +886,7 @@ var _ = Describe("Generating vector config for cloudwatch sts", func() {
 
 			` + cwSinkRoleTLSInsecureCredentials + `
 			`
-				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], op)
+				element := New(helpers.FormatComponentID(output.Name), output, pipelineName, secrets[output.Secret.Name], nil, op)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(expConf))

--- a/internal/generator/vector/output/common/acknowledgements.go
+++ b/internal/generator/vector/output/common/acknowledgements.go
@@ -1,0 +1,30 @@
+package common
+
+type Acknowledgments struct {
+	ID      string
+	Enabled bool
+}
+
+func NewAcknowledgments(id string, s ConfigStrategy) Acknowledgments {
+	a := Acknowledgments{
+		ID: id,
+	}
+	if s == nil {
+		return a
+	}
+	return s.VisitAcknowledgements(a)
+}
+
+func (a Acknowledgments) Name() string {
+	return "acknowledgements"
+}
+
+func (a Acknowledgments) Template() string {
+	if !a.Enabled {
+		return `{{define "` + a.Name() + `" -}}{{end}}`
+	}
+	return `{{define "` + a.Name() + `" -}}
+[sinks.{{.ID}}.acknowledgements]
+enabled = {{.Enabled}}
+{{end}}`
+}

--- a/internal/generator/vector/output/common/batch.go
+++ b/internal/generator/vector/output/common/batch.go
@@ -1,0 +1,45 @@
+package common
+
+import "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
+
+type Batch struct {
+	ComponentID string
+	MaxBytes    helpers.OptionalPair
+	MaxEvents   helpers.OptionalPair
+	TimeoutSec  helpers.OptionalPair
+}
+
+func NewBatch(id string, s ConfigStrategy) Batch {
+	b := Batch{
+		ComponentID: id,
+		MaxBytes:    helpers.NewOptionalPair("max_bytes", nil),
+		MaxEvents:   helpers.NewOptionalPair("max_events", nil),
+		TimeoutSec:  helpers.NewOptionalPair("timeout_sec", nil),
+	}
+	if s != nil {
+		b = s.VisitBatch(b)
+	}
+	return b
+}
+
+func (b Batch) Name() string {
+	return "batch"
+}
+
+func (b Batch) isEmpty() bool {
+	return b.MaxEvents.String()+
+		b.MaxBytes.String()+
+		b.TimeoutSec.String() == ""
+}
+
+func (b Batch) Template() string {
+	if b.isEmpty() {
+		return `{{define "` + b.Name() + `" -}}{{end}}`
+	}
+	return `{{define "` + b.Name() + `" -}}
+[sinks.{{.ComponentID}}.batch]
+{{.MaxBytes}}
+{{.MaxEvents}}
+{{.TimeoutSec}}
+{{end}}`
+}

--- a/internal/generator/vector/output/common/buffer.go
+++ b/internal/generator/vector/output/common/buffer.go
@@ -1,24 +1,47 @@
 package common
 
+import "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
+
+const (
+	BufferWhenFullBlock      = "block"
+	BufferWhenFullDropNewest = "drop_newest"
+)
+
 type Buffer struct {
 	ComponentID string
-	WhenFull    string
+	WhenFull    helpers.OptionalPair
+	MaxEvents   helpers.OptionalPair
 }
 
-func NewBuffer(id string) Buffer {
-	return Buffer{
+func NewBuffer(id string, s ConfigStrategy) Buffer {
+	b := Buffer{
 		ComponentID: id,
-		WhenFull:    "drop_newest",
+		WhenFull:    helpers.NewOptionalPair("when_full", nil),
+		MaxEvents:   helpers.NewOptionalPair("max_events", nil),
 	}
+	if s != nil {
+		b = s.VisitBuffer(b)
+	}
+	return b
 }
 
 func (b Buffer) Name() string {
 	return "buffer"
 }
 
+func (b Buffer) isEmpty() bool {
+	return b.MaxEvents.String()+
+		b.WhenFull.String()+
+		b.MaxEvents.String() == ""
+}
+
 func (b Buffer) Template() string {
+	if b.isEmpty() {
+		return `{{define "` + b.Name() + `" -}}{{end}}`
+	}
 	return `{{define "` + b.Name() + `" -}}
 [sinks.{{.ComponentID}}.buffer]
-when_full = "{{.WhenFull}}"
+{{.WhenFull}}
+{{.MaxEvents}}
 {{end}}`
 }

--- a/internal/generator/vector/output/common/config_strategy.go
+++ b/internal/generator/vector/output/common/config_strategy.go
@@ -1,0 +1,20 @@
+package common
+
+// ConfigStrategy abstracts the generator specific sections from the domain
+type ConfigStrategy interface {
+	VisitAcknowledgements(a Acknowledgments) Acknowledgments
+	VisitBatch(b Batch) Batch
+	VisitRequest(r Request) Request
+	VisitBuffer(b Buffer) Buffer
+
+	// VisitSink allows setting top-level sink parameters
+	VisitSink(s SinkConfig)
+}
+
+// SinkConfig is an abstraction to set common root level configuration parameters of a sink (e.g. compression)
+// Not all sinks may support all parameters
+type SinkConfig interface {
+
+	// SetCompression of the sink
+	SetCompression(algo string)
+}

--- a/internal/generator/vector/output/common/root.go
+++ b/internal/generator/vector/output/common/root.go
@@ -1,0 +1,13 @@
+package common
+
+import "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
+
+type RootMixin struct {
+	Compression helpers.OptionalPair
+}
+
+func NewRootMixin(compression interface{}) RootMixin {
+	return RootMixin{
+		Compression: helpers.NewOptionalPair("compression", compression),
+	}
+}

--- a/internal/generator/vector/output/config_strategy.go
+++ b/internal/generator/vector/output/config_strategy.go
@@ -1,0 +1,59 @@
+package output
+
+import (
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
+)
+
+func (o Output) VisitSink(s common.SinkConfig) {
+	if o.spec.Tuning != nil {
+		comp := o.spec.Tuning.Compression
+		if comp != "" && comp != "none" {
+			s.SetCompression(comp)
+		}
+	}
+}
+
+// VisitAcknowledgements enables acknowledgements when an output is tuned for AtLeastOnce delivery
+func (o Output) VisitAcknowledgements(a common.Acknowledgments) common.Acknowledgments {
+	a.Enabled = o.spec.Tuning != nil && o.spec.Tuning.Delivery == logging.OutputDeliveryModeAtLeastOnce
+	return a
+}
+
+func (o Output) VisitBatch(b common.Batch) common.Batch {
+	if o.spec.Tuning != nil && o.spec.Tuning.MaxWrite != nil && !o.spec.Tuning.MaxWrite.IsZero() {
+		b.MaxBytes.Value = o.spec.Tuning.MaxWrite.Value()
+	}
+	return b
+}
+
+func (o Output) VisitRequest(r common.Request) common.Request {
+	if o.spec.Tuning != nil {
+		if o.spec.Tuning.MinRetryDuration != nil && o.spec.Tuning.MinRetryDuration.Seconds() > 0 {
+			r.RetryInitialBackoffSec.Value = o.spec.Tuning.MinRetryDuration.Seconds()
+		}
+		if o.spec.Tuning.MaxRetryDuration != nil && o.spec.Tuning.MaxRetryDuration.Seconds() > 0 {
+			r.RetryMaxDurationSec.Value = o.spec.Tuning.MaxRetryDuration.Seconds()
+		}
+	} else {
+		r.RetryAttempts.Value = 17
+	}
+
+	return r
+}
+
+// VisitBuffer modifies the buffer behavior depending upon the value
+// of the tuning.Delivery mode
+func (o Output) VisitBuffer(b common.Buffer) common.Buffer {
+	if o.spec.Tuning != nil {
+		switch o.spec.Tuning.Delivery {
+		case logging.OutputDeliveryModeAtLeastOnce:
+			b.WhenFull.Value = common.BufferWhenFullBlock
+		case logging.OutputDeliveryModeAtMostOnce:
+			b.WhenFull.Value = common.BufferWhenFullDropNewest
+		}
+	} else {
+		b.WhenFull.Value = common.BufferWhenFullDropNewest
+	}
+	return b
+}

--- a/internal/generator/vector/output/config_strategy_test.go
+++ b/internal/generator/vector/output/config_strategy_test.go
@@ -1,0 +1,171 @@
+package output
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"time"
+)
+
+type fakeSink struct {
+	Compression string
+}
+
+func (s *fakeSink) SetCompression(algo string) {
+	s.Compression = algo
+}
+
+var _ = Describe("ConfigStrategy for tuning Outputs", func() {
+
+	const (
+		ID = "id"
+	)
+
+	Context("Compression", func() {
+		It("should not set the compression when none", func() {
+			output := NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{
+					Compression: "none",
+				},
+			}, nil, framework.NoOptions)
+			sink := &fakeSink{}
+			output.VisitSink(sink)
+			Expect(sink.Compression).To(BeEmpty())
+		})
+		It("should not set the compression when empty", func() {
+			output := NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{
+					Compression: "",
+				},
+			}, nil, framework.NoOptions)
+			sink := &fakeSink{}
+			output.VisitSink(sink)
+			Expect(sink.Compression).To(BeEmpty())
+		})
+		It("should set the compression when not empty or none", func() {
+			output := NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{
+					Compression: "gzip",
+				},
+			}, nil, framework.NoOptions)
+			sink := &fakeSink{}
+			output.VisitSink(sink)
+			Expect(sink.Compression).To(Equal("gzip"))
+		})
+	})
+	Context("MaxRetryDuration", func() {
+
+		It("should rely upon the defaults and generate nothing when zero", func() {
+			output := NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{}}, nil, nil)
+			Expect(``).To(EqualConfigFrom(common.NewRequest(ID, output)))
+		})
+
+		It("should set request.retry_max_duration_secs for values greater then zero", func() {
+			output := NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{
+					MaxRetryDuration: utils.GetPtr(35 * 1000 * time.Millisecond),
+				},
+			}, nil, nil)
+
+			Expect(`
+[sinks.id.request]
+retry_max_duration_secs = 35
+`).To(EqualConfigFrom(common.NewRequest(ID, output)))
+
+		})
+	})
+	Context("MinRetryDuration", func() {
+
+		It("should rely upon the defaults and generate nothing when zero", func() {
+			output := NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{}}, nil, nil)
+			Expect(``).To(EqualConfigFrom(common.NewRequest(ID, output)))
+		})
+
+		It("should set request.retry_initial_backoff_secs for values greater then zero", func() {
+			output := NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{
+					MinRetryDuration: utils.GetPtr(25 * 1000 * time.Millisecond),
+				},
+			}, nil, nil)
+
+			Expect(`
+[sinks.id.request]
+retry_initial_backoff_secs = 25
+`).To(EqualConfigFrom(common.NewRequest(ID, output)))
+
+		})
+	})
+	Context("MaxWrite", func() {
+
+		It("should rely upon the defaults and generate nothing when zero", func() {
+			output := NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{}}, nil, nil)
+			Expect(``).To(EqualConfigFrom(common.NewBatch(ID, output)))
+		})
+
+		It("should set batch.max_bytes for values greater then zero", func() {
+			output := NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{
+					MaxWrite: utils.GetPtr(resource.MustParse("1Ki")),
+				},
+			}, nil, nil)
+
+			Expect(`
+[sinks.id.batch]
+max_bytes = 1024
+`).To(EqualConfigFrom(common.NewBatch(ID, output)))
+
+		})
+	})
+
+	Context("when delivery is spec'd", func() {
+
+		Context("AtLeastOnce", func() {
+			var output = NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{
+					Delivery: logging.OutputDeliveryModeAtLeastOnce,
+				},
+			}, nil, nil)
+			It("should enable acknowledgments", func() {
+				Expect(`
+[sinks.id.acknowledgements]
+enabled = true
+`).To(EqualConfigFrom(common.NewAcknowledgments(ID, output)))
+
+			})
+			It("should block when the buffer becomes full", func() {
+				Expect(`
+[sinks.id.buffer]
+when_full = "block"
+`).To(EqualConfigFrom(common.NewBuffer(ID, output)))
+			})
+		})
+
+		Context("AtMostOnce", func() {
+
+			var output = NewOutput(logging.OutputSpec{
+				Tuning: &logging.OutputTuningSpec{
+					Delivery: logging.OutputDeliveryModeAtMostOnce,
+				},
+			}, nil, nil)
+
+			It("should not enable acknowledgements and not be present", func() {
+				Expect("").To(EqualConfigFrom(common.NewAcknowledgments(ID, output)))
+				Expect("").To(EqualConfigFrom(common.NewAcknowledgments(ID, nil)), "exp it to handle a nil config strategy")
+			})
+			It("should drop_newest when the buffer becomes full", func() {
+				Expect(`
+[sinks.id.buffer]
+when_full = "drop_newest"
+`).To(EqualConfigFrom(common.NewBuffer(ID, output)))
+			})
+		})
+	})
+})

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Generate Vector config", func() {
 	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op framework.Options) []framework.Element {
 		e := []framework.Element{}
 		for _, o := range clfspec.Outputs {
-			e = framework.MergeElements(e, New(vectorhelpers.FormatComponentID(o.Name), o, inputPipeline, secrets[o.Name], op))
+			e = framework.MergeElements(e, New(vectorhelpers.FormatComponentID(o.Name), o, inputPipeline, secrets[o.Name], nil, op))
 		}
 		return e
 	}
@@ -121,11 +121,7 @@ encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
 
-[sinks.es_1.buffer]
-when_full = "drop_newest"
-
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 
 # Basic Auth Config
@@ -232,11 +228,7 @@ encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
 
-[sinks.es_1.buffer]
-when_full = "drop_newest"
-
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 
 [sinks.es_1.tls]
@@ -332,11 +324,7 @@ encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
 
-[sinks.es_1.buffer]
-when_full = "drop_newest"
-
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),
@@ -431,11 +419,7 @@ encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
 
-[sinks.es_1.buffer]
-when_full = "drop_newest"
-
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 
 [sinks.es_1.tls]
@@ -571,12 +555,10 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
-[sinks.es_1.buffer]
-when_full = "drop_newest"
 
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
+
 [sinks.es_1.tls]
 key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
@@ -655,11 +637,8 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
-[sinks.es_2.buffer]
-when_full = "drop_newest"
 
 [sinks.es_2.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 
 [sinks.es_2.tls]
@@ -772,11 +751,8 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
-[sinks.es_1.buffer]
-when_full = "drop_newest"
 
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),
@@ -880,11 +856,8 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
-[sinks.es_1.buffer]
-when_full = "drop_newest"
 
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),
@@ -994,11 +967,8 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
-[sinks.es_1.buffer]
-when_full = "drop_newest"
 
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),
@@ -1121,11 +1091,8 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
-[sinks.es_1.buffer]
-when_full = "drop_newest"
 
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),
@@ -1216,11 +1183,8 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
-[sinks.es_1.buffer]
-when_full = "drop_newest"
 
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),
@@ -1319,11 +1283,8 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v5"
-[sinks.es_1.buffer]
-when_full = "drop_newest"
 
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),
@@ -1422,11 +1383,8 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
-[sinks.es_1.buffer]
-when_full = "drop_newest"
 
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),
@@ -1525,11 +1483,8 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v7"
-[sinks.es_1.buffer]
-when_full = "drop_newest"
 
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),
@@ -1629,11 +1584,8 @@ bulk.action = "create"
 encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v9"
-[sinks.es_1.buffer]
-when_full = "drop_newest"
 
 [sinks.es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 `,
 		}),

--- a/internal/generator/vector/output/factory.go
+++ b/internal/generator/vector/output/factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/azuremonitor"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/cloudwatch"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/elasticsearch"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/gcl"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/http"
@@ -17,7 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func New(o logging.OutputSpec, inputs []string, secrets map[string]*corev1.Secret, op Options) []Element {
+func New(o logging.OutputSpec, inputs []string, secrets map[string]*corev1.Secret, strategy common.ConfigStrategy, op Options) []Element {
 	secret := helpers.GetOutputSecret(o, secrets)
 	helpers.SetTLSProfileOptions(o, op)
 
@@ -32,23 +33,23 @@ func New(o logging.OutputSpec, inputs []string, secrets map[string]*corev1.Secre
 
 	switch o.Type {
 	case logging.OutputTypeKafka:
-		els = append(els, kafka.New(baseID, o, inputs, secret, op)...)
+		els = append(els, kafka.New(baseID, o, inputs, secret, strategy, op)...)
 	case logging.OutputTypeLoki:
-		els = append(els, loki.New(baseID, o, inputs, secret, op)...)
+		els = append(els, loki.New(baseID, o, inputs, secret, strategy, op)...)
 	case logging.OutputTypeElasticsearch:
-		els = append(els, elasticsearch.New(baseID, o, inputs, secret, op)...)
+		els = append(els, elasticsearch.New(baseID, o, inputs, secret, strategy, op)...)
 	case logging.OutputTypeCloudwatch:
-		els = append(els, cloudwatch.New(baseID, o, inputs, secret, op)...)
+		els = append(els, cloudwatch.New(baseID, o, inputs, secret, strategy, op)...)
 	case logging.OutputTypeGoogleCloudLogging:
-		els = append(els, gcl.New(baseID, o, inputs, secret, op)...)
+		els = append(els, gcl.New(baseID, o, inputs, secret, strategy, op)...)
 	case logging.OutputTypeSplunk:
-		els = append(els, splunk.New(baseID, o, inputs, secret, op)...)
+		els = append(els, splunk.New(baseID, o, inputs, secret, strategy, op)...)
 	case logging.OutputTypeHttp:
-		els = append(els, http.New(baseID, o, inputs, secret, op)...)
+		els = append(els, http.New(baseID, o, inputs, secret, strategy, op)...)
 	case logging.OutputTypeSyslog:
-		els = append(els, syslog.New(baseID, o, inputs, secret, op)...)
+		els = append(els, syslog.New(baseID, o, inputs, secret, strategy, op)...)
 	case logging.OutputTypeAzureMonitor:
-		els = append(els, azuremonitor.New(baseID, o, inputs, secret, op)...)
+		els = append(els, azuremonitor.New(baseID, o, inputs, secret, strategy, op)...)
 	}
 	return els
 }

--- a/internal/generator/vector/output/factory_test.go
+++ b/internal/generator/vector/output/factory_test.go
@@ -19,7 +19,7 @@ var _ = Describe("output/factory.go", func() {
 		if err != nil {
 			Fail(fmt.Sprintf("Error reading the file %q with exp config: %v", exp, err))
 		}
-		Expect(string(exp)).To(EqualConfigFrom(New(o, []string{"application"}, secrets, framework.Options{})))
+		Expect(string(exp)).To(EqualConfigFrom(New(o, []string{"application"}, secrets, &Output{}, framework.Options{})))
 
 	},
 		Entry("should honor global minTLSVersion & ciphers with loki as the default logstore regardless of the feature gate setting",

--- a/internal/generator/vector/output/gcl/gcl_test.go
+++ b/internal/generator/vector/output/gcl/gcl_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Generate Vector config", func() {
 	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op framework.Options) []framework.Element {
 		e := []framework.Element{}
 		for _, o := range clfspec.Outputs {
-			e = framework.MergeElements(e, New(vectorhelpers.FormatComponentID(o.Name), o, inputPipeline, secrets[o.Name], op))
+			e = framework.MergeElements(e, New(vectorhelpers.FormatComponentID(o.Name), o, inputPipeline, secrets[o.Name], nil, op))
 		}
 		return e
 	}
@@ -90,13 +90,6 @@ severity_key = "level"
 [sinks.gcl_1.resource]
 type = "k8s_node"
 node_name = "{{hostname}}"
-
-[sinks.gcl_1.buffer]
-when_full = "drop_newest"
-
-[sinks.gcl_1.request]
-retry_attempts = 17
-
 `,
 		}),
 		Entry("with TLS config with default minTLSVersion & ciphers", helpers.ConfGenerateTest{
@@ -171,12 +164,6 @@ severity_key = "level"
 [sinks.gcl_tls.resource]
 type = "k8s_node"
 node_name = "{{hostname}}"
-
-[sinks.gcl_tls.buffer]
-when_full = "drop_newest"
-
-[sinks.gcl_tls.request]
-retry_attempts = 17
 
 [sinks.gcl_tls.tls]
 min_tls_version = "` + defaultTLS + `"
@@ -256,13 +243,6 @@ severity_key = "level"
 [sinks.gcl_tls.resource]
 type = "k8s_node"
 node_name = "{{hostname}}"
-
-[sinks.gcl_tls.buffer]
-when_full = "drop_newest"
-
-[sinks.gcl_tls.request]
-retry_attempts = 17
-
 
 [sinks.gcl_tls.tls]
 min_tls_version = "` + defaultTLS + `"

--- a/internal/generator/vector/output/http/http_test.go
+++ b/internal/generator/vector/output/http/http_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("Generate vector config", func() {
 	DescribeTable("for Http output", func(output logging.OutputSpec, secret *corev1.Secret, op framework.Options, exp string) {
-		conf := New(helpers.FormatComponentID(output.Name), output, []string{"application"}, secret, op) //, includeNS, excludes)
+		conf := New(helpers.FormatComponentID(output.Name), output, []string{"application"}, secret, nil, op) //, includeNS, excludes)
 		Expect(exp).To(EqualConfigFrom(conf))
 	},
 		Entry("",
@@ -87,11 +87,7 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
-[sinks.http_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.http_receiver.request]
-retry_attempts = 17
 timeout_secs = 10
 headers = {"h1"="v1","h2"="v2"}
 
@@ -168,11 +164,7 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
-[sinks.http_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.http_receiver.request]
-retry_attempts = 17
 timeout_secs = 10
 headers = {"h1"="v1","h2"="v2"}
 
@@ -246,11 +238,8 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
-[sinks.http_receiver.buffer]
-when_full = "drop_newest"
 
 [sinks.http_receiver.request]
-retry_attempts = 17
 timeout_secs = 50
 headers = {"k1"="v1","k2"="v2"}
 
@@ -324,11 +313,7 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
-[sinks.http_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.http_receiver.request]
-retry_attempts = 17
 timeout_secs = 50
 headers = {"k1"="v1","k2"="v2"}
 
@@ -408,11 +393,7 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
-[sinks.http_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.http_receiver.request]
-retry_attempts = 17
 timeout_secs = 50
 headers = {"k1"="v1","k2"="v2"}
 
@@ -489,11 +470,7 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
-[sinks.http_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.http_receiver.request]
-retry_attempts = 17
 timeout_secs = 50
 headers = {"k1"="v1","k2"="v2"}
 
@@ -611,11 +588,7 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
-[sinks.http_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.http_receiver.request]
-retry_attempts = 17
 timeout_secs = 10
 headers = {"h1"="v1","h2"="v2"}
 
@@ -685,11 +658,7 @@ method = "post"
 [sinks.http_receiver.encoding]
 codec = "json"
 
-[sinks.http_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.http_receiver.request]
-retry_attempts = 17
 timeout_secs = 10
 
 # Basic Auth Config

--- a/internal/generator/vector/output/kafka/kafka_test.go
+++ b/internal/generator/vector/output/kafka/kafka_test.go
@@ -17,7 +17,7 @@ import (
 
 var _ = Describe("Generate vector config", func() {
 	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op framework.Options) []framework.Element {
-		return New(vectorhelpers.FormatComponentID(clfspec.Outputs[0].Name), clfspec.Outputs[0], []string{"pipeline_1", "pipeline_2"}, secrets[clfspec.Outputs[0].Name], op)
+		return New(vectorhelpers.FormatComponentID(clfspec.Outputs[0].Name), clfspec.Outputs[0], []string{"pipeline_1", "pipeline_2"}, secrets[clfspec.Outputs[0].Name], nil, op)
 	}
 	DescribeTable("for kafka output", helpers.TestGenerateConfWith(f),
 		Entry("with plaintext sasl, to single topic", helpers.ConfGenerateTest{
@@ -83,9 +83,6 @@ topic = "build_complete"
 [sinks.kafka_receiver.encoding]
 codec = "json"
 timestamp_format = "rfc3339"
-
-[sinks.kafka_receiver.buffer]
-when_full = "drop_newest"
 
 # SASL Config
 [sinks.kafka_receiver.sasl]
@@ -160,9 +157,6 @@ topic = "build_complete"
 [sinks.kafka_receiver.encoding]
 codec = "json"
 timestamp_format = "rfc3339"
-
-[sinks.kafka_receiver.buffer]
-when_full = "drop_newest"
 
 [sinks.kafka_receiver.tls]
 enabled = true
@@ -244,9 +238,6 @@ topic = "build_complete"
 codec = "json"
 timestamp_format = "rfc3339"
 
-[sinks.kafka_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.kafka_receiver.tls]
 enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
@@ -319,9 +310,6 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
-[sinks.kafka_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.kafka_receiver.tls]
 enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
@@ -393,9 +381,6 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
-[sinks.kafka_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.kafka_receiver.tls]
 enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
@@ -465,9 +450,6 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
-[sinks.kafka_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.kafka_receiver.librdkafka_options]
 "enable.ssl.certificate.verification" = "false"
 [sinks.kafka_receiver.tls]
@@ -534,9 +516,6 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
-[sinks.kafka_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.kafka_receiver.tls]
 enabled = true
 key_pass = "junk"
@@ -589,9 +568,6 @@ topic = "topic"
 [sinks.kafka_receiver.encoding]
 codec = "json"
 timestamp_format = "rfc3339"
-
-[sinks.kafka_receiver.buffer]
-when_full = "drop_newest"
 `,
 		}),
 		Entry("with plain TLS - no secret", helpers.ConfGenerateTest{
@@ -641,9 +617,6 @@ topic = "topic"
 [sinks.kafka_receiver.encoding]
 codec = "json"
 timestamp_format = "rfc3339"
-
-[sinks.kafka_receiver.buffer]
-when_full = "drop_newest"
 `,
 		}),
 		Entry("without security", helpers.ConfGenerateTest{
@@ -693,9 +666,6 @@ topic = "topic"
 [sinks.kafka_receiver.encoding]
 codec = "json"
 timestamp_format = "rfc3339"
-
-[sinks.kafka_receiver.buffer]
-when_full = "drop_newest"
 `,
 		}),
 	)

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Generate vector config", func() {
 	defaultCiphers := "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
 	inputPipeline := []string{"application"}
 	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op framework.Options) []framework.Element {
-		return New(vectorhelpers.FormatComponentID(clfspec.Outputs[0].Name), clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], op)
+		return New(vectorhelpers.FormatComponentID(clfspec.Outputs[0].Name), clfspec.Outputs[0], inputPipeline, secrets[clfspec.Outputs[0].Name], nil, op)
 	}
 	DescribeTable("for Loki output", helpers.TestGenerateConfWith(f),
 		Entry("with default labels", helpers.ConfGenerateTest{
@@ -118,12 +118,6 @@ healthcheck.enabled = false
 
 [sinks.loki_receiver.encoding]
 codec = "json"
-
-[sinks.loki_receiver.buffer]
-when_full = "drop_newest"
-
-[sinks.loki_receiver.request]
-retry_attempts = 17
 
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
@@ -206,12 +200,6 @@ healthcheck.enabled = false
 [sinks.loki_receiver.encoding]
 codec = "json"
 
-[sinks.loki_receiver.buffer]
-when_full = "drop_newest"
-
-[sinks.loki_receiver.request]
-retry_attempts = 17
-
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
@@ -292,12 +280,6 @@ tenant_id = "{{foo.bar.baz}}"
 [sinks.loki_receiver.encoding]
 codec = "json"
 
-[sinks.loki_receiver.buffer]
-when_full = "drop_newest"
-
-[sinks.loki_receiver.request]
-retry_attempts = 17
-
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
@@ -375,12 +357,6 @@ healthcheck.enabled = false
 
 [sinks.loki_receiver.encoding]
 codec = "json"
-
-[sinks.loki_receiver.buffer]
-when_full = "drop_newest"
-
-[sinks.loki_receiver.request]
-retry_attempts = 17
 
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
@@ -461,12 +437,6 @@ healthcheck.enabled = false
 [sinks.loki_receiver.encoding]
 codec = "json"
 
-[sinks.loki_receiver.buffer]
-when_full = "drop_newest"
-
-[sinks.loki_receiver.request]
-retry_attempts = 17
-
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
@@ -535,12 +505,6 @@ healthcheck.enabled = false
 
 [sinks.loki_receiver.encoding]
 codec = "json"
-
-[sinks.loki_receiver.buffer]
-when_full = "drop_newest"
-
-[sinks.loki_receiver.request]
-retry_attempts = 17
 
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
@@ -620,12 +584,6 @@ healthcheck.enabled = false
 [sinks.loki_receiver.encoding]
 codec = "json"
 
-[sinks.loki_receiver.buffer]
-when_full = "drop_newest"
-
-[sinks.loki_receiver.request]
-retry_attempts = 17
-
 [sinks.loki_receiver.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
@@ -648,7 +606,7 @@ token = "token-for-custom-loki"
 var _ = Describe("Generate vector config for in cluster loki", func() {
 	inputPipeline := []string{"application"}
 	var f = func(clspec logging.CollectionSpec, secrets map[string]*corev1.Secret, clfspec logging.ClusterLogForwarderSpec, op framework.Options) []framework.Element {
-		return New(vectorhelpers.FormatComponentID(clfspec.Outputs[0].Name), clfspec.Outputs[0], inputPipeline, secrets[constants.LogCollectorToken], framework.NoOptions)
+		return New(vectorhelpers.FormatComponentID(clfspec.Outputs[0].Name), clfspec.Outputs[0], inputPipeline, secrets[constants.LogCollectorToken], nil, framework.NoOptions)
 	}
 	DescribeTable("for Loki output", helpers.TestGenerateConfWith(f),
 		Entry("with default logcollector bearer token", helpers.ConfGenerateTest{
@@ -710,12 +668,6 @@ healthcheck.enabled = false
 
 [sinks.default_loki_apps.encoding]
 codec = "json"
-
-[sinks.default_loki_apps.buffer]
-when_full = "drop_newest"
-
-[sinks.default_loki_apps.request]
-retry_attempts = 17
 
 [sinks.default_loki_apps.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"

--- a/internal/generator/vector/output/splunk/splunk_test.go
+++ b/internal/generator/vector/output/splunk/splunk_test.go
@@ -55,12 +55,6 @@ default_token = "` + hecToken + `"
 timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
-
-[sinks.splunk_hec.buffer]
-when_full = "drop_newest"
-
-[sinks.splunk_hec.request]
-retry_attempts = 17
 `
 		splunkSinkTls = splunkDedot + `
 [sinks.splunk_hec]
@@ -73,11 +67,6 @@ timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
 
-[sinks.splunk_hec.buffer]
-when_full = "drop_newest"
-
-[sinks.splunk_hec.request]
-retry_attempts = 17
 [sinks.splunk_hec.tls]
 key_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.crt"
@@ -93,12 +82,6 @@ default_token = "` + hecToken + `"
 timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
-
-[sinks.splunk_hec.buffer]
-when_full = "drop_newest"
-
-[sinks.splunk_hec.request]
-retry_attempts = 17
 
 [sinks.splunk_hec.tls]
 verify_certificate = false
@@ -118,12 +101,6 @@ timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
 
-[sinks.splunk_hec.buffer]
-when_full = "drop_newest"
-
-[sinks.splunk_hec.request]
-retry_attempts = 17
-
 [sinks.splunk_hec.tls]
 verify_certificate = false
 verify_hostname = false
@@ -139,12 +116,6 @@ timestamp_key = "@timestamp"
 
 [sinks.splunk_hec.encoding]
 codec = "json"
-
-[sinks.splunk_hec.buffer]
-when_full = "drop_newest"
-
-[sinks.splunk_hec.request]
-retry_attempts = 17
 
 [sinks.splunk_hec.tls]
 key_pass = "junk"
@@ -248,35 +219,35 @@ key_pass = "junk"
 		})
 
 		It("should provide a valid config", func() {
-			element := New(vectorhelpers.FormatComponentID(output.Name), output, []string{"pipelineName"}, secrets[output.Secret.Name], nil)
+			element := New(vectorhelpers.FormatComponentID(output.Name), output, []string{"pipelineName"}, secrets[output.Secret.Name], nil, nil)
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(splunkSink))
 		})
 
 		It("should provide a valid config with passphrase", func() {
-			element := New(vectorhelpers.FormatComponentID(output.Name), outputWithPassphrase, []string{"pipelineName"}, secrets[outputWithPassphrase.Secret.Name], nil)
+			element := New(vectorhelpers.FormatComponentID(output.Name), outputWithPassphrase, []string{"pipelineName"}, secrets[outputWithPassphrase.Secret.Name], nil, nil)
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(splunkSinkPassphrase))
 		})
 
 		It("should provide a valid config with TLS", func() {
-			element := New(vectorhelpers.FormatComponentID(output.Name), outputWithTls, []string{"pipelineName"}, secrets[outputWithTls.Secret.Name], nil)
+			element := New(vectorhelpers.FormatComponentID(output.Name), outputWithTls, []string{"pipelineName"}, secrets[outputWithTls.Secret.Name], nil, nil)
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(splunkSinkTls))
 		})
 
 		It("should provide a valid config with tls.insecureSkipVerify=true", func() {
-			element := New(vectorhelpers.FormatComponentID(output.Name), outputWithTlsSkipVerify, []string{"pipelineName"}, secrets[outputWithTls.Secret.Name], nil)
+			element := New(vectorhelpers.FormatComponentID(output.Name), outputWithTlsSkipVerify, []string{"pipelineName"}, secrets[outputWithTls.Secret.Name], nil, nil)
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(splunkSinkTlsSkipVerify))
 		})
 
 		It("should provide a valid config with tls.insecureSkipVerify=true without secret", func() {
-			element := New(vectorhelpers.FormatComponentID(output.Name), outputWithTlsSkipVerifyNoCert, []string{"pipelineName"}, nil, nil)
+			element := New(vectorhelpers.FormatComponentID(output.Name), outputWithTlsSkipVerifyNoCert, []string{"pipelineName"}, nil, nil, nil)
 			results, err := g.GenerateConf(element...)
 			Expect(err).To(BeNil())
 			Expect(results).To(EqualTrimLines(splunkSinkTlsSkipVerifyNoCert))
@@ -329,12 +300,6 @@ timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
 except_fields = ["write_index"]
-
-[sinks.splunk_hec.buffer]
-when_full = "drop_newest"
-
-[sinks.splunk_hec.request]
-retry_attempts = 17
 `
 
 				splunkSinkIndexKey = `
@@ -370,7 +335,7 @@ source = '''
 
 			It("should provide a valid config with indexKey specified", func() {
 				splunkOutputSpec.Splunk.IndexKey = "kubernetes.namespace_name"
-				element := New(vectorhelpers.FormatComponentID(output.Name), splunkOutputSpec, []string{"pipelineName"}, secrets[output.Secret.Name], nil)
+				element := New(vectorhelpers.FormatComponentID(output.Name), splunkOutputSpec, []string{"pipelineName"}, secrets[output.Secret.Name], nil, nil)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(splunkIndexRemap + splunkSinkIndexKey + splunkWithIndexDedot))
@@ -378,7 +343,7 @@ source = '''
 
 			It("should provide a valid config with indexName specified", func() {
 				splunkOutputSpec.Splunk.IndexName = "custom-index"
-				element := New(vectorhelpers.FormatComponentID(output.Name), splunkOutputSpec, []string{"pipelineName"}, secrets[output.Secret.Name], nil)
+				element := New(vectorhelpers.FormatComponentID(output.Name), splunkOutputSpec, []string{"pipelineName"}, secrets[output.Secret.Name], nil, nil)
 				results, err := g.GenerateConf(element...)
 				Expect(err).To(BeNil())
 				Expect(results).To(EqualTrimLines(splunkIndexRemap + splunkSinkIndexName + splunkWithIndexDedot))

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -84,12 +84,7 @@ severity = "{{.Severity}}"
 {{end}}`
 }
 
-func Conf(o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
-	id := vectorhelpers.FormatComponentID(o.Name)
-	return New(id, o, inputs, secret, op)
-}
-
-func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret, op Options) []Element {
+func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret, strategy common.ConfigStrategy, op Options) []Element {
 	if genhelper.IsDebugOutput(op) {
 		return []Element{
 			Debug(id, vectorhelpers.MakeInputs(inputs...)),

--- a/test/functional/outputs/http/forward_to_http_test.go
+++ b/test/functional/outputs/http/forward_to_http_test.go
@@ -2,7 +2,9 @@ package http
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -26,6 +28,12 @@ var _ = Describe("[Functional][Outputs][Http] Functional tests", func() {
 		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
 			FromInput(logging.InputNameApplication).
 			ToHttpOutput()
+		framework.Forwarder.Spec.Outputs[0].Tuning = &logging.OutputTuningSpec{
+			Delivery:         logging.OutputDeliveryModeAtLeastOnce,
+			MaxRetryDuration: utils.GetPtr(30 * time.Second),
+			MinRetryDuration: utils.GetPtr(5 * time.Second),
+			MaxWrite:         utils.GetPtr(resource.MustParse("1M")),
+		}
 	})
 
 	AfterEach(func() {

--- a/test/matchers/generator_element.go
+++ b/test/matchers/generator_element.go
@@ -41,14 +41,14 @@ func (m *GeneratorElementMatcher) FailureMessage(expected interface{}) (message 
 	if m.err != nil {
 		return fmt.Sprintf("Error generating 'expected' conf: %v", m.err)
 	}
-	return fmt.Sprintf("Expected element to produce a config from 'elements'\nactual:\n\n%s\n\ndiff: %s\n", m.actual, m.diff)
+	return fmt.Sprintf("Expected element to produce a config from 'elements'\nexpected:\n%s\nactual:\n\n%s\n\ndiff: %s\n", expected, m.actual, m.diff)
 }
 
 func (m *GeneratorElementMatcher) NegatedFailureMessage(expected interface{}) (message string) {
 	if m.err != nil {
 		return fmt.Sprintf("Error generating 'expected' conf: %v", m.err)
 	}
-	return fmt.Sprintf("Expected element to not produce a config from 'elements'\nactual:\n\n%s\n\ndiff: %s\n", m.actual, m.diff)
+	return fmt.Sprintf("Expected element to not produce a config from 'elements'\nexpected:\n%sactual:\n\n%s\n\ndiff: %s\n", expected, m.actual, m.diff)
 }
 
 func generateConf(expected interface{}) (string, error) {


### PR DESCRIPTION
### Description
This PR:
* Implements the output tuning spec to allow output modification
* Adds a config strategy to abstract domain logic from generators
* Modifies tuning spec parameters to be pointers to differentiate unset from zero


### Links
* https://issues.redhat.com/browse/LOG-5054
