### PR TITLE
LOG-5646: fix buffer usage calculation

### DIFF
--- a/internal/metrics/dashboard/openshift-logging-dashboard.json
+++ b/internal/metrics/dashboard/openshift-logging-dashboard.json
@@ -1889,7 +1889,7 @@
             {
               "datasource": "${datasource}",
               "editorMode": "code",
-              "expr": "100 * (label_replace(sum by(hostname) (vector_buffer_byte_size{component_kind='sink', buffer_type='disk'}), 'instance', '$1', 'hostname', '(.*)') / on(instance) group_left() sum by(instance) (node_filesystem_size_bytes{mountpoint='/var'}))",
+              "expr": "label_replace(sum by(hostname) (vector_buffer_byte_size{component_kind='sink', buffer_type='disk'}), 'instance', '$1', 'hostname', '(.*)') / on(instance) group_left() sum by(instance) (node_filesystem_size_bytes{mountpoint='/var'})",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
### Description
This PR fixes expiration for buffer usage calculation, result should not multiply value by 100 because it will be done automatically by dashboard 
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5646
- Enhancement proposal:
