### PR TITLE
LOG-5465: Do not deploy logging ConsolePlugin if already managed by COO

### DIFF
--- a/internal/consoleplugin/coo_compatibility.go
+++ b/internal/consoleplugin/coo_compatibility.go
@@ -1,0 +1,80 @@
+package consoleplugin
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/ViaQ/logerr/v2/log/static"
+	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	uiPluginAPIVersion = "observability.openshift.io/v1alpha1"
+	uiPluginKind       = "UIPlugin"
+)
+
+func (r *Reconciler) checkObservabilityOperator(ctx context.Context) (bool, error) {
+	cooManaged, err := r.isManagedByObservabilityOperator(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if !cooManaged {
+		// ConsolePlugin exists but is not managed by Cluster Observability Operator
+		return false, nil
+	}
+
+	// COO is installed in parallel and is managing the logging-view-plugin.
+	// The cluster-scoped resources are already "adopted" by COO at this point, so we only need to clean up
+	// our namespaced resources in openshift-logging: Deployment, Service and ConfigMap
+	log.V(3).Info("Found ConsolePlugin managed by Cluster Observability Operator")
+
+	err = r.each(func(m mutable) error {
+		if m.o == &r.consolePlugin {
+			// Do not operate on the ConsolePlugin
+			return nil
+		}
+
+		err := r.c.Delete(ctx, m.o)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return false, fmt.Errorf("error removing console resources due to COO presence: %w", err)
+	}
+
+	return true, nil
+}
+
+func (r *Reconciler) isManagedByObservabilityOperator(ctx context.Context) (bool, error) {
+	key := client.ObjectKey{
+		Name: Name,
+	}
+
+	plugin := &consolev1alpha1.ConsolePlugin{}
+	err := r.c.Get(ctx, key, plugin)
+	switch {
+	case apierrors.IsNotFound(err):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("error getting ConsolePlugin: %w", err)
+	default:
+		return hasUIPluginOwner(plugin), nil
+	}
+}
+
+func hasUIPluginOwner(plugin *consolev1alpha1.ConsolePlugin) bool {
+	ownerRef := metav1.GetControllerOf(plugin)
+	if ownerRef == nil {
+		return false
+	}
+
+	return ownerRef.APIVersion == uiPluginAPIVersion && ownerRef.Kind == uiPluginKind
+}

--- a/internal/consoleplugin/coo_compatibility_test.go
+++ b/internal/consoleplugin/coo_compatibility_test.go
@@ -1,0 +1,165 @@
+package consoleplugin
+
+import (
+	"context"
+	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+
+	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testClusterVersion = "v4.14.0"
+	testLokiService    = "testing-loki-gateway-http"
+)
+
+var (
+	testBoolTrue = true
+)
+
+var _ = Describe("Cluster Observability Operator compatibility", func() {
+	var (
+		clWithLoki = &loggingv1.ClusterLogging{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.SingletonName,
+				Namespace: constants.OpenshiftNS,
+			},
+			Spec: loggingv1.ClusterLoggingSpec{
+				LogStore: &loggingv1.LogStoreSpec{
+					Type: loggingv1.LogStoreTypeLokiStack,
+					LokiStack: loggingv1.LokiStackStoreSpec{
+						Name: "testing-loki",
+					},
+				},
+			},
+		}
+
+		clWithoutLoki = &loggingv1.ClusterLogging{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.SingletonName,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+
+		ctx = context.Background()
+	)
+
+	It("should deploy normally when no COO is present", func() {
+		c := fake.NewFakeClient() //nolint
+		r := NewReconciler(c, NewConfig(clWithLoki, testLokiService, FeaturesForOCP(testClusterVersion)))
+		err := r.Reconcile(ctx)
+		Expect(err).To(BeNil())
+
+		Expect(checkResourceExists(ctx, c, &consolev1alpha1.ConsolePlugin{}, "", Name)).To(BeTrue())
+		Expect(checkResourceExists(ctx, c, &appsv1.Deployment{}, constants.OpenshiftNS, Name)).To(BeTrue())
+		Expect(checkResourceExists(ctx, c, &corev1.Service{}, constants.OpenshiftNS, Name)).To(BeTrue())
+		Expect(checkResourceExists(ctx, c, &corev1.ConfigMap{}, constants.OpenshiftNS, Name)).To(BeTrue())
+	})
+
+	It("should remove the existing resources when the COO manages the ConsolePlugin", func() {
+		cooConsolePlugin := &consolev1alpha1.ConsolePlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: Name,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Controller: &testBoolTrue,
+						APIVersion: uiPluginAPIVersion,
+						Kind:       uiPluginKind,
+						Name:       "ui-logging",
+					},
+				},
+			},
+		}
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+
+		c := fake.NewFakeClient(cooConsolePlugin, deployment, service, configMap) //nolint
+		r := NewReconciler(c, NewConfig(clWithLoki, testLokiService, FeaturesForOCP(testClusterVersion)))
+		err := r.Reconcile(ctx)
+		Expect(err).To(BeNil())
+
+		Expect(checkResourceExists(ctx, c, &consolev1alpha1.ConsolePlugin{}, "", Name)).To(BeTrue())
+		Expect(checkResourceExists(ctx, c, &appsv1.Deployment{}, constants.OpenshiftNS, Name)).To(BeFalse())
+		Expect(checkResourceExists(ctx, c, &corev1.Service{}, constants.OpenshiftNS, Name)).To(BeFalse())
+		Expect(checkResourceExists(ctx, c, &corev1.ConfigMap{}, constants.OpenshiftNS, Name)).To(BeFalse())
+	})
+
+	It("should not remove ConsolePlugin if managed by COO", func() {
+		cooConsolePlugin := &consolev1alpha1.ConsolePlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: Name,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Controller: &testBoolTrue,
+						APIVersion: uiPluginAPIVersion,
+						Kind:       uiPluginKind,
+						Name:       "ui-logging",
+					},
+				},
+			},
+		}
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: constants.OpenshiftNS,
+			},
+		}
+
+		c := fake.NewFakeClient(cooConsolePlugin, deployment, service, configMap) //nolint
+		r := NewReconciler(c, NewConfig(clWithoutLoki, "", FeaturesForOCP(testClusterVersion)))
+		err := r.Delete(ctx)
+		Expect(err).To(BeNil())
+
+		Expect(checkResourceExists(ctx, c, &consolev1alpha1.ConsolePlugin{}, "", Name)).To(BeTrue())
+		Expect(checkResourceExists(ctx, c, &appsv1.Deployment{}, constants.OpenshiftNS, Name)).To(BeFalse())
+		Expect(checkResourceExists(ctx, c, &corev1.Service{}, constants.OpenshiftNS, Name)).To(BeFalse())
+		Expect(checkResourceExists(ctx, c, &corev1.ConfigMap{}, constants.OpenshiftNS, Name)).To(BeFalse())
+	})
+})
+
+func checkResourceExists(ctx context.Context, c client.Client, obj client.Object, namespace, name string) bool {
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	err := c.Get(ctx, key, obj)
+	return !apierrors.IsNotFound(err)
+}

--- a/internal/consoleplugin/reconciler.go
+++ b/internal/consoleplugin/reconciler.go
@@ -3,14 +3,14 @@ package consoleplugin
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"strings"
 
-	log "github.com/ViaQ/logerr/v2/log/static"
-	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
+
+	log "github.com/ViaQ/logerr/v2/log/static"
+	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,23 +54,39 @@ func NewReconciler(c client.Client, cf Config) *Reconciler {
 	return r
 }
 
-func ConsoleCapabilityEnabled(c client.Client, plugin consolev1alpha1.ConsolePlugin) bool {
+// CapabilityEnabled can be used to check if ConsolePlugin is available as a resource in the Kubernetes cluster.
+func CapabilityEnabled(ctx context.Context, c client.Client) bool {
+	key := client.ObjectKey{
+		Name: Name,
+	}
+
 	current := &consolev1alpha1.ConsolePlugin{}
-	key := types.NamespacedName{Namespace: plugin.Namespace, Name: plugin.Name}
-	err := c.Get(context.TODO(), key, current)
+	err := c.Get(ctx, key, current)
 
 	return err == nil || !metaerrors.IsNoMatchError(err)
 }
 
 // Reconcile creates or updates cluster objects to match config.
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	if !ConsoleCapabilityEnabled(r.c, r.consolePlugin) {
+	if !CapabilityEnabled(ctx, r.c) {
 		log.V(3).Info("Cluster console capability disabled.  Skipping logging console plugin reconciliation")
 		return nil
 	}
+
+	cooManaged, err := r.checkObservabilityOperator(ctx)
+	switch {
+	case err != nil:
+		return fmt.Errorf("error checking for observability operator managed ConsolePlugin: %w", err)
+	case cooManaged:
+		// ConsolePlugin is managed by COO -> we're done here
+		return nil
+	default:
+		// No error and not managed by COO -> continue normally
+	}
+
 	modified := false
 	// Call CreateOrUpdate for each object.
-	err := r.each(func(m mutable) error {
+	err = r.each(func(m mutable) error {
 		return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			result, err := controllerutil.CreateOrUpdate(ctx, r.c, m.o, m.mutate)
 			if err == nil && result != controllerutil.OperationResultNone {
@@ -93,12 +109,26 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 
 // Delete the consoleplugin and related objects.
 func (r *Reconciler) Delete(ctx context.Context) error {
-	if !ConsoleCapabilityEnabled(r.c, r.consolePlugin) {
+	if !CapabilityEnabled(ctx, r.c) {
 		log.V(3).Info("Cluster console capability disabled.  Skipping logging console plugin deletion")
 		return nil
 	}
+
 	var errs []error // Collect errors, don't stop on first.
 	_ = r.each(func(m mutable) error {
+		if m.o == &r.consolePlugin {
+			cooManaged, err := r.isManagedByObservabilityOperator(ctx)
+			if err != nil {
+				errs = append(errs, err)
+				return nil
+			}
+
+			if cooManaged {
+				// Skip removing ConsolePlugin when managed by COO
+				return nil
+			}
+		}
+
 		err := r.c.Delete(ctx, m.o)
 		if err != nil && !apierrors.IsNotFound(err) {
 			errs = append(errs, err)


### PR DESCRIPTION
### Description

This is a backport of #2509 to `release-5.6`.

### Links

- Depending on PR(s): #2509
- JIRA: [LOG-5465](https://issues.redhat.com//browse/LOG-5465)
