### PR TITLE
LOG-5062: add name verification for CR in legacy mode installation

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_name.go
+++ b/internal/validations/clusterlogforwarder/validate_name.go
@@ -10,6 +10,11 @@ import (
 
 func validateName(clf v1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *v1.ClusterLogForwarderStatus) {
 
+	if clf.Namespace == constants.OpenshiftNS && clf.Name != constants.SingletonName {
+		return errors.NewValidationError("Name %s is not valid for ClusterLoggingForwarder, only '%s' name can be defined for a CR deploys a CR in %s namespace",
+			clf.Name, constants.SingletonName, constants.OpenshiftNS), nil
+	}
+
 	if clf.Namespace == constants.OpenshiftNS && clf.Name == constants.CollectorName {
 		return errors.NewValidationError("Name %q conflicts with an object for the legacy ClusterLogForwarder deployment.  Choose another", clf.Name), nil
 	}

--- a/internal/validations/clusterlogforwarder/validate_name_test.go
+++ b/internal/validations/clusterlogforwarder/validate_name_test.go
@@ -1,8 +1,11 @@
 package clusterlogforwarder
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/test/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,6 +35,13 @@ var _ = Describe("[internal][validations] ClusterLogForwarder", func() {
 		It("should fail validation when the name results in an object that will fail name validation (e.g. service)", func() {
 			clf := runtime.NewClusterLogForwarder()
 			clf.Namespace = "foobar"
+			clf.Name = "65409debug-3y8sw019"
+			Expect(validateName(*clf, k8sClient, extras)).To(Not(Succeed()))
+		})
+
+		It(fmt.Sprintf("should fail validation when the name of CR not equal to %s in %s namespace", constants.SingletonName, constants.OpenshiftNS), func() {
+			clf := runtime.NewClusterLogForwarder()
+			clf.Namespace = constants.OpenshiftNS
 			clf.Name = "65409debug-3y8sw019"
 			Expect(validateName(*clf, k8sClient, extras)).To(Not(Succeed()))
 		})

--- a/internal/validations/clusterlogging/validate_clusterlogging_spec.go
+++ b/internal/validations/clusterlogging/validate_clusterlogging_spec.go
@@ -8,6 +8,11 @@ import (
 
 func validateClusterLoggingSpec(cl v1.ClusterLogging) error {
 
+	if cl.Namespace == constants.OpenshiftNS && cl.Name != constants.SingletonName {
+		return errors.NewValidationError("Name %s is not valid for ClusterLogging, only '%s' name can be defined for a CR when deploys a CR in %s namespace",
+			cl.Name, constants.SingletonName, constants.OpenshiftNS)
+	}
+
 	if cl.Namespace == constants.OpenshiftNS && cl.Name == constants.SingletonName {
 		if cl.Spec.Collection != nil && !cl.Spec.Collection.Type.IsSupportedCollector() {
 			return errors.NewValidationError("Collector implementation is not supported: %q", cl.Spec.Collection.Type)

--- a/internal/validations/clusterlogging/validate_clusterlogging_spec_test.go
+++ b/internal/validations/clusterlogging/validate_clusterlogging_spec_test.go
@@ -1,9 +1,12 @@
 package clusterlogging
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/test/runtime"
 )
 
@@ -73,6 +76,11 @@ var _ = Describe("[internal][validations] ClusterLogging", func() {
 			It("should pass when collection.type is spec'd", func() {
 				err := validateClusterLoggingSpec(*cl)
 				Expect(err).To(Succeed())
+			})
+			It(fmt.Sprintf("should fail validation when the name of CR not equal to %s in %s namespace", constants.SingletonName, constants.OpenshiftNS), func() {
+				cl.Namespace = constants.OpenshiftNS
+				err := validateClusterLoggingSpec(*cl)
+				Expect(err).To(Not(Succeed()))
 			})
 
 		})


### PR DESCRIPTION
### Description
This PR addresses to fix incorrect validation message for CRs named differently than "instance" in openshift-logging namespace.

- Enhanced validation logic to accurately enforce name restrictions.
- Updated validation message to provide clearer guidance: "Only instance name can be defined for a CR when deployed in `openshift-logging` namespace."

ClusterLogging: 
```
status:
  conditions:
    - lastTransitionTime: '2024-02-12T14:11:09Z'
      reason: ValidationFailure
      status: 'False'
      type: Ready
    - lastTransitionTime: '2024-02-12T14:11:09Z'
      message: >-
        Name instance2 is not valid for ClusterLogging, only 'instance' name can
        be defined for a CR when deploys a CR in openshift-logging namespace
      reason: ValidationFailure
      status: 'True'
      type: Validation
```
ClusterLoggingForwarder
```
status:
  conditions:
    - lastTransitionTime: '2024-02-12T14:12:28Z'
      reason: ValidationFailure
      status: 'False'
      type: Ready
    - lastTransitionTime: '2024-02-12T14:12:28Z'
      message: >-
        Name not-instance is not valid for ClusterLoggingForwarder, only
        'instance' name can be defined for a CR deploys a CR in
        openshift-logging namespace
      reason: ValidationFailure
      status: 'True'
      type: Validation
```

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5062
- Enhancement proposal:
