### PR TITLE
Add 5.9.0 container image to must-gather annotation

### DIFF
--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -118,7 +118,7 @@ metadata:
     certified: "false"
     console.openshift.io/plugins: '["logging-view-plugin"]'
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-01-09T03:03:58Z"
+    createdAt: "2024-04-18T15:39:46Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing your aggregated logging stack.
     features.operators.openshift.io/cnf: "false"
@@ -135,6 +135,7 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-logging
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-logging/cluster-logging-rhel9-operator@sha256:b3a09d6dfc5109cd5d3ebf24201f9d0549d77f8965907c1b6b15faba15c767eb
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
       Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -23,6 +23,7 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-logging
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift-logging/cluster-logging-rhel9-operator@sha256:b3a09d6dfc5109cd5d3ebf24201f9d0549d77f8965907c1b6b15faba15c767eb
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
       Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -34,7 +35,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: clusterlogging.v0.0.0
+  name: clusterlogging.v5.9.0
   namespace: openshift-logging
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
### Description
Add the latest CLO container image to the bundle annotation, to accommodate the new `--all-images` flag.   This should eventually go into a CPaaS file?... so we can keep the image updated.  For now, the latest from the container catalog should be good.  Will need to be in 6.0 release as well.

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5108
- Enhancement proposal: https://groups.google.com/a/redhat.com/g/aos-logging/c/_-YYN3-2dOc/m/wzX3SWQFAwAJ
