### PR TITLE
LOG-5214: maxWrite, delivery is ignore when output is syslog

### DIFF
--- a/internal/validations/clusterlogforwarder/outputs/tuning.go
+++ b/internal/validations/clusterlogforwarder/outputs/tuning.go
@@ -10,11 +10,13 @@ const (
 
 	maxRetryDurationNotSupportedForType = "maxRetryDuration is not supported for the output type"
 	minRetryDurationNotSupportedForType = "minRetryDuration is not supported for the output type"
+	maxWriteNotSupportedForType         = "maxWrite is not supported for the output type"
 )
 
 var (
 	unsupportedCompression = sets.NewString(loggingv1.OutputTypeSyslog, loggingv1.OutputTypeAzureMonitor, loggingv1.OutputTypeGoogleCloudLogging)
 	unsupportedRequest     = sets.NewString(loggingv1.OutputTypeSyslog, loggingv1.OutputTypeKafka)
+	unsupportedBatch       = sets.NewString(loggingv1.OutputTypeSyslog)
 )
 
 func VerifyTuning(spec loggingv1.OutputSpec) (valid bool, msg string) {
@@ -25,6 +27,11 @@ func VerifyTuning(spec loggingv1.OutputSpec) (valid bool, msg string) {
 	//compression
 	if unsupportedCompression.Has(spec.Type) && spec.Tuning.Compression != "" && spec.Tuning.Compression != "none" {
 		return false, compressionNotSupportedForType
+	}
+
+	// batch
+	if unsupportedBatch.Has(spec.Type) && spec.Tuning.MaxWrite != nil && !spec.Tuning.MaxWrite.IsZero() {
+		return false, maxWriteNotSupportedForType
 	}
 
 	// lz4 is only supported for kafka

--- a/internal/validations/clusterlogforwarder/outputs/tuning_test.go
+++ b/internal/validations/clusterlogforwarder/outputs/tuning_test.go
@@ -90,6 +90,12 @@ var _ = Describe("Validate ", func() {
 				Compression: "lz4",
 			},
 		}),
+		Entry("should fail for syslog when maxWrite is spec'd", false, loggingv1.OutputSpec{
+			Type: loggingv1.OutputTypeSyslog,
+			Tuning: &loggingv1.OutputTuningSpec{
+				MaxWrite: utils.GetPtr(resource.MustParse("10M")),
+			},
+		}),
 	)
 
 })


### PR DESCRIPTION
### Description
This PR adds in a validation to reject `syslog` sinks from setting `maxWrite` as a tuning option as it is not supported. This also adds `acknowledgement` support for future implementation.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5214