### PR TITLE
LOG-5734: Refactor e2e container security test

### DIFF
--- a/hack/testing-olm/test-030-collection.sh
+++ b/hack/testing-olm/test-030-collection.sh
@@ -10,7 +10,7 @@ os::test::junit::declare_suite_start "[ClusterLogging] Collection"
 start_seconds=$(date +%s)
 
 TEST_DIR=${TEST_DIR:-'./test/e2e/collection/*/'}
-INCLUDES="(deployment|tuning)"
+INCLUDES="*"
 ARTIFACT_DIR=${ARTIFACT_DIR:-"$repo_dir/_output"}
 if [ ! -d $ARTIFACT_DIR ] ; then
   mkdir -p $ARTIFACT_DIR

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -39,8 +39,6 @@ const (
 	sourceOVNPath                   = "/var/log/ovn"
 	sourceOAuthAPIServerName        = "varlogoauthapiserver"
 	sourceOAuthAPIServerPath        = "/var/log/oauth-apiserver"
-	sourceOAuthServerName           = "varlogoauthserver"
-	sourceOAuthServerPath           = "/var/log/oauth-server"
 	sourceOpenshiftAPIServerName    = "varlogopenshiftapiserver"
 	sourceOpenshiftAPIServerPath    = "/var/log/openshift-apiserver"
 	sourceKubeAPIServerName         = "varlogkubeapiserver"
@@ -146,7 +144,6 @@ func (f *Factory) NewPodSpec(trustedCABundle *v1.ConfigMap, spec obs.ClusterLogF
 			v1.Volume{Name: sourceAuditdName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceAuditdPath}}},
 			v1.Volume{Name: sourceAuditOVNName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOVNPath}}},
 			v1.Volume{Name: sourceOAuthAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOAuthAPIServerPath}}},
-			v1.Volume{Name: sourceOAuthServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOAuthServerPath}}},
 			v1.Volume{Name: sourceOpenshiftAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOpenshiftAPIServerPath}}},
 			v1.Volume{Name: sourceKubeAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceKubeAPIServerPath}}},
 		)
@@ -211,6 +208,7 @@ func (f *Factory) NewCollectorContainer(inputs internalobs.Inputs, secretVolumes
 		}
 		if inputs.HasAuditSource(obs.AuditSourceOpenShift) {
 			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceOpenshiftAPIServerName, ReadOnly: true, MountPath: sourceOpenshiftAPIServerPath})
+			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceAuditOVNName, ReadOnly: true, MountPath: sourceOAuthAPIServerPath})
 		}
 		if inputs.HasAuditSource(obs.AuditSourceOVN) {
 			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceAuditOVNName, ReadOnly: true, MountPath: sourceOVNPath})

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -278,7 +278,7 @@ var _ = Describe("Factory#Daemonset#NewPodSpec", func() {
 		Context("and mounting volumes", func() {
 			It("should mount host path volumes", func() {
 				Expect(podSpec.Volumes).To(IncludeVolume(v1.Volume{Name: sourcePodsName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourcePodsPath}}}))
-				Expect(podSpec.Volumes).To(HaveLen(17))
+				Expect(podSpec.Volumes).To(HaveLen(16))
 			})
 
 			It("should mount all volumes for output configmaps", func() {

--- a/test/e2e/collection/security/container_security_test.go
+++ b/test/e2e/collection/security/container_security_test.go
@@ -2,19 +2,17 @@ package security
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/test/helpers"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	internalruntime "github.com/openshift/cluster-logging-operator/internal/runtime"
+	obsruntime "github.com/openshift/cluster-logging-operator/internal/runtime/observability"
+	corev1 "k8s.io/api/core/v1"
 	"runtime"
-	"strconv"
-	"strings"
 	"time"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
-	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/test/helpers/oc"
@@ -22,10 +20,15 @@ import (
 
 var _ = Describe("Tests of collector container security stance", func() {
 
+	const (
+		namespace = constants.OpenshiftNS
+		name      = constants.CollectorName
+	)
+
 	var (
 		collector               string
 		runInCollectorContainer = func(command string, args ...string) (string, error) {
-			return oc.Exec().WithNamespace(constants.OpenshiftNS).Pod(collector).Container(constants.CollectorName).WithCmd(command, args...).RunFor(time.Second * 15)
+			return oc.Exec().WithNamespace(namespace).Pod(collector).Container(name).WithCmd(command, args...).RunFor(time.Second * 15)
 		}
 		checkMountReadOnly = func(mount string) {
 			touchFile := mount + "/1"
@@ -35,80 +38,71 @@ var _ = Describe("Tests of collector container security stance", func() {
 		}
 
 		verifyNamespaceLabels = func() {
-			labels, err := oc.Get().Resource("namespaces", constants.OpenshiftNS).OutputJsonpath("{.metadata.labels}").Run()
+			labels, err := oc.Get().Resource("namespaces", namespace).OutputJsonpath("{.metadata.labels}").Run()
 			Expect(err).To(BeNil())
 			// In ocp 4.12+ only enforce is required
 			expMatch := fmt.Sprintf(`{.*"%s":"%s".*}`, constants.PodSecurityLabelEnforce, constants.PodSecurityLabelValue)
 			Expect(labels).To(MatchRegexp(expMatch), "Expected label to be found")
 		}
-		e2e *framework.E2ETestFramework
+		e2e            *framework.E2ETestFramework
+		serviceAccount *corev1.ServiceAccount
+		err            error
 	)
 
 	AfterEach(func() {
 		e2e.Cleanup()
-		e2e.WaitForCleanupCompletion(constants.OpenshiftNS, []string{constants.CollectorName})
+		e2e.WaitForCleanupCompletion(namespace, []string{name})
 	}, framework.DefaultCleanUpTimeout)
 
-	var _ = DescribeTable("collector containers should have tight security settings", func(collectorType logging.LogCollectionType) {
+	It("should have tight security settings", func() {
 		_, filename, _, _ := runtime.Caller(0)
 		log.Info("Running ", "filename", filename)
 		e2e = framework.NewE2ETestFramework()
 
-		forwarder := &logging.ClusterLogForwarder{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       logging.ClusterLogForwarderKind,
-				APIVersion: logging.GroupVersion.String(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      constants.SingletonName,
-				Namespace: constants.OpenshiftNS,
-			},
-			Spec: logging.ClusterLogForwarderSpec{
-				Outputs: []logging.OutputSpec{
-					{
-						Name: "es",
-						Type: logging.OutputTypeElasticsearch,
-						URL:  "http://foo.bar.svc:24224",
-					},
-				},
-				Pipelines: []logging.PipelineSpec{
-					{
-						Name:       "infra-pipe",
-						OutputRefs: []string{"es"},
-						InputRefs:  []string{logging.InputNameInfrastructure, logging.InputNameApplication, logging.InputNameAudit},
-					},
-				},
-			},
-		}
-		if err := e2e.CreateClusterLogForwarder(forwarder); err != nil {
-			Fail(fmt.Sprintf("Unable to create an instance of clusterlogforwarder: %v", err))
-		}
-		if err := e2e.DeployComponents(helpers.ComponentTypeCollectorVector); err != nil {
-			Fail(fmt.Sprintf("Unable to create an instance of cluster logging: %v", err))
-		}
-		nodes := 0
-		out, err := oc.Literal().From("oc get nodes -o name").Run()
-		if err != nil {
-			Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", helpers.ComponentTypeCollector, err))
-		}
-		nodes = len(strings.Split(out, "\n"))
-		log.V(3).Info("Waiting for a stable number collectors to be ready", "nodes", nodes)
-		if err := e2e.WaitForResourceCondition(constants.OpenshiftNS, "daemonset", constants.CollectorName, "", "{.status.numberReady}", 10,
-			func(out string) (bool, error) {
-				ready, err := strconv.Atoi(strings.TrimSpace(out))
-				if err != nil {
-					return false, err
-				}
-				log.V(3).Info("Checking ready pods", "pods", ready, "need", nodes)
-				if ready == nodes {
-					return true, nil
-				}
-				return false, nil
-			}); err != nil {
-			Fail(fmt.Sprintf("Failed waiting for component %s to be ready: %v", helpers.ComponentTypeCollector, err))
+		if serviceAccount, err = e2e.BuildAuthorizationFor(namespace, name).
+			AllowClusterRole(framework.ClusterRoleCollectInfrastructureLogs).
+			AllowClusterRole(framework.ClusterRoleCollectApplicationLogs).
+			AllowClusterRole(framework.ClusterRoleCollectAuditLogs).Create(); err != nil {
+			Fail(err.Error())
 		}
 
-		pod, err := oc.Get().WithNamespace(constants.OpenshiftNS).Pod().Selector("component=collector").OutputJsonpath("{.items[0].metadata.name}").Run()
+		forwarder := obsruntime.NewClusterLogForwarder(namespace, name, internalruntime.Initialize,
+			func(clf *obs.ClusterLogForwarder) {
+				clf.Spec = obs.ClusterLogForwarderSpec{
+					Outputs: []obs.OutputSpec{
+						{
+							Name: "es",
+							Type: obs.OutputTypeElasticsearch,
+							Elasticsearch: &obs.Elasticsearch{
+								URLSpec: obs.URLSpec{
+									URL: "http://foo.bar.svc:24224",
+								},
+							},
+						},
+					},
+					Pipelines: []obs.PipelineSpec{
+						{
+							Name:       "infra-pipe",
+							OutputRefs: []string{"es"},
+							InputRefs:  []string{string(obs.InputTypeInfrastructure), string(obs.InputTypeApplication), string(obs.InputTypeAudit)},
+						},
+					},
+					ServiceAccount: obs.ServiceAccount{
+						Name: serviceAccount.Name,
+					},
+				}
+			})
+
+		if err := e2e.CreateObservabilityClusterLogForwarder(forwarder); err != nil {
+			Fail(fmt.Sprintf("Unable to create an instance of clusterlogforwarder: %v", err))
+		}
+
+		log.V(3).Info("Waiting for a stable number collectors to be ready")
+		if err := e2e.WaitForDaemonSet(forwarder.Namespace, forwarder.Name); err != nil {
+			Fail(fmt.Sprintf("Failed waiting for collector %s/%s to be ready: %v", forwarder.Namespace, forwarder.Name, err))
+		}
+
+		pod, err := oc.Get().WithNamespace(forwarder.Namespace).Pod().Selector("component=collector").OutputJsonpath("{.items[0].metadata.name}").Run()
 		Expect(err).To(BeNil())
 		collector = pod
 		Expect(collector).To(Not(BeNil()))
@@ -136,26 +130,22 @@ var _ = Describe("Tests of collector container security stance", func() {
 		}
 
 		By("not running as a privileged container")
-		result, err = oc.Get().WithNamespace(constants.OpenshiftNS).Pod().Selector("component=collector").
+		result, err = oc.Get().WithNamespace(forwarder.Namespace).Pod().Selector("component=collector").
 			OutputJsonpath("{.items[0].spec.containers[0].securityContext.privileged}").Run()
 		Expect(result).To(BeEmpty())
 		Expect(err).NotTo(HaveOccurred())
 
 		//TODO: fix me for vector buffered
-		//if collectorType == logging.LogCollectionTypeFluentd {
 		//	By("making sure on disk footprint is readable only to the collector")
 		//	Eventually(func() (string, error) {
 		//		return runInCollectorContainer("bash", "-ceuo", "pipefail", `stat --format=%a /var/lib/fluentd/es/* | sort -u`)
 		//	}).
 		//		WithTimeout(2*time.Minute).
 		//		Should(Equal("600"), "Exp the data directory to have alternate permissions")
-		//}
 
 		// LOG-2620: containers violate PodSecurity for 4.12+
 		By("making sure collector namespace has the pod security label")
 		verifyNamespaceLabels()
 
-	},
-		Entry("for vector impl", logging.LogCollectionTypeVector),
-	)
+	})
 })


### PR DESCRIPTION
### Description
This PR:
* Enables the e2e container security test for observability
* Fixes Audit OpenShift logs to mount the oauth audit files into the collector 

### Links
 * https://issues.redhat.com/browse/LOG-5734

cc @Clee2691 @cahartma 
