### PR TITLE
Move startup script to file and use go-embed

### DIFF
--- a/internal/collector/vector/run-vector.sh
+++ b/internal/collector/vector/run-vector.sh
@@ -1,8 +1,4 @@
-package vector
-
-// RunVectorScript is the run-vector.sh script for launching the Vector container process
-// will override content of /scripts/run-vector.sh in https://github.com/ViaQ/vector
-const RunVectorScript = `#!/bin/bash
+#!/bin/bash
 
 set -uo pipefail
 
@@ -32,4 +28,3 @@ popd
 
 echo "Starting Vector process..."
 exec /usr/bin/vector --config-toml /etc/vector/vector.toml
-`

--- a/internal/collector/vector/utils.go
+++ b/internal/collector/vector/utils.go
@@ -1,8 +1,11 @@
 package vector
 
 import (
-	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"path"
+
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+
+	_ "embed"
 )
 
 const (
@@ -14,6 +17,12 @@ const (
 	SecretDataReaderFile = "read_secret_data.sh"
 	SecretDataReaderPath = "/usr/bin/" + "read_secret_data.sh"
 )
+
+// RunVectorScript is the run-vector.sh script for launching the Vector container process
+// will override content of /scripts/run-vector.sh in https://github.com/ViaQ/vector
+//
+//go:embed run-vector.sh
+var RunVectorScript string
 
 func GetDataPath(namespace, forwarderName string) string {
 	//legacy installation


### PR DESCRIPTION
### Description

This PR moves the `run-vector.sh` startup script from a constant to a file that is injected into the executable using `go-embed`. This change makes the file more easily discoverable in the repository and syntax highlighting and linting tools also work better with a separate file instead of a string constant.

This is just a "code style" change.
