### PR TITLE
LOG-5143: The tune option can not be appled when output name is default.

### DIFF
--- a/internal/logstore/lokistack/logstore_lokistack.go
+++ b/internal/logstore/lokistack/logstore_lokistack.go
@@ -219,6 +219,7 @@ func ProcessForwarderPipelines(logStore *loggingv1.LogStoreSpec, namespace strin
 	if spec.Outputs != nil {
 		outputs = spec.Outputs
 	}
+	outputMap := spec.OutputMap()
 	// Now create output from each input
 	for input := range needOutput {
 		tenant := getInputTypeFromName(spec, input)
@@ -229,6 +230,7 @@ func ProcessForwarderPipelines(logStore *loggingv1.LogStoreSpec, namespace strin
 			Secret: &loggingv1.OutputSecretSpec{
 				Name: saTokenSecret,
 			},
+			Tuning: getDefaultTuneSpec(outputMap),
 		})
 	}
 
@@ -299,4 +301,12 @@ func FormatOutputNameFromInput(inputName string) string {
 	}
 
 	return loggingv1.OutputNameDefault + "-" + inputName
+}
+
+// getDefaultTuneSpec returns a tuning spec if defined for the default lokistack in spec.Outputs
+func getDefaultTuneSpec(outputMap map[string]*loggingv1.OutputSpec) *loggingv1.OutputTuningSpec {
+	if output, ok := outputMap[loggingv1.OutputNameDefault]; ok && output.Type == loggingv1.OutputTypeLoki {
+		return output.Tuning
+	}
+	return nil
 }

--- a/internal/logstore/lokistack/logstore_lokistack_test.go
+++ b/internal/logstore/lokistack/logstore_lokistack_test.go
@@ -62,6 +62,53 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 			},
 		},
 		{
+			desc: "single tenant - single output with defined default tune spec",
+			spec: loggingv1.ClusterLogForwarderSpec{
+				Outputs: []loggingv1.OutputSpec{
+					{
+						Name: loggingv1.OutputNameDefault,
+						Type: loggingv1.OutputTypeLoki,
+						Tuning: &loggingv1.OutputTuningSpec{
+							Delivery: loggingv1.OutputDeliveryModeAtLeastOnce,
+						},
+					},
+				},
+				Pipelines: []loggingv1.PipelineSpec{
+					{
+						OutputRefs: []string{loggingv1.OutputNameDefault},
+						InputRefs:  []string{loggingv1.InputNameApplication},
+					},
+				},
+			},
+			wantOutputs: []loggingv1.OutputSpec{
+				{
+					Name: loggingv1.OutputNameDefault,
+					Type: loggingv1.OutputTypeLoki,
+					Tuning: &loggingv1.OutputTuningSpec{
+						Delivery: loggingv1.OutputDeliveryModeAtLeastOnce,
+					},
+				},
+				{
+					Name: loggingv1.OutputNameDefault + "-loki-apps",
+					Type: loggingv1.OutputTypeLoki,
+					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/application",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
+					Tuning: &loggingv1.OutputTuningSpec{
+						Delivery: loggingv1.OutputDeliveryModeAtLeastOnce,
+					},
+				},
+			},
+			wantPipelines: []loggingv1.PipelineSpec{
+				{
+					Name:       "default_loki_pipeline_0_",
+					OutputRefs: []string{loggingv1.OutputNameDefault + "-loki-apps"},
+					InputRefs:  []string{loggingv1.InputNameApplication},
+				},
+			},
+		},
+		{
 			desc: "multiple tenants - single output",
 			spec: loggingv1.ClusterLogForwarderSpec{
 				Pipelines: []loggingv1.PipelineSpec{
@@ -89,6 +136,72 @@ func TestProcessPipelinesForLokiStack(t *testing.T) {
 					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/infrastructure",
 					Secret: &loggingv1.OutputSecretSpec{
 						Name: constants.LogCollectorToken,
+					},
+				},
+			},
+			wantPipelines: []loggingv1.PipelineSpec{
+				{
+					Name:       "default_loki_pipeline_0_",
+					OutputRefs: []string{loggingv1.OutputNameDefault + "-loki-apps"},
+					InputRefs:  []string{loggingv1.InputNameApplication},
+				},
+				{
+					Name:       "default_loki_pipeline_1_",
+					OutputRefs: []string{loggingv1.OutputNameDefault + "-loki-infra"},
+					InputRefs:  []string{loggingv1.InputNameInfrastructure},
+				},
+			},
+		},
+		{
+			desc: "multiple tenants - single output with defined default tuning spec",
+			spec: loggingv1.ClusterLogForwarderSpec{
+				Outputs: []loggingv1.OutputSpec{
+					{
+						Name: loggingv1.OutputNameDefault,
+						Type: loggingv1.OutputTypeLoki,
+						Tuning: &loggingv1.OutputTuningSpec{
+							Delivery: loggingv1.OutputDeliveryModeAtLeastOnce,
+						},
+					},
+				},
+				Pipelines: []loggingv1.PipelineSpec{
+					{
+						OutputRefs: []string{loggingv1.OutputNameDefault},
+						InputRefs: []string{
+							loggingv1.InputNameApplication,
+							loggingv1.InputNameInfrastructure,
+						},
+					},
+				},
+			},
+			wantOutputs: []loggingv1.OutputSpec{
+				{
+					Name: loggingv1.OutputNameDefault,
+					Type: loggingv1.OutputTypeLoki,
+					Tuning: &loggingv1.OutputTuningSpec{
+						Delivery: loggingv1.OutputDeliveryModeAtLeastOnce,
+					},
+				},
+				{
+					Name: loggingv1.OutputNameDefault + "-loki-apps",
+					Type: loggingv1.OutputTypeLoki,
+					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/application",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
+					Tuning: &loggingv1.OutputTuningSpec{
+						Delivery: loggingv1.OutputDeliveryModeAtLeastOnce,
+					},
+				},
+				{
+					Name: loggingv1.OutputNameDefault + "-loki-infra",
+					Type: loggingv1.OutputTypeLoki,
+					URL:  "https://lokistack-testing-gateway-http.aNamespace.svc:8080/api/logs/v1/infrastructure",
+					Secret: &loggingv1.OutputSecretSpec{
+						Name: constants.LogCollectorToken,
+					},
+					Tuning: &loggingv1.OutputTuningSpec{
+						Delivery: loggingv1.OutputDeliveryModeAtLeastOnce,
 					},
 				},
 			},

--- a/internal/migrations/clusterlogforwarder/migrate_clusterlogforwarder.go
+++ b/internal/migrations/clusterlogforwarder/migrate_clusterlogforwarder.go
@@ -2,6 +2,7 @@ package clusterlogforwarder
 
 import (
 	"fmt"
+
 	log "github.com/ViaQ/logerr/v2/log/static"
 	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
@@ -77,6 +78,9 @@ func migrateDefaultOutput(spec loggingv1.ClusterLogForwarderSpec, logStore *logg
 					}
 					if output.Elasticsearch != nil {
 						defaultOutput.Elasticsearch = output.Elasticsearch
+					}
+					if output.Tuning != nil {
+						defaultOutput.Tuning = output.Tuning
 					}
 					output = defaultOutput
 					// We set this, so we know it was our default that was migrated

--- a/internal/migrations/clusterlogforwarder/migrate_clusterlogforwarder_test.go
+++ b/internal/migrations/clusterlogforwarder/migrate_clusterlogforwarder_test.go
@@ -2,6 +2,7 @@ package clusterlogforwarder
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
@@ -206,91 +207,77 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 			Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 		})
 
-		Context("when a pipeline references 'default'", func() {
+		It("processes custom pipelines to default LokiStack log store with default loki output spec'd with tuning parameters", func() {
+			logstore = &logging.LogStoreSpec{
+				Type: logging.LogStoreTypeLokiStack,
+				LokiStack: logging.LokiStackStoreSpec{
+					Name: "lokistack-testing",
+				},
+			}
+			tune := &logging.OutputTuningSpec{
+				Delivery:    logging.OutputDeliveryModeAtLeastOnce,
+				Compression: "gzip",
+			}
+			outputWithTuning := logging.OutputSpec{
+				Name:   logging.OutputNameDefault,
+				Type:   logging.OutputTypeLoki,
+				Tuning: tune,
+			}
+			spec = logging.ClusterLogForwarderSpec{
+				Outputs: []logging.OutputSpec{
+					outputWithTuning,
+				},
+				Pipelines: []logging.PipelineSpec{
+					{
+						InputRefs:  []string{logging.InputNameApplication, logging.InputNameAudit},
+						OutputRefs: []string{"default"},
+					},
+				},
+			}
 
-			var exp logging.ClusterLogForwarderSpec
-			BeforeEach(func() {
-				logstore = &logging.LogStoreSpec{Type: logging.OutputTypeElasticsearch}
-				pipelines[0].OutputRefs = append(spec.Pipelines[0].OutputRefs, logging.OutputNameDefault)
-				spec = logging.ClusterLogForwarderSpec{
-					Outputs:   outputs,
-					Pipelines: pipelines,
-				}
-			})
+			spec, extras, _ = MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
 
-			Context("and outputs does not explicitly spec 'default'", func() {
-				BeforeEach(func() {
-					exp = *spec.DeepCopy()
-					exp.Outputs = append(outputs, NewDefaultOutput(nil, constants.CollectorName))
-					exp.ServiceAccountName = constants.CollectorServiceAccountName
-				})
-
-				It("should add the default OutputSpec", func() {
-					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
-					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
-					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
-				})
-
-				It("should add the default OutputSpec and OutputDefaults when OutputDefaults are spec'd", func() {
-					spec.OutputDefaults = &logging.OutputDefaults{
-						Elasticsearch: &logging.ElasticsearchStructuredSpec{
-							StructuredTypeKey: "foo.bar",
+			Expect(spec).To(Equal(
+				logging.ClusterLogForwarderSpec{
+					Pipelines: []logging.PipelineSpec{
+						{
+							Name:       "default_loki_pipeline_0_",
+							InputRefs:  []string{logging.InputNameApplication},
+							OutputRefs: []string{"default-loki-apps"},
 						},
-					}
-					exp.Outputs[1].Elasticsearch = &logging.Elasticsearch{ElasticsearchStructuredSpec: *spec.OutputDefaults.Elasticsearch}
-					exp.OutputDefaults = spec.OutputDefaults
-
-					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
-
-					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and OutputDefault %v", pipelines, spec.OutputDefaults))
-					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
-				})
-			})
-
-			Context("and outputs includes an OutputSpec named 'default'", func() {
-				var tobereplaced logging.OutputSpec
-				BeforeEach(func() {
-					tobereplaced = logging.OutputSpec{
-						Name:   logging.OutputNameDefault,
-						Type:   logging.OutputTypeElasticsearch,
-						URL:    "thiswillgetreplaced",
-						Secret: &logging.OutputSecretSpec{Name: "replacem"},
-					}
-
-				})
-
-				It("should replace the OutputSpec with the default OutputSpec", func() {
-					spec = logging.ClusterLogForwarderSpec{
-						Outputs:   append(outputs, tobereplaced),
-						Pipelines: pipelines,
-					}
-					exp = *spec.DeepCopy()
-					exp.Outputs = append(outputs, NewDefaultOutput(nil, constants.CollectorName))
-					exp.ServiceAccountName = constants.CollectorServiceAccountName
-
-					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
-					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
-					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
-				})
-
-				It("should replace the OutputSpec with the default OutputSpec and use the config (e.g. structureTypeKey) defined in the original OutputSpec", func() {
-					tobereplaced.Elasticsearch = esSpec
-					spec = logging.ClusterLogForwarderSpec{
-						Outputs:        append(outputs, tobereplaced),
-						Pipelines:      pipelines,
-						OutputDefaults: &logging.OutputDefaults{Elasticsearch: &logging.ElasticsearchStructuredSpec{StructuredTypeKey: "abc"}},
-					}
-					exp = *spec.DeepCopy()
-					exp.Outputs = append(outputs, NewDefaultOutput(&logging.OutputDefaults{Elasticsearch: &esSpec.ElasticsearchStructuredSpec}, constants.CollectorName))
-					exp.ServiceAccountName = constants.CollectorServiceAccountName
-
-					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
-					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
-					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
-				})
-			})
-
+						{
+							Name:       "default_loki_pipeline_1_",
+							InputRefs:  []string{logging.InputNameAudit},
+							OutputRefs: []string{"default-loki-audit"},
+						},
+					},
+					Outputs: []logging.OutputSpec{
+						outputWithTuning,
+						{
+							Name: "default-loki-apps",
+							Type: logging.OutputTypeLoki,
+							URL:  "https://lokistack-testing-gateway-http.openshift-logging.svc:8080/api/logs/v1/application",
+							Secret: &logging.OutputSecretSpec{
+								Name: constants.LogCollectorToken,
+							},
+							Tuning: tune,
+						},
+						{
+							Name: "default-loki-audit",
+							Type: logging.OutputTypeLoki,
+							URL:  "https://lokistack-testing-gateway-http.openshift-logging.svc:8080/api/logs/v1/audit",
+							Secret: &logging.OutputSecretSpec{
+								Name: constants.LogCollectorToken,
+							},
+							Tuning: tune,
+						},
+					},
+					ServiceAccountName: constants.CollectorServiceAccountName,
+				},
+			))
+			Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 		})
+
 		Context("when a pipeline references 'default'", func() {
 
 			var exp logging.ClusterLogForwarderSpec
@@ -315,6 +302,7 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v", pipelines))
 					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 				})
+
 				It("should add the default OutputSpec and OutputDefaults when OutputDefaults are spec'd", func() {
 					spec.OutputDefaults = &logging.OutputDefaults{
 						Elasticsearch: &logging.ElasticsearchStructuredSpec{
@@ -372,7 +360,28 @@ var _ = Describe("MigrateClusterLogForwarderSpec", func() {
 					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
 					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
 				})
+
+				It("should replace the OutputSpec with the default OutputSpec and use the tune spec defined in the original OutputSpec", func() {
+					tuneSpec := &logging.OutputTuningSpec{
+						Delivery: logging.OutputDeliveryModeAtLeastOnce,
+					}
+					tobereplaced.Tuning = tuneSpec
+					spec = logging.ClusterLogForwarderSpec{
+						Outputs:   append(outputs, tobereplaced),
+						Pipelines: pipelines,
+					}
+					exp = *spec.DeepCopy()
+					defaultOut := NewDefaultOutput(nil, constants.CollectorName)
+					defaultOut.Tuning = tuneSpec
+					exp.Outputs = append(outputs, defaultOut)
+					exp.ServiceAccountName = constants.CollectorServiceAccountName
+
+					forwarderSpec, extras, _ := MigrateClusterLogForwarderSpec(constants.OpenshiftNS, constants.SingletonName, spec, logstore, extras, constants.CollectorName, constants.LogCollectorToken)
+					Expect(forwarderSpec).To(Equal(exp), fmt.Sprintf("Exp. default output because of pipeline %v and ElasticsearchSpec %v", pipelines, esSpec))
+					Expect(extras).To(Equal(map[string]bool{constants.MigrateDefaultOutput: true}))
+				})
 			})
+
 		})
 	})
 })


### PR DESCRIPTION
### Description
This PR fixes the issue where the default outputs (Elasticsearch & LokiStack) did not take into account the tuning parameters if a user defined them in the outputs.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5143

