### PR TITLE
LOG-5558: Add support for tls from configmap

### DIFF
--- a/internal/generator/vector/helpers/helpers.go
+++ b/internal/generator/vector/helpers/helpers.go
@@ -56,8 +56,8 @@ func ListenOnAllLocalInterfacesAddress() string {
 	return listenAllAddress
 }
 
-func AuthPath(name string, file string) string {
-	return fmt.Sprintf("%q", filepath.Join("/var/run/ocp-collector/auth", name, file))
+func ConfigPath(name string, file string) string {
+	return fmt.Sprintf("%q", filepath.Join("/var/run/ocp-collector/config", name, file))
 }
 
 func SecretPath(secretName string, file string) string {

--- a/internal/generator/vector/input/receiver_syslog_tls_from_configmap.toml
+++ b/internal/generator/vector/input/receiver_syslog_tls_from_configmap.toml
@@ -1,0 +1,17 @@
+[sources.input_myreceiver]
+type = "syslog"
+address = "[::]:12345"
+mode = "tcp"
+
+[sources.input_myreceiver.tls]
+key_file = "/var/run/ocp-collector/secrets/instance-myreceiver/tls.key"
+crt_file = "/var/run/ocp-collector/config/instance-myreceiver/my.crt"
+ca_file = "/var/run/ocp-collector/config/instance-myreceiver/ca.crt"
+
+[transforms.input_myreceiver_meta]
+type = "remap"
+inputs = ["input_myreceiver"]
+source = '''
+  .log_source = "node"
+  .log_type = "infrastructure"
+'''

--- a/internal/generator/vector/input/source_test.go
+++ b/internal/generator/vector/input/source_test.go
@@ -365,5 +365,35 @@ var _ = Describe("inputs", func() {
 		},
 			"receiver_syslog.toml",
 		),
+		Entry("with a syslog receiver and tls from configmaps", obs.InputSpec{
+			Type: obs.InputTypeReceiver,
+			Name: "myreceiver",
+			Receiver: &obs.ReceiverSpec{
+				Type: obs.ReceiverTypeSyslog,
+				Port: 12345,
+				TLS: &obs.InputTLSSpec{
+					CA: &obs.ConfigMapOrSecretKey{
+						ConfigMap: &corev1.LocalObjectReference{
+							Name: secretName,
+						},
+						Key: "ca.crt",
+					},
+					Certificate: &obs.ConfigMapOrSecretKey{
+						ConfigMap: &corev1.LocalObjectReference{
+							Name: secretName,
+						},
+						Key: "my.crt",
+					},
+					Key: &obs.SecretKey{
+						Secret: &corev1.LocalObjectReference{
+							Name: secretName,
+						},
+						Key: constants.ClientPrivateKey,
+					},
+				},
+			},
+		},
+			"receiver_syslog_tls_from_configmap.toml",
+		),
 	)
 })

--- a/internal/generator/vector/output/common/tls/tls.go
+++ b/internal/generator/vector/output/common/tls/tls.go
@@ -45,7 +45,7 @@ func ConfigMapOrSecretPath(resource *obs.ConfigMapOrSecretKey) string {
 	if resource.Secret != nil {
 		return helpers.SecretPath(resource.Secret.Name, resource.Key)
 	} else if resource.ConfigMap != nil {
-		return helpers.AuthPath(resource.ConfigMap.Name, resource.Key)
+		return helpers.ConfigPath(resource.ConfigMap.Name, resource.Key)
 	}
 	return ""
 }

--- a/internal/generator/vector/output/http/http_test.go
+++ b/internal/generator/vector/output/http/http_test.go
@@ -110,6 +110,29 @@ var _ = Describe("Generate vector config", func() {
 				spec.HTTP.Authentication = nil
 				spec.TLS = tlsSpec
 			}, secrets, framework.NoOptions, "http_with_tls.toml"),
+			Entry("with token auth", func(spec *obs.OutputSpec) {
+				spec.HTTP.Authentication = nil
+				spec.TLS = &obs.OutputTLSSpec{
+					CA: &obs.ConfigMapOrSecretKey{
+						ConfigMap: &corev1.LocalObjectReference{
+							Name: secretName,
+						},
+						Key: "ca.crt",
+					},
+					Certificate: &obs.ConfigMapOrSecretKey{
+						ConfigMap: &corev1.LocalObjectReference{
+							Name: secretName,
+						},
+						Key: "my.crt",
+					},
+					Key: &obs.SecretKey{
+						Secret: &corev1.LocalObjectReference{
+							Name: secretName,
+						},
+						Key: constants.ClientPrivateKey,
+					},
+				}
+			}, secrets, framework.NoOptions, "http_with_tls_using_configmaps.toml"),
 		)
 	})
 

--- a/internal/generator/vector/output/http/http_with_tls_using_configmaps.toml
+++ b/internal/generator/vector/output/http/http_with_tls_using_configmaps.toml
@@ -1,0 +1,16 @@
+[sinks.http_receiver]
+type = "http"
+inputs = ["application"]
+uri = "https://my-logstore.com"
+method = "post"
+
+[sinks.http_receiver.encoding]
+codec = "json"
+
+[sinks.http_receiver.request]
+headers = {"h1"="v1","h2"="v2"}
+
+[sinks.http_receiver.tls]
+key_file = "/var/run/ocp-collector/secrets/http-receiver/tls.key"
+crt_file = "/var/run/ocp-collector/config/http-receiver/my.crt"
+ca_file = "/var/run/ocp-collector/config/http-receiver/ca.crt"


### PR DESCRIPTION
### Description
This PR:
* Modifies TLS source and sink generation to retrieve certain tls config from configmaps

### Links
* https://issues.redhat.com/browse/LOG-5558
