### PR TITLE
LOG-5125: Disable API and feature gate for OTEL

### DIFF
--- a/api/logging/v1/output_types.go
+++ b/api/logging/v1/output_types.go
@@ -320,7 +320,8 @@ type Http struct {
 	// +kubebuilder:validation:Enum:=opentelemetry;viaq
 	// +kubebuilder:default:viaq
 	// +optional
-	Schema string `json:"schema,omitempty"`
+	// +operator-sdk:csv:customresourcedefinitions:xDescriptors={"urn:alm:descriptor:com.tectonic.ui:hidden"}
+	Schema string `json:"-"`
 }
 
 type AzureMonitor struct {

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -659,15 +659,6 @@ spec:
                           - TRACE
                           - PATCH
                           type: string
-                        schema:
-                          description: "Schema enables configuration of the way log
-                            records are normalized. \n Supported models: viaq(default),
-                            opentelemetry \n Logs are converted to the Open Telemetry
-                            specification according to schema value"
-                          enum:
-                          - opentelemetry
-                          - viaq
-                          type: string
                         timeout:
                           description: Timeout specifies the Http request timeout
                             in seconds. If not set, 10secs is used.

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -660,15 +660,6 @@ spec:
                           - TRACE
                           - PATCH
                           type: string
-                        schema:
-                          description: "Schema enables configuration of the way log
-                            records are normalized. \n Supported models: viaq(default),
-                            opentelemetry \n Logs are converted to the Open Telemetry
-                            specification according to schema value"
-                          enum:
-                          - opentelemetry
-                          - viaq
-                          type: string
                         timeout:
                           description: Timeout specifies the Http request timeout
                             in seconds. If not set, 10secs is used.

--- a/internal/k8shandler/forwarding.go
+++ b/internal/k8shandler/forwarding.go
@@ -32,11 +32,6 @@ func EvaluateAnnotationsForEnabledCapabilities(forwarder *logging.ClusterLogForw
 			if strings.ToLower(value) == "true" {
 				options[helpers.EnableDebugOutput] = "true"
 			}
-
-		case constants.AnnotationEnableSchema:
-			if strings.ToLower(value) == constants.Enabled {
-				options[constants.AnnotationEnableSchema] = "true"
-			}
 		}
 	}
 }

--- a/test/functional/normalization/schema/otel_test.go
+++ b/test/functional/normalization/schema/otel_test.go
@@ -32,7 +32,7 @@ var _ = Describe("[Functional][Normalization][Schema] OTEL", func() {
 		framework.Cleanup()
 	})
 
-	It("should normalize application logs to OTEL format for HTTP sink", func() {
+	It("should not normalize application logs to OTEL format for HTTP sink", func() {
 		functional.NewClusterLogForwarderBuilder(framework.Forwarder).
 			FromInput(loggingv1.InputNameApplication).
 			ToHttpOutputWithSchema(constants.OTELSchema)
@@ -52,11 +52,10 @@ var _ = Describe("[Functional][Normalization][Schema] OTEL", func() {
 
 		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
 		otelLog := logs[0].ContainerLog
-		Expect(otelLog.TimeUnixNano).To(Equal(timestampNano), "Expect timestamp to be converted into unix nano")
-		Expect(otelLog.SeverityText).ToNot(BeNil(), "Expect severityText to exist")
-		Expect(otelLog.SeverityNumber).To(Equal(9), "Expect severityNumber to parse to 9")
-		Expect(otelLog.Resources).ToNot(BeNil(), "Expect resources to exist")
-		Expect(otelLog.Resources.K8s.Namespace.Name).To(Equal(appNamespace), "Expect namespace name to be nested under k8s.namespace")
+		Expect(otelLog.TimeUnixNano).ToNot(Equal(timestampNano), "Expect timestamp to not be converted into unix nano")
+		Expect(otelLog.SeverityText).To(BeEmpty(), "Expect severityText to be an empty string")
+		Expect(otelLog.SeverityNumber).ToNot(Equal(9), "Expect severityNumber to not be parsed to 9")
+		Expect(otelLog.Resources.K8s.Namespace.Name).ToNot(Equal(appNamespace), "Expect namespace name to not be nested under k8s.namespace")
 	})
 
 })


### PR DESCRIPTION
### Description
This PR disables the API for the `OTEL` schema option under the `http` sink for vector. It also disables the feature gate that was required to enable it.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5125

