### PR TITLE
LOG-5062: align validation with documentation

### DIFF
--- a/internal/controller/forwarding/forwarding_controller_test.go
+++ b/internal/controller/forwarding/forwarding_controller_test.go
@@ -75,7 +75,10 @@ var _ = Describe("ReconcileForwarder", func() {
 					Type: logging.LogCollectionTypeVector,
 				},
 			}
-			client = fake.NewClientBuilder().WithRuntimeObjects(exp).Build()
+
+			clf := runtime.NewClusterLogForwarder(exp.Namespace, exp.Name)
+
+			client = fake.NewClientBuilder().WithRuntimeObjects(exp, clf).Build()
 			controller := ReconcileForwarder{
 				Client: client,
 			}

--- a/internal/validations/clusterlogging/validate_clusterlogging_spec.go
+++ b/internal/validations/clusterlogging/validate_clusterlogging_spec.go
@@ -1,12 +1,18 @@
 package clusterlogging
 
 import (
+	"context"
+	"fmt"
+
 	v1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/validations/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateClusterLoggingSpec(cl v1.ClusterLogging) error {
+func validateClusterLoggingSpec(cl v1.ClusterLogging, k8sClient client.Client) error {
 
 	if cl.Namespace == constants.OpenshiftNS && cl.Name == constants.SingletonName {
 		if cl.Spec.Collection != nil && !cl.Spec.Collection.Type.IsSupportedCollector() {
@@ -15,6 +21,7 @@ func validateClusterLoggingSpec(cl v1.ClusterLogging) error {
 		return nil
 	}
 	spec := cl.Spec
+
 	if spec.Forwarder != nil || spec.LogStore != nil || spec.Curation != nil || spec.Visualization != nil {
 		return errors.NewValidationError("Only spec.collection is allowed when using multiple instances of ClusterLogForwarder: %s/%s", cl.Namespace, cl.Name)
 	}
@@ -25,4 +32,31 @@ func validateClusterLoggingSpec(cl v1.ClusterLogging) error {
 		return errors.NewValidationError("Only vector collector impl is supported when using multiple instances of ClusterLogForwarder: %s/%s", cl.Namespace, cl.Name)
 	}
 	return nil
+}
+
+//CL(openshift-logging/instance) only - This is a valid LEGACY use case
+//CL(openshift-logging/instance) & CLF(openshift-logging/instance) - This is a valid LEGACY usecase
+//CL(ANY_NS/OTHER) - This is an invalid use case
+//CLF(ANY_NS/ANY_NAME) - This is a valid mCLF use case
+//CL(ANY_NS/ANY_NAME) && CLF(ANY_NS/ANY_NAME) - This is a valid mCLF use case
+func validateSetup(cl v1.ClusterLogging, k8sClient client.Client) error {
+	key := types.NamespacedName{Name: cl.Name, Namespace: cl.Namespace}
+	clf := &v1.ClusterLogForwarder{}
+
+	// Check if ClusterLogForwarder exists
+	err := k8sClient.Get(context.TODO(), key, clf)
+	isCLFNotFound := apierrors.IsNotFound(err)
+	if isCLFNotFound {
+		// Determine if it's a legacy or mCLF instance
+		isLegacy := cl.Namespace == constants.OpenshiftNS && cl.Name == constants.SingletonName
+
+		if isLegacy {
+			return nil // Legacy ClusterLogging with no ClusterLogForwarder, valid use case
+		} else {
+			msg := fmt.Sprintf("ClusterLogging instance requires to have a ClusterLogForwarder deployed in the same namespace and named the same, if not eqauls %s/%s", constants.OpenshiftNS, constants.SingletonName)
+			return errors.NewValidationError(msg)
+		}
+	}
+
+	return nil // Legacy ClusterLogging with existing ClusterLogForwarder or mCLF ClusterLogForwarder, valid use case
 }

--- a/internal/validations/clusterlogging/validate_clusterlogging_spec_test.go
+++ b/internal/validations/clusterlogging/validate_clusterlogging_spec_test.go
@@ -5,13 +5,16 @@ import (
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("[internal][validations] ClusterLogging", func() {
 
 	Context("#validateClusterLoggingSpec", func() {
 		var (
-			cl *logging.ClusterLogging
+			cl        *logging.ClusterLogging
+			k8sClient client.Client
 		)
 		BeforeEach(func() {
 			cl = runtime.NewClusterLogging()
@@ -21,17 +24,19 @@ var _ = Describe("[internal][validations] ClusterLogging", func() {
 			cl.Spec.Visualization = &logging.VisualizationSpec{}
 			cl.Spec.Curation = &logging.CurationSpec{}
 			cl.Spec.Forwarder = &logging.ForwarderSpec{}
+			k8sClient = fake.NewClientBuilder().Build()
 		})
 
 		Context("for resource in openshift-logging named 'instance'", func() {
 			It("should pass validation with no regressions since this is the legacy mode", func() {
-				Expect(validateClusterLoggingSpec(*cl)).To(Succeed())
+				Expect(validateClusterLoggingSpec(*cl, k8sClient)).To(Succeed())
 			})
 		})
 
 		Context("for resource not in openshift-logging or not named 'instance' in openshift-logging", func() {
 
 			BeforeEach(func() {
+				k8sClient = fake.NewClientBuilder().Build()
 				cl = runtime.NewClusterLogging()
 				cl.Namespace = "a test namespace"
 				cl.Name = "mycollector"
@@ -52,26 +57,26 @@ var _ = Describe("[internal][validations] ClusterLogging", func() {
 				cl.Spec.Visualization = &logging.VisualizationSpec{}
 				cl.Spec.Curation = &logging.CurationSpec{}
 				cl.Spec.Forwarder = &logging.ForwarderSpec{}
-				err := validateClusterLoggingSpec(*cl)
+				err := validateClusterLoggingSpec(*cl, k8sClient)
 				Expect(err).To(Not(Succeed()))
 			})
 			It("should fail when collection.logs is spec'd", func() {
 				cl.Spec.Collection.Logs = &logging.LogCollectionSpec{}
-				err := validateClusterLoggingSpec(*cl)
+				err := validateClusterLoggingSpec(*cl, k8sClient)
 				Expect(err).To(Not(Succeed()))
 			})
 			It("should fail when collection.type of fluentd is spec'd", func() {
 				cl.Spec.Collection.Type = logging.LogCollectionTypeFluentd
-				err := validateClusterLoggingSpec(*cl)
+				err := validateClusterLoggingSpec(*cl, k8sClient)
 				Expect(err).To(Not(Succeed()))
 			})
 			It("should fail when collection.type is empty", func() {
 				cl.Spec.Collection.Type = ""
-				err := validateClusterLoggingSpec(*cl)
+				err := validateClusterLoggingSpec(*cl, k8sClient)
 				Expect(err).To(Not(Succeed()))
 			})
 			It("should pass when collection.type is spec'd", func() {
-				err := validateClusterLoggingSpec(*cl)
+				err := validateClusterLoggingSpec(*cl, k8sClient)
 				Expect(err).To(Succeed())
 			})
 
@@ -79,4 +84,66 @@ var _ = Describe("[internal][validations] ClusterLogging", func() {
 
 	})
 
+	Context("#validateClusterLoggingSetUp", func() {
+		var (
+			cl             *logging.ClusterLogging
+			clf            *logging.ClusterLogForwarder
+			k8sClient      client.Client
+			otherNamespace = "other-namespace"
+			otherName      = "other-name"
+		)
+		BeforeEach(func() {
+			cl = runtime.NewClusterLogging()
+			clf = runtime.NewClusterLogForwarder()
+			k8sClient = fake.NewClientBuilder().Build()
+		})
+
+		It("should pass when CL(openshift-logging/instance) only - This is a valid LEGACY use case", func() {
+			err := validateSetup(*cl, k8sClient)
+			Expect(err).To(Succeed())
+		})
+
+		It("should pass when CL(openshift-logging/instance) & CLF(openshift-logging/instance) - This is a valid LEGACY use case", func() {
+			k8sClient = fake.NewClientBuilder().WithRuntimeObjects(clf).Build()
+			err := validateSetup(*cl, k8sClient)
+			Expect(err).To(Succeed())
+		})
+
+		It("should fail when CL(ANY_NS/instance) - This is an invalid use case", func() {
+			cl.Namespace = otherNamespace
+			err := validateSetup(*cl, k8sClient)
+			Expect(err).To(Not(Succeed()))
+		})
+
+		It("should pass when CL(ANY_NS/instance) & CLF(ANY_NS/instance) - This is a valid mCLF use case", func() {
+			cl.Namespace = otherNamespace
+			clf.Namespace = otherNamespace
+			k8sClient = fake.NewClientBuilder().WithRuntimeObjects(clf).Build()
+			err := validateSetup(*cl, k8sClient)
+			Expect(err).To(Succeed())
+		})
+
+		It("should fail when CL(openshift-logging/OTHER_NAME) - This is an invalid use case", func() {
+			cl.Name = otherName
+			err := validateSetup(*cl, k8sClient)
+			Expect(err).To(Not(Succeed()))
+		})
+
+		It("should fail when CL(ANY_NS/OTHER_NAME) - This is an invalid use case", func() {
+			cl.Name = otherName
+			cl.Namespace = otherNamespace
+			err := validateSetup(*cl, k8sClient)
+			Expect(err).To(Not(Succeed()))
+		})
+
+		It("should pass when CL(ANY_NS/ANY_NAME) && CLF(ANY_NS/ANY_NAME) - This is a valid use case", func() {
+			cl.Name = otherName
+			cl.Namespace = otherNamespace
+			clf.Name = otherName
+			clf.Namespace = otherNamespace
+			k8sClient = fake.NewClientBuilder().WithRuntimeObjects(clf).Build()
+			err := validateSetup(*cl, k8sClient)
+			Expect(err).To(Succeed())
+		})
+	})
 })

--- a/internal/validations/clusterlogging/validations.go
+++ b/internal/validations/clusterlogging/validations.go
@@ -7,7 +7,7 @@ import (
 
 func Validate(cl v1.ClusterLogging, k8sClient client.Client, extras map[string]bool) error {
 	for _, validate := range validations {
-		if err := validate(cl); err != nil {
+		if err := validate(cl, k8sClient); err != nil {
 			return err
 		}
 	}
@@ -16,6 +16,7 @@ func Validate(cl v1.ClusterLogging, k8sClient client.Client, extras map[string]b
 
 // validations are the set of admission rules for validating
 // a ClusterLogging
-var validations = []func(cl v1.ClusterLogging) error{
+var validations = []func(cl v1.ClusterLogging, k8sClient client.Client) error{
+	validateSetup,
 	validateClusterLoggingSpec,
 }


### PR DESCRIPTION
### Description
This PR address to align validation feature with current documentation. During validation for `ClusterLogging` we will check is `ClusterLogForwarder`  in the same namespace named the same exist if not, exception will throw. 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5062
- Enhancement proposal:
