### PR TITLE
extend wait for multi-clf test

### DIFF
--- a/hack/testing-olm/test-1343-minimal-multi-clf.sh
+++ b/hack/testing-olm/test-1343-minimal-multi-clf.sh
@@ -63,4 +63,4 @@ os::cmd::expect_success "oc -n $LOGGING_NS create -f ${repo_dir}/hack/clusterlog
 
 assert_collector_exist my-collector
 
-os::cmd::expect_success "oc -n $LOGGING_NS wait -lcomponent=collector --for=jsonpath='{.status.phase}'=Running pod"
+os::cmd::try_until_success "oc -n $LOGGING_NS wait -lcomponent=collector --for=jsonpath='{.status.phase}'=Running pod" ${TIMEOUT_MIN}


### PR DESCRIPTION
### Description

This PR:
* extends the wait time for the multi-clf test to 90s as it appears the pods comeup but the wait times out prematurely

cc @Clee2691 @cahartma @vparfonov 