### PR TITLE
LOG-5462: Do not deploy logging ConsolePlugin if already managed by COO

### DIFF
--- a/internal/visualization/console/coo_compatibility.go
+++ b/internal/visualization/console/coo_compatibility.go
@@ -1,0 +1,80 @@
+package console
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/ViaQ/logerr/v2/log/static"
+	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	uiPluginAPIVersion = "observability.openshift.io/v1alpha1"
+	uiPluginKind       = "UIPlugin"
+)
+
+func (r *Reconciler) checkObservabilityOperator(ctx context.Context) (bool, error) {
+	cooManaged, err := r.isManagedByObservabilityOperator(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if !cooManaged {
+		// ConsolePlugin exists but is not managed by Cluster Observability Operator
+		return false, nil
+	}
+
+	// COO is installed in parallel and is managing the logging-view-plugin.
+	// The cluster-scoped resources are already "adopted" by COO at this point, so we only need to clean up
+	// our namespaced resources in openshift-logging: Deployment, Service and ConfigMap
+	log.V(3).Info("Found ConsolePlugin managed by Cluster Observability Operator")
+
+	err = r.each(func(m mutable) error {
+		if m.o == &r.consolePlugin {
+			// Do not operate on the ConsolePlugin
+			return nil
+		}
+
+		err := r.c.Delete(ctx, m.o)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return false, fmt.Errorf("error removing console resources due to COO presence: %w", err)
+	}
+
+	return true, nil
+}
+
+func (r *Reconciler) isManagedByObservabilityOperator(ctx context.Context) (bool, error) {
+	key := client.ObjectKey{
+		Name: Name,
+	}
+
+	plugin := &consolev1alpha1.ConsolePlugin{}
+	err := r.c.Get(ctx, key, plugin)
+	switch {
+	case apierrors.IsNotFound(err):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("error getting ConsolePlugin: %w", err)
+	default:
+		return hasUIPluginOwner(plugin), nil
+	}
+}
+
+func hasUIPluginOwner(plugin *consolev1alpha1.ConsolePlugin) bool {
+	ownerRef := metav1.GetControllerOf(plugin)
+	if ownerRef == nil {
+		return false
+	}
+
+	return ownerRef.APIVersion == uiPluginAPIVersion && ownerRef.Kind == uiPluginKind
+}

--- a/internal/visualization/console/coo_compatibility_test.go
+++ b/internal/visualization/console/coo_compatibility_test.go
@@ -1,0 +1,154 @@
+package console
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
+	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testClusterVersion = "v4.14.0"
+)
+
+var _ = Describe("Cluster Observability Operator compatibility", func() {
+	var (
+		clWithLoki = &loggingv1.ClusterLogging{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.SingletonName,
+				Namespace: constants.OpenshiftNS,
+			},
+			Spec: loggingv1.ClusterLoggingSpec{
+				LogStore: &loggingv1.LogStoreSpec{
+					Type: loggingv1.LogStoreTypeLokiStack,
+					LokiStack: loggingv1.LokiStackStoreSpec{
+						Name: "testing-loki",
+					},
+				},
+			},
+		}
+
+		clWithoutLoki = &loggingv1.ClusterLogging{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.SingletonName,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+	)
+
+	It("should deploy normally when no COO is present", func() {
+		c := fake.NewFakeClient()
+		err := ReconcilePlugin(c, clWithLoki, clWithLoki, testClusterVersion)
+		Expect(err).To(BeNil())
+
+		Expect(checkResourceExists(ctx, c, &consolev1alpha1.ConsolePlugin{}, "", Name)).To(BeTrue())
+		Expect(checkResourceExists(ctx, c, &appsv1.Deployment{}, constants.OpenshiftNS, Name)).To(BeTrue())
+		Expect(checkResourceExists(ctx, c, &corev1.Service{}, constants.OpenshiftNS, Name)).To(BeTrue())
+		Expect(checkResourceExists(ctx, c, &corev1.ConfigMap{}, constants.OpenshiftNS, Name)).To(BeTrue())
+	})
+
+	It("should remove the existing resources when the COO manages the ConsolePlugin", func() {
+		cooConsolePlugin := &consolev1alpha1.ConsolePlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: Name,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Controller: ptr.To(true),
+						APIVersion: uiPluginAPIVersion,
+						Kind:       uiPluginKind,
+						Name:       "ui-logging",
+					},
+				},
+			},
+		}
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+
+		c := fake.NewFakeClient(cooConsolePlugin, deployment, service, configMap)
+		err := ReconcilePlugin(c, clWithLoki, clWithLoki, testClusterVersion)
+		Expect(err).To(BeNil())
+
+		Expect(checkResourceExists(ctx, c, &consolev1alpha1.ConsolePlugin{}, "", Name)).To(BeTrue())
+		Expect(checkResourceExists(ctx, c, &appsv1.Deployment{}, constants.OpenshiftNS, Name)).To(BeFalse())
+		Expect(checkResourceExists(ctx, c, &corev1.Service{}, constants.OpenshiftNS, Name)).To(BeFalse())
+		Expect(checkResourceExists(ctx, c, &corev1.ConfigMap{}, constants.OpenshiftNS, Name)).To(BeFalse())
+	})
+
+	It("should not remove ConsolePlugin if managed by COO", func() {
+		cooConsolePlugin := &consolev1alpha1.ConsolePlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: Name,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Controller: ptr.To(true),
+						APIVersion: uiPluginAPIVersion,
+						Kind:       uiPluginKind,
+						Name:       "ui-logging",
+					},
+				},
+			},
+		}
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+
+		c := fake.NewFakeClient(cooConsolePlugin, deployment, service, configMap)
+		err := ReconcilePlugin(c, clWithoutLoki, clWithoutLoki, testClusterVersion)
+		Expect(err).To(BeNil())
+
+		Expect(checkResourceExists(ctx, c, &consolev1alpha1.ConsolePlugin{}, "", Name)).To(BeTrue())
+		Expect(checkResourceExists(ctx, c, &appsv1.Deployment{}, constants.OpenshiftNS, Name)).To(BeFalse())
+		Expect(checkResourceExists(ctx, c, &corev1.Service{}, constants.OpenshiftNS, Name)).To(BeFalse())
+		Expect(checkResourceExists(ctx, c, &corev1.ConfigMap{}, constants.OpenshiftNS, Name)).To(BeFalse())
+	})
+})
+
+func checkResourceExists(ctx context.Context, c client.Client, obj client.Object, namespace, name string) bool {
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	err := c.Get(ctx, key, obj)
+	return !apierrors.IsNotFound(err)
+}


### PR DESCRIPTION
### Description

Currently the logging-view-plugin is managed by CLO and deployed either when the ClusterLogging references a LokiStack as default storage or has a special annotation. In the future the logging UI will be managed by the Cluster Observability Operator (see rhobs/observability-operator#477). This PR makes CLO aware of the COO managing the logging UI, so that both operators do not interfere with each other.

### Links

- JIRA: LOG-5462
