### PR TITLE
LOG-5123: revert LOG-4536 due to log loss

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -421,9 +421,6 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
-[sinks.output_kafka_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.output_kafka_receiver.tls]
 enabled = true
 min_tls_version = "VersionTLS12"

--- a/internal/generator/vector/conf/complex_drop_filter.toml
+++ b/internal/generator/vector/conf/complex_drop_filter.toml
@@ -427,9 +427,6 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
-[sinks.output_kafka_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.output_kafka_receiver.tls]
 enabled = true
 min_tls_version = "VersionTLS12"

--- a/internal/generator/vector/conf/complex_es_no_ver.toml
+++ b/internal/generator/vector/conf/complex_es_no_ver.toml
@@ -451,11 +451,7 @@ encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
 
-[sinks.output_es_1.buffer]
-when_full = "drop_newest"
-
 [sinks.output_es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 
 [sinks.output_es_1.tls]
@@ -541,11 +537,7 @@ encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
 
-[sinks.output_es_2.buffer]
-when_full = "drop_newest"
-
 [sinks.output_es_2.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 
 [sinks.output_es_2.tls]

--- a/internal/generator/vector/conf/complex_es_v6.toml
+++ b/internal/generator/vector/conf/complex_es_v6.toml
@@ -451,11 +451,7 @@ encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
 
-[sinks.output_default.buffer]
-when_full = "drop_newest"
-
 [sinks.output_default.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 
 [sinks.output_default.tls]
@@ -541,11 +537,7 @@ encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v6"
 
-[sinks.output_es_1.buffer]
-when_full = "drop_newest"
-
 [sinks.output_es_1.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 
 [sinks.output_es_1.tls]
@@ -634,11 +626,7 @@ encoding.except_fields = ["write_index"]
 id_key = "_id"
 api_version = "v8"
 
-[sinks.output_es_2.buffer]
-when_full = "drop_newest"
-
 [sinks.output_es_2.request]
-retry_attempts = 17
 timeout_secs = 2147483648
 
 [sinks.output_es_2.tls]

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -467,9 +467,6 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
-[sinks.output_kafka_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.output_kafka_receiver.tls]
 enabled = true
 min_tls_version = "VersionTLS12"

--- a/internal/generator/vector/conf/complex_otel.toml
+++ b/internal/generator/vector/conf/complex_otel.toml
@@ -466,11 +466,7 @@ method = "post"
 [sinks.output_http_receiver.encoding]
 codec = "json"
 
-[sinks.output_http_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.output_http_receiver.request]
-retry_attempts = 17
 timeout_secs = 10
 headers = {"h1"="v1","h2"="v2"}
 

--- a/internal/generator/vector/conf/complex_prune_filter.toml
+++ b/internal/generator/vector/conf/complex_prune_filter.toml
@@ -443,9 +443,6 @@ topic = "topic"
 codec = "json"
 timestamp_format = "rfc3339"
 
-[sinks.output_kafka_receiver.buffer]
-when_full = "drop_newest"
-
 [sinks.output_kafka_receiver.tls]
 enabled = true
 min_tls_version = "VersionTLS12"

--- a/internal/generator/vector/output/config_strategy.go
+++ b/internal/generator/vector/output/config_strategy.go
@@ -35,8 +35,6 @@ func (o Output) VisitRequest(r common.Request) common.Request {
 		if o.spec.Tuning.MaxRetryDuration != nil && o.spec.Tuning.MaxRetryDuration.Seconds() > 0 {
 			r.RetryMaxDurationSec.Value = o.spec.Tuning.MaxRetryDuration.Seconds()
 		}
-	} else {
-		r.RetryAttempts.Value = 17
 	}
 
 	return r
@@ -52,8 +50,6 @@ func (o Output) VisitBuffer(b common.Buffer) common.Buffer {
 		case logging.OutputDeliveryModeAtMostOnce:
 			b.WhenFull.Value = common.BufferWhenFullDropNewest
 		}
-	} else {
-		b.WhenFull.Value = common.BufferWhenFullDropNewest
 	}
 	return b
 }

--- a/internal/generator/vector/output/factory_test_loki_no_throttle.toml
+++ b/internal/generator/vector/output/factory_test_loki_no_throttle.toml
@@ -40,12 +40,6 @@ healthcheck.enabled = false
 [sinks.output_default_loki_apps.encoding]
 codec = "json"
 
-[sinks.output_default_loki_apps.buffer]
-when_full = "drop_newest"
-
-[sinks.output_default_loki_apps.request]
-retry_attempts = 17
-
 [sinks.output_default_loki_apps.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"

--- a/internal/generator/vector/output/factory_test_loki_with_throttle.toml
+++ b/internal/generator/vector/output/factory_test_loki_with_throttle.toml
@@ -46,12 +46,6 @@ healthcheck.enabled = false
 [sinks.output_default_loki_apps.encoding]
 codec = "json"
 
-[sinks.output_default_loki_apps.buffer]
-when_full = "drop_newest"
-
-[sinks.output_default_loki_apps.request]
-retry_attempts = 17
-
 [sinks.output_default_loki_apps.labels]
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"


### PR DESCRIPTION
### Description
This PR reverts #2220 which introduces significant log loss.  The intent is to do more testing to determine if rotate_wait setting may have resolved  high memory consumption

### Links
* https://issues.redhat.com/browse/LOG-5123
