### PR TITLE
LOG-5664: refactor function prune filter test for observability API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ test-functional:
 	RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	go test -race \
+		./test/functional/filters/prune \
 		./test/functional/normalization \
 		./test/functional/outputs/azuremonitor \
 		-ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0

--- a/internal/api/observability/secrets.go
+++ b/internal/api/observability/secrets.go
@@ -1,0 +1,16 @@
+package observability
+
+import (
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NewSecretKey returns a SecretKey with the given key name and secret
+func NewSecretKey(keyName, secretName string) *obs.SecretKey {
+	return &obs.SecretKey{
+		Key: keyName,
+		Secret: &corev1.LocalObjectReference{
+			Name: secretName,
+		},
+	}
+}

--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -394,6 +394,7 @@ codec = "json"
 timestamp_format = "rfc3339"
 
 [sinks.output_kafka_receiver.tls]
+enabled = true
 min_tls_version = "VersionTLS12"
 ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -421,6 +421,7 @@ codec = "json"
 timestamp_format = "rfc3339"
 
 [sinks.output_kafka_receiver.tls]
+enabled = true
 min_tls_version = "VersionTLS12"
 ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -157,6 +157,7 @@ codec = "json"
 timestamp_format = "rfc3339"
 
 [sinks.output_kafka_receiver.tls]
+enabled = true
 min_tls_version = "VersionTLS12"
 ciphersuites = "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,DHE-RSA-AES128-GCM-SHA256,DHE-RSA-AES256-GCM-SHA384"
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"

--- a/internal/generator/vector/output/kafka/kafka.go
+++ b/internal/generator/vector/output/kafka/kafka.go
@@ -64,7 +64,7 @@ func New(id string, o obs.OutputSpec, inputs []string, secrets vectorhelpers.Sec
 	if o.TLS != nil {
 		skipVerify := o.TLS.InsecureSkipVerify
 		o.TLS.InsecureSkipVerify = false
-		tlsConfig = []Element{tls.New(id, o.TLS, secrets, op)}
+		tlsConfig = []Element{tls.New(id, o.TLS, secrets, op, Option{tls.IncludeEnabled, ""})}
 		if skipVerify {
 			tlsConfig = append(tlsConfig, InsecureTLS{
 				ComponentID: id,

--- a/internal/generator/vector/output/kafka/kafka_insecure_skipverify.toml
+++ b/internal/generator/vector/output/kafka/kafka_insecure_skipverify.toml
@@ -9,6 +9,7 @@ codec = "json"
 timestamp_format = "rfc3339"
 
 [sinks.kafka_receiver.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"

--- a/internal/generator/vector/output/kafka/kafka_multi_brokers_with_tls_single_topic.toml
+++ b/internal/generator/vector/output/kafka/kafka_multi_brokers_with_tls_single_topic.toml
@@ -9,6 +9,7 @@ codec = "json"
 timestamp_format = "rfc3339"
 
 [sinks.kafka_receiver.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"

--- a/internal/generator/vector/output/kafka/kafka_sasl_scram_with_tls.toml
+++ b/internal/generator/vector/output/kafka/kafka_sasl_scram_with_tls.toml
@@ -14,6 +14,7 @@ password = "SECRET[from_secret.kafka_receiver_1_password]"
 mechanism = "SCRAM-SHA-256"
 
 [sinks.kafka_receiver.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"

--- a/internal/generator/vector/output/kafka/kafka_sasl_with_tls_single_topic.toml
+++ b/internal/generator/vector/output/kafka/kafka_sasl_with_tls_single_topic.toml
@@ -14,6 +14,7 @@ password = "SECRET[from_secret.kafka_receiver_1_password]"
 mechanism = "PLAIN"
 
 [sinks.kafka_receiver.tls]
+enabled = true
 key_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.key"
 crt_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/tls.crt"
 ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"

--- a/test/runtime/observability/cluster_log_forwarder_test.go
+++ b/test/runtime/observability/cluster_log_forwarder_test.go
@@ -24,7 +24,7 @@ var _ = Describe("ClustLogForwarderBuilder", func() {
 			pipelineBuilder := NewClusterLogForwarderBuilder(forwarder).
 				FromInput(logging.InputTypeApplication)
 			pipelineBuilder.ToElasticSearchOutput()
-			pipelineBuilder.ToSyslogOutput()
+			pipelineBuilder.ToSyslogOutput(logging.SyslogRFC5424)
 
 			Expect(test.YAMLString(forwarder.Spec)).To(MatchYAML(`inputs:
 - application: {}
@@ -38,6 +38,7 @@ outputs:
   type: elasticsearch
 - name: syslog
   syslog:
+    rfc: RFC5424
     url: tcp://0.0.0.0:24224
   type: syslog
 pipelines:


### PR DESCRIPTION
### Description
This PR:
* Refactors the functional prune filter test to use the observability API
* Fixes kafka TLS config to include enable=true

### Links
https://issues.redhat.com/browse/LOG-5664

cc @Clee2691 @cahartma 
