### PR TITLE
LOG-5121: Prevent LogType names from starting with underscores (_) for Azure log forwarder

### DIFF
--- a/internal/validations/clusterlogforwarder/outputs/azuremonitor.go
+++ b/internal/validations/clusterlogforwarder/outputs/azuremonitor.go
@@ -1,23 +1,24 @@
 package outputs
 
 import (
+	"regexp"
+
 	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/status"
 	"github.com/openshift/cluster-logging-operator/internal/validations/clusterlogforwarder/conditions"
 	corev1 "k8s.io/api/core/v1"
-	"regexp"
 )
 
 func VerifyAzureMonitorLog(name string, azml *loggingv1.AzureMonitor) (bool, status.Condition) {
-	pattern := "^[a-zA-Z0-9_]{1,100}$"
+	pattern := "^[a-zA-Z0-9][a-zA-Z0-9_]{0,99}$"
 	// Compile the regex pattern
 	reg := regexp.MustCompile(pattern)
 	if azml.LogType == "" {
 		return false, conditions.CondInvalid("output %q: LogType must be set.", name)
 	}
 	if !reg.MatchString(azml.LogType) {
-		return false, conditions.CondInvalid("output %q: LogType can only contain letters, numbers, and underscores (_), and may not exceed 100 characters.", name)
+		return false, conditions.CondInvalid("output %q: LogType names must start with a letter/number, contain only letters/numbers/underscores (_), and be between 1-100 characters.", name)
 	}
 	if azml.CustomerId == "" {
 		return false, conditions.CondInvalid("output %q: CustomerId must be set.", name)

--- a/internal/validations/clusterlogforwarder/outputs/azuremonitor_test.go
+++ b/internal/validations/clusterlogforwarder/outputs/azuremonitor_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Validate AzureMonitor:", func() {
 			}
 			valid, st := VerifyAzureMonitorLog("azureMonitor", azureMonitor)
 			Expect(valid).To(BeFalse())
-			Expect(map[string]status.Condition{"azureMonitor": st}).To(HaveCondition("Ready", false, loggingv1.ReasonInvalid, "output \"azureMonitor\": LogType can only contain letters, numbers, and underscores \\(_\\), and may not exceed 100 characters."))
+			Expect(map[string]status.Condition{"azureMonitor": st}).To(HaveCondition("Ready", false, loggingv1.ReasonInvalid, "output \"azureMonitor\": LogType names must start with a letter/number, contain only letters/numbers/underscores \\(_\\), and be between 1-100 characters."))
 		})
 
 		It("should fail if logType bad format: longer than 100", func() {
@@ -51,7 +51,17 @@ var _ = Describe("Validate AzureMonitor:", func() {
 			}
 			valid, st := VerifyAzureMonitorLog("azureMonitor", azureMonitor)
 			Expect(valid).To(BeFalse())
-			Expect(map[string]status.Condition{"azureMonitor": st}).To(HaveCondition("Ready", false, loggingv1.ReasonInvalid, "output \"azureMonitor\": LogType can only contain letters, numbers, and underscores \\(_\\), and may not exceed 100 characters."))
+			Expect(map[string]status.Condition{"azureMonitor": st}).To(HaveCondition("Ready", false, loggingv1.ReasonInvalid, "output \"azureMonitor\": LogType names must start with a letter/number, contain only letters/numbers/underscores \\(_\\), and be between 1-100 characters."))
+		})
+
+		It("should fail if logType bad format: begins on '_'", func() {
+			azureMonitor := &loggingv1.AzureMonitor{
+				CustomerId: "customer",
+				LogType:    "_testType",
+			}
+			valid, st := VerifyAzureMonitorLog("azureMonitor", azureMonitor)
+			Expect(valid).To(BeFalse())
+			Expect(map[string]status.Condition{"azureMonitor": st}).To(HaveCondition("Ready", false, loggingv1.ReasonInvalid, "output \"azureMonitor\": LogType names must start with a letter/number, contain only letters/numbers/underscores \\(_\\), and be between 1-100 characters."))
 		})
 
 		It("should fail if no customerId", func() {

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec_test.go
@@ -2,9 +2,10 @@ package clusterlogforwarder
 
 import (
 	"fmt"
+	"testing"
+
 	v12 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-logging-operator/test/helpers/rand"
-	"testing"
 
 	"github.com/openshift/cluster-logging-operator/internal/migrations/clusterlogforwarder"
 	v1 "k8s.io/apiserver/pkg/apis/audit/v1"
@@ -343,7 +344,7 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 				},
 			}
 			verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
-			Expect(clfStatus.Outputs["azml"]).To(HaveCondition("Ready", false, "Invalid", "output \"azml\": LogType can only contain letters, numbers, and underscores \\(_\\), and may not exceed 100 characters."))
+			Expect(clfStatus.Outputs["azml"]).To(HaveCondition("Ready", false, "Invalid", "output \"azml\": LogType names must start with a letter/number, contain only letters/numbers/underscores \\(_\\), and be between 1-100 characters."))
 		})
 
 		It("should fail Azure Monitor Logs output without OutputTypeSpec", func() {
@@ -387,7 +388,7 @@ var _ = Describe("Validate clusterlogforwarderspec", func() {
 				},
 			}
 			verifyOutputs(namespace, client, forwarderSpec, clfStatus, extras)
-			Expect(clfStatus.Outputs["azml"]).To(HaveCondition("Ready", false, "Invalid", "output \"azml\": LogType can only contain letters, numbers, and underscores \\(_\\), and may not exceed 100 characters."))
+			Expect(clfStatus.Outputs["azml"]).To(HaveCondition("Ready", false, "Invalid", "output \"azml\": LogType names must start with a letter/number, contain only letters/numbers/underscores \\(_\\), and be between 1-100 characters."))
 		})
 
 		It("should fail Azure Monitor Logs output without CustomerId", func() {


### PR DESCRIPTION
### Description
This PR implements a rule to prevent LogType names from starting with an underscore (_). 
`_invalidName` : not valid name


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5121
- Enhancement proposal:
