### PR TITLE
LOG-5474: Fix CLO rotate_wait_ms to rotate_wait_secs

### DIFF
--- a/config/overlays/stable/deployment_patch.yaml
+++ b/config/overlays/stable/deployment_patch.yaml
@@ -15,7 +15,7 @@ spec:
           env:
             # EDIT HERE: change the 'value' fields to the related images you want to use.
             - name: RELATED_IMAGE_VECTOR
-              value: quay.io/openshift-logging/vector:5.9
+              value: quay.io/openshift-logging/vector:6.0
             - name: RELATED_IMAGE_FLUENTD
               value: quay.io/openshift-logging/fluentd:5.9.0
             - name: RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER

--- a/internal/cmd/functional-benchmarker/config/options.go
+++ b/internal/cmd/functional-benchmarker/config/options.go
@@ -4,10 +4,11 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"io"
 	"os"
 	"time"
+
+	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -18,7 +19,7 @@ import (
 
 const (
 	LogStressorImage = "quay.io/openshift-logging/cluster-logging-load-client:0.2"
-	imageVector      = "quay.io/openshift-logging/vector:5.9"
+	imageVector      = "quay.io/openshift-logging/vector:6.0"
 	imageFluentd     = "quay.io/openshift-logging/fluentd:5.9"
 )
 

--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -81,7 +81,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"
@@ -117,7 +117,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_mytestapp_container_meta]
 type = "remap"

--- a/internal/generator/vector/conf/complex_drop_filter.toml
+++ b/internal/generator/vector/conf/complex_drop_filter.toml
@@ -81,7 +81,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"
@@ -117,7 +117,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_mytestapp_container_meta]
 type = "remap"

--- a/internal/generator/vector/conf/complex_es_no_ver.toml
+++ b/internal/generator/vector/conf/complex_es_no_ver.toml
@@ -20,7 +20,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_application_container_meta]
 type = "remap"
@@ -104,7 +104,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"

--- a/internal/generator/vector/conf/complex_es_v6.toml
+++ b/internal/generator/vector/conf/complex_es_v6.toml
@@ -20,7 +20,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_application_container_meta]
 type = "remap"
@@ -104,7 +104,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -81,7 +81,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"
@@ -152,7 +152,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_mytestapp_container_meta]
 type = "remap"

--- a/internal/generator/vector/conf/complex_otel.toml
+++ b/internal/generator/vector/conf/complex_otel.toml
@@ -81,7 +81,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"
@@ -117,7 +117,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_mytestapp_container_meta]
 type = "remap"

--- a/internal/generator/vector/conf/complex_prune_filter.toml
+++ b/internal/generator/vector/conf/complex_prune_filter.toml
@@ -81,7 +81,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"
@@ -117,7 +117,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_mytestapp_container_meta]
 type = "remap"

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -21,7 +21,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_myinfra_container_meta]
 type = "remap"
@@ -45,7 +45,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_mytestapp_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application.toml
+++ b/internal/generator/vector/input/application.toml
@@ -11,7 +11,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_application_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_exclude_container_from_infra.toml
+++ b/internal/generator/vector/input/application_exclude_container_from_infra.toml
@@ -12,7 +12,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_excludes_container.toml
+++ b/internal/generator/vector/input/application_excludes_container.toml
@@ -11,7 +11,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_includes_container.toml
+++ b/internal/generator/vector/input/application_includes_container.toml
@@ -12,7 +12,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_excludes.toml
+++ b/internal/generator/vector/input/application_with_excludes.toml
@@ -11,7 +11,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_includes.toml
+++ b/internal/generator/vector/input/application_with_includes.toml
@@ -12,7 +12,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_includes_excludes.toml
@@ -12,7 +12,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_infra_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_excludes.toml
@@ -12,7 +12,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
@@ -12,7 +12,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_matchLabels.toml
+++ b/internal/generator/vector/input/application_with_matchLabels.toml
@@ -12,7 +12,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
@@ -12,7 +12,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_throttle.toml
+++ b/internal/generator/vector/input/application_with_throttle.toml
@@ -11,7 +11,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_application_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/infrastructure.toml
+++ b/internal/generator/vector/input/infrastructure.toml
@@ -12,7 +12,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/infrastructure_container.toml
+++ b/internal/generator/vector/input/infrastructure_container.toml
@@ -12,7 +12,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 
 [transforms.input_myinfra_container_meta]
 type = "remap"

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -2,11 +2,12 @@ package source
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
-	"github.com/openshift/cluster-logging-operator/internal/utils/sets"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/utils/sets"
 )
 
 type KubernetesLogs struct {
@@ -44,7 +45,7 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5
 {{end}}`
 }
 

--- a/internal/generator/vector/source/kubernetes_logs_no_includes_excludes.toml
+++ b/internal/generator/vector/source/kubernetes_logs_no_includes_excludes.toml
@@ -10,4 +10,4 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5

--- a/internal/generator/vector/source/kubernetes_logs_with_includes.toml
+++ b/internal/generator/vector/source/kubernetes_logs_with_includes.toml
@@ -12,4 +12,4 @@ pod_annotation_fields.pod_annotations = "kubernetes.annotations"
 pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
-rotate_wait_ms = 5000
+rotate_wait_secs = 5


### PR DESCRIPTION
### Description
This PR fixes `rotate_wait_ms` to `rotate_wait_secs` as this was implemented in upstream `vector:0.37.0`. This also changes CLO to use `vector:6.0` in the deployment patch & functional benchmarker.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5474