### PR TITLE
LOG-5740: Enable multiple outputs test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,7 @@ test-functional:
 		./test/functional/outputs/splunk \
 		./test/functional/outputs/logstash \
 		./test/functional/outputs/syslog \
+		./test/functional/outputs/multiple \
 		-ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
 
 .PHONY: test-functional-vector

--- a/test/functional/outputs/multiple/forward_to_multiple_outputs_test.go
+++ b/test/functional/outputs/multiple/forward_to_multiple_outputs_test.go
@@ -3,12 +3,12 @@ package multiple
 import (
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
-	testruntime "github.com/openshift/cluster-logging-operator/test/runtime"
+	testruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 
-	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 )
 
@@ -22,7 +22,7 @@ var _ = Describe("[Functional][Outputs][Multiple]", func() {
 	BeforeEach(func() {
 		framework = functional.NewCollectorFunctionalFramework()
 		builder = testruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
-			FromInput(loggingv1.InputNameApplication)
+			FromInput(obs.InputTypeApplication)
 		builder.ToHttpOutput()
 		builder.ToElasticSearchOutput()
 	})
@@ -33,23 +33,22 @@ var _ = Describe("[Functional][Outputs][Multiple]", func() {
 	Describe("when multiple outputs are configured", func() {
 
 		Describe("and both are accepting logs", func() {
-
 			BeforeEach(func() {
 				Expect(framework.Deploy()).To(BeNil())
 				Expect(framework.WritesApplicationLogs(1)).To(BeNil())
 			})
 
 			It("should send logs to the http receiver and elasticsearch", func() {
-				logs, err := framework.ReadApplicationLogsFrom(loggingv1.OutputTypeHttp)
-				Expect(err).To(BeNil(), "Expected no error reading logs from %s", loggingv1.OutputTypeHttp)
-				Expect(logs).To(HaveLen(1), "Exp. to receive a log message at output type %s", loggingv1.OutputTypeHttp)
+				logs, err := framework.ReadApplicationLogsFrom(string(obs.OutputTypeHTTP))
+				Expect(err).To(BeNil(), "Expected no error reading logs from %s", obs.OutputTypeHTTP)
+				Expect(logs).To(HaveLen(1), "Exp. to receive a log message at output type %s", obs.OutputTypeHTTP)
 
-				raw, err := framework.GetLogsFromElasticSearch(loggingv1.OutputTypeElasticsearch, loggingv1.InputNameApplication)
+				raw, err := framework.GetLogsFromElasticSearch(string(obs.OutputTypeElasticsearch), string(obs.InputTypeApplication))
 				Expect(err).To(BeNil(), "Expected no errors reading the logs")
 				Expect(raw).To(Not(BeEmpty()))
 				err = types.StrictlyParseLogsFromSlice(raw, &logs)
 				Expect(err).To(BeNil(), "Expected no errors parsing the logs")
-				Expect(logs).To(HaveLen(1), "Exp. to receive a log message at output type %s", loggingv1.OutputTypeElasticsearch)
+				Expect(logs).To(HaveLen(1), "Exp. to receive a log message at output type %s", obs.OutputTypeElasticsearch)
 
 			})
 		})
@@ -57,17 +56,15 @@ var _ = Describe("[Functional][Outputs][Multiple]", func() {
 		Describe("and one store is not available", func() {
 			BeforeEach(func() {
 				Expect(framework.DeployWithVisitor(func(builder *runtime.PodBuilder) error {
-					return framework.AddFluentdHttpOutput(builder, framework.Forwarder.Spec.Outputs[0])
+					return framework.AddFluentdHttpOutput(builder, framework.Forwarder.Spec.Outputs[1])
 				})).To(BeNil())
 				Expect(framework.WritesApplicationLogs(1)).To(BeNil())
 			})
 			It("should send logs to the http receiver only", func() {
-				logs, err := framework.ReadApplicationLogsFrom(loggingv1.OutputTypeHttp)
-				Expect(err).To(BeNil(), "Expected no error reading logs from %s", loggingv1.OutputTypeHttp)
-				Expect(logs).To(HaveLen(1), "Exp. to receive a log message at output type %s", loggingv1.OutputTypeHttp)
-
+				logs, err := framework.ReadApplicationLogsFrom(string(obs.OutputTypeHTTP))
+				Expect(err).To(BeNil(), "Expected no error reading logs from %s", obs.OutputTypeHTTP)
+				Expect(logs).To(HaveLen(1), "Exp. to receive a log message at output type %s", obs.OutputTypeHTTP)
 			})
 		})
-
 	})
 })


### PR DESCRIPTION
### Description
This PR refactors the multiple outputs functional tests to observability API

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5740
- Blocked by: https://github.com/openshift/cluster-logging-operator/pull/2592

