### PR TITLE
Update templates to fix truncated docs

### DIFF
--- a/config/docs/templates/apis/asciidoc/members.tpl
+++ b/config/docs/templates/apis/asciidoc/members.tpl
@@ -85,6 +85,6 @@ Type:: {{ (yamlType .Type) }}
            {{- if (isOptionalMember .) -}}
               {{- $extra = (printf "%s %s" $extra "*(optional)*") -}}
            {{- end -}}
-           |{{ (fieldName .) }}|{{ (yamlType .Type)}}| {{ $extra }} {{ (comments .CommentLines "summary") }}
+           |{{ (fieldName .) }}|{{ (yamlType .Type)}}| {{ $extra }} {{ (comments .CommentLines "") }}
        {{- end }}
 {{ end }}


### PR DESCRIPTION
### Description
The `summary` setting was causing docs to be cut off mid sentence when generating API docs. This PR removes that setting.

/cc @jcantrill 
/assign @alanconway 

/cherry-pick release-5.8
/cherry-pick release-5.7
/cherry-pick release-5.6
