### PR TITLE
LOG-5372: Enable log level for vector

### DIFF
--- a/docs/features/log_level.adoc
+++ b/docs/features/log_level.adoc
@@ -1,0 +1,42 @@
+== Vector Collector: Configuring Log Level
+
+This feature enables configuring the log level of the Vector collector. The log level can be configured through an annotation on the `ClusterLogForwarder` along with the appropriate log level. Internally, this sets the `VECTOR_LOG` environment variable to the desired log level.
+
+Annotation: `observability.openshift.io/log-level`.
+
+The Cluster Logging Operator will default Vector's log level to `warn`.footnote:[https://issues.redhat.com/browse/LOG-3435[LOG-3435]]
+
+Supported values are: footnote:[https://vector.dev/docs/administration/monitoring/#levels[Vector Log Levels]]
+
+. `trace`
+. `debug`
+. `info`
+. `warn`
+. `error`
+. `off`
+
+=== Example
+.Enable Debug Log Level for Vector
+[source]
+----
+apiVersion: "logging.openshift.io/v1"
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+  annotations:
+    observability.openshift.io/log-level: "debug"
+spec:
+  outputs:
+  - name: devel
+    type: elasticsearch
+  pipelines:
+   - name: devel-logs
+     inputRefs:
+     - application
+     outputRefs:
+     - devel
+----
+This configuration will configure vector's log level to `debug`.
+
+

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -79,6 +79,20 @@ var _ = Describe("Factory#Daemonset#NewPodSpec", func() {
 				Expect(collector.VolumeMounts).To(ContainElement(expectedContainerVolume))
 			})
 		})
+
+		Context("with vector collector", func() {
+			It("should set VECTOR_LOG env variable with debug value", func() {
+				logLevelDebug := "debug"
+				factory.CollectorType = logging.LogCollectionTypeVector
+				factory.ImageName = constants.VectorName
+				factory.Visit = vector.CollectorVisitor
+				factory.LogLevel = logLevelDebug
+
+				podSpec = *factory.NewPodSpec(nil, logging.ClusterLogForwarderSpec{}, "1234", "", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+				collector = podSpec.Containers[0]
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{Name: "VECTOR_LOG", Value: logLevelDebug}))
+			})
+		})
 	})
 
 	Describe("when creating the podSpec", func() {

--- a/internal/collector/fluentd/visitors.go
+++ b/internal/collector/fluentd/visitors.go
@@ -21,7 +21,7 @@ var (
 	DefaultCpuRequest = resource.MustParse("100m")
 )
 
-func CollectorVisitor(collectorContainer *v1.Container, podSpec *v1.PodSpec, resNames *factory.ForwarderResourceNames, namespace string) {
+func CollectorVisitor(collectorContainer *v1.Container, podSpec *v1.PodSpec, resNames *factory.ForwarderResourceNames, namespace, logLevel string) {
 
 	collectorContainer.Env = append(collectorContainer.Env,
 		v1.EnvVar{

--- a/internal/collector/vector/visitors.go
+++ b/internal/collector/vector/visitors.go
@@ -8,9 +8,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func CollectorVisitor(collectorContainer *corev1.Container, podSpec *corev1.PodSpec, resNames *factory.ForwarderResourceNames, namespace string) {
+func CollectorVisitor(collectorContainer *corev1.Container, podSpec *corev1.PodSpec, resNames *factory.ForwarderResourceNames, namespace, logLevel string) {
 	collectorContainer.Env = append(collectorContainer.Env,
-		corev1.EnvVar{Name: "VECTOR_LOG", Value: "WARN"},
+		corev1.EnvVar{Name: "VECTOR_LOG", Value: logLevel},
 		corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "kubernetes.default.svc"},
 		corev1.EnvVar{
 			Name: "VECTOR_SELF_NODE_NAME",

--- a/internal/constants/features.go
+++ b/internal/constants/features.go
@@ -26,4 +26,9 @@ const (
 	// instead of a daemonset to support the HCP use case of using the collector for collecting
 	// audit logs via a webhook.
 	AnnotationEnableCollectorAsDeployment = "logging.openshift.io/dev-preview-enable-collector-as-deployment"
+
+	// AnnotationVectorLogLevel is used to set the log level of vector.
+	// Log level can be one of: trace, debug, info, warn, error, off.
+	// CLO's default log level for vector is `warn`: https://issues.redhat.com/browse/LOG-3435
+	AnnotationVectorLogLevel = "observability.openshift.io/log-level"
 )

--- a/internal/k8shandler/clusterloggingrequest.go
+++ b/internal/k8shandler/clusterloggingrequest.go
@@ -46,6 +46,10 @@ type ClusterLoggingRequest struct {
 
 	// Determine the collector deployment strategy; Daemonset || Deployment
 	isDaemonset bool
+
+	// Vector log level
+	// Default is `warn`: https://issues.redhat.com/browse/LOG-3435
+	LogLevel string
 }
 
 func NewClusterLoggingRequest(cl *logging.ClusterLogging, forwarder *logging.ClusterLogForwarder, requestClient client.Client, reader client.Reader, r record.EventRecorder, clusterVersion, clusterID string, resourceNames *factory.ForwarderResourceNames) ClusterLoggingRequest {
@@ -60,6 +64,7 @@ func NewClusterLoggingRequest(cl *logging.ClusterLogging, forwarder *logging.Clu
 		ResourceNames:  resourceNames,
 		ResourceOwner:  utils.AsOwner(forwarder),
 		isDaemonset:    true,
+		LogLevel:       "warn",
 	}
 
 	// Owner is always the ClusterLogging instance for legacy ClusterLogging
@@ -74,6 +79,10 @@ func NewClusterLoggingRequest(cl *logging.ClusterLogging, forwarder *logging.Clu
 		if inputs.Len() == 1 && inputs.Has(logging.InputNameReceiver) {
 			request.isDaemonset = false
 		}
+	}
+
+	if level, ok := request.Forwarder.Annotations[constants.AnnotationVectorLogLevel]; ok {
+		request.LogLevel = level
 	}
 
 	return request

--- a/internal/k8shandler/collection.go
+++ b/internal/k8shandler/collection.go
@@ -82,7 +82,7 @@ func (clusterRequest *ClusterLoggingRequest) CreateOrUpdateCollection() (err err
 		return
 	}
 
-	factory := collector.New(collectorConfHash, clusterRequest.ClusterID, *clusterRequest.Cluster.Spec.Collection, clusterRequest.OutputSecrets, clusterRequest.Forwarder.Spec, clusterRequest.ResourceNames.CommonName, clusterRequest.ResourceNames, clusterRequest.isDaemonset)
+	factory := collector.New(collectorConfHash, clusterRequest.ClusterID, *clusterRequest.Cluster.Spec.Collection, clusterRequest.OutputSecrets, clusterRequest.Forwarder.Spec, clusterRequest.ResourceNames.CommonName, clusterRequest.ResourceNames, clusterRequest.isDaemonset, clusterRequest.LogLevel)
 
 	if err := network.ReconcileService(clusterRequest.EventRecorder, clusterRequest.Client, clusterRequest.Forwarder.Namespace, clusterRequest.ResourceNames.CommonName, constants.CollectorName, collector.MetricsPortName, clusterRequest.ResourceNames.SecretMetrics, collector.MetricsPort, clusterRequest.ResourceOwner, factory.CommonLabelInitializer); err != nil {
 		log.Error(err, "collector.ReconcileService")

--- a/internal/validations/clusterlogforwarder/validate_annotations.go
+++ b/internal/validations/clusterlogforwarder/validate_annotations.go
@@ -1,0 +1,27 @@
+package clusterlogforwarder
+
+import (
+	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/utils/sets"
+	"github.com/openshift/cluster-logging-operator/internal/validations/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var vectorLogLevelSet = sets.NewString("trace", "debug", "info", "warn", "error", "off")
+
+func validateAnnotations(clf loggingv1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *loggingv1.ClusterLogForwarderStatus) {
+	// No annotations to validate
+	if len(clf.Annotations) == 0 {
+		return nil, nil
+	}
+
+	// log level annotation
+	if level, ok := clf.Annotations[constants.AnnotationVectorLogLevel]; ok {
+		if !vectorLogLevelSet.Has(level) {
+			return errors.NewValidationError("log level: %q is not valid. Must be one of trace, debug, info, warn, error, off.", level), nil
+		}
+	}
+
+	return nil, nil
+}

--- a/internal/validations/clusterlogforwarder/validate_annotations_test.go
+++ b/internal/validations/clusterlogforwarder/validate_annotations_test.go
@@ -1,0 +1,43 @@
+package clusterlogforwarder
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/test/runtime"
+)
+
+var _ = Describe("[internal][validations] validate clusterlogforwarder annotations", func() {
+	var (
+		clf *loggingv1.ClusterLogForwarder
+	)
+
+	BeforeEach(func() {
+		clf = runtime.NewClusterLogForwarder()
+	})
+
+	Context("#validateLogLevel", func() {
+		It("should pass validation if no annotations are set", func() {
+			Expect(validateAnnotations(*clf, nil, nil)).To(Succeed())
+		})
+
+		It("should fail validation if log level is not supported", func() {
+			clf.Annotations = map[string]string{constants.AnnotationVectorLogLevel: "foo"}
+			err, _ := validateAnnotations(*clf, nil, nil)
+			Expect(err).ToNot(BeNil())
+		})
+
+		DescribeTable("valid log levels", func(level string) {
+			clf.Annotations = map[string]string{constants.AnnotationVectorLogLevel: level}
+			Expect(validateAnnotations(*clf, nil, nil)).To(Succeed())
+		},
+			Entry("should pass with level trace", "trace"),
+			Entry("should pass with level debug", "debug"),
+			Entry("should pass with level info", "info"),
+			Entry("should pass with level warn", "warn"),
+			Entry("should pass with level error", "error"),
+			Entry("should pass with level off", "off"))
+	})
+})

--- a/internal/validations/clusterlogforwarder/validations.go
+++ b/internal/validations/clusterlogforwarder/validations.go
@@ -29,4 +29,5 @@ var validations = []func(clf v1.ClusterLogForwarder, k8sClient client.Client, ex
 	validateUrlAccordingToTls,
 	validateHttpContentTypeHeaders,
 	ValidateServiceAccount,
+	validateAnnotations,
 }


### PR DESCRIPTION
### Description
This PR enables configuration of the log level for the Vector collector through an annotation in the `ClusterLogForwarder` resource.

This introduces a new annotation: `observability.openshift.io/log-level`.
The log level can be set to one of `trace`, `debug`, `info`, `warn`, `error`, `off`.

Vector's default log level is `info`.

```
apiVersion: "logging.openshift.io/v1"
kind: ClusterLogForwarder
metadata:
  name: instance
  namespace: openshift-logging
  annotations:
    observability.openshift.io/log-level: "debug"
spec:
...
```


/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5372
