### PR TITLE
LOG-5747: fix seeding of dashboards for green installations

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -184,6 +184,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Create initial dashboard config map on CLO install
+	if err = dashboard.ReconcileForDashboards(mgr.GetClient(), mgr.GetAPIReader()); err != nil {
+		log.Error(err, "unable to seed the initial dashboard")
+		os.Exit(1)
+	}
+
 	if err = (&observabilitycontroller.ClusterLogForwarderReconciler{
 		ForwarderContext: internalcontext.ForwarderContext{
 			Client:         mgr.GetClient(),


### PR DESCRIPTION
### Description
This PR:
* seeds the dashboards for greenfield installs that was broken as part of #2464 

### Links
https://issues.redhat.com/browse/LOG-5747