### PR TITLE
LOG-5476 OTLP output generator and transforms

### DIFF
--- a/api/logging/v1/output_types.go
+++ b/api/logging/v1/output_types.go
@@ -15,6 +15,7 @@ const (
 	OutputTypeSplunk             = "splunk"
 	OutputTypeHttp               = "http"
 	OutputTypeAzureMonitor       = "azureMonitor"
+	OutputTypeOtlp               = "otlp" // Value used only as a constant in 6.0 for wiring together validation logic
 )
 
 // OutputTypeSpec is a union of optional additional configuration specific to an

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: ClusterLogForwarderList
     plural: clusterlogforwarders
     shortNames:
-    - clf
+    - lf
     singular: clusterlogforwarder
   scope: Namespaced
   versions:

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -15,7 +15,7 @@ spec:
     listKind: ClusterLogForwarderList
     plural: clusterlogforwarders
     shortNames:
-    - clf
+    - lf
     singular: clusterlogforwarder
   scope: Namespaced
   versions:

--- a/internal/generator/vector/filter/filter.go
+++ b/internal/generator/vector/filter/filter.go
@@ -26,8 +26,8 @@ type InternalFilterSpec struct {
 	// RemapFilter is a filter that uses a remap transformation
 	RemapFilter RemapFilter
 
-	//TranformFactory takes an id, inputs and returns an Element
-	TranformFactory func(id string, inputs ...string) framework.Element
+	//TransformFactory takes an id, inputs and returns an Element
+	TransformFactory func(id string, inputs ...string) framework.Element
 }
 
 // RemapFilter is a remap transform that provides VRL script
@@ -53,7 +53,7 @@ func NewInternalFilterMap(filters map[string]*obs.FilterSpec) map[string]*Intern
 			internalFilter.RemapFilter = parse.NewParseFilter()
 		case obs.FilterTypeDetectMultiline:
 			internalFilter.SuppliesTransform = true
-			internalFilter.TranformFactory = multilineexception.NewDetectException
+			internalFilter.TransformFactory = multilineexception.NewDetectException
 		default:
 			log.V(0).Error(fmt.Errorf("unknown filter type: %v", f.Type), "This should have been caught by declarative API validation")
 		}

--- a/internal/generator/vector/filter/openshift/viaq/normalize.go
+++ b/internal/generator/vector/filter/openshift/viaq/normalize.go
@@ -56,7 +56,7 @@ if starts_with(pod_name, "eventrouter-") {
 	RemoveTimestampEnd = `del(.timestamp_end)`
 
 	ParseAndFlatten = `. = merge(., parse_json!(string!(.message))) ?? .
-del(.message)
+# del(.message)
 `
 	FixHostname = `.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""`
 )

--- a/internal/generator/vector/output/factory.go
+++ b/internal/generator/vector/output/factory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/azuremonitor"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/cloudwatch"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/otlp"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/elasticsearch"
@@ -52,6 +53,8 @@ func New(o obs.OutputSpec, inputs []string, secrets map[string]*corev1.Secret, s
 		els = append(els, syslog.New(baseID, o, inputs, secrets, strategy, op)...)
 	case obs.OutputTypeAzureMonitor:
 		els = append(els, azuremonitor.New(baseID, o, inputs, secrets, strategy, op)...)
+	case obs.OutputTypeOTLP:
+		els = append(els, otlp.New(baseID, o, inputs, secrets, strategy, op)...)
 	}
 	return els
 }

--- a/internal/generator/vector/output/otlp/group_by.go
+++ b/internal/generator/vector/output/otlp/group_by.go
@@ -1,0 +1,67 @@
+package otlp
+
+import (
+	"fmt"
+	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"strings"
+)
+
+type Reduce struct {
+	ComponentID string
+	Desc        string
+	Inputs      string
+	GroupBy     string
+	MaxEvents   string
+}
+
+func (r Reduce) Name() string {
+	return "reduceTemplate"
+}
+
+func (r Reduce) Template() string {
+	return `{{define "reduceTemplate" -}}
+{{if .Desc -}}
+# {{.Desc}}
+{{end -}}
+[transforms.{{.ComponentID}}]
+type = "reduce"
+inputs = {{.Inputs}}
+expire_after_ms = 10000
+max_events = {{.MaxEvents}}
+group_by = {{.GroupBy}}
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+{{end}}
+`
+}
+
+func GroupByContainer(id string, inputs []string) Element {
+	return Reduce{
+		Desc:        "Merge container logs and group by namespace, pod and container",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		MaxEvents:   "3",
+		GroupBy: MakeGroupBys(".openshift.cluster_id",
+			".kubernetes.namespace_name", ".kubernetes.pod_name", ".kubernetes.container_name"),
+	}
+}
+
+func GroupBySource(id string, inputs []string) Element {
+	return Reduce{
+		Desc:        "Merge audit and node logs and group by hostname and log_type",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		MaxEvents:   "3",
+		GroupBy: MakeGroupBys(".openshift.cluster_id",
+			".openshift.hostname", ".openshift.log_type"),
+	}
+}
+
+func MakeGroupBys(fields ...string) string {
+	out := make([]string, len(fields))
+	for i, o := range fields {
+		out[i] = fmt.Sprintf("%q", o)
+	}
+	return fmt.Sprintf("[%s]", strings.Join(out, ","))
+}

--- a/internal/generator/vector/output/otlp/otlp.go
+++ b/internal/generator/vector/output/otlp/otlp.go
@@ -1,0 +1,123 @@
+package otlp
+
+import (
+	obsv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	genhelper "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	vectorhelpers "github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common/auth"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common/tls"
+)
+
+type Otlp struct {
+	ComponentID      string
+	Inputs           string
+	URI              string
+	common.RootMixin //TODO: remove??
+}
+
+func (p Otlp) Name() string {
+	return "vectorOtlpTemplate"
+}
+
+func (p Otlp) Template() string {
+	return `{{define "` + p.Name() + `" -}}
+[sinks.{{.ComponentID}}]
+type = "http"
+inputs = {{.Inputs}}
+uri = "{{.URI}}"
+method = "post"
+payload_prefix = "{\"resourceLogs\":"
+payload_suffix = "}"
+encoding.codec = "json"
+{{.Compression}}
+{{end}}
+`
+}
+
+// TODO: test this for otlp
+func (p *Otlp) SetCompression(algo string) {
+	p.Compression.Value = algo
+}
+
+const (
+	logSourceContainer    = "container"
+	logSourceNode         = "node"
+	logSourceAuditd       = "auditd"
+	logSourceKubeAPI      = "kubeapi"
+	logSourceOpenshiftAPI = "openshiftapi"
+	logSourceOvn          = "ovn"
+)
+
+func New(id string, o obsv1.OutputSpec, inputs []string, secrets vectorhelpers.Secrets, strategy common.ConfigStrategy, op Options) []Element {
+	if genhelper.IsDebugOutput(op) {
+		return []Element{
+			elements.Debug(helpers.MakeID(id, "debug"), vectorhelpers.MakeInputs(inputs...)),
+		}
+	}
+	// TODO: create a pattern to filter by input so all this is not necessary
+	var els []Element
+	// Creates reroutes for 'container','node','auditd','kubeAPI','openshiftAPI','ovn'
+	rerouteID := vectorhelpers.MakeID(id, "reroute")
+	els = append(els, RouteBySource(rerouteID, inputs))
+	// Container
+	transformContainerID := vectorhelpers.MakeID(id, logSourceContainer)
+	reduceContainerID := vectorhelpers.MakeID(id, "groupby", "container")
+	els = append(els, TransformContainer(transformContainerID, []string{rerouteID + "." + logSourceContainer}))
+	// Group by cluster_id, namespace_name, pod_name, container_name
+	els = append(els, GroupByContainer(reduceContainerID, []string{transformContainerID}))
+	// Journal
+	transformNodeID := vectorhelpers.MakeID(id, logSourceNode)
+	els = append(els, TransformJournal(transformNodeID, []string{rerouteID + "." + logSourceNode}))
+	// Audit
+	transformAuditHostID := vectorhelpers.MakeID(id, logSourceAuditd)
+	transformAuditKubeID := vectorhelpers.MakeID(id, logSourceKubeAPI)
+	transformAuditOpenshiftID := vectorhelpers.MakeID(id, logSourceOpenshiftAPI)
+	transformAuditOvnID := vectorhelpers.MakeID(id, logSourceOvn)
+	reduceSourceID := vectorhelpers.MakeID(id, "groupby", "source")
+	els = append(els, TransformAuditHost(transformAuditHostID, []string{rerouteID + "." + logSourceAuditd}))
+	els = append(els, TransformAuditKube(transformAuditKubeID, []string{rerouteID + "." + logSourceKubeAPI}))
+	els = append(els, TransformAuditOpenshift(transformAuditOpenshiftID, []string{rerouteID + "." + logSourceOpenshiftAPI}))
+	els = append(els, TransformAuditOvn(transformAuditOvnID, []string{rerouteID + "." + logSourceOvn}))
+	// Group by cluster_id, hostname, log_type
+	els = append(els, GroupBySource(reduceSourceID, []string{
+		transformNodeID,
+		transformAuditHostID,
+		transformAuditKubeID,
+		transformAuditOpenshiftID,
+		transformAuditOvnID,
+	}))
+	// Normalize all into resource and scopeLogs objects
+	formatID := vectorhelpers.MakeID(id, "resource", "logs")
+	els = append(els, FormatResourceLog(formatID, []string{
+		reduceContainerID,
+		reduceSourceID,
+		rerouteID + "._unmatched", // mostly for debug, but could be necessary?
+	}))
+	// Create sink and wrap in `resourceLogs`
+	sink := Output(id, o, []string{formatID}, secrets, op)
+	if strategy != nil {
+		strategy.VisitSink(sink)
+	}
+	return MergeElements(
+		els,
+		[]Element{
+			sink,
+			common.NewAcknowledgments(id, strategy),
+			tls.New(id, o.TLS, secrets, op),
+			auth.HTTPAuth(id, o.OTLP.Authentication, secrets),
+		},
+	)
+}
+
+func Output(id string, o obsv1.OutputSpec, inputs []string, secrets vectorhelpers.Secrets, op Options) *Otlp {
+	return &Otlp{
+		ComponentID: id,
+		Inputs:      vectorhelpers.MakeInputs(inputs...),
+		URI:         o.OTLP.URL,
+		RootMixin:   common.NewRootMixin(nil),
+	}
+}

--- a/internal/generator/vector/output/otlp/otlp_all.toml
+++ b/internal/generator/vector/output/otlp/otlp_all.toml
@@ -1,0 +1,362 @@
+# Route container, journal, and audit logs separately
+[transforms.output_otel_collector_reroute]
+type = "route"
+inputs = ["pipeline_my_pipeline_viaq_0"]
+route.container = '.log_source == "container"'
+route.node = '.log_source == "node"'
+route.auditd = '.log_source == "auditd"'
+route.kubeapi = '.log_source == "kubeAPI"'
+route.openshiftapi = '.log_source == "openshiftAPI"'
+route.ovn = '.log_source == "ovn"'
+
+# Normalize container log records to OTLP semantic conventions
+[transforms.output_otel_collector_container]
+type = "remap"
+inputs = ["output_otel_collector_reroute.container"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "node.name", "value": {"stringValue": .hostname}},
+      {"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}}]
+  )
+  # Append container resource attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "k8s.pod.name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+  	{"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
+  	{"key": "k8s.container.name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+  	{"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
+  	{"key": "k8s.namespace.name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+  )
+  # Append kube pod labels
+  if exists(.kubernetes.labels) {
+      for_each(object!(.kubernetes.labels)) -> |key,value| {
+  	    resource.attributes = append(resource.attributes,
+
+              [{"key": "k8s.pod.label." + key, "value": {"stringValue": value}}]
+  	    )
+      }
+  }
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": string!(.message)}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(
+  	r.attributes,
+  	[{"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Openshift and kubernetes objects for grouping containers (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  .kubernetes = {
+      "namespace_name": .kubernetes.namespace_name,
+      "pod_name": .kubernetes.pod_name,
+      "container_name": .kubernetes.container_name
+  }
+  . = {
+    "openshift": o,
+    "kubernetes": .kubernetes,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Merge container logs and group by namespace, pod and container
+[transforms.output_otel_collector_groupby_container]
+type = "reduce"
+inputs = ["output_otel_collector_container"]
+expire_after_ms = 10000
+max_events = 3
+group_by = [".openshift.cluster_id",".kubernetes.namespace_name",".kubernetes.pod_name",".kubernetes.container_name"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Normalize node log events to OTLP semantic conventions
+[transforms.output_otel_collector_node]
+type = "remap"
+inputs = ["output_otel_collector_reroute.node"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "node.name", "value": {"stringValue": .hostname}},
+      {"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": string!(.message)}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(
+  	r.attributes,
+  	[{"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append log attributes for node logs
+  logAttribute = [
+    "systemd.t.BOOT_ID",
+    "systemd.t.CMDLINE",
+    "systemd.t.EXE",
+    "systemd.t.GID",
+    "systemd.t.MACHINE_ID",
+    "systemd.t.PID",
+    "systemd.u.SYSLOG_FACILITY",
+    "systemd.u.SYSLOG_IDENTIFIER",
+  ]
+  replacements = {
+    "SYSLOG.FACILITY": "syslog.facility",
+    "SYSLOG.IDENTIFIER": "syslog.identifier",
+    "PID": "syslog.procid"
+  }
+  for_each(logAttribute) -> |_,sub_key| {
+    path = split(sub_key,".")
+    if length(path) > 1 {
+  	sub_key = replace!(path[-1],"_",".")
+    }
+    if get!(replacements, [sub_key]) != null {
+  	sub_key = string!(get!(replacements, [sub_key]))
+    } else {
+  	sub_key = "system." + downcase(sub_key)
+    }
+    r.attributes = append(r.attributes,
+
+        [{"key": sub_key, "value": {"stringValue": get!(.,path)}}]
+    )
+  }
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit log record to OTLP semantic conventions
+[transforms.output_otel_collector_auditd]
+type = "remap"
+inputs = ["output_otel_collector_reroute.auditd"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "node.name", "value": {"stringValue": .hostname}},
+      {"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": string!(.message)}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(
+  	r.attributes,
+  	[{"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit log kube record to OTLP semantic conventions
+[transforms.output_otel_collector_kubeapi]
+type = "remap"
+inputs = ["output_otel_collector_reroute.kubeapi"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "node.name", "value": {"stringValue": .hostname}},
+      {"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": string!(.message)}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(
+  	r.attributes,
+  	[{"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append logRecord attributes
+  r.attributes = append(
+  	r.attributes,
+  	[{"key": "url.full", "value": {"stringValue": .requestURI}},
+  	{"key": "http.response.status.code", "value": {"stringValue": to_string!(get!(.,["responseStatus","code"]))}},
+  	{"key": "http.request.method", "value": {"stringValue": .verb}}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit openshiftAPI record to OTLP semantic conventions
+[transforms.output_otel_collector_openshiftapi]
+type = "remap"
+inputs = ["output_otel_collector_reroute.openshiftapi"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "node.name", "value": {"stringValue": .hostname}},
+      {"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": string!(.message)}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(
+  	r.attributes,
+  	[{"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append logRecord attributes
+  r.attributes = append(
+  	r.attributes,
+  	[{"key": "url.full", "value": {"stringValue": .requestURI}},
+  	{"key": "http.response.status.code", "value": {"stringValue": to_string!(get!(.,["responseStatus","code"]))}},
+  	{"key": "http.request.method", "value": {"stringValue": .verb}}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit log ovn records to OTLP semantic conventions
+[transforms.output_otel_collector_ovn]
+type = "remap"
+inputs = ["output_otel_collector_reroute.ovn"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "node.name", "value": {"stringValue": .hostname}},
+      {"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": string!(.message)}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(
+  	r.attributes,
+  	[{"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append logRecord attributes
+  r.attributes = append(
+  	r.attributes,
+  	[{"key": "url.full", "value": {"stringValue": .requestURI}},
+  	{"key": "http.response.status.code", "value": {"stringValue": to_string!(get!(.,["responseStatus","code"]))}},
+  	{"key": "http.request.method", "value": {"stringValue": .verb}}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Merge audit and node logs and group by hostname and log_type
+[transforms.output_otel_collector_groupby_source]
+type = "reduce"
+inputs = ["output_otel_collector_auditd","output_otel_collector_kubeapi","output_otel_collector_node","output_otel_collector_openshiftapi","output_otel_collector_ovn"]
+expire_after_ms = 10000
+max_events = 3
+group_by = [".openshift.cluster_id",".openshift.hostname",".openshift.log_type"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Create new resource object for OTLP JSON payload
+[transforms.output_otel_collector_resource_logs]
+type = "remap"
+inputs = ["output_otel_collector_groupby_container","output_otel_collector_groupby_source","output_otel_collector_reroute._unmatched"]
+source = '''
+  . = {
+        "resource": {
+           "attributes": .resource.attributes,
+        },
+        "scopeLogs": [
+          {"logRecords": .logRecords}
+        ]
+      }
+'''
+
+[sinks.output_otel_collector]
+type = "http"
+inputs = ["output_otel_collector_resource_logs"]
+uri = "http://localhost:4318/v1/logs"
+method = "post"
+payload_prefix = "{\"resourceLogs\":"
+payload_suffix = "}"
+encoding.codec = "json"

--- a/internal/generator/vector/output/otlp/otlp_test.go
+++ b/internal/generator/vector/output/otlp/otlp_test.go
@@ -1,0 +1,37 @@
+package otlp
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+)
+
+var _ = Describe("Generate vector config", func() {
+	DescribeTable("for OTLP output", func(output obs.OutputSpec, secret helpers.Secrets, op framework.Options, expFile string) {
+		exp, err := tomlContent.ReadFile(expFile)
+		if err != nil {
+			Fail(fmt.Sprintf("Error reading the file %q with exp config: %v", expFile, err))
+		}
+		conf := New(helpers.MakeOutputID(output.Name), output, []string{"pipeline_my_pipeline_viaq_0"}, secret, nil, op) //, includeNS, excludes)
+		Expect(string(exp)).To(EqualConfigFrom(conf))
+	},
+		Entry("with only URL spec'd",
+			obs.OutputSpec{
+				Type: logging.OutputTypeOtlp,
+				Name: "otel-collector",
+				OTLP: &obs.OTLP{
+					URL: "http://localhost:4318/v1/logs",
+				},
+			},
+			nil,
+			framework.NoOptions,
+			"otlp_all.toml",
+		),
+	)
+})

--- a/internal/generator/vector/output/otlp/route.go
+++ b/internal/generator/vector/output/otlp/route.go
@@ -1,0 +1,42 @@
+package otlp
+
+import (
+	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+)
+
+type Route struct {
+	ComponentID string
+	Desc        string
+	Inputs      string
+}
+
+func (r Route) Name() string {
+	return "routeTemplate"
+}
+
+func (r Route) Template() string {
+	return `{{define "routeTemplate" -}}
+{{if .Desc -}}
+# {{.Desc}}
+{{end -}}
+[transforms.{{.ComponentID}}]
+type = "route"
+inputs = {{.Inputs}}
+route.container = '.log_source == "container"'
+route.node = '.log_source == "node"'
+route.auditd = '.log_source == "auditd"'
+route.kubeapi = '.log_source == "kubeAPI"'
+route.openshiftapi = '.log_source == "openshiftAPI"'
+route.ovn = '.log_source == "ovn"'
+{{end}}
+`
+}
+
+func RouteBySource(id string, inputs []string) Element {
+	return Route{
+		Desc:        "Route container, journal, and audit logs separately",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+	}
+}

--- a/internal/generator/vector/output/otlp/suite_test.go
+++ b/internal/generator/vector/output/otlp/suite_test.go
@@ -1,0 +1,19 @@
+package otlp
+
+import (
+	"embed"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	//go:embed *.toml
+	tomlContent embed.FS
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][generator][vector][output][otlp] Suite")
+}

--- a/internal/generator/vector/output/otlp/transform.go
+++ b/internal/generator/vector/output/otlp/transform.go
@@ -1,0 +1,236 @@
+package otlp
+
+import (
+	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"strings"
+)
+
+// VRL for OTLP transforms by route
+const (
+	CreateResourceAttributes = `
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append( resource.attributes, 
+    [{"key": "node.name", "value": {"stringValue": .hostname}},
+    {"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}}]
+)
+`
+	AppendContainerAttributes = `
+# Append container resource attributes
+resource.attributes = append( resource.attributes,
+    [{"key": "k8s.pod.name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+	{"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
+	{"key": "k8s.container.name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+	{"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
+	{"key": "k8s.namespace.name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+)
+# Append kube pod labels
+if exists(.kubernetes.labels) {
+    for_each(object!(.kubernetes.labels)) -> |key,value| {  
+	    resource.attributes = append(resource.attributes, 
+            [{"key": "k8s.pod.label." + key, "value": {"stringValue": value}}]
+	    )
+    }
+}
+`
+	CreateLogRecord = `
+# Create logRecord object
+r = {}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+# Convert syslog severity keyword to number, default to 9 (unknown)
+r.severityNumber = to_syslog_severity(.level) ?? 9
+r.body = {"stringValue": string!(.message)}
+r.attributes = []
+
+# Append logRecord attributes
+r.attributes = append(
+	r.attributes,
+	[{"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+)
+
+`
+	AppendAPILogRecordAttributes = `
+# Append logRecord attributes
+r.attributes = append(
+	r.attributes,
+	[{"key": "url.full", "value": {"stringValue": .requestURI}},
+	{"key": "http.response.status.code", "value": {"stringValue": to_string!(get!(.,["responseStatus","code"]))}},
+	{"key": "http.request.method", "value": {"stringValue": .verb}}]
+)
+`
+	AppendNodeLogRecordAttributes = `
+# Append log attributes for node logs
+logAttribute = [
+  "systemd.t.BOOT_ID",
+  "systemd.t.CMDLINE",
+  "systemd.t.EXE",
+  "systemd.t.GID",
+  "systemd.t.MACHINE_ID",
+  "systemd.t.PID",
+  "systemd.u.SYSLOG_FACILITY",
+  "systemd.u.SYSLOG_IDENTIFIER",
+]
+replacements = {
+  "SYSLOG.FACILITY": "syslog.facility",
+  "SYSLOG.IDENTIFIER": "syslog.identifier",
+  "PID": "syslog.procid"
+}
+for_each(logAttribute) -> |_,sub_key| {
+  path = split(sub_key,".")
+  if length(path) > 1 {
+	sub_key = replace!(path[-1],"_",".")
+  }
+  if get!(replacements, [sub_key]) != null {
+	sub_key = string!(get!(replacements, [sub_key]))
+  } else {
+	sub_key = "system." + downcase(sub_key)
+  }
+  r.attributes = append(r.attributes,
+      [{"key": sub_key, "value": {"stringValue": get!(.,path)}}]
+  )
+}
+`
+	FinalObjectWithOpenshiftGrouping = `
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": get!(.,["openshift","cluster_id"])
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+`
+	FinalObjectWithKubeContainerGrouping = `
+# Openshift and kubernetes objects for grouping containers (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "cluster_id": get!(.,["openshift","cluster_id"])
+}
+.kubernetes = {
+    "namespace_name": .kubernetes.namespace_name,
+    "pod_name": .kubernetes.pod_name,
+    "container_name": .kubernetes.container_name
+}
+. = {
+  "openshift": o,
+  "kubernetes": .kubernetes,
+  "resource": resource,
+  "logRecords": r
+}
+`
+)
+
+func containerLogsVRL() string {
+	return strings.Join(helpers.TrimSpaces([]string{
+		CreateResourceAttributes,
+		AppendContainerAttributes,
+		CreateLogRecord,
+		FinalObjectWithKubeContainerGrouping,
+	}), "\n")
+}
+
+func nodeLogsVRL() string {
+	return strings.Join(helpers.TrimSpaces([]string{
+		CreateResourceAttributes,
+		CreateLogRecord,
+		AppendNodeLogRecordAttributes,
+		FinalObjectWithOpenshiftGrouping,
+	}), "\n")
+}
+
+func auditHostLogsVRL() string {
+	return strings.Join(helpers.TrimSpaces([]string{
+		CreateResourceAttributes,
+		CreateLogRecord,
+		FinalObjectWithOpenshiftGrouping,
+	}), "\n")
+}
+
+func auditAPILogsVRL() string {
+	return strings.Join(helpers.TrimSpaces([]string{
+		CreateResourceAttributes,
+		CreateLogRecord,
+		AppendAPILogRecordAttributes,
+		FinalObjectWithOpenshiftGrouping,
+	}), "\n")
+}
+
+func TransformContainer(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize container log records to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         containerLogsVRL(),
+	}
+}
+
+func TransformJournal(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize node log events to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         nodeLogsVRL(),
+	}
+}
+
+func TransformAuditHost(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize audit log record to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         auditHostLogsVRL(),
+	}
+}
+
+func TransformAuditKube(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize audit log kube record to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         auditAPILogsVRL(),
+	}
+}
+func TransformAuditOpenshift(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize audit openshiftAPI record to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         auditAPILogsVRL(),
+	}
+}
+func TransformAuditOvn(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize audit log ovn records to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         auditAPILogsVRL(),
+	}
+}
+
+// FormatResourceLog Drops everything except resource.attributes and scopeLogs.logRecords
+func FormatResourceLog(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Create new resource object for OTLP JSON payload",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL: strings.TrimSpace(`
+. = {
+      "resource": {
+         "attributes": .resource.attributes,
+      },
+      "scopeLogs": [
+        {"logRecords": .logRecords}
+      ]
+    }
+`),
+	}
+}

--- a/internal/generator/vector/pipeline/adapter.go
+++ b/internal/generator/vector/pipeline/adapter.go
@@ -84,14 +84,13 @@ func NewPipeline(index int, p obs.PipelineSpec, inputs map[string]helpers.InputC
 
 // TODO: add migration to treat like any other
 func addPrefilters(p *Pipeline) {
-
 	prefilters := []string{}
 	if viaq.HasJournalSource(p.inputSpecs) {
 		prefilters = append(prefilters, viaq.ViaqJournal)
 		p.filterMap[viaq.ViaqJournal] = filter.InternalFilterSpec{
 			FilterSpec:        &obs.FilterSpec{Type: viaq.ViaqJournal},
 			SuppliesTransform: true,
-			TranformFactory: func(id string, inputs ...string) framework.Element {
+			TransformFactory: func(id string, inputs ...string) framework.Element {
 				return viaq.NewJournal(id, inputs...)
 			},
 		}
@@ -101,7 +100,7 @@ func addPrefilters(p *Pipeline) {
 	p.filterMap[viaq.Viaq] = filter.InternalFilterSpec{
 		FilterSpec:        &obs.FilterSpec{Type: viaq.Viaq},
 		SuppliesTransform: true,
-		TranformFactory: func(id string, inputs ...string) framework.Element {
+		TransformFactory: func(id string, inputs ...string) framework.Element {
 			return viaq.New(id, inputs, p.inputSpecs)
 		},
 	}
@@ -160,7 +159,7 @@ func NewPipelineFilter(pipelineName, filterRef string, spec filter.InternalFilte
 		return &PipelineFilter{
 			ids: ids,
 			transformFactory: func(inputs ...string) framework.Element {
-				return spec.TranformFactory(ids[0], inputs...)
+				return spec.TransformFactory(ids[0], inputs...)
 			},
 		}
 	}

--- a/internal/validations/clusterlogforwarder/validate_collector_compatibility.go
+++ b/internal/validations/clusterlogforwarder/validate_collector_compatibility.go
@@ -19,6 +19,7 @@ var (
 		v1.OutputTypeSyslog,
 		v1.OutputTypeCloudwatch,
 		v1.OutputTypeAzureMonitor,
+		v1.OutputTypeOtlp,
 	)
 
 	fluentd = sets.NewString(
@@ -45,6 +46,7 @@ var (
 // Syslog              | Fluentd, Vector
 // Amazon CloudWatch   | Fluentd, Vector
 // Azure Monitor Logs  | Vector
+// OTLP                | Vector
 // TODO: Might we need this when we write migration code?
 func validateCollectorCompatibility(clf v1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *v1.ClusterLogForwarderStatus) {
 	collector := constants.VectorName


### PR DESCRIPTION
### Description
Output generator and transforms based on initial commit of api changes for OTLP output.   For now, I have removed the deletion of .file and .log_source and .message from certain input transforms.   This is necessary to route OTLP logs by source and log type.   Unit tests are failing (I can update tests if we agree).

Also fixes an issue found with cloudwatch groups and stream names resulting from our new config where we deleted .tag and .log_source before the sink.   

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- Parent task:  https://issues.redhat.com/browse/LOG-5370
- Sub-task: https://issues.redhat.com/browse/LOG-5476 
- Other tasks:  https://issues.redhat.com/browse/LOG-5477 https://issues.redhat.com/browse/LOG-5478 https://issues.redhat.com/browse/LOG-5479 https://issues.redhat.com/browse/LOG-5480
- Enhancement proposal: https://github.com/openshift/enhancements/pull/1618

