### PR TITLE
LOG-5132: Identify fields that should be omitted from pruning

### DIFF
--- a/api/logging/v1/filter_types.go
+++ b/api/logging/v1/filter_types.go
@@ -62,6 +62,8 @@ type PruneFilterSpec struct {
 	// The path can contain alpha-numeric characters and underscores (a-zA-Z0-9_).
 	// If segments contain characters outside of this range, the segment must be quoted otherwise paths do NOT need to be quoted.
 	// Examples: `.kubernetes.namespace_name`, `.log_type`, '.kubernetes.labels.foobar', `.kubernetes.labels."foo-bar/baz"`
+	// NOTE1: `In` CANNOT contain `.log_type` or `.message` as those fields are required and cannot be pruned.
+	// NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` CANNOT be added to this list as it is a required field.
 	// +optional
 	In []string `json:"in,omitempty"`
 
@@ -70,6 +72,8 @@ type PruneFilterSpec struct {
 	// The path can contain alpha-numeric characters and underscores (a-zA-Z0-9_).
 	// If segments contain characters outside of this range, the segment must be quoted otherwise paths do NOT need to be quoted.
 	// Examples: `.kubernetes.namespace_name`, `.log_type`, '.kubernetes.labels.foobar', `.kubernetes.labels."foo-bar/baz"`
+	// NOTE1: `NotIn` MUST contain `.log_type` and `.message` as those fields are required and cannot be pruned.
+	// NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` MUST be added to this list as it is a required field.
 	// +optional
 	NotIn []string `json:"notIn,omitempty"`
 }

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -288,7 +288,12 @@ spec:
                             (a-zA-Z0-9_). If segments contain characters outside of
                             this range, the segment must be quoted otherwise paths
                             do NOT need to be quoted. Examples: `.kubernetes.namespace_name`,
-                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`'
+                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`
+                            NOTE1: `In` CANNOT contain `.log_type` or `.message` as
+                            those fields are required and cannot be pruned. NOTE2:
+                            If this filter is used in a pipeline with GoogleCloudLogging,
+                            `.hostname` CANNOT be added to this list as it is a required
+                            field.'
                           items:
                             type: string
                           type: array
@@ -300,7 +305,12 @@ spec:
                             and underscores (a-zA-Z0-9_). If segments contain characters
                             outside of this range, the segment must be quoted otherwise
                             paths do NOT need to be quoted. Examples: `.kubernetes.namespace_name`,
-                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`'
+                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`
+                            NOTE1: `NotIn` MUST contain `.log_type` and `.message`
+                            as those fields are required and cannot be pruned. NOTE2:
+                            If this filter is used in a pipeline with GoogleCloudLogging,
+                            `.hostname` MUST be added to this list as it is a required
+                            field.'
                           items:
                             type: string
                           type: array

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -289,7 +289,12 @@ spec:
                             (a-zA-Z0-9_). If segments contain characters outside of
                             this range, the segment must be quoted otherwise paths
                             do NOT need to be quoted. Examples: `.kubernetes.namespace_name`,
-                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`'
+                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`
+                            NOTE1: `In` CANNOT contain `.log_type` or `.message` as
+                            those fields are required and cannot be pruned. NOTE2:
+                            If this filter is used in a pipeline with GoogleCloudLogging,
+                            `.hostname` CANNOT be added to this list as it is a required
+                            field.'
                           items:
                             type: string
                           type: array
@@ -301,7 +306,12 @@ spec:
                             and underscores (a-zA-Z0-9_). If segments contain characters
                             outside of this range, the segment must be quoted otherwise
                             paths do NOT need to be quoted. Examples: `.kubernetes.namespace_name`,
-                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`'
+                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`
+                            NOTE1: `NotIn` MUST contain `.log_type` and `.message`
+                            as those fields are required and cannot be pruned. NOTE2:
+                            If this filter is used in a pipeline with GoogleCloudLogging,
+                            `.hostname` MUST be added to this list as it is a required
+                            field.'
                           items:
                             type: string
                           type: array

--- a/docs/features/logforwarding/filters/drop-filter.adoc
+++ b/docs/features/logforwarding/filters/drop-filter.adoc
@@ -34,7 +34,7 @@ spec:
     - name: my-drop
       type: drop
       drop:
-        # 1. drop logs with a namespace of openshift-logging
+        # 1. drop logs with a namespace that leads with `openshift`
         - test:
           - field: .kubernetes.namespace_name
             matches: "openshift*"

--- a/docs/features/logforwarding/filters/prune-filter.adoc
+++ b/docs/features/logforwarding/filters/prune-filter.adoc
@@ -16,7 +16,17 @@ The prune filter extends the filter API by adding a `prune` field and the `in`, 
 * Dot-delimited field path: A path to a field in the log record. It must start with a dot (`.`). The path can contain alpha-numeric characters and underscores `(a-zA-Z0-9_)`. If segments contain characters outside of this range, the segment must be quoted.
 ** Examples: `.kubernetes.namespace_name`, `.log_type`, `.kubernetes.labels.foobar`, `.kubernetes.labels."foo-bar/baz"`
 
-NOTE: `notIn` takes precedence over `in`. That is, if both `in` and `notIn` are specified, vector will initially prune fields **NOT** listed in the `notIn` list followed by pruning fields specified in the `in` list.
+.Note #1
+[NOTE] 
+`notIn` takes precedence over `in`. That is, if both `in` and `notIn` are specified, vector will initially prune fields **NOT** listed in the `notIn` list followed by pruning fields specified in the `in` list.
+
+.Note #2
+[NOTE]
+`in` **CANNOT** contain `.log_type` or `.message` as those fields are required and cannot be pruned. Additionally if this filter is used in a pipeline with `GoogleCloudLogging`, `.hostname` **CANNOT** be added to the `in` list as it is also a required field.
+
+.Note #3
+[NOTE]
+`notIn` **MUST** contain `.log_type` and `.message` as those fields are required and cannot be pruned. Additionally if this filter is used in a pipeline with `GoogleCloudLogging`, `.hostname` **MUST** be added to the `notIn` list as it is also a required field.
 
 === Example:
 

--- a/internal/validations/clusterlogforwarder/validate_collector_compatibility.go
+++ b/internal/validations/clusterlogforwarder/validate_collector_compatibility.go
@@ -32,19 +32,19 @@ var (
 	)
 )
 
-//validateCollectorCompatibility checking is given collector support proposed output if not error will return, nil otherwise
+// validateCollectorCompatibility checking is given collector support proposed output if not error will return, nil otherwise
 //
-//Output type         | Supported collector type
-//Elasticsearch       | Fluentd, Vector
-//Fluent Forward      | Fluentd
-//Google Cloud Logging| Vector
-//HTTP                | Fluentd, Vector
-//Kafka               | Fluentd, Vector
-//Loki                | Fluentd, Vector
-//Splunk              | Vector
-//Syslog              | Fluentd, Vector
-//Amazon CloudWatch   | Fluentd, Vector
-//Azure Monitor Logs  | Vector
+// Output type         | Supported collector type
+// Elasticsearch       | Fluentd, Vector
+// Fluent Forward      | Fluentd
+// Google Cloud Logging| Vector
+// HTTP                | Fluentd, Vector
+// Kafka               | Fluentd, Vector
+// Loki                | Fluentd, Vector
+// Splunk              | Vector
+// Syslog              | Fluentd, Vector
+// Amazon CloudWatch   | Fluentd, Vector
+// Azure Monitor Logs  | Vector
 func validateCollectorCompatibility(clf v1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *v1.ClusterLogForwarderStatus) {
 	collector := constants.VectorName
 	supportedOutputs := vector

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -402,6 +402,10 @@ func (f *CollectorFunctionalFramework) addOutputContainers(b *runtime.PodBuilder
 			if err := f.AddSplunkOutput(b, output); err != nil {
 				return err
 			}
+		case logging.OutputTypeCloudwatch:
+			if err := f.AddCloudWatchOutput(b, output); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/test/functional/filters/prune/prune_filter_test.go
+++ b/test/functional/filters/prune/prune_filter_test.go
@@ -1,9 +1,18 @@
 package prune
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	"github.com/openshift/cluster-logging-operator/test/helpers/azuremonitor"
+	"github.com/openshift/cluster-logging-operator/test/helpers/kafka"
+	"github.com/openshift/cluster-logging-operator/test/helpers/loki"
+	"github.com/openshift/cluster-logging-operator/test/helpers/rand"
+	v1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -28,30 +37,19 @@ var _ = Describe("[Functional][Filters][Prune] Prune filter", func() {
 			f = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
 			specialCharLabel := "foo-bar/baz"
 			f.Labels = map[string]string{specialCharLabel: "specialCharLabel"}
-			f.Forwarder.Spec.Filters = []logging.FilterSpec{
-				{
-					Name: pruneFilterName,
-					Type: logging.FilterPrune,
-					FilterTypeSpec: logging.FilterTypeSpec{
+
+			functional.NewClusterLogForwarderBuilder(f.Forwarder).
+				FromInput(logging.InputNameApplication).
+				WithFilterWithVisitor(pruneFilterName, func(spec *logging.FilterSpec) {
+					spec.Type = logging.FilterPrune
+					spec.FilterTypeSpec = logging.FilterTypeSpec{
 						PruneFilterSpec: &logging.PruneFilterSpec{
 							In:    []string{".kubernetes.namespace_name", ".kubernetes.container_name", `.kubernetes.labels."foo-bar/baz"`},
 							NotIn: []string{".log_type", ".message", ".kubernetes", ".openshift", `."@timestamp"`},
 						},
-					},
-				},
-			}
-			functional.NewClusterLogForwarderBuilder(f.Forwarder).
-				FromInput(logging.InputNameApplication).
+					}
+				}).
 				ToElasticSearchOutput()
-
-			f.Forwarder.Spec.Pipelines = []logging.PipelineSpec{
-				{
-					Name:       "myPrunePipeline",
-					FilterRefs: []string{pruneFilterName},
-					InputRefs:  []string{logging.InputNameApplication, logging.InputNameAudit, logging.InputNameInfrastructure},
-					OutputRefs: []string{logging.OutputTypeElasticsearch},
-				},
-			}
 
 			Expect(f.Deploy()).To(BeNil())
 			msg := functional.NewFullCRIOLogMessage(functional.CRIOTime(time.Now()), "my error message")
@@ -78,6 +76,160 @@ var _ = Describe("[Functional][Filters][Prune] Prune filter", func() {
 			Expect(log.Level).To(BeEmpty())
 
 		})
+	})
 
+	Context("minimal set of fields for each output", func() {
+		var (
+			pipelineBuilder *functional.PipelineBuilder
+			secret          *v1.Secret
+
+			sharedKey  = rand.Word(16)
+			customerId = strings.ToLower(string(rand.Word(16)))
+		)
+
+		BeforeEach(func() {
+			f = functional.NewCollectorFunctionalFrameworkUsingCollector(logging.LogCollectionTypeVector)
+			pipelineBuilder = functional.NewClusterLogForwarderBuilder(f.Forwarder).
+				FromInput(logging.InputNameApplication).
+				WithFilterWithVisitor(pruneFilterName, func(spec *logging.FilterSpec) {
+					spec.Type = logging.FilterPrune
+					spec.FilterTypeSpec = logging.FilterTypeSpec{
+						PruneFilterSpec: &logging.PruneFilterSpec{NotIn: []string{".log_type", ".message"}},
+					}
+				})
+		})
+
+		It("should send to Elasticsearch with only .log_type and .message", func() {
+			pipelineBuilder.ToElasticSearchOutput()
+			Expect(f.Deploy()).To(BeNil())
+
+			msg := functional.NewCRIOLogMessage(functional.CRIOTime(time.Now()), "This is my test message", false)
+			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(BeNil())
+
+			logs, err := f.ReadApplicationLogsFrom(logging.OutputTypeElasticsearch)
+			Expect(err).To(BeNil(), "Error fetching logs from %s: %v", logging.OutputTypeElasticsearch, err)
+			Expect(logs).To(Not(BeEmpty()), "Exp. logs to be forwarded to %s", logging.OutputTypeElasticsearch)
+		})
+
+		It("should send to Splunk with only .log_type and .message", func() {
+			pipelineBuilder.ToSplunkOutput()
+			secret = runtime.NewSecret(f.Namespace, "splunk-secret",
+				map[string][]byte{
+					"hecToken": []byte(string(functional.HecToken)),
+				},
+			)
+			f.Secrets = append(f.Secrets, secret)
+
+			Expect(f.Deploy()).To(BeNil())
+			time.Sleep(90 * time.Second)
+
+			msg := functional.NewCRIOLogMessage(functional.CRIOTime(time.Now()), "This is my test message", false)
+			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(BeNil())
+
+			// Get logs
+			logs, err := f.ReadAppLogsByIndexFromSplunk(f.Namespace, f.Name, "*")
+			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+			Expect(logs).ToNot(BeEmpty())
+		})
+
+		It("should send to Loki with only .log_type and .message", func() {
+			l := loki.NewReceiver(f.Namespace, "loki-server")
+			Expect(l.Create(f.Test.Client)).To(Succeed())
+			pipelineBuilder.ToOutputWithVisitor(func(spec *logging.OutputSpec) {
+				spec.Type = logging.OutputTypeLoki
+				spec.URL = l.InternalURL("").String()
+			}, logging.OutputTypeLoki)
+
+			Expect(f.Deploy()).To(BeNil())
+			msg := functional.NewCRIOLogMessage(functional.CRIOTime(time.Now()), "This is my test message", false)
+			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(BeNil())
+			_, err := l.QueryUntil(`{log_type=~".+"}`, "", 1)
+			Expect(err).To(Succeed())
+		})
+
+		It("should send to Kafka with only .log_type and .message", func() {
+			pipelineBuilder.ToKafkaOutput()
+			f.Secrets = append(f.Secrets, kafka.NewBrokerSecret(f.Namespace))
+
+			Expect(f.Deploy()).To(BeNil())
+
+			msg := functional.NewCRIOLogMessage(functional.CRIOTime(time.Now()), "This is my test message", false)
+			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(BeNil())
+			// Read line from Kafka output
+			logs, err := f.ReadApplicationLogsFrom(logging.OutputTypeKafka)
+			Expect(err).To(BeNil(), "Error fetching logs from %s: %v", logging.OutputTypeKafka, err)
+			Expect(logs).To(Not(BeEmpty()), "Exp. logs to be forwarded to %s", logging.OutputTypeKafka)
+		})
+
+		It("should send to HTTP with only .log_type and .message", func() {
+			pipelineBuilder.ToHttpOutput()
+			Expect(f.Deploy()).To(BeNil())
+
+			msg := functional.NewCRIOLogMessage(functional.CRIOTime(time.Now()), "This is my test message", false)
+			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(BeNil())
+
+			raw, err := f.ReadRawApplicationLogsFrom(logging.OutputTypeHttp)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs for type")
+			Expect(raw).ToNot(BeEmpty())
+		})
+
+		It("should send to Syslog with only .log_type and .message", func() {
+			pipelineBuilder.ToSyslogOutput()
+			Expect(f.Deploy()).To(BeNil())
+			msg := functional.NewCRIOLogMessage(functional.CRIOTime(time.Now()), "This is my test message", false)
+			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(BeNil())
+			outputlogs, err := f.ReadRawApplicationLogsFrom(logging.OutputTypeSyslog)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+		})
+
+		It("should send to AzureMonitor with only .log_type and .message", func() {
+			pipelineBuilder.ToAzureMonitorOutputWithCuId(customerId)
+
+			secret := runtime.NewSecret(f.Namespace, azuremonitor.AzureSecretName,
+				map[string][]byte{
+					constants.SharedKey: sharedKey,
+				},
+			)
+			f.Secrets = append(f.Secrets, secret)
+
+			Expect(f.DeployWithVisitor(func(b *runtime.PodBuilder) error {
+				altHost := fmt.Sprintf("%s.%s", customerId, azuremonitor.AzureDomain)
+				return azuremonitor.NewMockoonVisitor(b, altHost, f)
+			})).To(BeNil())
+
+			msg := functional.NewCRIOLogMessage(functional.CRIOTime(time.Now()), "This is my test message", false)
+			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(BeNil())
+
+			time.Sleep(30 * time.Second)
+			appLogs, err := azuremonitor.ReadApplicationLogFromMockoon(f)
+			Expect(err).To(BeNil())
+			Expect(appLogs).ToNot(BeNil())
+		})
+
+		It("should send to CloudWatch with only .log_type and .message", func() {
+			pipelineBuilder.ToCloudwatchOutput()
+
+			secret = runtime.NewSecret(f.Namespace, functional.CloudwatchSecret,
+				map[string][]byte{
+					"aws_access_key_id":     []byte(functional.AwsAccessKeyID),
+					"aws_secret_access_key": []byte(functional.AwsSecretAccessKey),
+				},
+			)
+
+			f.Secrets = append(f.Secrets, secret)
+
+			Expect(f.Deploy()).To(BeNil())
+
+			// Write/ read logs
+			msg := functional.NewCRIOLogMessage(functional.CRIOTime(time.Now()), "This is my test message", false)
+			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(BeNil())
+
+			time.Sleep(10 * time.Second)
+
+			logs, err := f.ReadLogsFromCloudwatch(logging.InputNameApplication)
+			Expect(err).To(BeNil())
+			Expect(logs).To(HaveLen(1))
+		})
 	})
 })

--- a/test/functional/outputs/splunk/forward_to_splunk_test.go
+++ b/test/functional/outputs/splunk/forward_to_splunk_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Forwarding to Splunk", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			time.Sleep(45 * time.Second)
+			time.Sleep(90 * time.Second)
 
 			// Write app logs
 			timestamp := "2020-11-04T18:13:59.061892+00:00"
@@ -125,7 +125,7 @@ var _ = Describe("Forwarding to Splunk", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			time.Sleep(45 * time.Second)
+			time.Sleep(90 * time.Second)
 
 			// Write app logs
 			timestamp := "2020-11-04T18:13:59.061892+00:00"
@@ -156,7 +156,7 @@ var _ = Describe("Forwarding to Splunk", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			time.Sleep(45 * time.Second)
+			time.Sleep(90 * time.Second)
 
 			// Write app logs
 			timestamp := "2020-11-04T18:13:59.061892+00:00"

--- a/test/helpers/azuremonitor/mockoon.go
+++ b/test/helpers/azuremonitor/mockoon.go
@@ -25,6 +25,8 @@ const (
 	azureApiJsonFile = "azure-http-data-collector-api.json"
 	image            = "quay.io/openshift-logging/mockoon-cli:6.2.0"
 	data             = "data"
+	AzureDomain      = "acme.com"
+	AzureSecretName  = "azure-secret"
 )
 
 type MockoonLog struct {
@@ -104,7 +106,7 @@ func ReadApplicationLogFromMockoon(framework *functional.CollectorFunctionalFram
 	return extractStructuredLogs(output, "application")
 }
 
-//parse output and extract structured log by given log type
+// parse output and extract structured log by given log type
 func extractStructuredLogs(output, logType string) ([]types.ApplicationLog, error) {
 	var logs []MockoonLog
 


### PR DESCRIPTION
### Description
This PR ensures a fixed set of fields are not pruned from any log records and are required fields.
These fields are:
1. `.log_type`
2. `.message`
3. `.hostname` [^1]

[^1]: Only applies if a pipeline references `GoogleCloudLogging` as a destination, the `.hostname` field cannot be pruned from the log record.

> [!NOTE]  
> See upstream docs and API docs for more information.

This PR also refactors the `CloudWatch` functional test to make it easier to deploy.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5132

