### PR TITLE
LOG-5200: fix source collected bytes metric

### DIFF
--- a/internal/metrics/dashboard/openshift-logging-dashboard.json
+++ b/internal/metrics/dashboard/openshift-logging-dashboard.json
@@ -64,7 +64,7 @@
           },
           "targets": [
             {
-              "expr": "sum by(job, namespace, app_kubernetes_io_name) (increase(vector_processed_bytes_total{component_kind=\"source\", component_type!=\"internal_metrics\"}[24h]))",
+              "expr": "sum by(job, namespace, app_kubernetes_io_name) (increase(vector_component_received_bytes_total{component_kind=\"source\", component_type!=\"internal_metrics\"}[24h]))",
               "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
               "interval": "",
               "exemplar": true,
@@ -317,7 +317,7 @@
           "pluginVersion": "8.5.0",
           "targets": [
             {
-              "expr": "sum by(app_kubernetes_io_name, namespace, job) (rate(vector_processed_bytes_total{component_kind=\"source\", component_type!=\"internal_metrics\"}[5m]))",
+              "expr": "sum by(app_kubernetes_io_name, namespace, job) (rate(vector_component_received_bytes_total{component_kind=\"source\", component_type!=\"internal_metrics\"}[5m]))",
               "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
               "interval": "",
               "exemplar": true,


### PR DESCRIPTION
### Description
This PR:
* fixes the collector dashboard  source metrics to use `vector_component_received_bytes_total`

### Links
https://issues.redhat.com/browse/LOG-5200

![image](https://github.com/openshift/cluster-logging-operator/assets/4548408/bb96a461-43ea-467e-b710-bd93f4e0bd43)

