### PR TITLE
LOG-5166: Validate allocated buffer for CLF

### DIFF
--- a/internal/generator/vector/output/common/buffer.go
+++ b/internal/generator/vector/output/common/buffer.go
@@ -3,6 +3,9 @@ package common
 import "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
 
 const (
+	//BufferMinSizeBytes is the minimal buffer required by vector for disk buffers
+	BufferMinSizeBytes       = 268435488
+	BufferTypeDisk           = "disk"
 	BufferWhenFullBlock      = "block"
 	BufferWhenFullDropNewest = "drop_newest"
 )

--- a/internal/generator/vector/output/config_strategy.go
+++ b/internal/generator/vector/output/config_strategy.go
@@ -7,11 +7,6 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
 )
 
-const (
-	minBufferSize   = 268435488
-	buffertTypeDisk = "disk"
-)
-
 func (o Output) VisitSink(s common.SinkConfig) {
 	if o.spec.Tuning != nil {
 		comp := o.spec.Tuning.Compression
@@ -56,8 +51,8 @@ func (o Output) VisitBuffer(b common.Buffer) common.Buffer {
 		switch o.spec.Tuning.Delivery {
 		case logging.OutputDeliveryModeAtLeastOnce:
 			b.WhenFull.Value = common.BufferWhenFullBlock
-			b.Type.Value = buffertTypeDisk
-			b.MaxSize.Value = minBufferSize
+			b.Type.Value = common.BufferTypeDisk
+			b.MaxSize.Value = common.BufferMinSizeBytes
 		case logging.OutputDeliveryModeAtMostOnce:
 			b.WhenFull.Value = common.BufferWhenFullDropNewest
 		}

--- a/internal/validations/clusterlogforwarder/outputs/tuning.go
+++ b/internal/validations/clusterlogforwarder/outputs/tuning.go
@@ -1,8 +1,14 @@
 package outputs
 
 import (
+	"context"
+	"fmt"
 	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
 	"github.com/openshift/cluster-logging-operator/internal/utils/sets"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sync"
 )
 
 const (
@@ -11,6 +17,14 @@ const (
 	maxRetryDurationNotSupportedForType = "maxRetryDuration is not supported for the output type"
 	minRetryDurationNotSupportedForType = "minRetryDuration is not supported for the output type"
 	maxWriteNotSupportedForType         = "maxWrite is not supported for the output type"
+
+	nodeDiskLimitExceeded = "The amount of allocated buffer exceeds the allowed node limit for all ClusterLogForwarders. The delivery mode for one or more outputs for any ClusterLogForwarder must be adjusted."
+
+	//nodeDiskLimitPercent is the maximum disk usage by all forwarder deployments
+	nodeDiskLimitPercent = 15
+
+	//nodeDiskSize is the assumed size of the disk of an OCP cluster
+	nodeDiskSize = "120G"
 )
 
 var (
@@ -39,7 +53,16 @@ var (
 	}
 	unsupportedRequest = sets.NewString(loggingv1.OutputTypeSyslog, loggingv1.OutputTypeKafka)
 	unsupportedBatch   = sets.NewString(loggingv1.OutputTypeSyslog)
+
+	nodeDiskLimitBytes int64
+
+	lock sync.Mutex
 )
+
+func init() {
+	diskSizeBytes := resource.MustParse(nodeDiskSize)
+	nodeDiskLimitBytes = diskSizeBytes.Value() * nodeDiskLimitPercent / 100
+}
 
 func VerifyTuning(spec loggingv1.OutputSpec) (bool, string) {
 	if spec.Tuning == nil {
@@ -83,4 +106,34 @@ func verifyCompression(outputType string, compression string) string {
 	}
 
 	return ""
+}
+
+// ValidateCumulativeDiskBuffer validates outputs using disk buffers for all ClusterLogForwarders do not exceed the allowed threshold
+func ValidateCumulativeDiskBuffer(clf loggingv1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *loggingv1.ClusterLogForwarderStatus) {
+	lock.Lock()
+	defer lock.Unlock()
+	all := &loggingv1.ClusterLogForwarderList{}
+	if err := k8sClient.List(context.TODO(), all); err != nil {
+		return err, nil
+	}
+	allocatedBufferBytes := gatherAllocatedBuffer(clf)
+	for _, anotherCLF := range all.Items {
+		if anotherCLF.Namespace != clf.Namespace && anotherCLF.Name != clf.Name {
+			allocatedBufferBytes += gatherAllocatedBuffer(anotherCLF)
+		}
+	}
+	if allocatedBufferBytes > nodeDiskLimitBytes {
+		return fmt.Errorf(nodeDiskLimitExceeded), nil
+	}
+	return nil, nil
+}
+
+func gatherAllocatedBuffer(clf loggingv1.ClusterLogForwarder) int64 {
+	allocatedBufferBytes := int64(0)
+	for _, o := range clf.Spec.Outputs {
+		if o.Tuning != nil && o.Tuning.Delivery == loggingv1.OutputDeliveryModeAtLeastOnce {
+			allocatedBufferBytes += common.BufferMinSizeBytes
+		}
+	}
+	return allocatedBufferBytes
 }

--- a/internal/validations/clusterlogforwarder/outputs/tuning_test.go
+++ b/internal/validations/clusterlogforwarder/outputs/tuning_test.go
@@ -1,6 +1,11 @@
 package outputs
 
 import (
+	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -138,4 +143,75 @@ var _ = Describe("Validate ", func() {
 
 		})
 	})
+})
+
+var _ = Describe("ValidateCumulativeDiskBuffer", func() {
+
+	Context("when delivery mode is AtLeastOnce", func() {
+		var (
+			clf        *loggingv1.ClusterLogForwarder
+			extras     = map[string]bool{}
+			fakeClient client.Client
+			nodeDisk   = resource.MustParse("120G")
+			maxBuffer  = nodeDisk.Value() * nodeDiskLimitPercent / 100
+
+			builder *fake.ClientBuilder
+		)
+
+		BeforeEach(func() {
+			builder = fake.NewClientBuilder()
+			clf = runtime.NewClusterLogForwarder("testme", "checkme")
+			clf.Spec = loggingv1.ClusterLogForwarderSpec{
+				Outputs: []loggingv1.OutputSpec{
+					{
+						Tuning: &loggingv1.OutputTuningSpec{
+							Delivery: loggingv1.OutputDeliveryModeAtLeastOnce,
+						},
+					},
+				},
+			}
+		})
+
+		Context("and the node disk limit is below capacity", func() {
+			It("should not fail validation", func() {
+				fakeClient = builder.Build()
+				err, _ := ValidateCumulativeDiskBuffer(*clf, fakeClient, extras)
+				Expect(err).To(Succeed())
+			})
+		})
+
+		Context("and the node disk limit is at capacity", func() {
+			BeforeEach(func() {
+				totBuffer := int64(0)
+				for totBuffer < maxBuffer {
+					totBuffer += common.BufferMinSizeBytes
+					clf := runtime.NewClusterLogForwarder(fmt.Sprintf("mynamespace-%d", totBuffer/1000), "aforwarder")
+					clf.Spec = loggingv1.ClusterLogForwarderSpec{
+						Outputs: []loggingv1.OutputSpec{
+							{
+								Name: "anAtLeastOnceOutput",
+							},
+							{
+								Name: "anAtLeastOnceOutput",
+								Tuning: &loggingv1.OutputTuningSpec{
+									Delivery: loggingv1.OutputDeliveryModeAtLeastOnce,
+								},
+							},
+						},
+					}
+					builder.WithRuntimeObjects(clf)
+				}
+
+				builder.WithRuntimeObjects(clf)
+				fakeClient = builder.Build()
+			})
+			It("should fail validation when the total amount of allocated buffer across all outputs for all CLF exceeds the threshold percentage of the node disk", func() {
+				err, _ := ValidateCumulativeDiskBuffer(*clf, fakeClient, extras)
+				Expect(err).ToNot(Succeed())
+			})
+
+		})
+
+	})
+
 })


### PR DESCRIPTION
### Description
This PR:
* validates all CLFs to determine if nodeDiskBufferLimit is exceeded when AtLeastOnce is enabled

### Links
* https://issues.redhat.com/browse/LOG-5166