### PR TITLE
LOG-5158: The invalid compression value, '', in vector.toml

### DIFF
--- a/api/logging/v1/cluster_log_forwarder_types.go
+++ b/api/logging/v1/cluster_log_forwarder_types.go
@@ -15,11 +15,12 @@ limitations under the License.
 package v1
 
 import (
+	"time"
+
 	openshiftv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-logging-operator/internal/status"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 const ClusterLogForwarderKind = "ClusterLogForwarder"
@@ -249,7 +250,7 @@ type OutputTuningSpec struct {
 	// It is an error if the compression type is not supported by the  output.
 	//
 	// +optional
-	// +kubebuilder:validation:Enum:='';gzip;none;snappy;zlib;zstd
+	// +kubebuilder:validation:Enum:=gzip;none;snappy;zlib;zstd
 	Compression string `json:"compression,omitempty"`
 
 	// MaxWrite limits the maximum payload in terms of bytes of a single "send" to the output.

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -978,7 +978,6 @@ spec:
                             sending over the network. It is an error if the compression
                             type is not supported by the  output.
                           enum:
-                          - ''''''
                           - gzip
                           - none
                           - snappy

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -979,7 +979,6 @@ spec:
                             sending over the network. It is an error if the compression
                             type is not supported by the  output.
                           enum:
-                          - ''''''
                           - gzip
                           - none
                           - snappy


### PR DESCRIPTION
### Description
This PR fixes the invalid configuration for `compression` in a `vector.toml` when an output spec's `''` as the compression.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5158

