### PR TITLE
Include missing verbs in RBAC configuration

### DIFF
--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -178,7 +178,7 @@ metadata:
     certified: "false"
     console.openshift.io/plugins: '["logging-view-plugin"]'
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-06-12T18:30:24Z"
+    createdAt: "2024-06-14T15:46:22Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing your aggregated logging stack.
     features.operators.openshift.io/cnf: "false"
@@ -733,6 +733,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - config.openshift.io
           resources:
@@ -851,8 +852,10 @@ spec:
           - securitycontextconstraints
           verbs:
           - create
+          - get
           - list
           - use
+          - watch
         serviceAccountName: cluster-logging-operator
       deployments:
       - name: cluster-logging-operator

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -44,6 +44,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:
@@ -162,5 +163,7 @@ rules:
   - securitycontextconstraints
   verbs:
   - create
+  - get
   - list
   - use
+  - watch

--- a/internal/controller/kubebuilder_rbac.go
+++ b/internal/controller/kubebuilder_rbac.go
@@ -17,10 +17,10 @@ package controller
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=*
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=*
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=*
-// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=create;use;list
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=create;use;get;list;watch
 // +kubebuilder:rbac:urls=/metrics,verbs=get
 
-// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusterversions,verbs=get;list
+// +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers;clusterversions,verbs=get;list;watch
 
 // +kubebuilder:rbac:groups=observability.openshift.io,resources=clusterlogforwarders,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=observability.openshift.io,resources=clusterlogforwarders/status,verbs=get;update;patch

--- a/internal/controller/observability/clusterlogforwarder_controller.go
+++ b/internal/controller/observability/clusterlogforwarder_controller.go
@@ -129,7 +129,6 @@ func (r *ClusterLogForwarderReconciler) SetupWithManager(mgr ctrl.Manager) error
 }
 
 func validateForwarder(forwarderContext internalcontext.ForwarderContext) (result ctrl.Result, err error) {
-	log.V(3).Info("obs-clusterlogforwarder-controller Error getting instance. It will be retried if other then 'NotFound'", "error", err.Error())
 	if failures := validations.ValidateClusterLogForwarder(forwarderContext); len(failures) > 0 {
 		// TODO: Evaluate failures
 		//if validationerrors.MustUndeployCollector(err) {


### PR DESCRIPTION
### Description

While running the CLO on a test cluster I noticed that it still produced two errors regarding RBAC for the `apiservers` and `securitycontextcontraints` resources. It looks as if the verbs needed to watch these resources were missing.

This is a follow-up fix for #2521 .
