### PR TITLE
Remove omitempty on required fields

### DIFF
--- a/api/observability/v1/clusterlogforwarder_types.go
+++ b/api/observability/v1/clusterlogforwarder_types.go
@@ -52,7 +52,7 @@ type ClusterLogForwarderSpec struct {
 	// +listType:=map
 	// +listMapKey:=name
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Log Forwarder Outputs"
-	Outputs []OutputSpec `json:"outputs,omitempty"`
+	Outputs []OutputSpec `json:"outputs"`
 
 	// Filters are applied to log records passing through a pipeline.
 	// There are different types of filter that can select and modify log records in different ways.
@@ -216,7 +216,7 @@ const (
 	// BearerTokenFromSecret specifies to use the token from the spec'd secret
 	BearerTokenFromSecret BearerTokenFrom = "secret"
 
-	//BearerTokenFromServiceAccountToken specifies to use the projected token associated with the forwarder service account
+	// BearerTokenFromServiceAccountToken specifies to use the projected token associated with the forwarder service account
 	BearerTokenFromServiceAccountToken BearerTokenFrom = "serviceAccountToken"
 )
 
@@ -224,7 +224,7 @@ type BearerTokenSecretKey struct {
 	// Name of the key used to get the value from the referenced Secret.
 	//
 	// +kubebuilder:validation:Required
-	Key string `json:"key,omitempty"`
+	Key string `json:"key"`
 
 	// Name of secret
 	//

--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -214,20 +214,20 @@ type AzureMonitorAuthentication struct {
 	//
 	// +kubebuilder:validation:Required
 	// +nullable
-	SharedKey *SecretKey `json:"sharedKey,omitempty"`
+	SharedKey *SecretKey `json:"sharedKey"`
 }
 
 type AzureMonitor struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Required
-	Authentication *AzureMonitorAuthentication `json:"authentication,omitempty"`
+	Authentication *AzureMonitorAuthentication `json:"authentication"`
 
 	// CustomerId che unique identifier for the Log Analytics workspace.
 	// https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell#request-uri-parameters
 	//
 	// +kubebuilder:validation:Required
-	CustomerId string `json:"customerId,omitempty"`
+	CustomerId string `json:"customerId"`
 
 	// LogType the record type of the data that is being submitted.
 	// Can only contain letters, numbers, and underscores (_), and may not exceed 100 characters.
@@ -277,7 +277,7 @@ type Cloudwatch struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Required
-	Authentication *CloudwatchAuthentication `json:"authentication,omitempty"`
+	Authentication *CloudwatchAuthentication `json:"authentication"`
 
 	// Tuning specs tuning for the output
 	//
@@ -312,7 +312,7 @@ type CloudwatchAuthentication struct {
 	//
 	// +kubebuilder:validation:Enum:=accessKey;iamRole
 	// +kubebuilder:validation:Required
-	Type CloudwatchAuthType `json:"type,omitempty"`
+	Type CloudwatchAuthType `json:"type"`
 
 	// AWSAccessKey points to the AWS access key id and secret to be used for authentication.
 	//
@@ -335,7 +335,7 @@ type CloudwatchIAMRole struct {
 	//
 	// +kubebuilder:validation:Required
 	// +nullable
-	RoleARN *SecretKey `json:"roleARN,omitempty"`
+	RoleARN *SecretKey `json:"roleARN"`
 
 	// Token specifies a bearer token to be used for authenticating requests.
 	//
@@ -349,13 +349,13 @@ type CloudwatchAWSAccessKey struct {
 	//
 	// +kubebuilder:validation:Required
 	// +nullable
-	KeyID *SecretKey `json:"keyID,omitempty"`
+	KeyID *SecretKey `json:"keyID"`
 
 	// AccessKeySecret points to the AWS access key secret to be used for authentication.
 	//
 	// +kubebuilder:validation:Required
 	// +nullable
-	KeySecret *SecretKey `json:"keySecret,omitempty"`
+	KeySecret *SecretKey `json:"keySecret"`
 }
 
 type IndexSpec struct {
@@ -365,7 +365,7 @@ type IndexSpec struct {
 	// +kubebuilder:validation:Pattern:=`^([a-zA-Z0-9-_.\/])*(\{\{[ ]?\.[a-zA-Z0-9_.]+?[ ]?\}\}([a-zA-Z0-9-_.\/])*)*([a-zA-Z0-9-_.\/])*$`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:="{{.log_type}}"
-	Index string `json:"index,omitempty"`
+	Index string `json:"index"`
 }
 
 type ElasticsearchTuningSpec struct {
@@ -426,14 +426,14 @@ type GoogleCloudLogging struct {
 	// ID must be one of the required ID fields for the output
 	//
 	// +kubebuilder:validation:Required
-	ID GoogleGloudLoggingID `json:"id,omitempty"`
+	ID GoogleGloudLoggingID `json:"id"`
 
 	// LogID is the log ID to which to publish logs. This identifies log stream.
 	//
 	// +kubebuilder:validation:Pattern:=`^([a-zA-Z0-9-_.\/])*(\{\{[ ]?\.[a-zA-Z0-9_.]+?[ ]?\}\}([a-zA-Z0-9-_.\/])*)*([a-zA-Z0-9-_.\/])*$`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:="{{.log_type}}"
-	LogID string `json:"logId,omitempty"`
+	LogID string `json:"logId"`
 
 	// Tuning specs tuning for the output
 	//
@@ -444,13 +444,14 @@ type GoogleCloudLogging struct {
 type GoogleGloudLoggingID struct {
 	// Type is the ID type provided
 	//
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum:=billingAccount;folder;project;organization
-	Type GoogleCloudLoggingIDType `json:"type,omitempty"`
+	Type GoogleCloudLoggingIDType `json:"type"`
 
 	// Value is the value of the ID
 	//
 	// +kubebuilder:validation:Required
-	Value string `json:"value,omitempty"`
+	Value string `json:"value"`
 }
 
 type GoogleCloudLoggingIDType string
@@ -564,7 +565,7 @@ type Kafka struct {
 	// +kubebuilder:validation:Pattern:=`^([a-zA-Z0-9-_.\/])*(\{\{[ ]?\.[a-zA-Z0-9_.]+?[ ]?\}\}([a-zA-Z0-9-_.\/])*)*([a-zA-Z0-9-_.\/])*$`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:="{{.log_type}}"
-	Topic string `json:"topic,omitempty"`
+	Topic string `json:"topic"`
 
 	// Brokers specifies the list of broker endpoints of a Kafka cluster.
 	// The list represents only the initial set used by the collector's Kafka client for the
@@ -605,7 +606,7 @@ type LokiStackAuthentication struct {
 	//
 	// +kubebuilder:validation:Required
 	// +nullable
-	Token *BearerToken `json:"token,omitempty"`
+	Token *BearerToken `json:"token"`
 }
 
 // LokiStack provides optional extra properties for `type: lokistack`
@@ -613,7 +614,7 @@ type LokiStack struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Required
-	Authentication *LokiStackAuthentication `json:"authentication,omitempty"`
+	Authentication *LokiStackAuthentication `json:"authentication"`
 
 	// Target points to the LokiStack resources that should be used as a target for the output.
 	//
@@ -679,7 +680,7 @@ type Loki struct {
 	// +kubebuilder:validation:Pattern:=`^([a-zA-Z0-9-_.\/])*(\{\{[ ]?\.[a-zA-Z0-9_.]+?[ ]?\}\}([a-zA-Z0-9-_.\/])*)*([a-zA-Z0-9-_.\/])*$`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:="{{.log_type}}"
-	TenantKey string `json:"tenantKey,omitempty"`
+	TenantKey string `json:"tenantKey"`
 }
 
 type SplunkTuningSpec struct {
@@ -697,7 +698,7 @@ type SplunkAuthentication struct {
 	// Token points to the secret containing the Splunk HEC token used for authenticating requests.
 	//
 	// +kubebuilder:validation:Required
-	Token *SecretKey `json:"token,omitempty"`
+	Token *SecretKey `json:"token"`
 }
 
 // Splunk Deliver log data to Splunk’s HTTP Event Collector
@@ -706,7 +707,7 @@ type Splunk struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Required
-	Authentication *SplunkAuthentication `json:"authentication,omitempty"`
+	Authentication *SplunkAuthentication `json:"authentication"`
 
 	// Tuning specs tuning for the output
 	//
@@ -734,7 +735,7 @@ type Syslog struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum:=RFC3164;RFC5424
 	// +kubebuilder:default:=RFC5424
-	RFC SyslogRFCType `json:"rfc,omitempty"`
+	RFC SyslogRFCType `json:"rfc"`
 
 	// Severity to set on outgoing syslog records.
 	//

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -815,6 +815,8 @@ spec:
                               - key
                               - secret
                               type: object
+                          required:
+                          - sharedKey
                           type: object
                         azureResourceId:
                           description: AzureResourceId the Resource ID of the Azure
@@ -863,6 +865,9 @@ spec:
                               format: int64
                               type: integer
                           type: object
+                      required:
+                      - authentication
+                      - customerId
                       type: object
                     cloudwatch:
                       description: Cloudwatch provides configuration for the output
@@ -927,6 +932,9 @@ spec:
                                   - key
                                   - secret
                                   type: object
+                              required:
+                              - keyID
+                              - keySecret
                               type: object
                             iamRole:
                               description: IAMRole points to the secret containing
@@ -985,11 +993,14 @@ spec:
                                           description: Name of secret
                                           type: string
                                       required:
+                                      - key
                                       - name
                                       type: object
                                   required:
                                   - from
                                   type: object
+                              required:
+                              - roleARN
                               type: object
                             type:
                               description: Type is the type of cloudwatch authentication
@@ -998,6 +1009,8 @@ spec:
                               - accessKey
                               - iamRole
                               type: string
+                          required:
+                          - type
                           type: object
                         groupName:
                           default: '{{.log_type}}'
@@ -1055,6 +1068,7 @@ spec:
                             part of `url` is ignored."
                           type: string
                       required:
+                      - authentication
                       - groupName
                       - region
                       type: object
@@ -1112,6 +1126,7 @@ spec:
                                       description: Name of secret
                                       type: string
                                   required:
+                                  - key
                                   - name
                                   type: object
                               required:
@@ -1206,6 +1221,7 @@ spec:
                           minimum: 6
                           type: integer
                       required:
+                      - index
                       - url
                       type: object
                     googleCloudLogging:
@@ -1259,6 +1275,9 @@ spec:
                             value:
                               description: Value is the value of the ID
                               type: string
+                          required:
+                          - type
+                          - value
                           type: object
                         logId:
                           default: '{{.log_type}}'
@@ -1296,6 +1315,9 @@ spec:
                               format: int64
                               type: integer
                           type: object
+                      required:
+                      - id
+                      - logId
                       type: object
                     http:
                       description: HTTP provided configuration for sending json encoded
@@ -1353,6 +1375,7 @@ spec:
                                       description: Name of secret
                                       type: string
                                   required:
+                                  - key
                                   - name
                                   type: object
                               required:
@@ -1585,6 +1608,7 @@ spec:
                             'tls'). The 'username@password' part of `url` is ignored."
                           type: string
                       required:
+                      - topic
                       - url
                       type: object
                     loki:
@@ -1643,6 +1667,7 @@ spec:
                                       description: Name of secret
                                       type: string
                                   required:
+                                  - key
                                   - name
                                   type: object
                               required:
@@ -1752,6 +1777,7 @@ spec:
                             'tls'). The 'username@password' part of `url` is ignored."
                           type: string
                       required:
+                      - tenantKey
                       - url
                       type: object
                     lokiStack:
@@ -1786,11 +1812,14 @@ spec:
                                       description: Name of secret
                                       type: string
                                   required:
+                                  - key
                                   - name
                                   type: object
                               required:
                               - from
                               type: object
+                          required:
+                          - token
                           type: object
                         labelKeys:
                           description: "LabelKeys is a list of log record keys that
@@ -1864,6 +1893,7 @@ spec:
                               type: integer
                           type: object
                       required:
+                      - authentication
                       - target
                       type: object
                     name:
@@ -1925,6 +1955,7 @@ spec:
                                       description: Name of secret
                                       type: string
                                   required:
+                                  - key
                                   - name
                                   type: object
                               required:
@@ -2057,6 +2088,8 @@ spec:
                               - key
                               - secret
                               type: object
+                          required:
+                          - token
                           type: object
                         index:
                           default: '{{.log_type}}'
@@ -2115,6 +2148,8 @@ spec:
                             'tls'). The 'username@password' part of `url` is ignored."
                           type: string
                       required:
+                      - authentication
+                      - index
                       - url
                       type: object
                     syslog:
@@ -2179,6 +2214,7 @@ spec:
                             'tls'). The 'username@password' part of `url` is ignored."
                           type: string
                       required:
+                      - rfc
                       - url
                       type: object
                     tls:
@@ -2478,6 +2514,7 @@ spec:
                 - name
                 type: object
             required:
+            - outputs
             - pipelines
             - serviceAccount
             type: object

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -816,6 +816,8 @@ spec:
                               - key
                               - secret
                               type: object
+                          required:
+                          - sharedKey
                           type: object
                         azureResourceId:
                           description: AzureResourceId the Resource ID of the Azure
@@ -864,6 +866,9 @@ spec:
                               format: int64
                               type: integer
                           type: object
+                      required:
+                      - authentication
+                      - customerId
                       type: object
                     cloudwatch:
                       description: Cloudwatch provides configuration for the output
@@ -928,6 +933,9 @@ spec:
                                   - key
                                   - secret
                                   type: object
+                              required:
+                              - keyID
+                              - keySecret
                               type: object
                             iamRole:
                               description: IAMRole points to the secret containing
@@ -986,11 +994,14 @@ spec:
                                           description: Name of secret
                                           type: string
                                       required:
+                                      - key
                                       - name
                                       type: object
                                   required:
                                   - from
                                   type: object
+                              required:
+                              - roleARN
                               type: object
                             type:
                               description: Type is the type of cloudwatch authentication
@@ -999,6 +1010,8 @@ spec:
                               - accessKey
                               - iamRole
                               type: string
+                          required:
+                          - type
                           type: object
                         groupName:
                           default: '{{.log_type}}'
@@ -1056,6 +1069,7 @@ spec:
                             part of `url` is ignored."
                           type: string
                       required:
+                      - authentication
                       - groupName
                       - region
                       type: object
@@ -1113,6 +1127,7 @@ spec:
                                       description: Name of secret
                                       type: string
                                   required:
+                                  - key
                                   - name
                                   type: object
                               required:
@@ -1207,6 +1222,7 @@ spec:
                           minimum: 6
                           type: integer
                       required:
+                      - index
                       - url
                       type: object
                     googleCloudLogging:
@@ -1260,6 +1276,9 @@ spec:
                             value:
                               description: Value is the value of the ID
                               type: string
+                          required:
+                          - type
+                          - value
                           type: object
                         logId:
                           default: '{{.log_type}}'
@@ -1297,6 +1316,9 @@ spec:
                               format: int64
                               type: integer
                           type: object
+                      required:
+                      - id
+                      - logId
                       type: object
                     http:
                       description: HTTP provided configuration for sending json encoded
@@ -1354,6 +1376,7 @@ spec:
                                       description: Name of secret
                                       type: string
                                   required:
+                                  - key
                                   - name
                                   type: object
                               required:
@@ -1586,6 +1609,7 @@ spec:
                             'tls'). The 'username@password' part of `url` is ignored."
                           type: string
                       required:
+                      - topic
                       - url
                       type: object
                     loki:
@@ -1644,6 +1668,7 @@ spec:
                                       description: Name of secret
                                       type: string
                                   required:
+                                  - key
                                   - name
                                   type: object
                               required:
@@ -1753,6 +1778,7 @@ spec:
                             'tls'). The 'username@password' part of `url` is ignored."
                           type: string
                       required:
+                      - tenantKey
                       - url
                       type: object
                     lokiStack:
@@ -1787,11 +1813,14 @@ spec:
                                       description: Name of secret
                                       type: string
                                   required:
+                                  - key
                                   - name
                                   type: object
                               required:
                               - from
                               type: object
+                          required:
+                          - token
                           type: object
                         labelKeys:
                           description: "LabelKeys is a list of log record keys that
@@ -1865,6 +1894,7 @@ spec:
                               type: integer
                           type: object
                       required:
+                      - authentication
                       - target
                       type: object
                     name:
@@ -1926,6 +1956,7 @@ spec:
                                       description: Name of secret
                                       type: string
                                   required:
+                                  - key
                                   - name
                                   type: object
                               required:
@@ -2058,6 +2089,8 @@ spec:
                               - key
                               - secret
                               type: object
+                          required:
+                          - token
                           type: object
                         index:
                           default: '{{.log_type}}'
@@ -2116,6 +2149,8 @@ spec:
                             'tls'). The 'username@password' part of `url` is ignored."
                           type: string
                       required:
+                      - authentication
+                      - index
                       - url
                       type: object
                     syslog:
@@ -2180,6 +2215,7 @@ spec:
                             'tls'). The 'username@password' part of `url` is ignored."
                           type: string
                       required:
+                      - rfc
                       - url
                       type: object
                     tls:
@@ -2479,6 +2515,7 @@ spec:
                 - name
                 type: object
             required:
+            - outputs
             - pipelines
             - serviceAccount
             type: object

--- a/test/runtime/observability/cluster_log_forwarder_test.go
+++ b/test/runtime/observability/cluster_log_forwarder_test.go
@@ -129,6 +129,7 @@ serviceAccount:
 					func(spec *obs.OutputSpec) {
 						spec.Type = obs.OutputTypeSyslog
 						spec.Syslog = &obs.Syslog{
+							RFC: obs.SyslogRFC5424,
 							URLSpec: obs.URLSpec{
 								URL: "tcp://0.0.0.0:24225",
 							},
@@ -162,6 +163,7 @@ outputs:
 - name: other
   type: syslog
   syslog:
+    rfc: RFC5424
     url: tcp://0.0.0.0:24225
 pipelines:
 - inputRefs:


### PR DESCRIPTION
### Description

When using `+kubebuilder:validation:Required` to mark a field of the CRD as required it can not be combined with `omitempty`. If `omitempty` is present then the `Required` is silently ignored.

This PR removes `omitempty` from all attributes having the `+kubebuilder:validation:Required` annotation in the comment, which adds new required fields to the generated CRD.
