### PR TITLE
LOG-5116: CLO CrashLoopBackOff when inputs.receiver does not spec a receiverTypeSpec

### DIFF
--- a/internal/metrics/telemetry/cluster_log_forwarder.go
+++ b/internal/metrics/telemetry/cluster_log_forwarder.go
@@ -38,7 +38,7 @@ func UpdateInfofromCLF(forwarder logging.ClusterLogForwarder) {
 					hasInput = true
 					// Check for receiver input types if not app, infra, or audit
 				} else {
-					if _, ok := inputs[inputtype]; ok && inputs[inputtype].Receiver != nil && labelname == inputs[inputtype].Receiver.Type {
+					if inputSpec, ok := inputs[inputtype]; ok && inputSpec.Receiver != nil && labelname == inputSpec.Receiver.Type {
 						hasInput = true
 					}
 				}

--- a/internal/migrations/clusterlogforwarder/migrate_inputs.go
+++ b/internal/migrations/clusterlogforwarder/migrate_inputs.go
@@ -7,7 +7,7 @@ import (
 
 func MigrateInputs(namespace, name string, spec loggingv1.ClusterLogForwarderSpec, logStore *loggingv1.LogStoreSpec, extras map[string]bool, logstoreSecretName, saTokenSecret string) (loggingv1.ClusterLogForwarderSpec, map[string]bool, []loggingv1.Condition) {
 	for i, input := range spec.Inputs {
-		if input.Receiver != nil {
+		if input.Receiver != nil && input.Receiver.ReceiverTypeSpec != nil {
 			if input.Receiver.HTTP != nil && input.Receiver.Type == "" {
 				input.Receiver.Type = loggingv1.ReceiverTypeHttp
 				spec.Inputs[i] = input

--- a/internal/migrations/clusterlogforwarder/migrate_inputs_test.go
+++ b/internal/migrations/clusterlogforwarder/migrate_inputs_test.go
@@ -177,5 +177,28 @@ var _ = Describe("migrateInputs", func() {
 			Expect(extras).To(BeEmpty())
 		})
 
+		It("should do nothing if receiver.type declared as syslog but receiverTypeSpec is nil", func() {
+			spec := logging.ClusterLogForwarderSpec{
+				Inputs: []logging.InputSpec{
+					{
+						Name: "my-custom-input",
+						Receiver: &logging.ReceiverSpec{
+							Type: logging.ReceiverTypeSyslog,
+						},
+					},
+				},
+			}
+			extras := map[string]bool{}
+			result, _, _ := MigrateInputs("", "", spec, nil, extras, "", "")
+			Expect(result.Inputs).To(HaveLen(1))
+			Expect(result.Inputs[0]).To(Equal(logging.InputSpec{
+				Name: "my-custom-input",
+				Receiver: &logging.ReceiverSpec{
+					Type: logging.ReceiverTypeSyslog,
+				},
+			}))
+			Expect(extras).To(BeEmpty())
+		})
+
 	})
 })


### PR DESCRIPTION
### Description
This PR fixes the `CrashLoopBackOff` that occurs when a receiver input spec defines a `receiver.type` but not a `receiver.receiverTypeSpec` such as `http` or `syslog`.

/cc @vparfonov @cahartma 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5116

