### PR TITLE
LOG-4910: remove collector daemonset only if 'Not authorized to collect' error occurs

### DIFF
--- a/internal/controller/forwarding/forwarding_controller.go
+++ b/internal/controller/forwarding/forwarding_controller.go
@@ -84,8 +84,8 @@ func (r *ReconcileForwarder) Reconcile(ctx context.Context, request ctrl.Request
 	// Fetch the ClusterLogForwarder instance
 	instance, err, status := loader.FetchClusterLogForwarder(r.Client, request.NamespacedName.Namespace, request.NamespacedName.Name, true, func() logging.ClusterLogging { return *cl })
 	if status != nil {
-		if err := instance.Status.Synchronize(status); err != nil {
-			return ctrl.Result{}, err
+		if syncErr := instance.Status.Synchronize(status); syncErr != nil {
+			return ctrl.Result{}, syncErr
 		}
 	}
 	if err != nil {

--- a/internal/validations/errors/errors.go
+++ b/internal/validations/errors/errors.go
@@ -32,5 +32,5 @@ func IsValidationError(err error) bool {
 }
 
 func MustUndeployCollector(err error) bool {
-	return !strings.Contains(err.Error(), NotAuthorizedToCollect)
+	return strings.Contains(err.Error(), NotAuthorizedToCollect)
 }

--- a/internal/validations/errors/errors_test.go
+++ b/internal/validations/errors/errors_test.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -22,17 +23,17 @@ var _ = Describe("[internal][validations][errors]", func() {
 	})
 	Context("#MustUndeployCollector", func() {
 
-		It("should fail when not authorized to collect", func() {
+		It("should pass when not authorized to collect", func() {
 			myerror := &ValidationError{
 				msg: "something" + NotAuthorizedToCollect,
 			}
-			Expect(MustUndeployCollector(myerror)).To(BeFalse())
+			Expect(MustUndeployCollector(myerror)).To(BeTrue())
 		})
-		It("should pass does not mention authorized to collect", func() {
+		It("should fail does not mention authorized to collect", func() {
 			myerror := &ValidationError{
 				msg: "something",
 			}
-			Expect(MustUndeployCollector(myerror)).To(BeTrue())
+			Expect(MustUndeployCollector(myerror)).To(BeFalse())
 		})
 
 	})


### PR DESCRIPTION
### Description
This PR addresses the behavior of the reconciliation process, specifically focusing on error handling: the reconciler should skip all errors and leave the collector instance unchanged, only removing it in the event of a `Not authorized to collect` error.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4910
- Enhancement proposal:
