### PR TITLE
LOG-5429: Update bundle after change to Prometheus rules

### DIFF
--- a/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -75,6 +75,7 @@ spec:
         sum(kube_pod_labels{namespace="openshift-logging",label_component='elasticsearch'}) > 0
       for: 5m
       labels:
+        namespace: openshift-logging
         service: storage
         severity: Warning
     - alert: FluentdDeprecation
@@ -89,6 +90,7 @@ spec:
         sum(kube_pod_labels{namespace="openshift-logging", label_implementation='fluentd', label_app_kubernetes_io_managed_by="cluster-logging-operator"}) > 0
       for: 5m
       labels:
+        namespace: openshift-logging
         service: collector
         severity: Warning
     - alert: KibanaDeprecation
@@ -101,6 +103,7 @@ spec:
         sum(kube_pod_labels{namespace="openshift-logging",label_component='kibana'}) > 0
       for: 5m
       labels:
+        namespace: openshift-logging
         service: visualization
         severity: Warning
   - name: logging_clusterlogging_telemetry.rules


### PR DESCRIPTION
### Description

The new `namespace` label is missing on the Prometheus rules in the bundle (see #2490).

/cc @vparfonov
/assign @jcantrill
