### PR TITLE
LOG-5042: Refactor Collector Alerts/Metrics according to changes in 6.0 version

### DIFF
--- a/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -49,58 +49,49 @@ spec:
       labels:
         service: collector
         severity: critical
-    - alert: FluentdQueueLengthIncreasing
-      annotations:
-        message: For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id
-          }}' average buffer queue length has increased continuously.
-        summary: Fluentd pod {{ $labels.pod }} is unable to keep up with traffic over
-          time for forwarder output {{ $labels.plugin_id }}.
-      expr: |
-        sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
-      for: 1h
-      labels:
-        service: collector
-        severity: Warning
     - alert: ElasticsearchDeprecation
       annotations:
-        message: The OpenShift Elasticsearch Operator is deprecated and is planned
-          to be removed in a future release. Red Hat provides bug fixes and support
-          for this feature during the current release lifecycle, but this feature
-          no longer receives enhancements. As an alternative to using the OpenShift
-          Elasticsearch Operator to manage the default log storage, you can use the
-          Loki Operator.
-        summary: Detected Elasticsearch as the in-cluster storage which is deprecated
-          and will be removed in a future release.
+        message: In Red Hat OpenShift Logging Operator 6.0, support for the Red Hat
+          Elasticsearch Operator has been removed. Bug fixes and support are provided
+          only through the end of the 5.9 lifecycle. As an alternative to the Elasticsearch
+          Operator, you can use the Loki Operator instead.
+        summary: Detected Elasticsearch as the in-cluster storage, which has been
+          removed in 6.0 release
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging",label_component='elasticsearch'}) > 0
       for: 5m
       labels:
+        namespace: openshift-logging
         service: storage
         severity: Warning
     - alert: FluentdDeprecation
       annotations:
-        message: Fluentd is deprecated and is planned to be removed in a future release.
-          Red Hat provides bug fixes and support for this feature during the current
-          release lifecycle, but this feature no longer receives enhancements. As
-          an alternative to Fluentd, you can use Vector instead.
-        summary: Detected Fluentd as the collector which is deprecated and will be
-          removed in a future release.
+        message: In Red Hat OpenShift Logging Operator 6.0, support for Fluentd as
+          a collector has been removed. Bug fixes and support are provided only through
+          the end of the 5.9 lifecycle. As an alternative to Fluentd, you can use
+          the Vector collector instead.
+        summary: Detected Fluentd as the collector, which has been removed in a 6.0
+          release
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging", label_implementation='fluentd', label_app_kubernetes_io_managed_by="cluster-logging-operator"}) > 0
       for: 5m
       labels:
+        namespace: openshift-logging
         service: collector
         severity: Warning
     - alert: KibanaDeprecation
       annotations:
-        message: The Kibana web console is now deprecated and is planned to be removed
-          in a future logging release.
-        summary: Detected Kibana as the visualization which is deprecated and will
-          be removed in a future release.
+        message: In Red Hat OpenShift Logging Operator 6.0, support for Kibana as
+          a data visualization dashboard has been removed. Bug fixes and support are
+          provided only through the end of the 5.9 lifecycle. As an alternative to
+          Kibana, you can use the Grafana Dashboard instead.
+        summary: Detected Kibana as the log data visualization, which has been removed
+          in the 6.0 release
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging",label_component='kibana'}) > 0
       for: 5m
       labels:
+        namespace: openshift-logging
         service: visualization
         severity: Warning
     - alert: DiskBufferUsage
@@ -118,14 +109,11 @@ spec:
   - name: logging_clusterlogging_telemetry.rules
     rules:
     - expr: |
-        sum by(cluster)(log_collected_bytes_total)
-      record: cluster:log_collected_bytes_total:sum
-    - expr: |
         sum by(cluster)(log_logged_bytes_total)
       record: cluster:log_logged_bytes_total:sum
     - expr: |
-        sum by(pod, namespace, app_kubernetes_io_part_of)(rate(vector_component_errors_total[2m])) or sum by(pod, namespace, app_kubernetes_io_part_of)(rate(fluentd_output_status_num_errors[2m]))
+        sum by(pod, namespace, app_kubernetes_io_instance)(rate(vector_component_errors_total[2m]))
       record: collector:log_num_errors:sum_rate
     - expr: |
-        sum by(pod, namespace, app_kubernetes_io_part_of)(rate(vector_component_received_events_total[2m])) or sum by(pod, namespace, app_kubernetes_io_part_of)(rate(fluentd_output_status_emit_records[2m]))
+        sum by(pod, namespace, app_kubernetes_io_instance)(rate(vector_component_received_events_total[2m]))
       record: collector:received_events:sum_rate

--- a/config/prometheus/collector_alerts.yaml
+++ b/config/prometheus/collector_alerts.yaml
@@ -45,46 +45,39 @@ spec:
       labels:
         service: collector
         severity: critical
-    - alert: FluentdQueueLengthIncreasing
-      annotations:
-        message: "For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id }}' average buffer queue length has increased continuously."
-        summary: "Fluentd pod {{ $labels.pod }} is unable to keep up with traffic over time for forwarder output {{ $labels.plugin_id }}."
-      expr: |
-        sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
-      for: 1h
-      labels:
-        service: collector
-        severity: Warning
     - alert: ElasticsearchDeprecation
       annotations:
-        message: "The OpenShift Elasticsearch Operator is deprecated and is planned to be removed in a future release. Red Hat provides bug fixes and support for this feature during the current release lifecycle, but this feature no longer receives enhancements. As an alternative to using the OpenShift Elasticsearch Operator to manage the default log storage, you can use the Loki Operator."
-        summary: "Detected Elasticsearch as the in-cluster storage which is deprecated and will be removed in a future release."
+        message: "In Red Hat OpenShift Logging Operator 6.0, support for the Red Hat Elasticsearch Operator has been removed. Bug fixes and support are provided only through the end of the 5.9 lifecycle. As an alternative to the Elasticsearch Operator, you can use the Loki Operator instead."
+        summary: "Detected Elasticsearch as the in-cluster storage, which has been removed in 6.0 release"
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging",label_component='elasticsearch'}) > 0
       for: 5m
       labels:
         service: storage
         severity: Warning
+        namespace: openshift-logging
     - alert: FluentdDeprecation
       annotations:
-        message: "Fluentd is deprecated and is planned to be removed in a future release. Red Hat provides bug fixes and support for this feature during the current release lifecycle, but this feature no longer receives enhancements. As an alternative to Fluentd, you can use Vector instead."
-        summary: "Detected Fluentd as the collector which is deprecated and will be removed in a future release."
+        message: "In Red Hat OpenShift Logging Operator 6.0, support for Fluentd as a collector has been removed. Bug fixes and support are provided only through the end of the 5.9 lifecycle. As an alternative to Fluentd, you can use the Vector collector instead."
+        summary: "Detected Fluentd as the collector, which has been removed in a 6.0 release"
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging", label_implementation='fluentd', label_app_kubernetes_io_managed_by="cluster-logging-operator"}) > 0
       for: 5m
       labels:
         service: collector
         severity: Warning
+        namespace: openshift-logging
     - alert: KibanaDeprecation
       annotations:
-        message: "The Kibana web console is now deprecated and is planned to be removed in a future logging release."
-        summary: "Detected Kibana as the visualization which is deprecated and will be removed in a future release."
+        message: "In Red Hat OpenShift Logging Operator 6.0, support for Kibana as a data visualization dashboard has been removed. Bug fixes and support are provided only through the end of the 5.9 lifecycle. As an alternative to Kibana, you can use the Grafana Dashboard instead."
+        summary: "Detected Kibana as the log data visualization, which has been removed in the 6.0 release"
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging",label_component='kibana'}) > 0
       for: 5m
       labels:
         service: visualization
         severity: Warning
+        namespace: openshift-logging
     - alert: DiskBufferUsage
       annotations:
         message: "Collectors potentially consuming too much node disk, {{ $value }}% "
@@ -99,14 +92,15 @@ spec:
   - name: logging_clusterlogging_telemetry.rules
     rules:
     - expr: |
-        sum by(cluster)(log_collected_bytes_total)
-      record: cluster:log_collected_bytes_total:sum
-    - expr: |
         sum by(cluster)(log_logged_bytes_total)
       record: cluster:log_logged_bytes_total:sum
     - expr: |
-        sum by(pod, namespace, app_kubernetes_io_part_of)(rate(vector_component_errors_total[2m])) or sum by(pod, namespace, app_kubernetes_io_part_of)(rate(fluentd_output_status_num_errors[2m]))
+        sum by(pod, namespace, app_kubernetes_io_instance)(rate(vector_component_errors_total[2m]))
       record: collector:log_num_errors:sum_rate
     - expr: |
-        sum by(pod, namespace, app_kubernetes_io_part_of)(rate(vector_component_received_events_total[2m])) or sum by(pod, namespace, app_kubernetes_io_part_of)(rate(fluentd_output_status_emit_records[2m]))
+        sum by(pod, namespace, app_kubernetes_io_instance)(rate(vector_component_received_events_total[2m]))
       record: collector:received_events:sum_rate
+
+
+
+

--- a/docs/administration/collector-metrics-and-alerts.adoc
+++ b/docs/administration/collector-metrics-and-alerts.adoc
@@ -1,15 +1,129 @@
-= Collector Metrics and Alerts
+== Collector Metrics
 
-== Vector output buffer alert
-In logging 6.0 (5.9.x) and later versions, added alerts for the Vector collector potentially consuming excessive node disk space.
-You can view this alerts in the OpenShift Container Platform web console.
+=== Log bytes collected (24h avg)
+The number of raw bytes accepted by collector from origin over 24-hour period.
+Summarized by  namespace an instance name.
+Metric source: Vector observability data
+[source]
+----
+sum by(namespace, app_kubernetes_io_instance) (increase(vector_component_received_bytes_total{component_kind=\"source\",
+component_type!=\"internal_metrics\"}[24h]))
+----
 
-image::buffer-alert.png[Fired allert]
+=== Log bytes sent (24h avg)
+The number of raw bytes sent by collector to the sinks over 24-hour period.
+Summarized by  namespace an instance name.
+Metric source: Vector observability data
+[source]
+----
+sum by (app_kubernetes_io_instance, namespace) (increase(vector_component_sent_bytes_total{component_kind=\"sink\",
+component_type!=\"prometheus_exporter\"}[24h]))
+
+----
+
+=== Log collection rate (5m avg)
+Calculates the rate of received bytes by collector over a 5-minute period.
+Organizes it by namespaces and instance names.
+Metric source: Vector observability data
+[source]
+----
+sum by(namespace, app_kubernetes_io_instance) (rate(vector_component_received_bytes_total{component_kind=\"source\", component_type!=\"internal_metrics\"}[5m]))",
+----
+
+=== Log send rate (5m avg)
+Calculates the rate of sent bytes by collector to the output  over a 5-minute period, organizes the data based on namespaces and instance names.
+Metric source: Vector observability data
+[source]
+----
+sum by (namespace, app_kubernetes_io_instance) (rate(vector_component_sent_bytes_total{component_kind=\"sink\", component_type!=\"prometheus_exporter\"}[5m]))
+----
+
+=== Total errors last 60m
+Monitor the total number of errors encountered by collector in last hour.
+Summarized the data based on namespaces and instance names.
+Metric source: Vector observability data
+[source]
+----
+sum by(namespace, app_kubernetes_io_instance) (increase(vector_component_errors_total[1h]))
+----
+
+=== Rate log bytes sent per output
+Showing how many bytes are being sent every second over a 5-minute period.
+The data is organized based on instance names, namespaces, component IDs, and types.
+Metric source: Vector observability data
+[source]
+----
+sum by (app_kubernetes_io_instance, namespace, component_id, component_type)(irate(vector_component_sent_bytes_total{component_kind=\"sink\", component_type!=\"prometheus_exporter\"}[5m]))
+----
+
+=== Top producing containers
+Query helps identify the top 10 containers that are generating the most log data in your system
+Metric source: Log File Metric Exporter
+[source]
+----
+topk(10, round(rate(log_logged_bytes_total[5m])))
+----
+
+=== Top producing containers in last 24 hours
+Selects the top 10 based on these aggregated values of total number of bytes
+Metric source: Log File Metric Exporter
+[source]
+----
+topk(10, sum(increase(log_logged_bytes_total[24h])) by (exported_namespace,  podname, containername))
+----
+
+=== Top collected containers - Bytes/Second
+Displays the top 10 containers with the highest rates
+Metric source: Vector observability data
+[source]
+----
+topk(10, round(rate(vector_component_received_event_bytes_total{component_type = \"kubernetes_logs\"}[5m])))
+----
+
+=== CPU
+CPU usage of "collector" containers on each node, namespace, and pod
+Metrics source: Kubernetes Metrics
+[source]
+----
+sum by(node,namespace,pod)(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container='collector'})",
+----
+
+=== Memory
+Memory usage of "collector" containers on each node, namespace, and pod
+Metrics source: Kubernetes Metrics
+[source]
+----
+sum by(node,namespace,pod)(node_namespace_pod_container:container_memory_rss{container=\"collector\"})
+----
+
+=== Running containers
+Running containers on each node
+Metrics source: Kubernetes Metrics
+[source]
+----
+sum by (node)(kubelet_running_containers{container_state="running"})
+----
+
+=== Open files for container logs
+Files reading by Vector collector summarized by hostname,namespace and pod
+Metric source: Vector observability data
+[source]
+----
+sum by(hostname,namespace,pod)(vector_open_files{component_kind=\"source\", component_type=\"kubernetes_logs\"})
+----
+
+=== File Descriptors In Use
+[source]
+----
+sum by(namespace, forwarder)(label_replace(container_file_descriptors{container=~'collector'}, 'forwarder', '$1', 'pod', '(.*).{6}'))
+----
 
 === Vector output buffer metrics
 Along with new alert was added 2 metrics dashboards which allow monitoring state of output buffer.
 
 - panel showing the absolute size of the Vector buffer via a graph by instance, namespace and instance name:
+
+Metric source: Vector observability data
 
 image::buffer-metric-1.png[]
 
@@ -26,6 +140,23 @@ image::buffer-metric-2.png[]
 ----
 100 * (label_replace(sum by(hostname) (vector_buffer_byte_size{component_kind='sink', buffer_type='disk'}), 'instance', '$1', 'hostname', '(.*)') / on(instance) group_left() sum by(instance) (node_filesystem_size_bytes{mountpoint='/var'}))
 ----
+
+== Collector Alerts
+
+=== DiskBufferUsage
+In logging 6.0 (5.9.x) and later versions, added alerts for the Vector collector potentially consuming excessive node disk space.
+You can view this alerts in the OpenShift Container Platform web console.
+
+image::buffer-alert.png[Fired allert]
+
+=== CollectorNodeDown
+
+Will be fired if collector component was offline for more than 10m
+
+=== CollectorVeryHighErrorRate
+
+Will be fired if collector component errors are very high, will contain namespace and pod name
+
 == Enabling ability to collect metrics from non infrastructure namespaces
 
 To make it possible for collecting Collector metrics in namespace different from "openshift-logging"
@@ -34,7 +165,7 @@ need to:
 - add label _openshift.io/cluster-monitoring: "true"_ to your namespace
 [source]
 ----
-oc label namespace {your-logging-ns} "openshift.io/cluster-monitoring='true'"
+oc label namespace {your-logging-ns} openshift.io/cluster-monitoring='true'
 ----
  - add role _prometheus-k8s_ to your namespace
 [source]

--- a/internal/metrics/dashboard/openshift-logging-dashboard.json
+++ b/internal/metrics/dashboard/openshift-logging-dashboard.json
@@ -64,24 +64,14 @@
           },
           "targets": [
             {
-              "expr": "sum by(job, namespace, app_kubernetes_io_name) (increase(vector_component_received_bytes_total{component_kind=\"source\", component_type!=\"internal_metrics\"}[24h]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
+              "expr": "sum by(namespace, app_kubernetes_io_instance) (increase(vector_component_received_bytes_total{component_kind=\"source\", component_type!=\"internal_metrics\"}[24h]))",
+              "legendFormat": "{{namespace}}/{{app_kubernetes_io_instance}}",
               "interval": "",
               "exemplar": true,
               "datasource": "${datasource}",
               "editorMode": "builder",
               "range": true,
               "refId": "A"
-            },
-            {
-              "expr": "sum by(job, namespace, app_kubernetes_io_name)(increase(log_collected_bytes_total[24h]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
-              "interval": "",
-              "exemplar": true,
-              "datasource": "${datasource}",
-              "editorMode": "builder",
-              "range": true,
-              "refId": "B"
             }
           ],
           "title": "Log bytes collected (24h avg)",
@@ -183,20 +173,10 @@
             {
               "datasource": "${datasource}",
               "editorMode": "builder",
-              "expr": "sum by (app_kubernetes_io_name, job, namespace) (increase(vector_component_sent_bytes_total{component_kind=\"sink\", component_type!=\"prometheus_exporter\"}[24h]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
+              "expr": "sum by (app_kubernetes_io_instance, namespace) (increase(vector_component_sent_bytes_total{component_kind=\"sink\", component_type!=\"prometheus_exporter\"}[24h]))",
+              "legendFormat": "{{namespace}}/{{app_kubernetes_io_instance}}",
               "range": true,
               "refId": "A"
-            },
-            {
-              "expr": "sum by(app_kubernetes_io_name, job, namespace) (increase(fluentd_output_status_emit_count{plugin_id!~'object:.+'}[24h]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
-              "interval": "",
-              "exemplar": true,
-              "datasource": "${datasource}",
-              "editorMode": "builder",
-              "range": true,
-              "refId": "B"
             }
           ],
           "title": "Log bytes sent (24h avg)",
@@ -317,21 +297,14 @@
           "pluginVersion": "8.5.0",
           "targets": [
             {
-              "expr": "sum by(app_kubernetes_io_name, namespace, job) (rate(vector_component_received_bytes_total{component_kind=\"source\", component_type!=\"internal_metrics\"}[5m]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
+              "expr": "sum by(namespace, app_kubernetes_io_instance) (rate(vector_component_received_bytes_total{component_kind=\"source\", component_type!=\"internal_metrics\"}[5m]))",
+              "legendFormat": "{{namespace}}/{{app_kubernetes_io_instance}}",
               "interval": "",
               "exemplar": true,
               "datasource": "${datasource}",
               "editorMode": "builder",
               "range": true,
               "refId": "A"
-            },
-            {
-              "expr": "sum by(app_kubernetes_io_name, namespace, job) (rate(log_collected_bytes_total[5m]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
-              "interval": "",
-              "exemplar": true,
-              "refId": "B"
             }
           ],
           "title": "Log collection rate (5m avg)",
@@ -452,21 +425,14 @@
           "pluginVersion": "8.5.0",
           "targets": [
             {
-              "expr": "sum by (app_kubernetes_io_name, namespace, job) (rate(vector_component_sent_bytes_total{component_kind=\"sink\", component_type!=\"prometheus_exporter\"}[5m]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
+              "expr": "sum by (namespace, app_kubernetes_io_instance) (rate(vector_component_sent_bytes_total{component_kind=\"sink\", component_type!=\"prometheus_exporter\"}[5m]))",
+              "legendFormat": "{{namespace}}/{{app_kubernetes_io_instance}}",
               "interval": "",
               "exemplar": true,
               "datasource": "${datasource}",
               "editorMode": "builder",
               "range": true,
               "refId": "A"
-            },
-            {
-              "expr": "sum by(app_kubernetes_io_name, namespace, job) (rate(fluentd_output_status_emit_count{plugin_id!~'object:.+'}[5m]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
-              "interval": "",
-              "exemplar": true,
-              "refId": "B"
             }
           ],
           "title": "Log send rate (5m avg)",
@@ -587,21 +553,14 @@
           "pluginVersion": "8.5.0",
           "targets": [
             {
-              "expr": "sum by(app_kubernetes_io_name, namespace, job) (increase(vector_component_errors_total[1h]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
+              "expr": "sum by(namespace, app_kubernetes_io_instance) (increase(vector_component_errors_total[1h]))",
+              "legendFormat": "{{namespace}}/{{app_kubernetes_io_instance}}",
               "interval": "",
               "exemplar": true,
               "datasource": "${datasource}",
               "editorMode": "builder",
               "range": true,
               "refId": "A"
-            },
-            {
-              "expr": "sum by(app_kubernetes_io_name, namespace, job) (increase(fluentd_output_status_num_errors[1h]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}}",
-              "interval": "",
-              "exemplar": true,
-              "refId": "B"
             }
           ],
           "title": "Total errors last 60m",
@@ -741,16 +700,8 @@
             {
               "datasource": "${datasource}",
               "editorMode": "code",
-              "expr": "sum by (job, namespace, app_kubernetes_io_name, component_id, component_type)(irate(vector_component_sent_bytes_total{component_kind=\"sink\", component_type!=\"prometheus_exporter\"}[5m]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}} | Output: {{component_type}}",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "datasource": "${datasource}",
-              "editorMode": "code",
-              "expr": "sum by (job, namespace, app_kubernetes_io_name, type)(irate(fluentd_output_status_emit_records{type=~\"elasticsearch|cloudwatch_logs|forward|http|kafka2|loki|remote_syslog\"}[5m]))",
-              "legendFormat": "{{namespace}}/{{job}}/{{app_kubernetes_io_name}} | Output: {{type}}",
+              "expr": "sum by (app_kubernetes_io_instance, namespace, component_id, component_type)(irate(vector_component_sent_bytes_total{component_kind=\"sink\", component_type!=\"prometheus_exporter\"}[5m]))",
+              "legendFormat": "{{namespace}}/{{app_kubernetes_io_instance}} | Output: {{component_type}}",
               "range": true,
               "refId": "A"
             }
@@ -1084,12 +1035,6 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "topk(10, round(rate(log_collected_bytes_total[5m])))",
-              "interval": "",
-              "legendFormat": "{{exported_namespace}}/{{podname}}/{{containername}}",
-              "refId": "A"
-            },
-            {
               "expr": "topk(10, round(rate(vector_component_received_event_bytes_total{component_type = \"kubernetes_logs\"}[5m])))",
               "interval": "",
               "legendFormat": "{{pod_namespace}}/{{pod_name}}/{{container_name}}",
@@ -1165,7 +1110,7 @@
           },
           "targets": [
             {
-              "expr": "topk(10, sum by (container_name, pod_name, pod_namespace) (label_replace(label_replace(label_replace(increase(log_collected_bytes_total[24h]), \"container_name\", \"$1\",\"containername\", \"(.*)\"),\"pod_name\", \"$1\",\"podname\", \"(.*)\"), \"pod_namespace\", \"$1\",\"exported_namespace\", \"(.*)\") or increase(vector_component_received_event_bytes_total{component_type=\"kubernetes_logs\"}[24h]))) / 1024 / 1024",
+              "expr": "topk(10, sum by (container_name, pod_name, pod_namespace) (increase(vector_component_received_event_bytes_total{component_type=\"kubernetes_logs\"}[24h]))) / 1024 / 1024",
               "format": "table",
               "instant": true,
               "refId": "A",


### PR DESCRIPTION
### Description
In this PR: 

- removed the alert related to the `Fluentd` collector: `FluentdQueueLengthIncreasing`
- updated metrics configuration to focus on `Vector` collector, removed dependencies on `Fluentd`
- all metrics now used the `app_kubernetes_io_instance` label, this should help accurate determination of the CLF instance
- update documentation with actual metrics and alerts

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5042
- Enhancement proposal:
