### PR TITLE
Revert "LOG-4809: reduce stream file size for functional-benchmarker"

### DIFF
--- a/internal/cmd/functional-benchmarker/stats/loss_stats.go
+++ b/internal/cmd/functional-benchmarker/stats/loss_stats.go
@@ -36,7 +36,7 @@ func (s *StreamLossStats) Range() int {
 }
 
 func (l *StreamLossStats) PercentCollected() float64 {
-	return float64(l.Collected) / float64(l.Range()+1) * 100.0
+	return float64(l.Collected) / float64(l.Range()) * 100.0
 }
 
 func (l *LossStats) LossStatsFor(stream string) (*StreamLossStats, error) {

--- a/internal/cmd/functional-benchmarker/stats/statistics.go
+++ b/internal/cmd/functional-benchmarker/stats/statistics.go
@@ -27,7 +27,7 @@ func (stats *Statistics) TotMessages() int {
 }
 
 func (stats *Statistics) MeanBloat() float64 {
-	return stats.GenericMean(func(l *PerfLog) float64 { return l.Bloat })
+	return stats.GenericMean((*PerfLog).Bloat)
 }
 
 func (stats *Statistics) Mean() float64 {

--- a/internal/cmd/functional-benchmarker/stats/types.go
+++ b/internal/cmd/functional-benchmarker/stats/types.go
@@ -3,40 +3,70 @@ package stats
 import (
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
-	"path"
+	"regexp"
 	"strconv"
 	"strings"
 )
 
+var (
+	perfLogPattern = regexp.MustCompile(`.*epoc_in\":(?P<epoc_in>[0-9\.]*).*epoc_out\":(?P<epoc_out>[0-9\.]*).*message\":\"(?P<message>.*(?P<stream>functional((\.0)?\.[0-9A-Z]*)?) - (?P<seqid>\d{10}) -.*?\").*?`)
+)
+
 type PerfLog struct {
-	Stream string `json:"stream,omitempty"`
+	Stream string
 	types.Timing
-	SequenceId    int
-	SequenceIdStr string `json:"seqid,omitempty"`
+	SequenceId int
 
 	// Bloat is the ratio of overall size / Message size
-	Bloat float64 `json:"Bloat,omitempty"`
+	bloat float64
 }
 
 type PerfLogs []PerfLog
 
+func (t *PerfLog) Bloat() float64 {
+	return t.bloat
+}
 func (t *PerfLog) ElapsedEpoc() float64 {
 	return t.EpocOut - t.EpocIn
 }
 
 // NewPerfLog creates a PerfLog from a line parsing it or returning nil if there is an error
-func NewPerfLog(line, fileName string) *PerfLog {
-	entry := &PerfLog{}
-	if err := types.ParseLogsFrom(line, entry, false); err != nil {
-		log.Error(err, "Error parsing line into PerfLog", "line", line)
-		return nil
+func NewPerfLog(line string) *PerfLog {
+	match := perfLogPattern.FindStringSubmatch(line)
+	if len(match) > 0 {
+		entry := PerfLog{}
+		for i, name := range perfLogPattern.SubexpNames() {
+			switch name {
+			case "message":
+				entry.bloat = float64(len(line)) / float64(len(match[i]))
+			case "stream":
+				entry.Stream = match[i]
+			case "seqid":
+				seqId, err := strconv.Atoi(strings.TrimSpace(match[i]))
+				if err != nil {
+					log.Error(err, "Skipping entry. Unable to parse sequence id", "match", match[i], "line", line)
+					return nil
+				}
+				entry.SequenceId = seqId
+			case "epoc_out":
+				epocOut, err := strconv.ParseFloat(strings.TrimSpace(match[i]), 64)
+				if err != nil {
+					log.Error(err, "Skipping entry. Unable to parse epic_out", "match", match[i], "line", line)
+					return nil
+				}
+				entry.EpocOut = epocOut
+			case "epoc_in":
+				epicIn, err := strconv.ParseFloat(strings.TrimSpace(match[i]), 64)
+				if err != nil {
+					log.Error(err, "Skipping entry. Unable to parse epic_in", "match", match[i], "line", line)
+					return nil
+				}
+				entry.EpocIn = epicIn
+			}
+		}
+
+		return &entry
 	}
-	seqId, err := strconv.Atoi(entry.SequenceIdStr)
-	if err != nil {
-		log.Error(err, "Skipping entry. Unable to parse sequence id", "seqId", entry.SequenceIdStr)
-		return nil
-	}
-	entry.SequenceId = seqId
-	entry.Stream = strings.TrimSuffix(path.Base(fileName), ".log")
-	return entry
+	log.V(4).Info("Failed to match perflog", "line", line)
+	return nil
 }

--- a/internal/cmd/functional-benchmarker/stats/types_test.go
+++ b/internal/cmd/functional-benchmarker/stats/types_test.go
@@ -7,14 +7,14 @@ import (
 
 var _ = Describe("Evaluating log loss stats", func() {
 
-	var sample = `{"bloat":2.4790528233151186,"epoc_in":1699990366.4195192,"epoc_out":1699990381.2199013,"seqid":"0000000003"}`
+	var sample = `{"@timestamp":"2023-06-09T16:48:18.929938124+00:00","docker":{"container_id":"8d5fb743542b8c13afb0d5d3cf4cb52e724750d63de58006f16784c9c00da641"},"epoc_in":1682023305.6504774,"epoc_out":1686329299.934293,"hostname":"ip-10-0-173-26.us-east-2.compute.internal","kubernetes":{"container_image":"quay.io/openshift-logging/cluster-logging-load-client:latest","container_image_id":"quay.io/openshift-logging/cluster-logging-load-client@sha256:c8682432425be4b6f64821f0634fb1150b7cf805da0fa724b6047135b9d4d783","container_name":"loader-0","flat_labels":["test-client=true","testname=functional","testtype=functional"],"host":"ip-10-0-173-26.us-east-2.compute.internal","labels":{"test-client":"true","testname":"functional","testtype":"functional"},"master_url":"https://kubernetes.default.svc","namespace_id":"1dca9c0d-1365-4090-9bb3-80fda9b5fec6","namespace_labels":{"kubernetes_io_metadata_name":"testhack-imh2tzge","pod-security_kubernetes_io_enforce":"privileged","security_openshift_io_scc_podSecurityLabelSync":"false","test-client":"true"},"namespace_name":"testhack-imh2tzge","pod_id":"ca9b1dbf-84f3-4aa5-a876-46c0f4bba186","pod_ip":"10.131.0.21","pod_name":"functional"},"level":"unknown","log_type":"application","message":"goloader seq - functional.0.00000000000000002A536241AD427647 - 0000000123 - hvFtZpIOtnnhugEaqJqWWHqCmVCQXExRcOnXEaGpwWgIUlRjtCXLhmQUuqgnpStPjMudPrjUFRBBqolWCNCXdGrpvCqIclJzokNTrQgSUDKmrisDaohrCGDEHeihthYcAyUXmxlQHTkWEfViIVtQHoCQEBDFFWXJfKFqrgpIjgAdqBYeillNOikhURuwFZTEmwcWLElnrlBkZICapoGmFNeBxotMRQXGQLtntyCDiYjiihtvutkzbnHixjFuXKWkhWJbzHiVTuFJvYDlXBKfqGVQejokSwYueuDCdoAxyZCLglsVPijCEmjjGQaKLzlMYZApIOcZdeWVYIWZszhVDDfXArvuVxIdCtKSWMkQJXVuukvkSqKZbkQFcvaZdbDINbYgDAXOPMlYdGTULIwQdTSYyLIlSVyrxSZCnjZfAUhOTObIAXOZJhoJOaKmOpMqzLgYgSaZBaWiMcczEXVzVVXOsjdUKNJgjmdoyhvjcRbGQcLQNpRuTRsgaTbgnziKpEOVlngQEKDIkelRRhdErcIKisDQYNOxhIOysuJXDVYKILOLvritsLpqMJFGuBJjUHcJamedAMPGzkGidwrPWZeScywFftuevYThNNTzNqaQAAyYoSpHbmoZomqSYtDxAfnpCHAOBidVMwMXNLMHUuvrGVCdRwvEignmJOqaPCnYzFSbfZQFjFauIQfjCCnRvnQHPrCKPbnDWhuphjFIFJwjFKKqqmfDzaxizIoEjCHkBGWTEfEKfDYBKhwHfqLRBsGidLzdmAzUImEqWBUDFXWCHBhLIGlyQvGOLDSBymDfydqGoqxtlwVJNzjQdGTExPgBRxQZpVuqpOXGCHIGzjvBmggNSwWqHoxsxexAmjhtfIFrhHFkpkfYlcBTOyxetSvtVCmpAsAwGTRsFmkueLsgFeTqWYiLznDvYWtyXDRBLqwqepDsPPMRslWLYhIWuPRNTWXKsfNbWXpfigOtShXEIPCSEArirHpLLeamyQJOWkIsNWRdErHMpRpzHZXu","openshift":{"cluster_id":"functional","sequence":21526},"path":"/","pipeline_metadata":{"collector":{"inputname":"fluent-plugin-systemd","ipaddr4":"10.131.0.21","name":"fluentd","received_at":"2023-06-09T16:48:18.930687+00:00","version":"1.14.6 1.6.0"}},"source_type":"http_server","timestamp":"2023-06-09T16:48:19.933871646Z","viaq_msg_id":"NGFlNDVhNzItN2ZjZi00Nzc3LTliMzItOTlmZWEyODliYWJj"}`
 
 	It("NewPerfLog", func() {
-		log := NewPerfLog(sample, "loader-0.log")
-		Expect(log.Bloat).To(BeNumerically("~", 2.4, 0.1))
-		Expect(log.SequenceId).To(Equal(3))
-		Expect(log.EpocIn).To(Equal(1699990366.4195192))
-		Expect(log.EpocOut).To(Equal(1699990381.2199013))
-		Expect(log.Stream).To(Equal("loader-0"))
+		log := NewPerfLog(sample)
+		Expect(log.Bloat()).To(BeNumerically("~", 2.4, 0.1))
+		Expect(log.SequenceId).To(Equal(123))
+		Expect(log.EpocIn).To(Equal(1682023305.6504774))
+		Expect(log.EpocOut).To(Equal(1686329299.934293))
+		Expect(log.Stream).To(Equal("functional.0.00000000000000002A536241AD427647"))
 	})
 })


### PR DESCRIPTION
This reverts commit c8236e85e453f927b94bce81e1acecc0d52da8ec.

### Description
This PR:
* reverts https://github.com/openshift/cluster-logging-operator/pull/2243

because it causes the receiver to introduce duplicate logs (why???)

Reverting for testing consistency with 5.7 

cc @alanconway @cahartma 
