### PR TITLE
Add call to runtime SetLogger to resolve error

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,7 +86,10 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	utils.InitLogger("cluster-logging-operator")
+	logger := utils.InitLogger("cluster-logging-operator")
+	// LOG-5136 Fixes error caused by updates to controller-runtime
+	ctrl.SetLogger(logger)
+
 	log.Info("starting up...",
 		"operator_version", version.Version,
 		"go_version", runtime.Version(),


### PR DESCRIPTION
### Description
This quick fix adds a call to the controller-runtime SetLogger() to resolve an error in the CLO.   A recent update to the runtime now requires this call.
Following the fix, we are now seeing a series of runtime "info" logs generated for every watched resource.  Additionally, there are several "Reconciler errors" produced for various reasons, as well as a Warning about the CLF reconciler.   

I will create a new task to clean up the remaining messages (if possible).   Also, there've been several concerns raised with a confusion between log verbosity level and log priorty level.   Additional work will be required to refactor the levels.


/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- https://issues.redhat.com/browse/LOG-5136
