### PR TITLE
LOG-5384: Drop support for fluentd collector, fix the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ test-forwarder-generator: bin/forwarder-generator
 
 test-functional-benchmarker-vector: bin/functional-benchmarker
 	@rm -rf /tmp/benchmark-test-vector
-	@out=$$(RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) bin/functional-benchmarker --image=$(IMAGE_LOGGING_VECTOR) --collector-impl=vector --artifact-dir=/tmp/benchmark-test-vector 2>&1); if [ "$$?" != "0" ] ; then echo "$$out"; exit 1; fi
+	@out=$$(RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) bin/functional-benchmarker --image=$(IMAGE_LOGGING_VECTOR) --artifact-dir=/tmp/benchmark-test-vector 2>&1); if [ "$$?" != "0" ] ; then echo "$$out"; exit 1; fi
 
 .PHONY: test-unit
 test-unit: test-forwarder-generator


### PR DESCRIPTION
### Description

This PR adds a missing piece to the https://github.com/openshift/cluster-logging-operator/commit/81eb85dc3b0432e90044225c79932b6e78c409a0 commit and removes the `--collector-impl=vector` command line argument from the functional-benchmarker invocation in the Makefile. `--collector-impl` was removed in the aforementioned commit and now the test-functional-benchmarker-vector make target fails with the "flag provided but not defined: -collector-impl" error.
This issue came up during testing of https://github.com/ViaQ/vector/pull/173.

/cc @Clee2691 
/assign @jcantrill 

### Links
- JIRA:
https://issues.redhat.com/browse/LOG-5647
https://issues.redhat.com/browse/LOG-5384