### PR TITLE
LOG-5174 & LOG-5177 & LOG-5178 && LOG-5179

### DIFF
--- a/api/logging/v1/cluster_log_forwarder_types.go
+++ b/api/logging/v1/cluster_log_forwarder_types.go
@@ -250,7 +250,7 @@ type OutputTuningSpec struct {
 	// It is an error if the compression type is not supported by the  output.
 	//
 	// +optional
-	// +kubebuilder:validation:Enum:=gzip;none;snappy;zlib;zstd
+	// +kubebuilder:validation:Enum:=gzip;none;snappy;zlib;zstd;lz4
 	Compression string `json:"compression,omitempty"`
 
 	// MaxWrite limits the maximum payload in terms of bytes of a single "send" to the output.

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -983,6 +983,7 @@ spec:
                           - snappy
                           - zlib
                           - zstd
+                          - lz4
                           type: string
                         delivery:
                           description: "Delivery mode for log forwarding. \n - AtLeastOnce

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -984,6 +984,7 @@ spec:
                           - snappy
                           - zlib
                           - zstd
+                          - lz4
                           type: string
                         delivery:
                           description: "Delivery mode for log forwarding. \n - AtLeastOnce

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -2,10 +2,11 @@ package elasticsearch
 
 import (
 	"fmt"
+	"strings"
+
 	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
-	"strings"
 
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
@@ -192,7 +193,7 @@ func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret
 		[]Element{
 			SetESIndex(esIndexID, inputs, o, op),
 			FlattenLabels(dedotID, []string{esIndexID}),
-			Output(id, o, []string{dedotID}, secret, op),
+			sink,
 			common.NewAcknowledgments(id, strategy),
 			common.NewBatch(id, strategy),
 			common.NewBuffer(id, strategy),

--- a/internal/generator/vector/output/gcl/gcl.go
+++ b/internal/generator/vector/output/gcl/gcl.go
@@ -2,6 +2,7 @@ package gcl
 
 import (
 	"fmt"
+
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
@@ -52,7 +53,6 @@ inputs = {{.Inputs}}
 credentials_path = {{.CredentialsPath}}
 log_id = "{{.LogID}}"
 severity_key = "{{.SeverityKey}}"
-
 
 [sinks.{{.ComponentID}}.resource]
 type = "k8s_node"

--- a/internal/generator/vector/output/kafka/kafka.go
+++ b/internal/generator/vector/output/kafka/kafka.go
@@ -2,10 +2,11 @@ package kafka
 
 import (
 	"fmt"
-	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
-	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
 	"net/url"
 	"strings"
+
+	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
 
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
 
@@ -43,6 +44,7 @@ type = "kafka"
 inputs = {{.Inputs}}
 bootstrap_servers = {{.BootstrapServers}}
 topic = {{.Topic}}
+{{.Compression}}
 {{end}}
 `
 }
@@ -67,7 +69,7 @@ func New(id string, o logging.OutputSpec, inputs []string, secret *corev1.Secret
 	return MergeElements(
 		[]Element{
 			normalize.DedotLabels(dedottedID, inputs),
-			Output(id, o, []string{dedottedID}, secret, op, brokers),
+			sink,
 			Encoding(id, op),
 			common.NewAcknowledgments(id, strategy),
 			common.NewBatch(id, strategy),

--- a/internal/validations/clusterlogforwarder/outputs/tuning.go
+++ b/internal/validations/clusterlogforwarder/outputs/tuning.go
@@ -13,7 +13,7 @@ const (
 )
 
 var (
-	unsupportedCompression = sets.NewString(loggingv1.OutputTypeSyslog, loggingv1.OutputTypeAzureMonitor)
+	unsupportedCompression = sets.NewString(loggingv1.OutputTypeSyslog, loggingv1.OutputTypeAzureMonitor, loggingv1.OutputTypeGoogleCloudLogging)
 	unsupportedRequest     = sets.NewString(loggingv1.OutputTypeSyslog, loggingv1.OutputTypeKafka)
 )
 
@@ -24,6 +24,11 @@ func VerifyTuning(spec loggingv1.OutputSpec) (valid bool, msg string) {
 
 	//compression
 	if unsupportedCompression.Has(spec.Type) && spec.Tuning.Compression != "" && spec.Tuning.Compression != "none" {
+		return false, compressionNotSupportedForType
+	}
+
+	// lz4 is only supported for kafka
+	if spec.Tuning.Compression == "lz4" && spec.Type != loggingv1.OutputTypeKafka {
 		return false, compressionNotSupportedForType
 	}
 

--- a/internal/validations/clusterlogforwarder/outputs/tuning_test.go
+++ b/internal/validations/clusterlogforwarder/outputs/tuning_test.go
@@ -54,6 +54,18 @@ var _ = Describe("Validate ", func() {
 				Compression: "gzip",
 			},
 		}),
+		Entry("should fail for gcp when compression is spec'd", false, loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeGoogleCloudLogging,
+			Tuning: &loggingv1.OutputTuningSpec{
+				Compression: "gzip",
+			},
+		}),
+		Entry("should pass for gcp when compression is empty", true, loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeGoogleCloudLogging,
+			Tuning: &loggingv1.OutputTuningSpec{
+				Compression: "",
+			},
+		}),
 		Entry("should fail for kafka when MaxRetryDuration is spec'd", false, loggingv1.OutputSpec{
 			Type: loggingv1.OutputTypeKafka,
 			Tuning: &loggingv1.OutputTuningSpec{
@@ -64,6 +76,18 @@ var _ = Describe("Validate ", func() {
 			Type: loggingv1.OutputTypeKafka,
 			Tuning: &loggingv1.OutputTuningSpec{
 				MinRetryDuration: utils.GetPtr(time.Duration(1)),
+			},
+		}),
+		Entry("should pass for kafka when lz4 spec'd as compression", true, loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeKafka,
+			Tuning: &loggingv1.OutputTuningSpec{
+				Compression: "lz4",
+			},
+		}),
+		Entry("should fail for elasticsearch when lz4 spec'd as compression", false, loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeElasticsearch,
+			Tuning: &loggingv1.OutputTuningSpec{
+				Compression: "lz4",
 			},
 		}),
 	)

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	urlhelper "github.com/openshift/cluster-logging-operator/internal/generator/url"
 	"github.com/openshift/cluster-logging-operator/internal/validations/clusterlogforwarder/outputs"
-	"strings"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	configv1 "github.com/openshift/api/config/v1"
@@ -253,6 +254,7 @@ func verifyOutputs(namespace string, clfClient client.Client, spec *loggingv1.Cl
 
 		if valid, msg := outputs.VerifyTuning(output); !valid {
 			log.V(3).Info("verify output tuning failed", "output name", output.Name, "message", msg)
+			status.Outputs.Set(output.Name, conditions.CondInvalid("output %q: %s", output.Name, msg))
 			status.Outputs.Set(output.Name, loggingv1.NewCondition(loggingv1.ValidationCondition,
 				corev1.ConditionTrue,
 				loggingv1.ValidationFailureReason,


### PR DESCRIPTION
### Description
This PR fixes 4 issues:
1. Allow compression to be set for Elasticsearch. [1]
2. Allow compression to be set for Kafka as well as add a new compression type `lz4`. [2]
3. Added validation for GCP sink because it does not support compression. [3]
4. Fix CLF validation for invalid tune specs. Will now invalidate the CLF if any tune specs are invalid. [4]

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA:
  1. https://issues.redhat.com/browse/LOG-5174
  2. https://issues.redhat.com/browse/LOG-5177
  3. https://issues.redhat.com/browse/LOG-5178
  4. https://issues.redhat.com/browse/LOG-5179