### PR TITLE
LOG-5140: CLO panic when input.receiver.syslog is not defined.

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
@@ -137,10 +137,10 @@ func gatherPipelineInputs(clf loggingv1.ClusterLogForwarder) (sets.String, bool)
 			}
 		}
 
-		if input.Receiver != nil && input.Receiver.HTTP != nil {
+		if input.Receiver.IsHttpReceiver() || input.Receiver.IsSyslogReceiver() {
 			noOfReceivers += 1
 		}
-		if input.Receiver != nil && input.Receiver.Syslog != nil {
+		if input.Receiver.IsSyslogReceiver() {
 			inputTypes.Insert(loggingv1.InputNameInfrastructure)
 		}
 	}

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account_test.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account_test.go
@@ -219,6 +219,32 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder permissio
 			Expect(ValidateServiceAccount(customClf, k8sClient, extras)).To(Succeed())
 		})
 
+		It("should pass validation if service account can collect external logs and there is a Syslog receiver without receiverTypeSpec", func() {
+			const syslogInputName = `syslog-receiver`
+			customClf.Spec = loggingv1.ClusterLogForwarderSpec{
+				ServiceAccountName: clfServiceAccount.Name,
+
+				Inputs: []loggingv1.InputSpec{
+					{
+						Name: syslogInputName,
+						Receiver: &loggingv1.ReceiverSpec{
+							Type: loggingv1.ReceiverTypeSyslog,
+						},
+					},
+				},
+
+				Pipelines: []loggingv1.PipelineSpec{
+					{
+						Name: "pipeline1",
+						InputRefs: []string{
+							syslogInputName,
+						},
+					},
+				},
+			}
+			Expect(ValidateServiceAccount(customClf, k8sClient, extras)).To(Succeed())
+		})
+
 		Context("when evaluating custom application inputs that spec infrastructure namespaces", func() {
 			const appWithInfraNSInputName = "appWithInfra"
 			var k8sAppClient client.Client


### PR DESCRIPTION
### Description

This PR fixes a nil pointer exception during service account validation for custom CLFs if they spec a receiver input without a `receiverTypeSpec`.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5140

