### PR TITLE
[release-5.9]LOG-5308: add watcher for grafana-dashboard-cluster-logging configMap to support it reconciliation

### DIFF
--- a/internal/metrics/dashboard/dashboards.go
+++ b/internal/metrics/dashboard/dashboards.go
@@ -2,9 +2,8 @@ package dashboard
 
 import (
 	"context"
-	"fmt"
-
 	_ "embed"
+	"fmt"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
@@ -12,9 +11,14 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/internal/utils/comparators"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntime "sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -27,8 +31,23 @@ const (
 //go:embed openshift-logging-dashboard.json
 var DashboardConfig string
 
-func newDashboardConfigMap() *corev1.ConfigMap {
+var _ ctrlruntime.Reconciler = &ReconcileDashboards{}
 
+type ReconcileDashboards struct {
+	Client client.Client
+
+	// Reader is an initialized client.Reader that reads objects directly from the apiserver
+	// instead of the cache. Useful for cases where need to read/write to a namespace other than
+	// the deployed namespace (e.g. openshift-config-managed)
+	Reader client.Reader
+}
+
+func (r *ReconcileDashboards) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	log.V(3).Info("reconcile ", "ConfigMap", DashboardName)
+	return ctrl.Result{}, ReconcileForDashboards(r.Client, r.Reader)
+}
+
+func newDashboardConfigMap() *corev1.ConfigMap {
 	hash, err := utils.CalculateMD5Hash(DashboardConfig)
 	if err != nil {
 		log.Error(err, "Error calculated hash for metrics dashboard")
@@ -42,23 +61,21 @@ func newDashboardConfigMap() *corev1.ConfigMap {
 	runtime.NewConfigMapBuilder(cm).
 		AddLabel("console.openshift.io/dashboard", "true").
 		AddLabel(DashboardHashName, hash)
-
 	return cm
 }
 
-func ReconcileDashboards(k8sClient client.Client, reader client.Reader) error {
-	var err error
+func ReconcileForDashboards(k8sClient client.Client, reader client.Reader) error {
 	cm := newDashboardConfigMap()
 
 	current := &corev1.ConfigMap{}
 	key := client.ObjectKeyFromObject(cm)
-	err = reader.Get(context.TODO(), key, current)
+	err := reader.Get(context.TODO(), key, current)
 
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("failed to get %v configmap: %v", key, err)
 	}
 
-	if err := reconcile.Configmap(k8sClient, reader, cm, comparators.CompareLabels); err != nil {
+	if err = reconcile.Configmap(k8sClient, reader, cm, comparators.CompareLabels); err != nil {
 		return err
 	}
 
@@ -74,4 +91,24 @@ func RemoveDashboardConfigMap(c client.Client) (err error) {
 		},
 	}
 	return c.Delete(context.TODO(), cm)
+}
+
+// SetupWithManager sets up the controller with the Manager
+func (r *ReconcileDashboards) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		Watches(&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(func(cxt context.Context, obj client.Object) []ctrl.Request {
+				if obj.GetName() == DashboardName && obj.GetNamespace() == DashboardNS {
+					return []ctrl.Request{
+						{
+							NamespacedName: types.NamespacedName{
+								Namespace: obj.GetNamespace(),
+								Name:      obj.GetName(),
+							},
+						},
+					}
+				}
+				return nil
+			})).Complete(r)
 }

--- a/internal/metrics/dashboard/dashboards_test.go
+++ b/internal/metrics/dashboard/dashboards_test.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var _ = Describe("ReconcileDashboards", func() {
+var _ = Describe("ReconcileForDashboards", func() {
 	var (
 		fakeClient client.Client
 
@@ -41,7 +41,7 @@ var _ = Describe("ReconcileDashboards", func() {
 			setup(nil)
 		})
 		It("should create a new dashboard configmap", func() {
-			Expect(ReconcileDashboards(fakeClient, fakeClient)).To(Succeed())
+			Expect(ReconcileForDashboards(fakeClient, fakeClient)).To(Succeed())
 			Expect(GetDashboard()).To(Equal(exp))
 		})
 	})
@@ -52,13 +52,13 @@ var _ = Describe("ReconcileDashboards", func() {
 			initial := newDashboardConfigMap()
 			initial.Labels[DashboardHashName] = "abc"
 			setup(initial)
-			Expect(ReconcileDashboards(fakeClient, fakeClient)).To(Succeed())
+			Expect(ReconcileForDashboards(fakeClient, fakeClient)).To(Succeed())
 			Expect(GetDashboard()).To(Equal(exp), "Exp the configmap to be updated")
 		})
 
 		It("should do nothing to the configmap when the dashboard is the same", func() {
 			setup(initial)
-			Expect(ReconcileDashboards(fakeClient, fakeClient)).To(Succeed())
+			Expect(ReconcileForDashboards(fakeClient, fakeClient)).To(Succeed())
 			Expect(GetDashboard()).To(Equal(exp))
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>
Cherry-pick for https://github.com/openshift/cluster-logging-operator/pull/2427/
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
