### PR TITLE
LOG-5716: Enable syslog output functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ test-functional:
 		./test/functional/outputs/loki \
 		./test/functional/outputs/splunk \
 		./test/functional/outputs/logstash \
+		./test/functional/outputs/syslog \
 		-ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
 
 .PHONY: test-functional-vector

--- a/test/functional/outputs/syslog/rfc3164_test.go
+++ b/test/functional/outputs/syslog/rfc3164_test.go
@@ -2,14 +2,16 @@ package syslog
 
 import (
 	"fmt"
-	testruntime "github.com/openshift/cluster-logging-operator/test/runtime"
 	"time"
+
+	obstestruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
-	"github.com/openshift/cluster-logging-operator/test/framework/e2e"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	testfw "github.com/openshift/cluster-logging-operator/test/functional"
 )
@@ -23,26 +25,26 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 	)
 
 	BeforeEach(func() {
-		framework = functional.NewCollectorFunctionalFrameworkUsingCollector(testfw.LogCollectionType)
+		framework = functional.NewCollectorFunctionalFramework()
 		framework.MaxReadDuration = &maxReadDuration
 	})
 
 	AfterEach(func() {
 		framework.Cleanup()
 	})
+
+	// TODO: NEED TO FIX AS IT IS RELIANT ON TAG
 	DescribeTable("logforwarder configured with output.syslog.tag", func(tagSpec, expTag string, requiresFluentd bool) {
 		if requiresFluentd && testfw.LogCollectionType != logging.LogCollectionTypeFluentd {
 			Skip("TODO: fix me for vector?Does that make sense? Test requires fluentd")
 		}
-		testruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+		obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 			FromInput(logging.InputNameApplication).
-			ToOutputWithVisitor(func(spec *logging.OutputSpec) {
-				spec.Syslog.Facility = "user"
-				spec.Syslog.Severity = "debug"
-				spec.Syslog.PayloadKey = "message"
-				spec.Syslog.RFC = e2e.RFC3164.String()
-				spec.Syslog.Tag = tagSpec
-			}, logging.OutputTypeSyslog)
+			ToSyslogOutput(obs.SyslogRFC3164, func(output *obs.OutputSpec) {
+				output.Syslog.Facility = "user"
+				output.Syslog.Severity = "debug"
+				output.Syslog.PayloadKey = "message"
+			})
 		Expect(framework.Deploy()).To(BeNil())
 
 		record := `{"index": 1, "timestamp": 1, "tag_key": "rec_tag"}`
@@ -56,28 +58,25 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 		Expect(outputlogs[0]).To(MatchRegexp(expMatch), "Exp to find tag in received message")
 		Expect(outputlogs[0]).To(MatchRegexp(`{"index":.*1,.*"timestamp":.*1,.*"tag_key":.*"rec_tag"}`), "Exp to find the original message in received message")
 	},
-
-		Entry("should use the value from the record and include the message", "$.message.tag_key", "rec_tag", false),
-		Entry("should use the value from the complete tag and include the message", "tag", `kubernetes\.var\.log.pods\..*`, true),
-		Entry("should use values from parts of the tag and include the message", "${tag[0]}#${tag[-2]}", `kubernetes#.*`, true),
+	// Entry("should use the value from the record and include the message", "$.message.tag_key", "rec_tag", false),
 	)
+
 	Describe("configured with values for facility,severity", func() {
 		It("should use values from the record", func() {
-			testruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(logging.InputNameApplication).
-				ToOutputWithVisitor(func(spec *logging.OutputSpec) {
+				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
 					spec.Syslog.Facility = "$.message.facility_key"
 					spec.Syslog.Severity = "$.message.severity_key"
-					spec.Syslog.RFC = e2e.RFC3164.String()
-					spec.Syslog.Tag = "myTag"
-				}, logging.OutputTypeSyslog)
+					spec.Syslog.RFC = obs.SyslogRFC3164
+				})
 			Expect(framework.Deploy()).To(BeNil())
 
 			record := `{"index": 1, "timestamp": 1, "facility_key": "local0", "severity_key": "Informational"}`
 			crioMessage := functional.NewFullCRIOLogMessage(functional.CRIOTime(time.Now()), record)
 			Expect(framework.WriteMessagesToApplicationLog(crioMessage, 1)).To(BeNil())
 
-			outputlogs, err := framework.ReadRawApplicationLogsFrom(logging.OutputTypeSyslog)
+			outputlogs, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeSyslog))
 			Expect(err).To(BeNil(), "Expected no errors reading the logs")
 			Expect(outputlogs).To(HaveLen(1), "Expected the receiver to receive the message")
 
@@ -88,40 +87,33 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 		})
 	})
 
-	DescribeTable("configured to addLogSourceToMessage should add namespace, pod, container name", func(source string, requiresFluentd bool) {
-		if requiresFluentd && testfw.LogCollectionType != logging.LogCollectionTypeFluentd {
-			Skip("TODO fix for vector? Test requires fluentd")
-		}
+	// TODO: FIX AFTER ADDLOGSOURCE FINALIZED
+	DescribeTable("configured to addLogSourceToMessage should add namespace, pod, container name", func(source obs.InputType) {
 		writeLogs := framework.WriteMessagesToInfraContainerLog
 		readLogsFrom := framework.ReadInfrastructureLogsFrom
-		if source == logging.InputNameApplication {
+		if source == obs.InputTypeApplication {
 			writeLogs = framework.WriteMessagesToApplicationLog
 			readLogsFrom = framework.ReadRawApplicationLogsFrom
 		}
 
-		testruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+		obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 			FromInput(source).
-			ToOutputWithVisitor(func(spec *logging.OutputSpec) {
+			ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
 				spec.Syslog.Facility = "user"
 				spec.Syslog.Severity = "debug"
 				spec.Syslog.PayloadKey = "message"
-				spec.Syslog.RFC = e2e.RFC3164.String()
-				spec.Syslog.Tag = "mytag"
-				spec.Syslog.AddLogSource = true
-			}, logging.OutputTypeSyslog)
+			})
 		Expect(framework.Deploy()).To(BeNil())
 
 		crioMessage := functional.NewFullCRIOLogMessage(functional.CRIOTime(time.Now()), payload)
 		Expect(writeLogs(crioMessage, 1)).To(BeNil())
 
-		outputlogs, err := readLogsFrom(logging.OutputTypeSyslog)
+		outputlogs, err := readLogsFrom(string(obs.OutputTypeSyslog))
 		Expect(err).To(BeNil(), "Expected no errors reading the logs")
 		Expect(outputlogs).To(HaveLen(1), "Expected the receiver to receive the message")
 		expMatch := fmt.Sprintf(`namespace_name=.*, container_name=collector, pod_name=functional, message=%s`, payload)
 		Expect(outputlogs[0]).To(MatchRegexp(expMatch), "Exp. message source info to be added")
 	},
-
-		Entry("should support infrastructure logs", logging.InputNameInfrastructure, true),
-		Entry("should support application logs", logging.InputNameApplication, false),
+	// Entry("should support application logs", obs.InputTypeApplication, false),
 	)
 })

--- a/test/runtime/observability/cluster_log_forwarder.go
+++ b/test/runtime/observability/cluster_log_forwarder.go
@@ -158,6 +158,9 @@ func (p *PipelineBuilder) ToSyslogOutput(rfc obs.SyslogRFCType, visitors ...func
 				URL: "tcp://0.0.0.0:24224",
 			},
 		}
+		for _, v := range visitors {
+			v(output)
+		}
 	}
 	return p.ToOutputWithVisitor(v, string(obs.OutputTypeSyslog))
 }


### PR DESCRIPTION
### Description
This PR enables most of the syslog output functional tests. There are a couple tests that need revisting once API changes are finalized, mainly the `tag` and `log source` information.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5716
