### PR TITLE
[release-5.9] LOG-5108: Add must-gather annotation to csv

### DIFF
--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -118,7 +118,7 @@ metadata:
     certified: "false"
     console.openshift.io/plugins: '["logging-view-plugin"]'
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-01-09T03:03:58Z"
+    createdAt: "2024-05-16T15:26:45Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing your aggregated logging stack.
     features.operators.openshift.io/cnf: "false"
@@ -135,6 +135,7 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-logging
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
+    operators.openshift.io/must-gather-image: quay.io/openshift-logging/cluster-logging-operator:5.9
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
       Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -23,6 +23,7 @@ metadata:
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-logging
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
+    operators.openshift.io/must-gather-image: quay.io/openshift-logging/cluster-logging-operator:5.9
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
       Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-unknown


### PR DESCRIPTION
### Description
Add the latest CLO container image to the bundle annotation, to accommodate the new `--all-images` flag.  Original attempt was to add to annotations in CPaaS, but they are currently converted to labels.   Since we have instructions upstream on utilizing the quay image with must-gather, this should be sufficient for now.

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5108
- Enhancement proposal: https://groups.google.com/a/redhat.com/g/aos-logging/c/_-YYN3-2dOc/m/wzX3SWQFAwAJ
