### PR TITLE
LOG-5163: Rely upon http output timeout default

### DIFF
--- a/internal/generator/vector/conf/complex_otel.toml
+++ b/internal/generator/vector/conf/complex_otel.toml
@@ -467,7 +467,6 @@ method = "post"
 codec = "json"
 
 [sinks.output_http_receiver.request]
-timeout_secs = 10
 headers = {"h1"="v1","h2"="v2"}
 
 [sinks.output_http_receiver.tls]

--- a/internal/generator/vector/output/common/request.go
+++ b/internal/generator/vector/output/common/request.go
@@ -38,7 +38,7 @@ func (r *Request) Name() string {
 }
 
 func (r *Request) isEmpty() bool {
-	return r.RetryInitialBackoffSec.String()+
+	return len(r.headers) == 0 && r.RetryInitialBackoffSec.String()+
 		r.RetryMaxDurationSec.String()+
 		r.RetryAttempts.String()+
 		r.Concurrency.String()+

--- a/internal/generator/vector/output/http/http.go
+++ b/internal/generator/vector/output/http/http.go
@@ -15,10 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const (
-	DefaultHttpTimeoutSecs = 10
-)
-
 var (
 	httpEncodingJson = fmt.Sprintf("%q", "json")
 )
@@ -64,40 +60,6 @@ func (h HttpEncoding) Template() string {
 	return `{{define "` + h.Name() + `" -}}
 [sinks.{{.ComponentID}}.encoding]
 codec = {{.Codec}}
-{{end}}`
-}
-
-type HttpBatch struct {
-	ComponentID string
-	MaxBytes    string
-}
-
-func (b HttpBatch) Name() string {
-	return "vectorHttpBatch"
-}
-
-func (b HttpBatch) Template() string {
-	return `{{define "` + b.Name() + `" -}}
-[sinks.{{.ComponentID}}.batch]
-max_bytes = {{.MaxBytes}}
-{{end}}`
-}
-
-type HttpRequest struct {
-	ComponentID string
-	Timeout     string
-	Headers     Element
-}
-
-func (h HttpRequest) Name() string {
-	return "vectorHttpRequest"
-}
-
-func (h HttpRequest) Template() string {
-	return `{{define "` + h.Name() + `" -}}
-[sinks.{{.ComponentID}}.request]
-timeout_secs = {{.Timeout}}
-{{kv .Headers -}}
 {{end}}`
 }
 
@@ -184,12 +146,10 @@ func Method(h *logging.Http) string {
 }
 
 func Request(id string, o logging.OutputSpec, strategy common.ConfigStrategy) *common.Request {
-	timeout := DefaultHttpTimeoutSecs
-	if o.Http != nil && o.Http.Timeout != 0 {
-		timeout = o.Http.Timeout
-	}
 	req := common.NewRequest(id, strategy)
-	req.TimeoutSecs.Value = timeout
+	if o.Http != nil && o.Http.Timeout != 0 {
+		req.TimeoutSecs.Value = o.Http.Timeout
+	}
 	if o.Http != nil && len(o.Http.Headers) != 0 {
 		req.SetHeaders(o.Http.Headers)
 	}

--- a/internal/generator/vector/output/http/http_test.go
+++ b/internal/generator/vector/output/http/http_test.go
@@ -88,7 +88,6 @@ method = "post"
 codec = "json"
 
 [sinks.http_receiver.request]
-timeout_secs = 10
 headers = {"h1"="v1","h2"="v2"}
 
 # Basic Auth Config
@@ -165,7 +164,6 @@ method = "post"
 codec = "json"
 
 [sinks.http_receiver.request]
-timeout_secs = 10
 headers = {"h1"="v1","h2"="v2"}
 
 # Bearer Auth Config
@@ -589,7 +587,6 @@ method = "post"
 codec = "json"
 
 [sinks.http_receiver.request]
-timeout_secs = 10
 headers = {"h1"="v1","h2"="v2"}
 
 # Basic Auth Config
@@ -657,9 +654,6 @@ method = "post"
 
 [sinks.http_receiver.encoding]
 codec = "json"
-
-[sinks.http_receiver.request]
-timeout_secs = 10
 
 # Basic Auth Config
 [sinks.http_receiver.auth]


### PR DESCRIPTION
### Description
This PR:
* Revert http output types to rely upon the defaults because the override was unintentionally added
* Removes unused http batch templates

### Links
* https://issues.redhat.com/browse/LOG-5163

cc @Clee2691 
