### PR TITLE
LOG-5216: CLO raises many 'error removing stale http input services'

### DIFF
--- a/internal/k8shandler/logstore.go
+++ b/internal/k8shandler/logstore.go
@@ -20,7 +20,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateLogStore() (err error
 			instance, err, _ := loader.FetchClusterLogging(clusterRequest.Client, clusterRequest.Cluster.Namespace, clusterRequest.Cluster.Name, true)
 			return &instance, err
 		}
-		return eslogstore.Reconcile(clusterRequest.Client, clusterRequest.Cluster.Spec.LogStore, clusterRequest.Cluster.Namespace, clusterRequest.ResourceNames.InternalLogStoreSecret, utils.AsOwner(clusterRequest.Cluster), fetchClusterLogging)
+		return eslogstore.Reconcile(clusterRequest.Reader, clusterRequest.Client, clusterRequest.Cluster.Spec.LogStore, clusterRequest.Cluster.Namespace, clusterRequest.ResourceNames.InternalLogStoreSecret, utils.AsOwner(clusterRequest.Cluster), fetchClusterLogging)
 	case logging.LogStoreTypeLokiStack:
 		if clusterRequest.Cluster.DeletionTimestamp == nil {
 			return lokistack.ReconcileLokiWriteRbac(clusterRequest.Client)

--- a/internal/k8shandler/reconciler.go
+++ b/internal/k8shandler/reconciler.go
@@ -84,7 +84,7 @@ func Reconcile(cl *logging.ClusterLogging, forwarder *logging.ClusterLogForwarde
 
 	// Clean up any stale http input services
 	if err = clusterLoggingRequest.RemoveInputServices([]metav1.OwnerReference{utils.AsOwner(forwarder)}, false); err != nil {
-		return fmt.Errorf("error removing stale http input services")
+		return fmt.Errorf("error removing stale http input services. %v", err)
 	}
 
 	//if there is no early exit from reconciler then new CL spec is applied successfully hence healthStatus is set to true or 1

--- a/internal/k8shandler/service.go
+++ b/internal/k8shandler/service.go
@@ -44,11 +44,11 @@ func (clusterRequest *ClusterLoggingRequest) RemoveInputService(serviceName stri
 	return nil
 }
 
-// GetServiceList returns a list of services based on a key/value label
+// GetServiceList returns a list of services based on a key/value label and namespace
 func (clusterRequest *ClusterLoggingRequest) GetServiceList(key, val, namespace string) (*core.ServiceList, error) {
 	labelSelector, _ := labels.Parse(fmt.Sprintf("%s=%s", key, val))
 	httpServices := core.ServiceList{}
-	if err := clusterRequest.Client.List(context.TODO(), &httpServices, &client.ListOptions{LabelSelector: labelSelector, Namespace: namespace}); err != nil {
+	if err := clusterRequest.Reader.List(context.TODO(), &httpServices, &client.ListOptions{LabelSelector: labelSelector, Namespace: namespace}); err != nil {
 		return nil, fmt.Errorf("failure listing services with label: %s,  %v", fmt.Sprintf("%s=%s", key, val), err)
 	}
 	return &httpServices, nil

--- a/internal/logstore/elasticsearch/reconcile.go
+++ b/internal/logstore/elasticsearch/reconcile.go
@@ -13,12 +13,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Reconcile(k8sClient client.Client, logStore *logging.LogStoreSpec, namespace, logstoreSecretName string, ownerRef v1.OwnerReference, fetchClusterLogging func() (*logging.ClusterLogging, error)) error {
+func Reconcile(reader client.Reader, k8sClient client.Client, logStore *logging.LogStoreSpec, namespace, logstoreSecretName string, ownerRef v1.OwnerReference, fetchClusterLogging func() (*logging.ClusterLogging, error)) error {
 	if err := ReconcileCustomResource(k8sClient, logStore, namespace, logstoreSecretName, ownerRef); err != nil {
 		return err
 	}
 
-	if err := UpdateStatus(k8sClient, namespace, fetchClusterLogging); err != nil {
+	if err := UpdateStatus(reader, k8sClient, namespace, fetchClusterLogging); err != nil {
 		log.Error(err, "Failed to update Cluster Logging Elasticsearch status")
 	}
 


### PR DESCRIPTION
### Description
This PR fixes the errors arising from using `client.Client` to list services because of the change in namespaces watched. `client.Reader` is needed to list objects from specific namespaces because it bypasses the cache.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5216

