### PR TITLE
LOG-5145: Correct the range of supported ocp versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ coverage: test-unit
 test-cluster:
 	go test  -cover -race ./test/... -- -root=$(CURDIR)
 
-OPENSHIFT_VERSIONS?="v4.13-v4.17"
+OPENSHIFT_VERSIONS?="v4.13-v4.16"
 # Generate bundle manifests and metadata, then validate generated files.
 BUNDLE_VERSION?=$(VERSION)
 CHANNEL=$(or $(filename $(OVERLAY)),stable)

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -16,7 +16,7 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.13-v4.17"
+LABEL com.redhat.openshift.versions="v4.13-v4.16"
 
 LABEL \
     com.redhat.component="cluster-logging-operator" \


### PR DESCRIPTION
### Description
Correct the range of supported ocp versions

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- https://issues.redhat.com/browse/LOG-5145
