### PR TITLE
LOG-5322 & LOG-5323 segfaults if PrunfilterSpec or DropTestsSpec not spec'd

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_filters.go
+++ b/internal/validations/clusterlogforwarder/validate_filters.go
@@ -42,6 +42,11 @@ func ValidateFilters(clf loggingv1.ClusterLogForwarder, k8sClient client.Client,
 // validateDropFilter validates each test and their associated conditions in a drop filter.
 // It sets the filter status for the specific drop test index to better diagnose problems
 func validateDropFilter(filterSpec *loggingv1.FilterSpec, clfStatus *loggingv1.NamedConditions) {
+	if filterSpec.DropTestsSpec == nil {
+		clfStatus.Set(filterSpec.Name, conditions.CondInvalid("drop filter must have at least one test spec'd"))
+		return
+	}
+
 	var err error
 	// Validate each test
 	for i, dropTest := range *filterSpec.DropTestsSpec {
@@ -72,6 +77,10 @@ func validateDropFilter(filterSpec *loggingv1.FilterSpec, clfStatus *loggingv1.N
 }
 
 func validatePruneFilter(filterSpec *loggingv1.FilterSpec, clfStatus *loggingv1.NamedConditions) {
+	if filterSpec.PruneFilterSpec == nil {
+		clfStatus.Set(filterSpec.Name, conditions.CondInvalid("prune filter must have one or both of `in`, `notIn`"))
+		return
+	}
 	errList := []string{}
 	// Validate `in` paths
 	if filterSpec.PruneFilterSpec.In != nil {

--- a/internal/validations/clusterlogforwarder/validate_filters_test.go
+++ b/internal/validations/clusterlogforwarder/validate_filters_test.go
@@ -181,6 +181,22 @@ var _ = Describe("[internal][validations] ClusterLogForwarder: Filters", func() 
 				},
 			),
 		)
+
+		It("should fail if no drop conditions spec'd", func() {
+			clf := &v1.ClusterLogForwarder{
+				Spec: v1.ClusterLogForwarderSpec{
+					Filters: []v1.FilterSpec{
+						{
+							Name: myDrop,
+							Type: v1.FilterDrop,
+						},
+					},
+				},
+			}
+			err, status := ValidateFilters(*clf, nil, nil)
+			Expect(err).ToNot(BeNil())
+			Expect(status.Filters[myDrop]).To(HaveCondition(v1.ConditionReady, false, v1.ReasonInvalid, "drop filter must have at least one test spec'd"))
+		})
 	})
 
 	Context("#validatePruneFilter", func() {
@@ -440,6 +456,22 @@ var _ = Describe("[internal][validations] ClusterLogForwarder: Filters", func() 
 				Expect(status.Filters[myPrune]).To(HaveCondition(v1.ConditionReady, false, v1.ReasonInvalid, ".+is/are required fields and must be included.+"))
 			})
 
+		})
+
+		It("should fail validation if prune filter spec'd without pruneFilterSpec", func() {
+			clf := &v1.ClusterLogForwarder{
+				Spec: v1.ClusterLogForwarderSpec{
+					Filters: []v1.FilterSpec{
+						{
+							Name: myPrune,
+							Type: v1.FilterPrune,
+						},
+					},
+				},
+			}
+			err, status := ValidateFilters(*clf, nil, nil)
+			Expect(err).ToNot(BeNil())
+			Expect(status.Filters[myPrune]).To(HaveCondition(v1.ConditionReady, false, v1.ReasonInvalid, "prune filter must have one or both of `in`, `notIn`"))
 		})
 
 	})


### PR DESCRIPTION
### Description
This PR adds a `nil` check for drop and prune filters during validation and will raise a validation error if the appropriate `FilterTypeSpec` is not defined.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA:
1. https://issues.redhat.com/browse/LOG-5322
2. https://issues.redhat.com/browse/LOG-5323

