### PR TITLE
LOG-5053: ensure inputs has right setted type before clfSpec migration 

### DIFF
--- a/api/logging/v1/input_receiver_types.go
+++ b/api/logging/v1/input_receiver_types.go
@@ -16,7 +16,6 @@ const (
 type ReceiverSpec struct {
 
 	// Type of Receiver plugin.
-	// +kubebuilder:validation:Enum:=http;syslog
 	// +optional
 	Type string `json:"type"`
 

--- a/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterlogforwarders.yaml
@@ -504,9 +504,6 @@ spec:
                           type: object
                         type:
                           description: Type of Receiver plugin.
-                          enum:
-                          - http
-                          - syslog
                           type: string
                       type: object
                   required:

--- a/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterlogforwarders.yaml
@@ -505,9 +505,6 @@ spec:
                           type: object
                         type:
                           description: Type of Receiver plugin.
-                          enum:
-                          - http
-                          - syslog
                           type: string
                       type: object
                   required:

--- a/internal/migrations/clusterlogforwarder/migrate_inputs.go
+++ b/internal/migrations/clusterlogforwarder/migrate_inputs.go
@@ -6,19 +6,6 @@ import (
 )
 
 func MigrateInputs(namespace, name string, spec loggingv1.ClusterLogForwarderSpec, logStore *loggingv1.LogStoreSpec, extras map[string]bool, logstoreSecretName, saTokenSecret string) (loggingv1.ClusterLogForwarderSpec, map[string]bool, []loggingv1.Condition) {
-	for i, input := range spec.Inputs {
-		if input.Receiver != nil && input.Receiver.ReceiverTypeSpec != nil {
-			if input.Receiver.HTTP != nil && input.Receiver.Type == "" {
-				input.Receiver.Type = loggingv1.ReceiverTypeHttp
-				spec.Inputs[i] = input
-			}
-			if input.Receiver.Syslog != nil && input.Receiver.Type == "" {
-				input.Receiver.Type = loggingv1.ReceiverTypeSyslog
-				spec.Inputs[i] = input
-			}
-		}
-	}
-
 	inputs := map[string]loggingv1.InputSpec{}
 	for _, p := range spec.Pipelines {
 		for _, i := range p.InputRefs {
@@ -50,6 +37,22 @@ func MigrateInputs(namespace, name string, spec loggingv1.ClusterLogForwarderSpe
 	}
 	for _, i := range inputs {
 		spec.Inputs = append(spec.Inputs, i)
+	}
+	return spec, extras, nil
+}
+
+func EnsureInputsHasType(namespace, name string, spec loggingv1.ClusterLogForwarderSpec, logStore *loggingv1.LogStoreSpec, extras map[string]bool, logstoreSecretName, saTokenSecret string) (loggingv1.ClusterLogForwarderSpec, map[string]bool, []loggingv1.Condition) {
+	for i, input := range spec.Inputs {
+		if input.Receiver != nil && input.Receiver.ReceiverTypeSpec != nil {
+			if input.Receiver.HTTP != nil && input.Receiver.Type == "" {
+				input.Receiver.Type = loggingv1.ReceiverTypeHttp
+				spec.Inputs[i] = input
+			}
+			if input.Receiver.Syslog != nil && input.Receiver.Type == "" {
+				input.Receiver.Type = loggingv1.ReceiverTypeSyslog
+				spec.Inputs[i] = input
+			}
+		}
 	}
 	return spec, extras, nil
 }

--- a/internal/migrations/clusterlogforwarder/migrate_inputs_test.go
+++ b/internal/migrations/clusterlogforwarder/migrate_inputs_test.go
@@ -79,7 +79,7 @@ var _ = Describe("migrateInputs", func() {
 				},
 			}
 			extras := map[string]bool{}
-			result, _, _ := MigrateInputs("", "", spec, nil, extras, "", "")
+			result, _, _ := EnsureInputsHasType("", "", spec, nil, extras, "", "")
 			Expect(result.Inputs).To(HaveLen(1))
 			Expect(result.Inputs[0]).To(Equal(logging.InputSpec{
 				Name: "my-custom-input",
@@ -135,7 +135,7 @@ var _ = Describe("migrateInputs", func() {
 				},
 			}
 			extras := map[string]bool{}
-			result, _, _ := MigrateInputs("", "", spec, nil, extras, "", "")
+			result, _, _ := EnsureInputsHasType("", "", spec, nil, extras, "", "")
 			Expect(result.Inputs).To(HaveLen(1))
 			Expect(result.Inputs[0]).To(Equal(logging.InputSpec{
 				Name: "my-custom-input",

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -35,6 +35,7 @@ func MigrateClusterLogForwarder(namespace, name string, spec loggingv1.ClusterLo
 
 // migrations are the set of rules for migrating a ClusterLogForwarder that modify the spec
 var clfMigrations = []func(namespace, name string, spec loggingv1.ClusterLogForwarderSpec, logStore *loggingv1.LogStoreSpec, extras map[string]bool, logstoreSecretName, saTokenSecret string) (loggingv1.ClusterLogForwarderSpec, map[string]bool, []loggingv1.Condition){
+	clusterlogforwarder.EnsureInputsHasType,
 	clusterlogforwarder.MigrateClusterLogForwarderSpec,
 	clusterlogforwarder.MigrateInputs,
 	clusterlogforwarder.DropUnreferencedOutputs,


### PR DESCRIPTION
### Description
This PR addressed to fix issue during migration CLF with not properly configured `Type` in `ReceiverSpec`

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5053
- Enhancement proposal:
