### PR TITLE
LOG-5692: Enable deploy as deployment e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ apply: namespace $(OPERATOR_SDK) ## Install kustomized resources directly to the
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	$(WATCH_EVENTS) $(KUSTOMIZE) build $(or $(OVERLAY),config/manifests) | oc apply -f -; $(WAIT_FOR_OPERATOR)
 
-E2E_TEST_INCLUDES=logforwarding
+E2E_TEST_INCLUDES=logforwarding|collection
 CLF_TEST_INCLUDES=http
 .PHONY: test-e2e
 test-e2e: $(JUNITREPORT)

--- a/api/observability/v1/input_types.go
+++ b/api/observability/v1/input_types.go
@@ -246,6 +246,10 @@ type ReceiverSpec struct {
 
 	// TLS contains settings for controlling options of TLS connections.
 	//
+	// The operator will request certificates from the cluster's cert signing service when TLS is not defined.
+	// The certificates are injected into a secret named "<clusterlogforwarder.name>-<input.name>" which is mounted into
+	// the collector. The collector is configured to use the public and private key provided by the service
+	//
 	// +kubebuilder:validation:Optional
 	TLS *InputTLSSpec `json:"tls,omitempty"`
 

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -618,8 +618,12 @@ spec:
                           minimum: 1024
                           type: integer
                         tls:
-                          description: TLS contains settings for controlling options
-                            of TLS connections.
+                          description: "TLS contains settings for controlling options
+                            of TLS connections. \n The operator will request certificates
+                            from the cluster's cert signing service when TLS is not
+                            defined. The certificates are injected into a secret named
+                            \"<clusterlogforwarder.name>-<input.name>\" which is mounted
+                            into the collector."
                           properties:
                             ca:
                               description: CA can be used to specify a custom list

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -619,8 +619,12 @@ spec:
                           minimum: 1024
                           type: integer
                         tls:
-                          description: TLS contains settings for controlling options
-                            of TLS connections.
+                          description: "TLS contains settings for controlling options
+                            of TLS connections. \n The operator will request certificates
+                            from the cluster's cert signing service when TLS is not
+                            defined. The certificates are injected into a secret named
+                            \"<clusterlogforwarder.name>-<input.name>\" which is mounted
+                            into the collector."
                           properties:
                             ca:
                               description: CA can be used to specify a custom list

--- a/hack/testing-olm/test-030-collection.sh
+++ b/hack/testing-olm/test-030-collection.sh
@@ -9,7 +9,7 @@ os::test::junit::declare_suite_start "[ClusterLogging] Collection"
 
 start_seconds=$(date +%s)
 
-TEST_DIR=${TEST_DIR:-'./test/e2e/collection/*/'}
+TEST_DIR=${TEST_DIR:-'./test/e2e/collection/deployment/'}
 ARTIFACT_DIR=${ARTIFACT_DIR:-"$repo_dir/_output"}
 if [ ! -d $ARTIFACT_DIR ] ; then
   mkdir -p $ARTIFACT_DIR

--- a/internal/api/context/context.go
+++ b/internal/api/context/context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 	kubernetes "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -30,4 +31,7 @@ type ForwarderContext struct {
 
 	// ClusterVersion is the version of the cluster on which the operator is deployed
 	ClusterVersion string
+
+	// AdditionalContext are additional context options to take pass along during reconciliation
+	AdditionalContext utils.Options
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Factory#Daemonset#NewPodSpec", func() {
 					},
 				},
 			},
-		}, "1234", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+		}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 		collector = podSpec.Containers[0]
 	})
 	Describe("when creating of the collector container", func() {
@@ -103,7 +103,7 @@ var _ = Describe("Factory#Daemonset#NewPodSpec", func() {
 			logLevelDebug := "debug"
 			factory.LogLevel = logLevelDebug
 
-			podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+			podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 			collector = podSpec.Containers[0]
 			Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{Name: "VECTOR_LOG", Value: logLevelDebug}))
 		})
@@ -151,7 +151,7 @@ var _ = Describe("Factory#Daemonset#NewPodSpec", func() {
 						providedToleration,
 					},
 				}
-				podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+				podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 				expTolerations := append(constants.DefaultTolerations(), providedToleration)
 				Expect(podSpec.Tolerations).To(Equal(expTolerations))
 			})
@@ -172,7 +172,7 @@ var _ = Describe("Factory#Daemonset#NewPodSpec", func() {
 						"foo": "bar",
 					},
 				}
-				podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+				podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 				Expect(podSpec.NodeSelector).To(Equal(expSelector))
 			})
 
@@ -205,7 +205,7 @@ var _ = Describe("Factory#Daemonset#NewPodSpec", func() {
 					Data: map[string]string{
 						constants.TrustedCABundleKey: caBundle,
 					},
-				}, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+				}, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 				collector = podSpec.Containers[0]
 
 				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{Name: "http_proxy", Value: httpproxy}))
@@ -254,7 +254,7 @@ var _ = Describe("Factory#Daemonset#NewPodSpec", func() {
 				Data: map[string]string{
 					constants.TrustedCABundleKey: caBundle,
 				},
-			}, obs.ClusterLogForwarderSpec{}, "foobar", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+			}, obs.ClusterLogForwarderSpec{}, "foobar", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 
 			collector = podSpec.Containers[0]
 			Expect(podSpec.Volumes).To(ContainElement(expectedPodSpecMetricsVol))
@@ -349,7 +349,7 @@ var _ = Describe("Factory#Deployment#NewPodSpec", func() {
 			ResourceNames: coreFactory.ResourceNames(*obsruntime.NewClusterLogForwarder(constants.OpenshiftNS, constants.SingletonName, runtime.Initialize)),
 			isDaemonset:   false,
 		}
-		podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+		podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 		collector = podSpec.Containers[0]
 	})
 	Describe("when creating the collector container", func() {
@@ -395,7 +395,7 @@ var _ = Describe("Factory#Deployment#NewPodSpec", func() {
 						providedToleration,
 					},
 				}
-				podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+				podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 				expTolerations := append(constants.DefaultTolerations(), providedToleration)
 				Expect(podSpec.Tolerations).To(Equal(expTolerations))
 			})
@@ -416,7 +416,7 @@ var _ = Describe("Factory#Deployment#NewPodSpec", func() {
 						"foo": "bar",
 					},
 				}
-				podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+				podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 				Expect(podSpec.NodeSelector).To(Equal(expSelector))
 			})
 
@@ -449,7 +449,7 @@ var _ = Describe("Factory#Deployment#NewPodSpec", func() {
 					Data: map[string]string{
 						constants.TrustedCABundleKey: caBundle,
 					},
-				}, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+				}, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 				collector = podSpec.Containers[0]
 
 				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{Name: "http_proxy", Value: httpproxy}))
@@ -501,7 +501,7 @@ var _ = Describe("Factory#Deployment#NewPodSpec", func() {
 					Data: map[string]string{
 						constants.TrustedCABundleKey: caBundle,
 					},
-				}, obs.ClusterLogForwarderSpec{}, "foobar", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+				}, obs.ClusterLogForwarderSpec{}, "foobar", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 
 				collector = podSpec.Containers[0]
 				Expect(podSpec.Volumes).To(ContainElement(expectedPodSpecMetricsVol))
@@ -651,7 +651,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch STS Resources", func() {
 			podSpec := *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{
 				Outputs:   outputs,
 				Pipelines: pipelines,
-			}, "1234", tls.GetClusterTLSProfileSpec(nil), nil, constants.OpenshiftNS)
+			}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 			collector := podSpec.Containers[0]
 
 			Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{

--- a/internal/collector/daemonset.go
+++ b/internal/collector/daemonset.go
@@ -19,15 +19,7 @@ import (
 // ReconcileDaemonset reconciles a daemonset specifically for the collector defined by the factory
 func (f *Factory) ReconcileDaemonset(er record.EventRecorder, k8sClient client.Client, namespace string, trustedCABundle *corev1.ConfigMap, owner metav1.OwnerReference) error {
 	tlsProfile, _ := tls.FetchAPIServerTlsProfile(k8sClient)
-
-	var receiverInputs []string
-	for _, input := range f.ForwarderSpec.Inputs {
-		if input.Receiver != nil {
-			receiverInputs = append(receiverInputs, f.ResourceNames.GenerateInputServiceName(input.Name))
-		}
-	}
-
-	desired := f.NewDaemonSet(namespace, f.ResourceNames.DaemonSetName(), trustedCABundle, tls.GetClusterTLSProfileSpec(tlsProfile), receiverInputs)
+	desired := f.NewDaemonSet(namespace, f.ResourceNames.DaemonSetName(), trustedCABundle, tls.GetClusterTLSProfileSpec(tlsProfile))
 	utils.AddOwnerRefToObject(desired, owner)
 	return reconcile.DaemonSet(er, k8sClient, desired)
 }

--- a/internal/collector/deployment.go
+++ b/internal/collector/deployment.go
@@ -19,15 +19,7 @@ import (
 // ReconcileDeployment reconciles a deployment specifically for the collector defined by the factory
 func (f *Factory) ReconcileDeployment(er record.EventRecorder, k8sClient client.Client, namespace string, trustedCABundle *corev1.ConfigMap, owner metav1.OwnerReference) error {
 	tlsProfile, _ := tls.FetchAPIServerTlsProfile(k8sClient)
-
-	var receiverInputs []string
-	for _, input := range f.ForwarderSpec.Inputs {
-		if input.Receiver != nil {
-			receiverInputs = append(receiverInputs, f.ResourceNames.GenerateInputServiceName(input.Name))
-		}
-	}
-
-	desired := f.NewDeployment(namespace, f.ResourceNames.DaemonSetName(), trustedCABundle, tls.GetClusterTLSProfileSpec(tlsProfile), receiverInputs)
+	desired := f.NewDeployment(namespace, f.ResourceNames.DaemonSetName(), trustedCABundle, tls.GetClusterTLSProfileSpec(tlsProfile))
 	utils.AddOwnerRefToObject(desired, owner)
 	return reconcile.Deployment(er, k8sClient, desired)
 }

--- a/internal/generator/framework/options.go
+++ b/internal/generator/framework/options.go
@@ -1,5 +1,9 @@
 package framework
 
+import (
+	utils "github.com/openshift/cluster-logging-operator/internal/utils"
+)
+
 const (
 	ClusterTLSProfileSpec = "tlsProfileSpec"
 
@@ -11,16 +15,10 @@ const (
 
 // Options is a map of Options used to customize the config generation. E.g. Debugging, legacy config generation
 // Deprecated
-type Options map[string]interface{}
+type Options = utils.Options
 
 // NoOptions is used to pass empty options
-var NoOptions = Options{}
-
-// Has takes a key and returns true if it exists
-func (o Options) Has(key string) bool {
-	_, found := o[key]
-	return found
-}
+var NoOptions = utils.NoOptions
 
 // TODO: unit me with functional.Option
 type Option struct {

--- a/internal/generator/framework/tls.go
+++ b/internal/generator/framework/tls.go
@@ -4,11 +4,12 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/tls"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"strings"
 )
 
 // TLSProfileInfo returns the minTLSVersion, ciphers as a delimited list given the available TLSSecurityProfile
-func (op Options) TLSProfileInfo(outputSpec obs.OutputSpec, separator string) (string, string) {
+func TLSProfileInfo(op utils.Options, outputSpec obs.OutputSpec, separator string) (string, string) {
 	var tlsProfileSpec configv1.TLSProfileSpec
 	if outputSpec.TLS != nil && outputSpec.TLS.TLSSecurityProfile != nil {
 		tlsProfileSpec = tls.GetClusterTLSProfileSpec(outputSpec.TLS.TLSSecurityProfile)
@@ -23,6 +24,6 @@ func (op Options) TLSProfileInfo(outputSpec obs.OutputSpec, separator string) (s
 }
 
 // SetTLSProfileOptionsFrom updates options to set the TLS profile based upon the output spec
-func (op Options) SetTLSProfileOptionsFrom(o obs.OutputSpec) {
-	op[MinTLSVersion], op[Ciphers] = op.TLSProfileInfo(o, ",")
+func SetTLSProfileOptionsFrom(op utils.Options, o obs.OutputSpec) {
+	op[MinTLSVersion], op[Ciphers] = TLSProfileInfo(op, o, ",")
 }

--- a/internal/generator/framework/tls_test.go
+++ b/internal/generator/framework/tls_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Options#TLSProfileInfo", func() {
 	Context("when a cluster profile is absent", func() {
 
 		It("should use the defaults when clf profile is nil and output.TLS is nil", func() {
-			minTLS, ciphers := options.TLSProfileInfo(obs.OutputSpec{}, ",")
+			minTLS, ciphers := TLSProfileInfo(options, obs.OutputSpec{}, ",")
 			Expect(minTLS).To(BeEquivalentTo(tls.DefaultMinTLSVersion))
 			Expect(ciphers).To(Equal(strings.Join(tls.DefaultTLSCiphers, ",")))
 		})
@@ -50,14 +50,14 @@ var _ = Describe("Options#TLSProfileInfo", func() {
 		})
 
 		It("should prefer the output profile over the cluster profile", func() {
-			minTLS, ciphers := options.TLSProfileInfo(outputSpec, ",")
+			minTLS, ciphers := TLSProfileInfo(options, outputSpec, ",")
 			spec := configv1.TLSProfiles[outputProfile.Type]
 			Expect(minTLS).To(BeEquivalentTo(spec.MinTLSVersion))
 			Expect(ciphers).To(Equal(strings.Join(spec.Ciphers, ",")))
 		})
 
 		It("should prefer the cluster profile when the forwarder and output.TLS are nil", func() {
-			minTLS, ciphers := options.TLSProfileInfo(obs.OutputSpec{}, ",")
+			minTLS, ciphers := TLSProfileInfo(options, obs.OutputSpec{}, ",")
 			Expect(minTLS).To(BeEquivalentTo(clusterMinTLSVersion))
 			Expect(ciphers).To(Equal(strings.Join(clusterCiphers, ",")))
 		})

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -114,6 +114,7 @@ address = "[::]:7777"
 decoding.codec = "json"
 
 [sources.input_myreceiver.tls]
+enabled = true
 min_tls_version = "VersionTLS12"
 ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"

--- a/internal/generator/vector/conf/conf.go
+++ b/internal/generator/vector/conf/conf.go
@@ -93,7 +93,7 @@ func Conf(secrets map[string]*corev1.Secret, clfspec obs.ClusterLogForwarderSpec
 		sections.Elements = append(sections.Elements, o.Elements()...)
 	}
 
-	minTlsVersion, cipherSuites := op.TLSProfileInfo(obs.OutputSpec{}, ",")
+	minTlsVersion, cipherSuites := framework.TLSProfileInfo(op, obs.OutputSpec{}, ",")
 	return []framework.Section{
 		{
 			Global(namespace, forwarderName),

--- a/internal/generator/vector/helpers/secrets.go
+++ b/internal/generator/vector/helpers/secrets.go
@@ -20,6 +20,7 @@ func GetOutputSecret(o logging.OutputSpec, secrets map[string]*corev1.Secret) *c
 type Secrets map[string]*corev1.Secret
 
 func (s Secrets) Names() (names []string) {
+
 	for name := range s {
 		names = append(names, name)
 	}

--- a/internal/generator/vector/input/receiver.go
+++ b/internal/generator/vector/input/receiver.go
@@ -51,6 +51,6 @@ func receiverTLS(id string, spec *obs.InputTLSSpec, secrets helpers.Secrets, op 
 			KeyPassphrase: spec.KeyPassphrase,
 		},
 	}
-	template := tls.New(id, tlsSpec, secrets, op, generator.Option{tls.Component, "sources"})
+	template := tls.New(id, tlsSpec, secrets, op, generator.Option{tls.Component, "sources"}, generator.Option{tls.IncludeEnabled, ""})
 	return template
 }

--- a/internal/generator/vector/input/receiver_http_audit.toml
+++ b/internal/generator/vector/input/receiver_http_audit.toml
@@ -4,6 +4,7 @@ address = "[::]:12345"
 decoding.codec = "json"
 
 [sources.input_myreceiver.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/instance-myreceiver/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/instance-myreceiver/tls.crt"
 

--- a/internal/generator/vector/input/receiver_syslog.toml
+++ b/internal/generator/vector/input/receiver_syslog.toml
@@ -4,6 +4,7 @@ address = "[::]:12345"
 mode = "tcp"
 
 [sources.input_myreceiver.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/instance-myreceiver/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/instance-myreceiver/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/instance-myreceiver/ca-bundle.crt"

--- a/internal/generator/vector/input/receiver_syslog_tls_from_configmap.toml
+++ b/internal/generator/vector/input/receiver_syslog_tls_from_configmap.toml
@@ -4,6 +4,7 @@ address = "[::]:12345"
 mode = "tcp"
 
 [sources.input_myreceiver.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/instance-myreceiver/tls.key"
 crt_file = "/var/run/ocp-collector/config/instance-myreceiver/my.crt"
 ca_file = "/var/run/ocp-collector/config/instance-myreceiver/ca.crt"

--- a/internal/generator/vector/output/factory.go
+++ b/internal/generator/vector/output/factory.go
@@ -22,7 +22,7 @@ import (
 )
 
 func New(o obs.OutputSpec, inputs []string, secrets map[string]*corev1.Secret, strategy common.ConfigStrategy, op Options) []Element {
-	op.SetTLSProfileOptionsFrom(o)
+	SetTLSProfileOptionsFrom(op, o)
 
 	var els []Element
 	baseID := helpers.MakeOutputID(o.Name)

--- a/internal/migrations/observability/migrate_inputs.go
+++ b/internal/migrations/observability/migrate_inputs.go
@@ -1,16 +1,21 @@
 package observability
 
 import (
+	"fmt"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MigrateInputs creates instances of inputSpec when a pipeline references one of the reserved input names (e.g. application)
 // This function is destructive and replaces any inputs that use the reserved input names
-func MigrateInputs(spec obs.ClusterLogForwarderSpec) (obs.ClusterLogForwarderSpec, []metav1.Condition) {
-	inputs := internalobs.Inputs(spec.Inputs).Map()
-	for _, p := range spec.Pipelines {
+func MigrateInputs(spec obs.ClusterLogForwarder, options utils.Options) (obs.ClusterLogForwarder, []metav1.Condition) {
+	inputs := internalobs.Inputs(spec.Spec.Inputs).Map()
+	for _, p := range spec.Spec.Pipelines {
 		for _, i := range p.InputRefs {
 			switch i {
 			case string(obs.InputTypeApplication):
@@ -38,9 +43,44 @@ func MigrateInputs(spec obs.ClusterLogForwarderSpec) (obs.ClusterLogForwarderSpe
 			}
 		}
 	}
-	spec.Inputs = []obs.InputSpec{}
+	spec.Spec.Inputs = []obs.InputSpec{}
 	for _, i := range inputs {
-		spec.Inputs = append(spec.Inputs, i)
+		i = migrateInputReceiver(i, spec.Name, options)
+		spec.Spec.Inputs = append(spec.Spec.Inputs, i)
 	}
 	return spec, nil
+}
+
+func migrateInputReceiver(spec obs.InputSpec, forwarderName string, options utils.Options) obs.InputSpec {
+	if spec.Type != obs.InputTypeReceiver {
+		return spec
+	}
+	if spec.Receiver != nil && spec.Receiver.TLS != nil {
+		return spec
+	}
+	secretName := fmt.Sprintf("%s-%s", forwarderName, spec.Name)
+	spec.Receiver.TLS = &obs.InputTLSSpec{
+		Key: &obs.SecretKey{
+			Key: constants.ClientPrivateKey,
+			Secret: &corev1.LocalObjectReference{
+				Name: secretName,
+			},
+		},
+		Certificate: &obs.ConfigMapOrSecretKey{
+			Key: constants.ClientCertKey,
+			Secret: &corev1.LocalObjectReference{
+				Name: secretName,
+			},
+		},
+	}
+	secrets := []*corev1.Secret{
+		runtime.NewSecret("", secretName, map[string][]byte{
+			constants.ClientPrivateKey: []byte{},
+			constants.ClientCertKey:    []byte{},
+		}),
+	}
+	utils.Update(options, GeneratedSecrets, secrets, func(existing []*corev1.Secret) []*corev1.Secret {
+		return append(existing, secrets...)
+	})
+	return spec
 }

--- a/internal/migrations/observability/migrate_inputs_test.go
+++ b/internal/migrations/observability/migrate_inputs_test.go
@@ -1,47 +1,65 @@
 package observability
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	corev1 "k8s.io/api/core/v1"
+	"sort"
 )
 
 var _ = Describe("migrateInputs", func() {
+	var (
+		initContext utils.Options
+	)
+	BeforeEach(func() {
+		initContext = utils.Options{}
+	})
 	Context("for reserved input names", func() {
 
 		It("should stub 'application' as an input when referenced", func() {
-			spec := obs.ClusterLogForwarderSpec{
-				Pipelines: []obs.PipelineSpec{
-					{InputRefs: []string{string(obs.InputTypeApplication)}},
+			spec := obs.ClusterLogForwarder{
+				Spec: obs.ClusterLogForwarderSpec{
+					Pipelines: []obs.PipelineSpec{
+						{InputRefs: []string{string(obs.InputTypeApplication)}},
+					},
 				},
 			}
-			result, _ := MigrateInputs(spec)
-			Expect(result.Inputs).To(HaveLen(1))
-			Expect(result.Inputs[0]).To(Equal(obs.InputSpec{Type: obs.InputTypeApplication, Name: string(obs.InputTypeApplication), Application: &obs.Application{}}))
+			result, _ := MigrateInputs(spec, initContext)
+			Expect(result.Spec.Inputs).To(HaveLen(1))
+			Expect(result.Spec.Inputs[0]).To(Equal(obs.InputSpec{Type: obs.InputTypeApplication, Name: string(obs.InputTypeApplication), Application: &obs.Application{}}))
 		})
 		It("should stub 'infrastructure' as an input when referenced", func() {
-			spec := obs.ClusterLogForwarderSpec{
-				Pipelines: []obs.PipelineSpec{
-					{InputRefs: []string{string(obs.InputTypeInfrastructure)}},
+			spec := obs.ClusterLogForwarder{
+				Spec: obs.ClusterLogForwarderSpec{
+					Pipelines: []obs.PipelineSpec{
+						{InputRefs: []string{string(obs.InputTypeInfrastructure)}},
+					},
 				},
 			}
-			result, _ := MigrateInputs(spec)
-			Expect(result.Inputs).To(HaveLen(1))
-			Expect(result.Inputs[0]).To(Equal(obs.InputSpec{Type: obs.InputTypeInfrastructure, Name: string(obs.InputTypeInfrastructure),
+			result, _ := MigrateInputs(spec, initContext)
+			Expect(result.Spec.Inputs).To(HaveLen(1))
+			Expect(result.Spec.Inputs[0]).To(Equal(obs.InputSpec{Type: obs.InputTypeInfrastructure, Name: string(obs.InputTypeInfrastructure),
 				Infrastructure: &obs.Infrastructure{
 					Sources: obs.InfrastructureSources,
 				}}))
 		})
 		It("should stub 'audit' as an input when referenced", func() {
-			spec := obs.ClusterLogForwarderSpec{
-				Pipelines: []obs.PipelineSpec{
-					{InputRefs: []string{string(obs.InputTypeAudit)}},
+			spec := obs.ClusterLogForwarder{
+				Spec: obs.ClusterLogForwarderSpec{
+					Pipelines: []obs.PipelineSpec{
+						{InputRefs: []string{string(obs.InputTypeAudit)}},
+					},
 				},
 			}
-			result, _ := MigrateInputs(spec)
-			Expect(result.Inputs).To(HaveLen(1))
-			Expect(result.Inputs[0]).To(Equal(obs.InputSpec{Type: obs.InputTypeAudit, Name: string(obs.InputTypeAudit),
+			result, _ := MigrateInputs(spec, initContext)
+			Expect(result.Spec.Inputs).To(HaveLen(1))
+			Expect(result.Spec.Inputs[0]).To(Equal(obs.InputSpec{Type: obs.InputTypeAudit, Name: string(obs.InputTypeAudit),
 				Audit: &obs.Audit{
 					Sources: obs.AuditSources,
 				}}))
@@ -49,39 +67,142 @@ var _ = Describe("migrateInputs", func() {
 	})
 	Context("when input name is the same as a reserved name", func() {
 		It("should replace the input with the 'reserved' representation", func() {
-			spec := obs.ClusterLogForwarderSpec{
-				Inputs: []obs.InputSpec{
-					{
-						Name: string(obs.InputTypeApplication),
-						Type: obs.InputTypeApplication,
-						Application: &obs.Application{
-							Includes: []obs.NamespaceContainerSpec{
-								{
-									Container: "foo",
+			spec := obs.ClusterLogForwarder{
+				Spec: obs.ClusterLogForwarderSpec{
+					Inputs: []obs.InputSpec{
+						{
+							Name: string(obs.InputTypeApplication),
+							Type: obs.InputTypeApplication,
+							Application: &obs.Application{
+								Includes: []obs.NamespaceContainerSpec{
+									{
+										Container: "foo",
+									},
+								},
+							},
+						},
+						{
+							Name: "my-bar",
+							Type: obs.InputTypeApplication,
+							Application: &obs.Application{
+								Includes: []obs.NamespaceContainerSpec{
+									{
+										Container: "foo",
+									},
 								},
 							},
 						},
 					},
-					{
-						Name: "my-bar",
-						Type: obs.InputTypeApplication,
-						Application: &obs.Application{
-							Includes: []obs.NamespaceContainerSpec{
-								{
-									Container: "foo",
-								},
-							},
-						},
+					Pipelines: []obs.PipelineSpec{
+						{InputRefs: []string{string(obs.InputTypeApplication)}},
 					},
-				},
-				Pipelines: []obs.PipelineSpec{
-					{InputRefs: []string{string(obs.InputTypeApplication)}},
 				},
 			}
-			result, _ := MigrateInputs(spec)
-			Expect(result.Inputs).To(HaveLen(2))
-			inputs := internalobs.Inputs(result.Inputs).Map()
+			result, _ := MigrateInputs(spec, initContext)
+			Expect(result.Spec.Inputs).To(HaveLen(2))
+			inputs := internalobs.Inputs(result.Spec.Inputs).Map()
 			Expect(inputs[string(obs.InputTypeApplication)]).To(Equal(obs.InputSpec{Name: string(obs.InputTypeApplication), Application: &obs.Application{}, Type: obs.InputTypeApplication}))
+		})
+	})
+
+	Context("for receiver inputs", func() {
+		const forwarderName = "myforwarder"
+		var (
+			spec obs.ClusterLogForwarder
+
+			migrate = func(spec, exp obs.ClusterLogForwarder) obs.ClusterLogForwarder {
+				migratedSpec, _ := MigrateInputs(spec, initContext)
+				sort.Slice(migratedSpec.Spec.Inputs, func(i, j int) bool {
+					return migratedSpec.Spec.Inputs[i].Name < migratedSpec.Spec.Inputs[j].Name
+				})
+				sort.Slice(exp.Spec.Inputs, func(i, j int) bool {
+					return exp.Spec.Inputs[i].Name < exp.Spec.Inputs[j].Name
+				})
+				return migratedSpec
+			}
+		)
+		It("should ignore non-receiver inputs", func() {
+			spec = obs.ClusterLogForwarder{
+				Spec: obs.ClusterLogForwarderSpec{
+					Inputs: []obs.InputSpec{
+						{Name: "anapp", Type: obs.InputTypeApplication},
+						{Name: "anInfra", Type: obs.InputTypeInfrastructure},
+						{Name: "anAudit", Type: obs.InputTypeAudit},
+					},
+				},
+			}
+			migratedSpec := migrate(spec, spec)
+			Expect(migratedSpec.Spec.Inputs).To(Equal(spec.Spec.Inputs))
+		})
+		It("should ignore migration when receiver specs TLS settings", func() {
+			spec = obs.ClusterLogForwarder{
+				Spec: obs.ClusterLogForwarderSpec{
+					Inputs: []obs.InputSpec{
+						{
+							Name: "anapp",
+							Type: obs.InputTypeReceiver,
+							Receiver: &obs.ReceiverSpec{
+								TLS: &obs.InputTLSSpec{},
+							},
+						},
+					},
+				},
+			}
+
+			migratedSpec := migrate(spec, spec)
+			Expect(migratedSpec.Spec.Inputs).To(Equal(spec.Spec.Inputs))
+		})
+		It("should add TLS settings that match the cert signing service when TLS is not spec'd", func() {
+			spec = obs.ClusterLogForwarder{
+				Spec: obs.ClusterLogForwarderSpec{
+					Inputs: []obs.InputSpec{
+						{
+							Name:     "anapp",
+							Type:     obs.InputTypeReceiver,
+							Receiver: &obs.ReceiverSpec{},
+						},
+					},
+				},
+			}
+			spec.Name = forwarderName
+			secretName := fmt.Sprintf("%s-%s", forwarderName, "anapp")
+
+			exp := obs.ClusterLogForwarderSpec{
+				Inputs: []obs.InputSpec{
+					{
+						Name: "anapp",
+						Type: obs.InputTypeReceiver,
+						Receiver: &obs.ReceiverSpec{
+							TLS: &obs.InputTLSSpec{
+								Key: &obs.SecretKey{
+									Key: constants.ClientPrivateKey,
+									Secret: &corev1.LocalObjectReference{
+										Name: secretName,
+									},
+								},
+								Certificate: &obs.ConfigMapOrSecretKey{
+									Key: constants.ClientCertKey,
+									Secret: &corev1.LocalObjectReference{
+										Name: secretName,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			migratedSpec := migrate(spec, spec)
+			Expect(migratedSpec.Spec.Inputs).To(Equal(exp.Inputs))
+			secrets, found := utils.GetOption[[]*corev1.Secret](initContext, GeneratedSecrets, []*corev1.Secret{})
+			Expect(found).To(BeTrue(), fmt.Sprintf("Exp. TLS secrets to add to deployment to be identified in the context: %v", initContext))
+			Expect(secrets).To(BeComparableTo([]*corev1.Secret{
+				runtime.NewSecret("", secretName,
+					map[string][]byte{
+						constants.ClientPrivateKey: []byte{},
+						constants.ClientCertKey:    []byte{},
+					}),
+			}), "Exp. context to include the secrets to mount to the deployment")
 		})
 	})
 

--- a/internal/migrations/observability/migrate_lokiStack.go
+++ b/internal/migrations/observability/migrate_lokiStack.go
@@ -12,14 +12,14 @@ import (
 )
 
 // MigrateLokiStack migrates a lokistack output into appropriate loki outputs based on defined inputs
-func MigrateLokiStack(spec obs.ClusterLogForwarderSpec) (obs.ClusterLogForwarderSpec, []metav1.Condition) {
+func MigrateLokiStack(spec obs.ClusterLogForwarder, options utils.Options) (obs.ClusterLogForwarder, []metav1.Condition) {
 	var outputs []obs.OutputSpec
 	var pipelines []obs.PipelineSpec
 	var migrationConditions []metav1.Condition
-	outputs, pipelines, migrationConditions = processForwarderPipelines(spec)
+	outputs, pipelines, migrationConditions = processForwarderPipelines(spec.Spec)
 
-	spec.Outputs = outputs
-	spec.Pipelines = pipelines
+	spec.Spec.Outputs = outputs
+	spec.Spec.Pipelines = pipelines
 
 	return spec, migrationConditions
 }

--- a/internal/migrations/observability/migrations.go
+++ b/internal/migrations/observability/migrations.go
@@ -2,23 +2,34 @@ package observability
 
 import (
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+
+	// GeneratedSecrets identifies the list of secrets that may not exist but should be considered when configuration and
+	// deploying the collector
+	GeneratedSecrets = "generatedSecrets"
 )
 
 // TODO: Refactor other migrations to observability
 // migrations are the set of rules for migrating a ClusterLogForwarder that modify the spec
-var clfMigrations = []func(spec obs.ClusterLogForwarderSpec) (obs.ClusterLogForwarderSpec, []metav1.Condition){
+var clfMigrations = []func(spec obs.ClusterLogForwarder, migrateContext utils.Options) (obs.ClusterLogForwarder, []metav1.Condition){
 	// clusterlogforwarder.EnsureInputsHasType,
 	MigrateLokiStack,
 	MigrateInputs,
 	// clusterlogforwarder.DropUnreferencedOutputs,
 }
 
-func MigrateClusterLogForwarder(spec obs.ClusterLogForwarderSpec) (obs.ClusterLogForwarderSpec, []metav1.Condition) {
+// MigrateClusterLogForwarder initializes the forwarder for fields that must be set and are inferred from settings already defined.
+// It additionally takes a context to pass decisions back such as secrets for receiver inputs that will exist after reconciliation
+// but may not exist when the configuration is being generated
+func MigrateClusterLogForwarder(spec obs.ClusterLogForwarder, migrateContext utils.Options) (obs.ClusterLogForwarder, []metav1.Condition) {
 	conditions := []metav1.Condition{}
 	for _, migrate := range clfMigrations {
 		var migrationConditions []metav1.Condition
-		spec, migrationConditions = migrate(spec)
+		spec, migrationConditions = migrate(spec, migrateContext)
 		conditions = append(conditions, migrationConditions...)
 	}
 	return spec, conditions

--- a/internal/utils/options.go
+++ b/internal/utils/options.go
@@ -1,0 +1,36 @@
+package utils
+
+// Options is a map of Options used to customize the config generation. E.g. Debugging, legacy config generation
+type Options map[string]interface{}
+
+// NoOptions is used to pass empty options
+var NoOptions = Options{}
+
+// Has takes a key and returns true if it exists
+func (o Options) Has(key string) bool {
+	_, found := o[key]
+	return found
+}
+
+// Update sets the named options with the provided value processing it using the provided function if not nil
+func Update[T any](options Options, name string, value T, updater func(T) T) {
+	if updater == nil {
+		updater = func(value T) T {
+			return value
+		}
+	}
+	if existingValue, found := options[name]; found {
+		options[name] = updater(existingValue.(T))
+	} else {
+		options[name] = value
+	}
+}
+
+// GetOption from the named value from the list of options and convert it as needed
+func GetOption[T any](options Options, name string, ifNotFound T) (T, bool) {
+	value, found := options[name]
+	if !found {
+		return ifNotFound, false
+	}
+	return value.(T), found
+}

--- a/internal/utils/options_test.go
+++ b/internal/utils/options_test.go
@@ -1,4 +1,4 @@
-package framework_test
+package utils_test
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/internal/validations/observability/inputs/receivers.go
+++ b/internal/validations/observability/inputs/receivers.go
@@ -3,8 +3,11 @@ package inputs
 import (
 	"fmt"
 	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/golang-collections/collections/set"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	. "github.com/openshift/cluster-logging-operator/internal/api/observability"
+	obsmigrate "github.com/openshift/cluster-logging-operator/internal/migrations/observability"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/internal/validations/observability/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +16,7 @@ import (
 )
 
 // ValidateReceiver validates receiver input specs
-func ValidateReceiver(spec obs.InputSpec, secrets map[string]*corev1.Secret, configMaps map[string]*corev1.ConfigMap) []metav1.Condition {
+func ValidateReceiver(spec obs.InputSpec, secrets map[string]*corev1.Secret, configMaps map[string]*corev1.ConfigMap, context utils.Options) []metav1.Condition {
 	if secrets == nil || configMaps == nil {
 		log.WithName("ValidateReceier").V(0).Info("runtime error: expected maps of secrets and configmaps")
 		os.Exit(1)
@@ -39,7 +42,10 @@ func ValidateReceiver(spec obs.InputSpec, secrets map[string]*corev1.Secret, con
 	}
 	if spec.Receiver.TLS != nil {
 		tlsSpec := obs.TLSSpec(*spec.Receiver.TLS)
-		if messages := common.ValidateConfigMapOrSecretKey(ConfigMapOrSecretKeys(tlsSpec), secrets, configMaps); len(messages) > 0 {
+		keys := ConfigMapOrSecretKeys(tlsSpec)
+		skipKeys := extractSecretKeysAsSet(context)
+		keys = removeGeneratedSecrets(keys, skipKeys)
+		if messages := common.ValidateConfigMapOrSecretKey(keys, secrets, configMaps); len(messages) > 0 {
 			return []metav1.Condition{
 				NewConditionFromPrefix(obs.ConditionTypeValidInputPrefix, spec.Name, false, obs.ReasonValidationFailure, strings.Join(messages, ",")),
 			}
@@ -49,4 +55,30 @@ func ValidateReceiver(spec obs.InputSpec, secrets map[string]*corev1.Secret, con
 	return []metav1.Condition{
 		NewConditionFromPrefix(obs.ConditionTypeValidInputPrefix, spec.Name, true, obs.ReasonValidationSuccess, fmt.Sprintf("input %q is valid", spec.Name)),
 	}
+}
+
+func removeGeneratedSecrets(keys []*obs.ConfigMapOrSecretKey, skipKeys *set.Set) (result []*obs.ConfigMapOrSecretKey) {
+	for _, secretKey := range keys {
+		if secretKey.Secret != nil {
+			key := fmt.Sprintf("%v_%v", secretKey.Secret.Name, secretKey.Key)
+			if !skipKeys.Has(key) {
+				result = append(result, secretKey)
+			}
+		} else { //configmap
+			result = append(result, secretKey)
+		}
+	}
+	return result
+}
+
+func extractSecretKeysAsSet(context utils.Options) *set.Set {
+	secretKeys := set.New()
+	if generatedSecrets, found := utils.GetOption[[]*corev1.Secret](context, obsmigrate.GeneratedSecrets, []*corev1.Secret{}); found {
+		for _, secret := range generatedSecrets {
+			for key, _ := range secret.Data {
+				secretKeys.Insert(fmt.Sprintf("%s_%s", secret.Name, key))
+			}
+		}
+	}
+	return secretKeys
 }

--- a/internal/validations/observability/inputs/validate.go
+++ b/internal/validations/observability/inputs/validate.go
@@ -18,7 +18,7 @@ func Validate(context internalcontext.ForwarderContext) {
 		case obs.InputTypeAudit:
 			conditions = ValidateAudit(i)
 		case obs.InputTypeReceiver:
-			conditions = ValidateReceiver(i, context.Secrets, context.ConfigMaps)
+			conditions = ValidateReceiver(i, context.Secrets, context.ConfigMaps, context.AdditionalContext)
 		}
 		results = append(results, conditions...)
 	}

--- a/test/e2e/collection/deployment/collector_as_deployment_test.go
+++ b/test/e2e/collection/deployment/collector_as_deployment_test.go
@@ -3,14 +3,15 @@ package deployment
 import (
 	"encoding/json"
 	"fmt"
-	"os"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	obsruntime "github.com/openshift/cluster-logging-operator/internal/runtime/observability"
+	corev1 "k8s.io/api/core/v1"
+	"strconv"
 	"strings"
 
-	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
-	"github.com/openshift/cluster-logging-operator/test/helpers"
-	testruntime "github.com/openshift/cluster-logging-operator/test/runtime"
 	apps "k8s.io/api/apps/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -19,141 +20,109 @@ import (
 
 var _ = Describe("Test collector deployment type", func() {
 	const (
-		fluentConf = `
-<system>
-  log_level info
-</system>
-<source>
-  @type http
-  port 24224
-  bind 0.0.0.0
-  body_size_limit 32m
-  keepalive_timeout 10s
-  # Headers are capitalized, and added with prefix "HTTP_"
-  add_http_headers true
-  add_remote_addr true
-  <parse>
-    @type json
-  </parse>
-  <transport tls>
-	  ca_path /etc/fluentd/secrets/ca-bundle.crt
-	  cert_path /etc/fluentd/secrets/tls.crt
-	  private_key_path /etc/fluentd/secrets/tls.key
-  </transport>
-</source>
-
-<match logs.app>
-  @type file
-  append true
-  path /tmp/app.logs
-  symlink_path /tmp/app-logs
-</match>
-<match logs.infra>
-  @type file
-  append true
-  path /tmp/infra.logs
-  symlink_path /tmp/infra-logs
-</match>
-<match logs.audit>
-  @type file
-  append true
-  path /tmp/audit.logs
-  symlink_path /tmp/audit-logs
-</match>
-<match **>
-	@type stdout
-</match>
-`
 		receiverPort = 8080
 		receiverName = "http-audit"
 	)
 	var (
 		err                  error
-		wd, _                = os.Getwd()
-		rootDir              = fmt.Sprintf("%s/../../../../", wd)
-		forwarder            *loggingv1.ClusterLogForwarder
+		forwarder            *obs.ClusterLogForwarder
+		forwarderName        = "my-forwarder"
 		deploymentAnnotation = map[string]string{constants.AnnotationEnableCollectorAsDeployment: "true"}
 		fluentDeployment     *apps.Deployment
+		deployNS             string
 		logGenNS             string
-		headers              = map[string]string{"h1": "v1", "h2": "v2"}
 		e2e                  = framework.NewE2ETestFramework()
-		fwdSpec              = loggingv1.ClusterLogForwarderSpec{
-			Inputs: []loggingv1.InputSpec{
-				{
-					Name: receiverName,
-					Receiver: &loggingv1.ReceiverSpec{
-						Type: loggingv1.ReceiverTypeHttp,
-						ReceiverTypeSpec: &loggingv1.ReceiverTypeSpec{
-							HTTP: &loggingv1.HTTPReceiver{
-								Format: loggingv1.FormatKubeAPIAudit,
-								Port:   receiverPort,
-							},
-						},
-					},
-				},
-			},
-			Outputs: []loggingv1.OutputSpec{
-				{
-					Name: "httpout-audit",
-					Type: loggingv1.OutputTypeHttp,
-					URL:  "https://fluent-receiver.openshift-logging.svc:24224/logs/audit",
-					OutputTypeSpec: loggingv1.OutputTypeSpec{
-						Http: &loggingv1.Http{
-							Headers: headers,
-							Method:  "POST",
-						},
-					},
-					Secret: &loggingv1.OutputSecretSpec{
-						Name: "fluent-receiver",
-					},
-					TLS: &loggingv1.OutputTLSSpec{
-						InsecureSkipVerify: true,
-					},
-				},
-			},
-			Pipelines: []loggingv1.PipelineSpec{
-				{
-					Name:       "input-receiver-logs",
-					OutputRefs: []string{"httpout-audit"},
-					InputRefs:  []string{"http-audit"},
-				},
-			},
-		}
+		serviceAccount       *corev1.ServiceAccount
 	)
 
 	Describe("with vector collector", func() {
 		BeforeEach(func() {
-			cr := helpers.NewClusterLogging(helpers.ComponentTypeCollectorVector)
-			if err = e2e.CreateClusterLogging(cr); err != nil {
-				Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
+			deployNS = e2e.CreateTestNamespace()
+			fluentDeployment, err = e2e.DeployFluentdReceiverWithConf(deployNS, true, framework.FluentConfHTTPWithTLS)
+			Expect(err).To(BeNil())
+			logStore := e2e.LogStores[fluentDeployment.GetName()]
+
+			if serviceAccount, err = e2e.BuildAuthorizationFor(deployNS, forwarderName).
+				AllowClusterRole(framework.ClusterRoleCollectInfrastructureLogs).Create(); err != nil {
+				Fail(err.Error())
 			}
-			forwarder = testruntime.NewClusterLogForwarder()
-			forwarder.Spec = fwdSpec
-			httpReceiverServiceName := fmt.Sprintf("%s-%s", constants.CollectorName, receiverName)
-			httpReceiverEndpoint := fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", httpReceiverServiceName, constants.OpenshiftNS, receiverPort)
+
+			httpReceiverServiceName := fmt.Sprintf("%s-%s", forwarderName, receiverName)
+			httpReceiverEndpoint := fmt.Sprintf("https://%s.%s.svc.cluster.local:%d", httpReceiverServiceName, deployNS, receiverPort)
 			if logGenNS, err = e2e.DeployCURLLogGenerator(httpReceiverEndpoint); err != nil {
 				Fail(fmt.Sprintf("unable to deploy log generator %v.", err))
 			}
+
+			forwarder = obsruntime.NewClusterLogForwarder(deployNS, forwarderName, runtime.Initialize, func(clf *obs.ClusterLogForwarder) {
+				clf.Spec.ServiceAccount.Name = serviceAccount.Name
+				clf.Annotations = deploymentAnnotation
+				clf.Spec.Inputs = []obs.InputSpec{
+					{
+						Name: receiverName,
+						Type: obs.InputTypeReceiver,
+						Receiver: &obs.ReceiverSpec{
+							Type: obs.ReceiverTypeHTTP,
+							Port: receiverPort,
+							HTTP: &obs.HTTPReceiver{
+								Format: obs.HTTPReceiverFormatKubeAPIAudit,
+							},
+						},
+					},
+				}
+				clf.Spec.Outputs = []obs.OutputSpec{
+					{
+						Name: "httpout-audit",
+						Type: obs.OutputTypeHTTP,
+						HTTP: &obs.HTTP{
+							URLSpec: obs.URLSpec{
+								URL: fmt.Sprintf("%s/logs/audit", logStore.ClusterLocalEndpoint()),
+							},
+							Method: "POST",
+						},
+						TLS: &obs.OutputTLSSpec{
+							InsecureSkipVerify: true,
+							TLSSpec: obs.TLSSpec{
+								CA: &obs.ConfigMapOrSecretKey{
+									Key: constants.TrustedCABundleKey,
+									Secret: &corev1.LocalObjectReference{
+										Name: framework.FluentdSecretName,
+									},
+								},
+							},
+						},
+					},
+				}
+				clf.Spec.Pipelines = []obs.PipelineSpec{
+					{
+						Name:       "input-receiver-logs",
+						OutputRefs: []string{"httpout-audit"},
+						InputRefs:  []string{"http-audit"},
+					},
+				}
+			})
 		})
 
-		It("collector should be a deployment when annotated and http receiver is the only input", func() {
-			fluentDeployment, err = e2e.DeployFluentdReceiverWithConf(rootDir, true, fluentConf)
-			Expect(err).To(BeNil())
-			forwarder.Annotations = deploymentAnnotation
-			if err := e2e.CreateClusterLogForwarder(forwarder); err != nil {
+		It("should be a deployment when annotated and http receiver is the only input", func() {
+			if err := e2e.CreateObservabilityClusterLogForwarder(forwarder); err != nil {
 				Fail(fmt.Sprintf("Unable to create an instance of logforwarder: %v", err))
 			}
-			components := []helpers.LogComponentType{helpers.ComponentTypeCollectorDeployment}
-			for _, component := range components {
-				if err := e2e.WaitFor(component); err != nil {
-					Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", component, err))
-				}
+			if err := e2e.WaitForResourceCondition(forwarder.Namespace, "deployment", forwarder.Name, "", "{.status.availableReplicas}", 1,
+				func(out string) (bool, error) {
+					out = strings.TrimSpace(out)
+					if out == "" {
+						return false, nil
+					}
+					available, err := strconv.Atoi(out)
+					if err != nil {
+						return false, err
+					}
+					return available >= 1, nil
+				}); err != nil {
+				Fail(err.Error())
 			}
 
 			logStore := e2e.LogStores[fluentDeployment.GetName()]
-			has, err := logStore.HasAuditLogs(framework.DefaultWaitForLogsTimeout)
-			Expect(err).To(BeNil())
-			Expect(has).To(BeTrue())
+			Expect(logStore.HasAuditLogs(framework.DefaultWaitForLogsTimeout)).To(BeTrue(), "exp. to find some audit logs")
 
 			collectedLogs, err := logStore.RetrieveLogs()
 			Expect(err).To(BeNil())
@@ -163,12 +132,7 @@ var _ = Describe("Test collector deployment type", func() {
 			auditLogs := map[string]interface{}{}
 			err = json.Unmarshal([]byte(auditLogsStr), &auditLogs)
 			Expect(err).To(BeNil(), auditLogsStr)
-			for k, v := range headers {
-				// Headers are capitalized, and sent with prefix "HTTP_"
-				headerVal, ok := auditLogs[fmt.Sprintf("HTTP_%s", strings.ToUpper(k))]
-				Expect(ok).To(BeTrue())
-				Expect(headerVal).To(Equal(v))
-			}
+
 			message, ok := auditLogs["log_message"]
 			Expect(ok).To(BeTrue())
 			Expect(message).To(Not(BeEmpty()))

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -191,7 +191,8 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 	}
 	secretMap := f.mapSecrets()
 	log.V(2).Info("Generating config", "forwarder", f.Forwarder)
-	f.Forwarder.Spec, _ = obsmigrations.MigrateClusterLogForwarder(f.Forwarder.Spec)
+	migrated, _ := obsmigrations.MigrateClusterLogForwarder(*f.Forwarder, utils.NoOptions)
+	f.Forwarder = &migrated
 	clfYaml, _ := yaml.Marshal(f.Forwarder)
 	debugOutput := false
 	testClient := client.Get().ControllerRuntimeClient()


### PR DESCRIPTION
### Description
This PR:
* enables deploy as a deployment e2e test
* Refactors options type into utils
* Contextually validates intput receiver secrets

### Links
* https://issues.redhat.com/browse/LOG-5692

cc @Clee2691 @cahartma 
