### PR TITLE
Correction to prevent appended field descriptions.

### DIFF
--- a/config/docs/templates/datamodels/asciidoc/members.tpl
+++ b/config/docs/templates/datamodels/asciidoc/members.tpl
@@ -93,6 +93,6 @@
            {{ end }}
            |{{ (fieldName .) }}
            |{{ (yamlType .Type)}}
-           a| {{ $extra }} {{ (comments .CommentLines "summary")}}
+           a| {{ $extra }} {{ (comments .CommentLines)}}
        {{ end }}
 {{ end }}


### PR DESCRIPTION
Expands on https://github.com/openshift/cluster-logging-operator/pull/2417 - to prevent truncated fields in API ref generation. 