### PR TITLE
LOG-5049: Deprecated non-working splunk fields and add validation

### DIFF
--- a/api/logging/v1/output_types.go
+++ b/api/logging/v1/output_types.go
@@ -275,11 +275,6 @@ type GoogleCloudLogging struct {
 // Splunk Deliver log data to Splunk’s HTTP Event Collector
 // Provides optional extra properties for `type: splunk_hec` ('splunk_hec_logs' after Vector 0.23
 type Splunk struct {
-	// Fields to be added to Splunk index. https://docs.splunk.com/Documentation/Splunk/8.0.0/Data/IFXandHEC
-	// Should be a valid JSON object
-	// +optional
-	Fields []string `json:"fields,omitempty"`
-
 	// IndexKey is a meta-data key field to use to send events to.
 	// For example: 'IndexKey: kubernetes.namespace_name` will use the kubernetes
 	// namespace as the index.
@@ -294,6 +289,11 @@ type Splunk struct {
 	// If IndexKey && IndexName are not specified, the default index defined within Splunk is used.
 	// +optional
 	IndexName string `json:"indexName,omitempty"`
+
+	// Deprecated. Fields to be added to Splunk index.
+	// +optional
+	// +deprecated
+	Fields []string `json:"fields,omitempty"`
 }
 
 // Http provided configuration for sending json encoded logs to a generic http endpoint.

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -786,8 +786,7 @@ spec:
                         (''splunk_hec_logs'' after Vector 0.23'
                       properties:
                         fields:
-                          description: Fields to be added to Splunk index. https://docs.splunk.com/Documentation/Splunk/8.0.0/Data/IFXandHEC
-                            Should be a valid JSON object
+                          description: Deprecated. Fields to be added to Splunk index.
                           items:
                             type: string
                           type: array

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -787,8 +787,7 @@ spec:
                         (''splunk_hec_logs'' after Vector 0.23'
                       properties:
                         fields:
-                          description: Fields to be added to Splunk index. https://docs.splunk.com/Documentation/Splunk/8.0.0/Data/IFXandHEC
-                            Should be a valid JSON object
+                          description: Deprecated. Fields to be added to Splunk index.
                           items:
                             type: string
                           type: array

--- a/internal/validations/clusterlogforwarder/conditions/set_conditions.go
+++ b/internal/validations/clusterlogforwarder/conditions/set_conditions.go
@@ -18,6 +18,10 @@ func CondMissing(format string, args ...interface{}) status.Condition {
 	return NotReady(logging.ReasonMissingResource, format, args...)
 }
 
+func CondDegraded(r status.ConditionReason, format string, args ...interface{}) status.Condition {
+	return logging.NewCondition(logging.ConditionDegraded, corev1.ConditionTrue, r, format, args...)
+}
+
 func CondReadyWithMessage(r status.ConditionReason, format string, args ...interface{}) status.Condition {
 	return logging.NewCondition(logging.ConditionReady, corev1.ConditionTrue, r, format, args...)
 }

--- a/internal/validations/clusterlogforwarder/outputs/splunk.go
+++ b/internal/validations/clusterlogforwarder/outputs/splunk.go
@@ -23,6 +23,10 @@ func VerifySplunk(name string, splunk *loggingv1.Splunk) (bool, status.Condition
 			return false, conditions.CondInvalid("output %q: IndexKey can only contain letters, numbers, and underscores (a-zA-Z0-9_). "+
 				"Segments that contain characters outside of this range must be quoted.", name)
 		}
+
+		if splunk.Fields != nil {
+			return true, conditions.CondDegraded(loggingv1.ReasonUnused, "Warning: Support for 'fields' is not implemented and deprecated for output %q", name)
+		}
 	}
 	return true, conditions.CondReady
 }

--- a/internal/validations/clusterlogforwarder/outputs/splunk_test.go
+++ b/internal/validations/clusterlogforwarder/outputs/splunk_test.go
@@ -43,6 +43,15 @@ var _ = Describe("Validate Splunk:", func() {
 			Expect(valid).To(BeFalse())
 			Expect(map[string]status.Condition{"splunk": st}).To(HaveCondition("Ready", false, loggingv1.ReasonInvalid, "output \"splunk\": IndexKey can only contain letters, numbers, and underscores \\(a-zA-Z0-9_\\). Segments that contain characters outside of this range must be quoted."))
 		})
+
+		It("should pass with condition Degraded if Fields is included in spec", func() {
+			splunk := &loggingv1.Splunk{
+				Fields: []string{"foo"},
+			}
+			valid, st := VerifySplunk("splunk", splunk)
+			Expect(valid).To(BeTrue())
+			Expect(map[string]status.Condition{"splunk": st}).To(HaveCondition(loggingv1.ConditionDegraded, true, loggingv1.ReasonUnused, "Warning: Support for 'fields' is not implemented and deprecated for output \"splunk\""))
+		})
 	})
 
 	Context("when validating secret for Splunk", func() {


### PR DESCRIPTION
### Description
After discussion about implementation difficulties, we have deprecated splunk.Fields.   They have indexKey or indexName to use instead.  The functionality has never been implemented in 2 years since the splunk forwarding was added.   

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- https://issues.redhat.com/browse/LOG-5049
- https://issues.redhat.com/browse/LOG-4558
