### PR TITLE
LOG-5148: The integer values are converted to float values

### DIFF
--- a/internal/generator/vector/output/config_strategy.go
+++ b/internal/generator/vector/output/config_strategy.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"time"
+
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
 )
@@ -29,11 +31,15 @@ func (o Output) VisitBatch(b common.Batch) common.Batch {
 
 func (o Output) VisitRequest(r common.Request) common.Request {
 	if o.spec.Tuning != nil {
+		var duration time.Duration
 		if o.spec.Tuning.MinRetryDuration != nil && o.spec.Tuning.MinRetryDuration.Seconds() > 0 {
-			r.RetryInitialBackoffSec.Value = o.spec.Tuning.MinRetryDuration.Seconds()
+			// time.Duration is default nanosecond. Convert to seconds first.
+			duration = *o.spec.Tuning.MinRetryDuration * time.Second
+			r.RetryInitialBackoffSec.Value = duration.Seconds()
 		}
 		if o.spec.Tuning.MaxRetryDuration != nil && o.spec.Tuning.MaxRetryDuration.Seconds() > 0 {
-			r.RetryMaxDurationSec.Value = o.spec.Tuning.MaxRetryDuration.Seconds()
+			duration = *o.spec.Tuning.MaxRetryDuration * time.Second
+			r.RetryMaxDurationSec.Value = duration.Seconds()
 		}
 	}
 

--- a/internal/generator/vector/output/config_strategy_test.go
+++ b/internal/generator/vector/output/config_strategy_test.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
@@ -9,7 +11,6 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"time"
 )
 
 type fakeSink struct {
@@ -69,7 +70,7 @@ var _ = Describe("ConfigStrategy for tuning Outputs", func() {
 		It("should set request.retry_max_duration_secs for values greater then zero", func() {
 			output := NewOutput(logging.OutputSpec{
 				Tuning: &logging.OutputTuningSpec{
-					MaxRetryDuration: utils.GetPtr(35 * 1000 * time.Millisecond),
+					MaxRetryDuration: utils.GetPtr(time.Duration(35)),
 				},
 			}, nil, nil)
 
@@ -91,7 +92,7 @@ retry_max_duration_secs = 35
 		It("should set request.retry_initial_backoff_secs for values greater then zero", func() {
 			output := NewOutput(logging.OutputSpec{
 				Tuning: &logging.OutputTuningSpec{
-					MinRetryDuration: utils.GetPtr(25 * 1000 * time.Millisecond),
+					MinRetryDuration: utils.GetPtr(time.Duration(25)),
 				},
 			}, nil, nil)
 

--- a/internal/validations/clusterlogforwarder/outputs/tuning_test.go
+++ b/internal/validations/clusterlogforwarder/outputs/tuning_test.go
@@ -1,13 +1,14 @@
 package outputs
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"time"
 )
 
 var _ = Describe("Validate ", func() {
@@ -24,8 +25,8 @@ var _ = Describe("Validate ", func() {
 			Tuning: &loggingv1.OutputTuningSpec{
 				Compression:      "gzip",
 				Delivery:         "AtLeastOnce",
-				MinRetryDuration: utils.GetPtr(10 * time.Second),
-				MaxRetryDuration: utils.GetPtr(20 * time.Second),
+				MinRetryDuration: utils.GetPtr(time.Duration(10)),
+				MaxRetryDuration: utils.GetPtr(time.Duration(20)),
 				MaxWrite:         utils.GetPtr(resource.MustParse("10M")),
 			},
 		}),
@@ -56,13 +57,13 @@ var _ = Describe("Validate ", func() {
 		Entry("should fail for kafka when MaxRetryDuration is spec'd", false, loggingv1.OutputSpec{
 			Type: loggingv1.OutputTypeKafka,
 			Tuning: &loggingv1.OutputTuningSpec{
-				MaxRetryDuration: utils.GetPtr(1 * time.Second),
+				MaxRetryDuration: utils.GetPtr(time.Duration(1)),
 			},
 		}),
 		Entry("should fail for kafka when MinRetryDuration is spec'd", false, loggingv1.OutputSpec{
 			Type: loggingv1.OutputTypeKafka,
 			Tuning: &loggingv1.OutputTuningSpec{
-				MinRetryDuration: utils.GetPtr(1 * time.Second),
+				MinRetryDuration: utils.GetPtr(time.Duration(1)),
 			},
 		}),
 	)

--- a/test/functional/outputs/http/forward_to_http_test.go
+++ b/test/functional/outputs/http/forward_to_http_test.go
@@ -2,9 +2,10 @@ package http
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -30,8 +31,8 @@ var _ = Describe("[Functional][Outputs][Http] Functional tests", func() {
 			ToHttpOutput()
 		framework.Forwarder.Spec.Outputs[0].Tuning = &logging.OutputTuningSpec{
 			Delivery:         logging.OutputDeliveryModeAtLeastOnce,
-			MaxRetryDuration: utils.GetPtr(30 * time.Second),
-			MinRetryDuration: utils.GetPtr(5 * time.Second),
+			MaxRetryDuration: utils.GetPtr(time.Duration(30)),
+			MinRetryDuration: utils.GetPtr(time.Duration(5)),
 			MaxWrite:         utils.GetPtr(resource.MustParse("1M")),
 		}
 	})


### PR DESCRIPTION
### Description
This PR fixes the collector pods `CrashLoopBackOff` when `maxRetryDuration` or `minRetryDuration` was spec'd for tuning. When a CLF spec'd 2 as the duration it would convert it to 2e-09s. A `time.Duration` is default to nanoseconds and must be converted to `seconds` first.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5148

