### PR TITLE
LOG-5309: Exclude log infra when collecting infra containers

### DIFF
--- a/internal/generator/vector/input/viaq.go
+++ b/internal/generator/vector/input/viaq.go
@@ -110,7 +110,7 @@ func NewViaQ(input logging.InputSpec, collectorNS string, resNames *factory.Forw
 			sources := sets.NewString(input.Infrastructure.Sources...)
 			if sources.Has(logging.InfrastructureSourceContainer) {
 				infraIncludes := source.NewContainerPathGlobBuilder().AddNamespaces(infraNamespaces...).Build()
-				cels, cids := NewViaqContainerSource(input, collectorNS, infraIncludes, "")
+				cels, cids := NewViaqContainerSource(input, collectorNS, infraIncludes, loggingExcludes)
 				els = append(els, cels...)
 				ids = append(ids, cids...)
 			}

--- a/internal/generator/vector/input/viaq_infrastructure_container.toml
+++ b/internal/generator/vector/input/viaq_infrastructure_container.toml
@@ -5,6 +5,7 @@ max_read_bytes = 3145728
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/default_*/*/*.log", "/var/log/pods/kube*_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log"]
+exclude_paths_glob_patterns = ["/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.tmp", "/var/log/pods/openshift-logging_*/gateway/*.log", "/var/log/pods/openshift-logging_*/loki*/*.log", "/var/log/pods/openshift-logging_*/opa/*.log", "/var/log/pods/openshift-logging_elasticsearch-*/*/*.log", "/var/log/pods/openshift-logging_kibana-*/*/*.log", "/var/log/pods/openshift-logging_logfilesmetricexporter-*/*/*.log"]
 pod_annotation_fields.pod_labels = "kubernetes.labels"
 pod_annotation_fields.pod_namespace = "kubernetes.namespace_name"
 pod_annotation_fields.pod_annotations = "kubernetes.annotations"


### PR DESCRIPTION
### Description
This PR:
* Excludes the collection of logging infra for infrastructure container inputs(with the exception of collector container)
* Collector containers will be part of a separate issue
### Links
https://issues.redhat.com/browse/LOG-5309
