### PR TITLE
[release-5.7] Updates to API template to meet docs standards

### DIFF
--- a/config/docs/templates/apis/asciidoc/members.tpl
+++ b/config/docs/templates/apis/asciidoc/members.tpl
@@ -3,18 +3,21 @@
  {{ if not (or (or (fieldEmbedded .Member) (hiddenMember .Member) (ignoreMember .Member))) }}
 
 === {{ .Path }}
-===== Description
+
 {{ if (isDeprecatedMember .Member) }}
-  {{ "**(DEPRECATED)**" }}
+  {{ "[IMPORTANT]\n" -}}
+  {{ "====\n" -}}
+  {{ "This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.\n" -}}
+  {{ "====" -}}
 {{ end }}
+
 {{ if .Type.Elem -}}
   {{ (comments .Type.Elem.CommentLines) }}
 {{- else -}}
   {{  (comments .Type.CommentLines) }}
 {{- end }}
 
-=====  Type
-* {{ (yamlType .Type) }}
+Type:: {{ (yamlType .Type) }}
 
 {{- template "properties" .Type  -}}
 {{- template "members" (nodeParent .Type .Path) -}}

--- a/config/docs/templates/apis/asciidoc/pkg.tpl
+++ b/config/docs/templates/apis/asciidoc/pkg.tpl
@@ -1,15 +1,27 @@
 {{- define "packages" -}}
-:toc:
-:toclevels: 2
-:toc-placement!:
+
+////
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="logging-5-x-reference"]
+= Logging 5.x API reference
+:context: filename
+
 toc::[]
+
+** These release notes are generated from the content in the openshift/cluster-logging-operator repository.
+** Do not modify the content here manually except for the metadata and section IDs - changes to the content should be made in the source code.
+////
 
 {{ range .packages -}}
 
     {{- range (sortedTypes (visibleTypes .Types )) -}}
         {{if isObjectRoot . }}
 
+["id=logging-5-x-reference-{{ (typeDisplayName .) }}"]
 == {{ (typeDisplayName .) }}
+
 {{  (comments .CommentLines) }}
 {{  template "type" (nodeParent . "") -}}
 

--- a/docs/reference/operator/api.adoc
+++ b/docs/reference/operator/api.adoc
@@ -1,9 +1,20 @@
-:toc:
-:toclevels: 2
-:toc-placement!:
+////
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="logging-5-x-reference"]
+= Logging 5.x API reference
+:context: filename
+
 toc::[]
 
+** These release notes are generated from the content in the openshift/cluster-logging-operator repository.
+** Do not modify the content here manually except for the metadata and section IDs - changes to the content should be made in the source code.
+////
+
+["id=logging-5-x-reference-ClusterLogForwarder"]
 == ClusterLogForwarder
+
 ClusterLogForwarder is an API to configure forwarding logs.
 
 You configure forwarding by specifying a list of `pipelines`,
@@ -27,12 +38,10 @@ For more details see the documentation on the API fields.
 |======================
 
 === .spec
-===== Description
 
 ClusterLogForwarderSpec defines how logs should be forwarded to remote targets.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -45,12 +54,10 @@ ClusterLogForwarderSpec defines how logs should be forwarded to remote targets.
 |======================
 
 === .spec.inputs[]
-===== Description
 
 InputSpec defines a selector of log messages.
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -61,13 +68,11 @@ InputSpec defines a selector of log messages.
 |======================
 
 === .spec.inputs[].application
-===== Description
 
 Application log selector.
 All conditions in the selector must be satisfied (logical AND) to select logs.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -78,18 +83,14 @@ All conditions in the selector must be satisfied (logical AND) to select logs.
 |======================
 
 === .spec.inputs[].application.namespaces[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .spec.inputs[].application.selector
-===== Description
 
 A label selector is a label query over a set of resources.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -99,16 +100,12 @@ A label selector is a label query over a set of resources.
 |======================
 
 === .spec.inputs[].application.selector.matchLabels
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.outputDefaults
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -118,12 +115,10 @@ A label selector is a label query over a set of resources.
 |======================
 
 === .spec.outputDefaults.elasticsearch
-===== Description
 
 ElasticsearchStructuredSpec is spec related to structured log changes to determine the elasticsearch index
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -135,12 +130,10 @@ ElasticsearchStructuredSpec is spec related to structured log changes to determi
 |======================
 
 === .spec.outputs[]
-===== Description
 
 Output defines a destination for log messages.
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -163,12 +156,10 @@ Output defines a destination for log messages.
 |======================
 
 === .spec.outputs[].secret
-===== Description
 
 OutputSecretSpec is a secret reference containing name only, no namespace.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -178,12 +169,10 @@ OutputSecretSpec is a secret reference containing name only, no namespace.
 |======================
 
 === .spec.outputs[].tls
-===== Description
 
 OutputTLSSpec contains options for TLS connections that are agnostic to the output type.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -194,10 +183,8 @@ OutputTLSSpec contains options for TLS connections that are agnostic to the outp
 |======================
 
 === .spec.outputs[].tls.securityProfile
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -211,10 +198,8 @@ OutputTLSSpec contains options for TLS connections that are agnostic to the outp
 |======================
 
 === .spec.outputs[].tls.securityProfile.custom
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -225,30 +210,22 @@ OutputTLSSpec contains options for TLS connections that are agnostic to the outp
 |======================
 
 === .spec.outputs[].tls.securityProfile.intermediate
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.outputs[].tls.securityProfile.modern
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.outputs[].tls.securityProfile.old
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.pipelines[]
-===== Description
 
 PipelinesSpec link a set of inputs to a set of outputs.
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -263,30 +240,22 @@ PipelinesSpec link a set of inputs to a set of outputs.
 |======================
 
 === .spec.pipelines[].inputRefs[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .spec.pipelines[].labels
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.pipelines[].outputRefs[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .status
-===== Description
 
 ClusterLogForwarderStatus defines the observed state of ClusterLogForwarder
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -299,30 +268,24 @@ ClusterLogForwarderStatus defines the observed state of ClusterLogForwarder
 |======================
 
 === .status.conditions
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.inputs
-===== Description
 
-=====  Type
-* Conditions
+Type:: Conditions
 
 === .status.outputs
-===== Description
 
-=====  Type
-* Conditions
+Type:: Conditions
 
 === .status.pipelines
-===== Description
 
-=====  Type
-* Conditions
+Type:: Conditions
 
+["id=logging-5-x-reference-ClusterLogging"]
 == ClusterLogging
+
 A Red Hat OpenShift Logging instance. ClusterLogging is the Schema for the clusterloggings API
 
 [options="header"]
@@ -334,12 +297,10 @@ A Red Hat OpenShift Logging instance. ClusterLogging is the Schema for the clust
 |======================
 
 === .spec
-===== Description
 
 ClusterLoggingSpec defines the desired state of ClusterLogging
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -354,12 +315,10 @@ ClusterLoggingSpec defines the desired state of ClusterLogging
 |======================
 
 === .spec.collection
-===== Description
 
 This is the struct that will contain information pertinent to Log and event collection
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -374,12 +333,10 @@ This is the struct that will contain information pertinent to Log and event coll
 |======================
 
 === .spec.collection.fluentd
-===== Description
 
 FluentdForwarderSpec represents the configuration for forwarders of type fluentd.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -390,7 +347,6 @@ FluentdForwarderSpec represents the configuration for forwarders of type fluentd
 |======================
 
 === .spec.collection.fluentd.buffer
-===== Description
 
 FluentdBufferSpec represents a subset of fluentd buffer parameters to tune
 the buffer configuration for all fluentd outputs. It supports a subset of
@@ -406,8 +362,7 @@ https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
 For retry parameters refer to:
 https://docs.fluentd.org/configuration/buffer-section#retries-parameters
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -426,7 +381,6 @@ https://docs.fluentd.org/configuration/buffer-section#retries-parameters
 |======================
 
 === .spec.collection.fluentd.inFile
-===== Description
 
 FluentdInFileSpec represents a subset of fluentd in-tail plugin parameters
 to tune the configuration for all fluentd in-tail inputs.
@@ -434,8 +388,7 @@ to tune the configuration for all fluentd in-tail inputs.
 For general parameters refer to:
 https://docs.fluentd.org/input/tail#parameters
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -445,15 +398,16 @@ https://docs.fluentd.org/input/tail#parameters
 |======================
 
 === .spec.collection.logs
-===== Description
 
-**(DEPRECATED)**
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
 
 Specification of Log Collection for the cluster
 See spec.collection
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -464,12 +418,10 @@ See spec.collection
 |======================
 
 === .spec.collection.logs.fluentd
-===== Description
 
 CollectorSpec is spec to define scheduling and resources for a collector
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -481,16 +433,12 @@ CollectorSpec is spec to define scheduling and resources for a collector
 |======================
 
 === .spec.collection.logs.fluentd.nodeSelector
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.collection.logs.fluentd.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -501,22 +449,16 @@ CollectorSpec is spec to define scheduling and resources for a collector
 |======================
 
 === .spec.collection.logs.fluentd.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.collection.logs.fluentd.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.collection.logs.fluentd.tolerations[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -530,20 +472,19 @@ CollectorSpec is spec to define scheduling and resources for a collector
 |======================
 
 === .spec.collection.logs.fluentd.tolerations[].tolerationSeconds
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .spec.curation
-===== Description
 
-**(DEPRECATED)**
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
 
 This is the struct that will contain information pertinent to Log curation (Curator)
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -554,10 +495,8 @@ This is the struct that will contain information pertinent to Log curation (Cura
 |======================
 
 === .spec.curation.curator
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -570,16 +509,12 @@ This is the struct that will contain information pertinent to Log curation (Cura
 |======================
 
 === .spec.curation.curator.nodeSelector
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.curation.curator.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -590,22 +525,16 @@ This is the struct that will contain information pertinent to Log curation (Cura
 |======================
 
 === .spec.curation.curator.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.curation.curator.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.curation.curator.tolerations[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -619,23 +548,22 @@ This is the struct that will contain information pertinent to Log curation (Cura
 |======================
 
 === .spec.curation.curator.tolerations[].tolerationSeconds
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .spec.forwarder
-===== Description
 
-**(DEPRECATED)**
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
 
 ForwarderSpec contains global tuning parameters for specific forwarder implementations.
 This field is not required for general use, it allows performance tuning by users
 familiar with the underlying forwarder technology.
 Currently supported: `fluentd`.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -645,12 +573,10 @@ Currently supported: `fluentd`.
 |======================
 
 === .spec.forwarder.fluentd
-===== Description
 
 FluentdForwarderSpec represents the configuration for forwarders of type fluentd.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -661,7 +587,6 @@ FluentdForwarderSpec represents the configuration for forwarders of type fluentd
 |======================
 
 === .spec.forwarder.fluentd.buffer
-===== Description
 
 FluentdBufferSpec represents a subset of fluentd buffer parameters to tune
 the buffer configuration for all fluentd outputs. It supports a subset of
@@ -677,8 +602,7 @@ https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
 For retry parameters refer to:
 https://docs.fluentd.org/configuration/buffer-section#retries-parameters
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -697,7 +621,6 @@ https://docs.fluentd.org/configuration/buffer-section#retries-parameters
 |======================
 
 === .spec.forwarder.fluentd.inFile
-===== Description
 
 FluentdInFileSpec represents a subset of fluentd in-tail plugin parameters
 to tune the configuration for all fluentd in-tail inputs.
@@ -705,8 +628,7 @@ to tune the configuration for all fluentd in-tail inputs.
 For general parameters refer to:
 https://docs.fluentd.org/input/tail#parameters
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -716,12 +638,10 @@ https://docs.fluentd.org/input/tail#parameters
 |======================
 
 === .spec.logStore
-===== Description
 
 The LogStoreSpec contains information about how logs are stored.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -734,12 +654,13 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch
-===== Description
 
-**(DEPRECATED)**
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -755,16 +676,12 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.nodeSelector
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.logStore.elasticsearch.proxy
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -774,10 +691,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.proxy.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -788,22 +703,16 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.proxy.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.logStore.elasticsearch.proxy.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.logStore.elasticsearch.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -814,22 +723,16 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.logStore.elasticsearch.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.logStore.elasticsearch.storage
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -840,10 +743,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.storage.size
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -856,10 +757,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.storage.size.d
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -869,10 +768,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.storage.size.d.Dec
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -883,10 +780,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.storage.size.d.Dec.unscaled
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -897,16 +792,12 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.storage.size.d.Dec.unscaled.abs
-===== Description
 
-=====  Type
-* Word
+Type:: Word
 
 === .spec.logStore.elasticsearch.storage.size.i
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 [options="header"]
 |======================
@@ -917,10 +808,8 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.tolerations[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -934,19 +823,15 @@ The LogStoreSpec contains information about how logs are stored.
 |======================
 
 === .spec.logStore.elasticsearch.tolerations[].tolerationSeconds
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .spec.logStore.lokistack
-===== Description
 
 LokiStackStoreSpec is used to set up cluster-logging to use a LokiStack as logging storage.
 It points to an existing LokiStack in the same namespace.
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -956,12 +841,13 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy
-===== Description
 
-**(DEPRECATED)**
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -973,10 +859,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.application
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -989,10 +873,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.application.namespaceSpec[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1003,10 +885,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.audit
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1019,10 +899,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.audit.namespaceSpec[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1033,10 +911,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.infra
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1049,10 +925,8 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.logStore.retentionPolicy.infra.namespaceSpec[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1063,12 +937,10 @@ It points to an existing LokiStack in the same namespace.
 |======================
 
 === .spec.visualization
-===== Description
 
 This is the struct that will contain information pertinent to Log visualization (Kibana)
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1082,12 +954,13 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana
-===== Description
 
-**(DEPRECATED)**
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1101,18 +974,17 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana.nodeSelector
-===== Description
 
-**(DEPRECATED)**
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.kibana.proxy
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1122,10 +994,8 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana.proxy.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1136,28 +1006,20 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana.proxy.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.kibana.proxy.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.kibana.replicas
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .spec.visualization.kibana.resources
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1168,24 +1030,21 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana.resources.limits
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.kibana.resources.requests
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.kibana.tolerations[]
-===== Description
 
-**(DEPRECATED)**
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1199,22 +1058,16 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.kibana.tolerations[].tolerationSeconds
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .spec.visualization.nodeSelector
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .spec.visualization.ocpConsole
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1225,10 +1078,8 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.tolerations[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1242,18 +1093,14 @@ This is the struct that will contain information pertinent to Log visualization 
 |======================
 
 === .spec.visualization.tolerations[].tolerationSeconds
-===== Description
 
-=====  Type
-* int
+Type:: int
 
 === .status
-===== Description
 
 ClusterLoggingStatus defines the observed state of ClusterLogging
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1267,12 +1114,13 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.collection
-===== Description
 
-**(DEPRECATED)**
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1282,10 +1130,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.collection.logs
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1295,10 +1141,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.collection.logs.fluentdStatus
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1311,30 +1155,22 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.collection.logs.fluentdStatus.clusterCondition
-===== Description
 
 `operator-sdk generate crds` does not allow map-of-slice, must use a named type.
 
-=====  Type
-* object
+Type:: object
 
 === .status.collection.logs.fluentdStatus.nodes
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.conditions
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.curation
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1344,10 +1180,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.curation.curatorStatus[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1360,18 +1194,14 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.curation.curatorStatus[].clusterCondition
-===== Description
 
 `operator-sdk generate crds` does not allow map-of-slice, must use a named type.
 
-=====  Type
-* object
+Type:: object
 
 === .status.logStore
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1381,10 +1211,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.logStore.elasticsearchStatus[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1404,10 +1232,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.logStore.elasticsearchStatus[].cluster
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1425,46 +1251,32 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.logStore.elasticsearchStatus[].clusterConditions
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.logStore.elasticsearchStatus[].deployments[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .status.logStore.elasticsearchStatus[].nodeConditions
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.logStore.elasticsearchStatus[].pods
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.logStore.elasticsearchStatus[].replicaSets[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .status.logStore.elasticsearchStatus[].statefulSets[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 === .status.visualization
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 [options="header"]
 |======================
@@ -1474,10 +1286,8 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.visualization.kibanaStatus[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 
 [options="header"]
 |======================
@@ -1491,14 +1301,10 @@ ClusterLoggingStatus defines the observed state of ClusterLogging
 |======================
 
 === .status.visualization.kibanaStatus[].clusterCondition
-===== Description
 
-=====  Type
-* object
+Type:: object
 
 === .status.visualization.kibanaStatus[].replicaSets[]
-===== Description
 
-=====  Type
-* array
+Type:: array
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/cluster-logging-operator/pull/2389 and regen of 5.7 API docs for inclusion in product docs.

/cc @alanconway
/assign @jcantrill

### Links
https://issues.redhat.com/browse/OBSDOCS-762