### PR TITLE
LOG-5117: Pruning field doesn't work when the specified field contains non-alphanumeric and non-underscores.

### DIFF
--- a/internal/generator/vector/filter/prune/filter_test.go
+++ b/internal/generator/vector/filter/prune/filter_test.go
@@ -1,0 +1,33 @@
+package prune
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("prune functions", func() {
+	DescribeTable("generates correct array of path segments", func(path string, expectedArray []string) {
+		Expect(splitPath(path)).To(Equal(expectedArray))
+	},
+		Entry("with single segment", `.foo`, []string{"foo"}),
+		Entry("with 2 segments", `.foo.bar`, []string{"foo", "bar"}),
+		Entry("with first segment in quotes", `."@foobar"`, []string{`"@foobar"`}),
+		Entry("with 1 quoted segment and one with quotes", `.foo."bar111-22/333"`, []string{"foo", `"bar111-22/333"`}),
+		Entry("with 2 non quoted segments and one quoted segment ", `.foo.bar."baz111-22/333"`, []string{"foo", "bar", `"baz111-22/333"`}),
+		Entry("with multiple quoted and unquoted segments", `.foo."@some"."d.f.g.o111-22/333".foo_bar`, []string{"foo", `"@some"`, `"d.f.g.o111-22/333"`, "foo_bar"}))
+
+	DescribeTable("generates array with path segments quoted", func(pathSegments []string, expectedArray []string) {
+		Expect(quotePathSegments(pathSegments)).To(Equal(expectedArray))
+	},
+		Entry("", []string{"foo"}, []string{`"foo"`}),
+		Entry("", []string{"foo", "bar", `"foo-bar"`}, []string{`"foo"`, `"bar"`, `"foo-bar"`}),
+	)
+
+	It("should generate string of an array of quoted path segments from dot-delimited path expressions", func() {
+		pathExpression := []string{`.foo.bar."foo.bar.baz-ok".foo123."bar/baz0-9.test"`, `.foo.bar`}
+		expectedString := `[["foo","bar","foo.bar.baz-ok","foo123","bar/baz0-9.test"],["foo","bar"]]`
+		Expect(generateQuotedPathSegmentArrayStr(pathExpression)).To(Equal(expectedString))
+	})
+
+})

--- a/internal/generator/vector/filter/prune/suite_test.go
+++ b/internal/generator/vector/filter/prune/suite_test.go
@@ -1,0 +1,13 @@
+package prune
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPruneFunctions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[filter][prune] Unit Tests")
+}

--- a/internal/generator/vector/pipeline/adapter_test.go
+++ b/internal/generator/vector/pipeline/adapter_test.go
@@ -55,7 +55,10 @@ var _ = Describe("pipeline/adapter.go", func() {
 								Type: logging.FilterPrune,
 								FilterTypeSpec: logging.FilterTypeSpec{
 									PruneFilterSpec: &logging.PruneFilterSpec{
-										In: []string{".kubernetes.labels", ".message", ".foo"},
+										In: []string{".foo.test",
+											".bar",
+											`.foo."@some"."d.f.g.o111-22/333".foo_bar`,
+											`.foo.labels."test.dot-with/slashes888"`},
 									},
 								},
 							},

--- a/internal/generator/vector/pipeline/adapter_test_prune_inOnly_filter.toml
+++ b/internal/generator/vector/pipeline/adapter_test_prune_inOnly_filter.toml
@@ -2,7 +2,7 @@
 type = "remap"
 inputs = ["input_app_in_viaq_logtype"]
 source = '''
-in = [["kubernetes","labels"],["message"],["foo"]]
+in = [["foo","test"],["bar"],["foo","@some","d.f.g.o111-22/333","foo_bar"],["foo","labels","test.dot-with/slashes888"]]
 
 # Remove keys from `in` list
 for_each(in) -> |_index, val| {


### PR DESCRIPTION
### Description
This PR fixes the issue that quoted fields containing a `.` wouldn't be pruned .
Example:
```
 .foo.bar."baz.test.field-111/222"
```

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5117

