### PR TITLE
LOG-5568: Remove pod security labels from resource init

### DIFF
--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -17,9 +17,6 @@ kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   name: cluster-logging-metadata-reader
-  labels:
-    pod-security.kubernetes.io/enforce: privileged
-    security.openshift.io/scc.podSecurityLabelSync: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -41,9 +38,6 @@ metadata:
   creationTimestamp: null
   name: scc
   namespace: openshift-logging
-  labels:
-    pod-security.kubernetes.io/enforce: privileged
-    security.openshift.io/scc.podSecurityLabelSync: "false"
 rules:
 - apiGroups:
     - security.openshift.io
@@ -64,9 +58,6 @@ metadata:
   creationTimestamp: null
   name: scc
   namespace: openshift-logging
-  labels:
-    pod-security.kubernetes.io/enforce: privileged
-    security.openshift.io/scc.podSecurityLabelSync: "false"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/internal/factory/daemonset_test.go
+++ b/internal/factory/daemonset_test.go
@@ -17,11 +17,9 @@ var _ = Describe("#NewDaemonSet", func() {
 			"logging-infra": "thecomponent",
 		}
 		expLabels = map[string]string{
-			"provider":                           "openshift",
-			"component":                          "thecomponent",
-			"logging-infra":                      "thecomponent",
-			"pod-security.kubernetes.io/enforce": "privileged",
-			"security.openshift.io/scc.podSecurityLabelSync": "false",
+			"provider":       "openshift",
+			"component":      "thecomponent",
+			"logging-infra":  "thecomponent",
 			"implementation": "collectorImpl",
 		}
 	)

--- a/internal/factory/deployment_test.go
+++ b/internal/factory/deployment_test.go
@@ -19,11 +19,9 @@ var _ = Describe("#NewDeployment", func() {
 			constants.CollectorDeploymentKind: constants.DeploymentType,
 		}
 		expLabels = map[string]string{
-			"provider":                           "openshift",
-			"component":                          "thecomponent",
-			"logging-infra":                      "thecomponent",
-			"pod-security.kubernetes.io/enforce": "privileged",
-			"security.openshift.io/scc.podSecurityLabelSync": "false",
+			"provider":                        "openshift",
+			"component":                       "thecomponent",
+			"logging-infra":                   "thecomponent",
 			"implementation":                  "collectorImpl",
 			constants.CollectorDeploymentKind: constants.DeploymentType,
 		}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -114,10 +114,6 @@ func Initialize(o runtime.Object, namespace, name string, visitors ...func(o run
 	m.SetNamespace(namespace)
 	m.SetName(name)
 	o.GetObjectKind().SetGroupVersionKind(GroupVersionKind(o))
-	m.SetLabels(map[string]string{
-		"pod-security.kubernetes.io/enforce":             "privileged",
-		"security.openshift.io/scc.podSecurityLabelSync": "false",
-	})
 	for _, visitor := range visitors {
 		visitor(o)
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -42,19 +42,13 @@ var _ = Describe("Object", func() {
 	DescribeTable("New",
 		func(got, want Object) { Expect(got).To(EqualDiff(want)) },
 		Entry("NewNamespace", NewNamespace("foo"), &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{
-				"pod-security.kubernetes.io/enforce":             "privileged",
-				"security.openshift.io/scc.podSecurityLabelSync": "false",
-			}},
-			TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+			TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
 		}),
 		Entry("NewConfigMap", NewConfigMap("ns", "foo", nil), &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns", Labels: map[string]string{
-				"pod-security.kubernetes.io/enforce":             "privileged",
-				"security.openshift.io/scc.podSecurityLabelSync": "false",
-			}},
-			TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
-			Data:     map[string]string{},
+			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns"},
+			TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+			Data:       map[string]string{},
 		}),
 		Entry("NewServiceMonitor", NewServiceMonitor("ns", "foo"), &monitoringv1.ServiceMonitor{
 			ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns"},


### PR DESCRIPTION
### Description
This PR:
* Drops labeling all resources using runtime functions with pod security labels which are only relevant to namespaces

### Links
* https://issues.redhat.com/browse/LOG-5568
