### PR TITLE
LOG-4672: ensure timestamp field has correct format for Splunk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,7 @@ test-functional-vector: test-functional-benchmarker-vector
 		./test/functional/outputs/cloudwatch/... \
 		./test/functional/outputs/loki/... \
 		./test/functional/outputs/http/... \
+		./test/functional/outputs/splunk/... \
 		./test/functional/outputs/syslog/... \
 		./test/functional/normalization/... \
 		./test/functional/flowcontrol/... \

--- a/internal/generator/vector/output/splunk/splunk_test.go
+++ b/internal/generator/vector/output/splunk/splunk_test.go
@@ -45,10 +45,26 @@ source = '''
   }
 '''
 `
-		splunkSink = splunkDedot + `
+		fixTimestamp = `
+	# Ensure timestamp field well formatted for Splunk
+	[transforms.splunk_hec_timestamp]
+	type = "remap"
+	inputs = ["splunk_hec_dedot"]
+	source = '''
+
+	ts, err = parse_timestamp(.@timestamp,"%+")
+	if err != null {
+		log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
+	} else {
+		.@timestamp = ts
+	}
+
+	'''
+`
+		splunkSink = splunkDedot + fixTimestamp + `
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_dedot"]
+inputs = ["splunk_hec_timestamp"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "` + hecToken + `"
@@ -56,10 +72,10 @@ timestamp_key = "@timestamp"
 [sinks.splunk_hec.encoding]
 codec = "json"
 `
-		splunkSinkTls = splunkDedot + `
+		splunkSinkTls = splunkDedot + fixTimestamp + `
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_dedot"]
+inputs = ["splunk_hec_timestamp"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "` + hecToken + `"
@@ -72,10 +88,10 @@ key_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/ca-bundle.crt"
 `
-		splunkSinkTlsSkipVerify = splunkDedot + `
+		splunkSinkTlsSkipVerify = splunkDedot + fixTimestamp + `
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_dedot"]
+inputs = ["splunk_hec_timestamp"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "` + hecToken + `"
@@ -90,10 +106,10 @@ key_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/vector-splunk-secret-tls/ca-bundle.crt"
 `
-		splunkSinkTlsSkipVerifyNoCert = splunkDedot + `
+		splunkSinkTlsSkipVerifyNoCert = splunkDedot + fixTimestamp + `
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_dedot"]
+inputs = ["splunk_hec_timestamp"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = ""
@@ -105,10 +121,10 @@ codec = "json"
 verify_certificate = false
 verify_hostname = false
 `
-		splunkSinkPassphrase = splunkDedot + `
+		splunkSinkPassphrase = splunkDedot + fixTimestamp + `
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_dedot"]
+inputs = ["splunk_hec_timestamp"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "` + hecToken + `"
@@ -288,10 +304,24 @@ source = '''
 	  }
   }
 '''
+# Ensure timestamp field well formatted for Splunk
+[transforms.splunk_hec_timestamp]
+type = "remap"
+inputs = ["splunk_hec_dedot"]
+source = '''
+
+ts, err = parse_timestamp(.@timestamp,"%+")
+if err != null {
+	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
+} else {
+	.@timestamp = ts
+}
+
+'''
 
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_dedot"]
+inputs = ["splunk_hec_timestamp"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "` + hecToken + `"


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### Description
This PR addresses an issue with improperly formatted timestamp fields in audit log records. The problem occurs with records such as `type=BPF msg=audit(1713260779.116:5146): prog-id=2650 op=LOAD`, where the timestamp field lacks proper formatting. To resolve this issue, a remap transformation has been added: `.@timestamp = parse_timestamp(.@timestamp,"%+")`. This transformation ensures that the timestamp field is correctly parsed and formatted, resolving the formatting issue observed in the audit log records.

Changes Made:
- added remap transformation to parse and format the timestamp field in audit log records.
- added functional test to confirm the fix and ensure that the timestamp field is correctly formatted after applying the remap transformation.
- enabling functional tests for Splunk Output in Makefike  

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma  <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill ef<!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick release-5.9 <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-4672
- Enhancement proposal:
