### PR TITLE
[release-5.6] Updates to API template to meet docs standards

### DIFF
--- a/config/docs/templates/apis/asciidoc/members.tpl
+++ b/config/docs/templates/apis/asciidoc/members.tpl
@@ -3,15 +3,21 @@
  {{ if not (or (or (fieldEmbedded .Member) (hiddenMember .Member) (ignoreMember .Member))) }}
 
 === {{ .Path }}
-===== Description
+
+{{ if (isDeprecatedMember .Member) }}
+  {{ "[IMPORTANT]\n" -}}
+  {{ "====\n" -}}
+  {{ "This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.\n" -}}
+  {{ "====" -}}
+{{ end }}
+
 {{ if .Type.Elem -}}
   {{ (comments .Type.Elem.CommentLines) }}
 {{- else -}}
   {{  (comments .Type.CommentLines) }}
 {{- end }}
 
-=====  Type
-* {{ (yamlType .Type) }}
+Type:: {{ (yamlType .Type) }}
 
 {{- template "properties" .Type  -}}
 {{- template "members" (nodeParent .Type .Path) -}}

--- a/config/docs/templates/apis/asciidoc/pkg.tpl
+++ b/config/docs/templates/apis/asciidoc/pkg.tpl
@@ -1,15 +1,27 @@
 {{- define "packages" -}}
-:toc:
-:toclevels: 2
-:toc-placement!:
+
+////
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="logging-5-x-reference"]
+= Logging 5.x API reference
+:context: filename
+
 toc::[]
+
+** These release notes are generated from the content in the openshift/cluster-logging-operator repository.
+** Do not modify the content here manually except for the metadata and section IDs - changes to the content should be made in the source code.
+////
 
 {{ range .packages -}}
 
     {{- range (sortedTypes (visibleTypes .Types )) -}}
-        {{- if isObjectRoot . -}}
+        {{if isObjectRoot . }}
 
+["id=logging-5-x-reference-{{ (typeDisplayName .) }}"]
 == {{ (typeDisplayName .) }}
+
 {{  (comments .CommentLines) }}
 {{  template "type" (nodeParent . "") -}}
 

--- a/docs/reference/operator/api.adoc
+++ b/docs/reference/operator/api.adoc
@@ -1,9 +1,20 @@
-:toc:
-:toclevels: 2
-:toc-placement!:
+////
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="logging-5-x-reference"]
+= Logging 5.x API reference
+:context: filename
+
 toc::[]
 
+** These release notes are generated from the content in the openshift/cluster-logging-operator repository.
+** Do not modify the content here manually except for the metadata and section IDs - changes to the content should be made in the source code.
+////
+
+["id=logging-5-x-reference-ClusterLogForwarder"]
 == ClusterLogForwarder
+
 ClusterLogForwarder is an API to configure forwarding logs.
 
 You configure forwarding by specifying a list of `pipelines`,
@@ -27,11 +38,10 @@ For more details see the documentation on the API fields.
 |======================
 
 === .spec
-===== Description
+
 ClusterLogForwarderSpec defines how logs should be forwarded to remote targets.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -44,11 +54,10 @@ ClusterLogForwarderSpec defines how logs should be forwarded to remote targets.
 |======================
 
 === .spec.inputs[]
-===== Description
+
 InputSpec defines a selector of log messages.
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -59,12 +68,11 @@ InputSpec defines a selector of log messages.
 |======================
 
 === .spec.inputs[].application
-===== Description
+
 Application log selector.
 All conditions in the selector must be satisfied (logical AND) to select logs.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -75,17 +83,14 @@ All conditions in the selector must be satisfied (logical AND) to select logs.
 |======================
 
 === .spec.inputs[].application.namespaces[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .spec.inputs[].application.selector
-===== Description
+
 A label selector is a label query over a set of resources.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -95,16 +100,12 @@ A label selector is a label query over a set of resources.
 |======================
 
 === .spec.inputs[].application.selector.matchLabels
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.outputDefaults
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -114,11 +115,10 @@ A label selector is a label query over a set of resources.
 |======================
 
 === .spec.outputDefaults.elasticsearch
-===== Description
+
 ElasticsearchStructuredSpec is spec related to structured log changes to determine the elasticsearch index
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -130,11 +130,10 @@ ElasticsearchStructuredSpec is spec related to structured log changes to determi
 |======================
 
 === .spec.outputs[]
-===== Description
+
 Output defines a destination for log messages.
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -156,11 +155,10 @@ Output defines a destination for log messages.
 |======================
 
 === .spec.outputs[].secret
-===== Description
+
 OutputSecretSpec is a secret reference containing name only, no namespace.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -170,11 +168,10 @@ OutputSecretSpec is a secret reference containing name only, no namespace.
 |======================
 
 === .spec.outputs[].tls
-===== Description
+
 OutputTLSSpec contains options for TLS connections that are agnostic to the output type.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -184,11 +181,10 @@ OutputTLSSpec contains options for TLS connections that are agnostic to the outp
 |======================
 
 === .spec.pipelines[]
-===== Description
+
 PipelinesSpec link a set of inputs to a set of outputs.
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -203,29 +199,22 @@ PipelinesSpec link a set of inputs to a set of outputs.
 |======================
 
 === .spec.pipelines[].inputRefs[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .spec.pipelines[].labels
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.pipelines[].outputRefs[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .status
-===== Description
+
 ClusterLogForwarderStatus defines the observed state of ClusterLogForwarder
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -238,28 +227,24 @@ ClusterLogForwarderStatus defines the observed state of ClusterLogForwarder
 |======================
 
 === .status.conditions
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.inputs
-===== Description
 
-=====  Type
-* Conditions
+Type:: Conditions
 
 === .status.outputs
-===== Description
 
-=====  Type
-* Conditions
+Type:: Conditions
 
 === .status.pipelines
-===== Description
 
-=====  Type
-* Conditions== ClusterLogging
+Type:: Conditions
+
+["id=logging-5-x-reference-ClusterLogging"]
+== ClusterLogging
+
 A Red Hat OpenShift Logging instance. ClusterLogging is the Schema for the clusterloggings API
 
 [options="header"]
@@ -271,11 +256,10 @@ A Red Hat OpenShift Logging instance. ClusterLogging is the Schema for the clust
 |======================
 
 === .spec
-===== Description
+
 ClusterLoggingSpec defines the desired state of ClusterLogging
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -290,11 +274,10 @@ ClusterLoggingSpec defines the desired state of ClusterLogging
 |======================
 
 === .spec.collection
-===== Description
+
 This is the struct that will contain information pertinent to Log and event collection
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -309,11 +292,10 @@ This is the struct that will contain information pertinent to Log and event coll
 |======================
 
 === .spec.collection.fluentd
-===== Description
+
 FluentdForwarderSpec represents the configuration for forwarders of type fluentd.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -324,7 +306,7 @@ FluentdForwarderSpec represents the configuration for forwarders of type fluentd
 |======================
 
 === .spec.collection.fluentd.buffer
-===== Description
+
 FluentdBufferSpec represents a subset of fluentd buffer parameters to tune
 the buffer configuration for all fluentd outputs. It supports a subset of
 parameters to configure buffer and queue sizing, flush operations and retry
@@ -339,8 +321,7 @@ https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
 For retry parameters refer to:
 https://docs.fluentd.org/configuration/buffer-section#retries-parameters
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -359,15 +340,14 @@ https://docs.fluentd.org/configuration/buffer-section#retries-parameters
 |======================
 
 === .spec.collection.fluentd.inFile
-===== Description
+
 FluentdInFileSpec represents a subset of fluentd in-tail plugin parameters
 to tune the configuration for all fluentd in-tail inputs.
 
 For general parameters refer to:
 https://docs.fluentd.org/input/tail#parameters
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -377,10 +357,13 @@ https://docs.fluentd.org/input/tail#parameters
 |======================
 
 === .spec.collection.logs
-===== Description
 
-=====  Type
-* object
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
+Type:: object
 
 [options="header"]
 |======================
@@ -391,11 +374,10 @@ https://docs.fluentd.org/input/tail#parameters
 |======================
 
 === .spec.collection.logs.fluentd
-===== Description
+
 CollectorSpec is spec to define scheduling and resources for a collector
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -407,16 +389,12 @@ CollectorSpec is spec to define scheduling and resources for a collector
 |======================
 
 === .spec.collection.logs.fluentd.nodeSelector
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.collection.logs.fluentd.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -427,22 +405,16 @@ CollectorSpec is spec to define scheduling and resources for a collector
 |======================
 
 === .spec.collection.logs.fluentd.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.collection.logs.fluentd.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.collection.logs.fluentd.tolerations[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -456,17 +428,19 @@ CollectorSpec is spec to define scheduling and resources for a collector
 |======================
 
 === .spec.collection.logs.fluentd.tolerations[].tolerationSeconds
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .spec.curation
-===== Description
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
 This is the struct that will contain information pertinent to Log curation (Curator)
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -477,10 +451,8 @@ This is the struct that will contain information pertinent to Log curation (Cura
 |======================
 
 === .spec.curation.curator
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -493,16 +465,12 @@ This is the struct that will contain information pertinent to Log curation (Cura
 |======================
 
 === .spec.curation.curator.nodeSelector
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.curation.curator.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -513,22 +481,16 @@ This is the struct that will contain information pertinent to Log curation (Cura
 |======================
 
 === .spec.curation.curator.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.curation.curator.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.curation.curator.tolerations[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -542,20 +504,22 @@ This is the struct that will contain information pertinent to Log curation (Cura
 |======================
 
 === .spec.curation.curator.tolerations[].tolerationSeconds
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .spec.forwarder
-===== Description
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
 ForwarderSpec contains global tuning parameters for specific forwarder implementations.
 This field is not required for general use, it allows performance tuning by users
 familiar with the underlying forwarder technology.
 Currently supported: `fluentd`.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -565,11 +529,10 @@ Currently supported: `fluentd`.
 |======================
 
 === .spec.forwarder.fluentd
-===== Description
+
 FluentdForwarderSpec represents the configuration for forwarders of type fluentd.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -580,7 +543,7 @@ FluentdForwarderSpec represents the configuration for forwarders of type fluentd
 |======================
 
 === .spec.forwarder.fluentd.buffer
-===== Description
+
 FluentdBufferSpec represents a subset of fluentd buffer parameters to tune
 the buffer configuration for all fluentd outputs. It supports a subset of
 parameters to configure buffer and queue sizing, flush operations and retry
@@ -595,8 +558,7 @@ https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
 For retry parameters refer to:
 https://docs.fluentd.org/configuration/buffer-section#retries-parameters
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -615,15 +577,14 @@ https://docs.fluentd.org/configuration/buffer-section#retries-parameters
 |======================
 
 === .spec.forwarder.fluentd.inFile
-===== Description
+
 FluentdInFileSpec represents a subset of fluentd in-tail plugin parameters
 to tune the configuration for all fluentd in-tail inputs.
 
 For general parameters refer to:
 https://docs.fluentd.org/input/tail#parameters
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -633,11 +594,10 @@ https://docs.fluentd.org/input/tail#parameters
 |======================
 
 === .spec.logStore
-===== Description
+
 The LogStoreSpec contains information about how logs are stored.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -650,10 +610,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -669,16 +627,12 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.nodeSelector
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.logStore.elasticsearch.proxy
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -688,10 +642,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.proxy.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -702,22 +654,16 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.proxy.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.logStore.elasticsearch.proxy.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.logStore.elasticsearch.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -728,22 +674,16 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.logStore.elasticsearch.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.logStore.elasticsearch.storage
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -754,10 +694,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.storage.size
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -770,10 +708,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.storage.size.d
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -783,10 +719,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.storage.size.d.Dec
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -797,10 +731,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.storage.size.d.Dec.unscaled
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -811,16 +743,12 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.storage.size.d.Dec.unscaled.abs
-===== Description
 
-=====  Type
-* Word
+Type:: Word
 
 === .spec.logStore.elasticsearch.storage.size.i
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 [options="header"]
 |======================
@@ -831,10 +759,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.tolerations[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -848,18 +774,15 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.tolerations[].tolerationSeconds
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .spec.logStore.lokistack
-===== Description
+
 LokiStackStoreSpec is used to set up cluster-logging to use a LokiStack as logging storage.
 It points to an existing LokiStack in the same namespace.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -869,10 +792,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -884,10 +805,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.application
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -900,10 +819,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.application.namespaceSpec[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -914,10 +831,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.audit
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -930,10 +845,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.audit.namespaceSpec[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -944,10 +857,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.infra
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -960,10 +871,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.infra.namespaceSpec[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -974,11 +883,10 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.visualization
-===== Description
+
 This is the struct that will contain information pertinent to Log visualization (Kibana)
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -989,10 +897,8 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1006,16 +912,12 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana.nodeSelector
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.kibana.proxy
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1025,10 +927,8 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana.proxy.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1039,28 +939,20 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana.proxy.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.kibana.proxy.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.kibana.replicas
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .spec.visualization.kibana.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1071,22 +963,16 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.kibana.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.kibana.tolerations[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1100,17 +986,14 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana.tolerations[].tolerationSeconds
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .status
-===== Description
+
 ClusterLoggingStatus defines the observed state of ClusterLogging
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1124,10 +1007,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.collection
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1137,10 +1018,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.collection.logs
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1150,10 +1029,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.collection.logs.fluentdStatus
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1166,29 +1043,22 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.collection.logs.fluentdStatus.clusterCondition
-===== Description
+
 `operator-sdk generate crds` does not allow map-of-slice, must use a named type.
 
-=====  Type
-* object
+Type:: object
 
 === .status.collection.logs.fluentdStatus.nodes
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.conditions
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.curation
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1198,10 +1068,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.curation.curatorStatus[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1214,17 +1082,14 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.curation.curatorStatus[].clusterCondition
-===== Description
+
 `operator-sdk generate crds` does not allow map-of-slice, must use a named type.
 
-=====  Type
-* object
+Type:: object
 
 === .status.logStore
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1234,10 +1099,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.logStore.elasticsearchStatus[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1257,10 +1120,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.logStore.elasticsearchStatus[].cluster
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1278,46 +1139,32 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.logStore.elasticsearchStatus[].clusterConditions
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.logStore.elasticsearchStatus[].deployments[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .status.logStore.elasticsearchStatus[].nodeConditions
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.logStore.elasticsearchStatus[].pods
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.logStore.elasticsearchStatus[].replicaSets[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .status.logStore.elasticsearchStatus[].statefulSets[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .status.visualization
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1327,10 +1174,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.visualization.kibanaStatus[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1344,14 +1189,10 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.visualization.kibanaStatus[].clusterCondition
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.visualization.kibanaStatus[].replicaSets[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/cluster-logging-operator/pull/2389 and regen of 5.6 API docs for inclusion in product docs.

/cc @alanconway
/assign @jcantrill

### Links
https://issues.redhat.com/browse/OBSDOCS-762

/hold