### PR TITLE
Remove unused function

### DIFF
--- a/version/cluster.go
+++ b/version/cluster.go
@@ -2,31 +2,17 @@ package version
 
 import (
 	"context"
-	"fmt"
+
 	log "github.com/ViaQ/logerr/v2/log/static"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-logging-operator/internal/hostedcontrolplane"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	operatorConditionName = "OPERATOR_CONDITION_NAME"
 )
 
 var (
 	clusterVersion string
 	clusterID      string
 )
-
-// OperatorVersion get clo operator version from OPERATOR_CONDITION_NAME ENV variable
-func OperatorVersion() (string, error) {
-	operatorVersion, found := os.LookupEnv(operatorConditionName)
-	if !found {
-		return "", fmt.Errorf("%s must be set", operatorConditionName)
-	}
-	return operatorVersion, nil
-}
 
 // ClusterVersion retrieves the ClusterVersion spec
 func ClusterVersion(k8client client.Reader) (string, string, error) {


### PR DESCRIPTION
### Description

`OPERATOR_CONDITION_NAME` is being injected by operator lifecycle manager into operator's deployments so that operators can know the name of the relevant `OperatorCondition` CR for cases when operators want to report some conditions or block their upgrades.

It seems like logging operator has a function which reads `OPERATOR_CONDITION_NAME`, but the function is never used. I suspect that there was previously reliance on `OperatorCondition` which is gone, but this function was left behind.

/cc jcantrill
/assign alanconway


### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
