### PR TITLE
LOG-5482 otlp output functional test 

### DIFF
--- a/internal/generator/vector/helpers/node.go
+++ b/internal/generator/vector/helpers/node.go
@@ -19,6 +19,11 @@ func MakeID(parts ...string) string {
 	return FormatComponentID(strings.Join(parts, "_"))
 }
 
+// MakeRouteInputID appends sourceType to rerouteId for input ids
+func MakeRouteInputID(rerouteId, sourceType string) string {
+	return strings.ToLower(strings.Join([]string{rerouteId, sourceType}, "."))
+}
+
 // MakeInputID for components that logically represent clf.input
 func MakeInputID(parts ...string) string {
 	parts = append([]string{"input"}, parts...)

--- a/internal/generator/vector/output/factory.go
+++ b/internal/generator/vector/output/factory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/azuremonitor"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/cloudwatch"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/otlp"
 
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/elasticsearch"
@@ -52,6 +53,8 @@ func New(o obs.OutputSpec, inputs []string, secrets map[string]*corev1.Secret, s
 		els = append(els, syslog.New(baseID, o, inputs, secrets, strategy, op)...)
 	case obs.OutputTypeAzureMonitor:
 		els = append(els, azuremonitor.New(baseID, o, inputs, secrets, strategy, op)...)
+	case obs.OutputTypeOTLP:
+		els = append(els, otlp.New(baseID, o, inputs, secrets, strategy, op)...)
 	}
 	return els
 }

--- a/internal/generator/vector/output/otlp/group_by.go
+++ b/internal/generator/vector/output/otlp/group_by.go
@@ -1,0 +1,76 @@
+package otlp
+
+import (
+	"fmt"
+	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"strings"
+)
+
+type Reduce struct {
+	ComponentID string
+	Desc        string
+	Inputs      string
+	GroupBy     string
+	MaxEvents   string
+}
+
+func (r Reduce) Name() string {
+	return "reduceTemplate"
+}
+
+func (r Reduce) Template() string {
+	return `{{define "reduceTemplate" -}}
+{{if .Desc -}}
+# {{.Desc}}
+{{end -}}
+[transforms.{{.ComponentID}}]
+type = "reduce"
+inputs = {{.Inputs}}
+expire_after_ms = 15000
+max_events = {{.MaxEvents}}
+group_by = {{.GroupBy}}
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+{{end}}
+`
+}
+
+func GroupByContainer(id string, inputs []string) Element {
+	return Reduce{
+		Desc:        "Merge container logs and group by namespace, pod and container",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		MaxEvents:   "250",
+		GroupBy: MakeGroupBys(".openshift.cluster_id",
+			".kubernetes.namespace_name", ".kubernetes.pod_name", ".kubernetes.container_name"),
+	}
+}
+
+func GroupBySource(id string, inputs []string) Element {
+	return Reduce{
+		Desc:        "Merge audit api and node logs and group by log_source",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		MaxEvents:   "250",
+		GroupBy:     MakeGroupBys(".openshift.cluster_id", ".openshift.log_source"),
+	}
+}
+
+func GroupByHost(id string, inputs []string) Element {
+	return Reduce{
+		Desc:        "Merge auditd host logs and group by hostname",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		MaxEvents:   "50",
+		GroupBy:     MakeGroupBys(".openshift.cluster_id", ".openshift.hostname"),
+	}
+}
+
+func MakeGroupBys(fields ...string) string {
+	out := make([]string, len(fields))
+	for i, o := range fields {
+		out[i] = fmt.Sprintf("%q", o)
+	}
+	return fmt.Sprintf("[%s]", strings.Join(out, ","))
+}

--- a/internal/generator/vector/output/otlp/otlp.go
+++ b/internal/generator/vector/output/otlp/otlp.go
@@ -1,0 +1,168 @@
+package otlp
+
+import (
+	"fmt"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	genhelper "github.com/openshift/cluster-logging-operator/internal/generator/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	vectorhelpers "github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common/auth"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common/tls"
+	"sort"
+	"strings"
+)
+
+type Otlp struct {
+	ComponentID      string
+	Inputs           string
+	URI              string
+	common.RootMixin //TODO: remove??
+}
+
+func (p Otlp) Name() string {
+	return "vectorOtlpTemplate"
+}
+
+func (p Otlp) Template() string {
+	return `{{define "` + p.Name() + `" -}}
+[sinks.{{.ComponentID}}]
+type = "http"
+inputs = {{.Inputs}}
+uri = "{{.URI}}"
+method = "post"
+payload_prefix = "{\"resourceLogs\":"
+payload_suffix = "}"
+{{.Compression}}
+{{end}}
+`
+}
+
+// TODO: test this for otlp
+func (p *Otlp) SetCompression(algo string) {
+	p.Compression.Value = algo
+}
+
+const (
+	logSourceContainer    = string(obs.ApplicationSourceContainer)
+	logSourceNode         = string(obs.InfrastructureSourceNode)
+	logSourceAuditd       = string(obs.AuditSourceAuditd)
+	logSourceKubeAPI      = string(obs.AuditSourceKube)
+	logSourceOpenshiftAPI = string(obs.AuditSourceOpenShift)
+	logSourceOvn          = string(obs.AuditSourceOVN)
+
+	// For now we are grouping all container logs by their ns, pod and container names
+	// so there is no distinction here at the moment.
+	// TODO: revise or remove
+	logSourceContainerApp   = string(obs.ApplicationSourceContainer)
+	logSourceContainerInfra = string(obs.InfrastructureSourceContainer)
+)
+
+func New(id string, o obs.OutputSpec, inputs []string, secrets vectorhelpers.Secrets, strategy common.ConfigStrategy, op Options) []Element {
+	if genhelper.IsDebugOutput(op) {
+		return []Element{
+			elements.Debug(helpers.MakeID(id, "debug"), vectorhelpers.MakeInputs(inputs...)),
+		}
+	}
+	// TODO: create a pattern to filter by input so all this is not necessary
+	var els []Element
+	// Creates reroutes for 'container','node','auditd','kubeAPI','openshiftAPI','ovn'
+	rerouteID := vectorhelpers.MakeID(id, "reroute") // "output_my_id_reroute
+	els = append(els, RouteBySource(rerouteID, inputs))
+	// Container
+	transformContainerID := vectorhelpers.MakeID(id, logSourceContainer)                       // "output_my_id_container"
+	transformContainerInputID := vectorhelpers.MakeRouteInputID(rerouteID, logSourceContainer) // "output_my_id_reroute.container"
+	reduceContainerID := vectorhelpers.MakeID(id, "groupby", "container")
+	els = append(els, TransformContainer(transformContainerID, []string{transformContainerInputID}))
+	// Group by cluster_id, namespace_name, pod_name, container_name
+	els = append(els, GroupByContainer(reduceContainerID, []string{transformContainerID}))
+	// Journal
+	transformNodeID := vectorhelpers.MakeID(id, logSourceNode)
+	transformNodeRouteID := vectorhelpers.MakeRouteInputID(rerouteID, logSourceNode)
+	els = append(els, TransformJournal(transformNodeID, []string{transformNodeRouteID}))
+	// Audit
+	transformAuditHostID := vectorhelpers.MakeID(id, logSourceAuditd)
+	transformAuditHostRouteID := vectorhelpers.MakeRouteInputID(rerouteID, logSourceAuditd)
+	transformAuditKubeID := vectorhelpers.MakeID(id, logSourceKubeAPI)
+	transformAuditKubeRouteID := vectorhelpers.MakeRouteInputID(rerouteID, logSourceKubeAPI)
+	transformAuditOpenshiftID := vectorhelpers.MakeID(id, logSourceOpenshiftAPI)
+	transformAuditOpenshiftRouteID := vectorhelpers.MakeRouteInputID(rerouteID, logSourceOpenshiftAPI)
+	transformAuditOvnID := vectorhelpers.MakeID(id, logSourceOvn)
+	transformAuditOvnRouteID := vectorhelpers.MakeRouteInputID(rerouteID, logSourceOvn)
+	reduceSourceID := vectorhelpers.MakeID(id, "groupby", "source")
+	reduceHostID := vectorhelpers.MakeID(id, "groupby", "host")
+	els = append(els, TransformAuditHost(transformAuditHostID, []string{transformAuditHostRouteID}))
+	els = append(els, TransformAuditKube(transformAuditKubeID, []string{transformAuditKubeRouteID}))
+	els = append(els, TransformAuditOpenshift(transformAuditOpenshiftID, []string{transformAuditOpenshiftRouteID}))
+	els = append(els, TransformAuditOvn(transformAuditOvnID, []string{transformAuditOvnRouteID}))
+	// Group by cluster_id, log_source
+	els = append(els, GroupBySource(reduceSourceID, []string{
+		transformNodeID,
+		transformAuditKubeID,
+		transformAuditOpenshiftID,
+		transformAuditOvnID,
+	}))
+	// Group by cluster_id, hostname
+	els = append(els, GroupByHost(reduceHostID, []string{
+		transformAuditHostID,
+	}))
+
+	// Normalize all into resource and scopeLogs objects
+	formatResourceLogsID := vectorhelpers.MakeID(id, "resource", "logs")
+	els = append(els, FormatResourceLog(formatResourceLogsID, []string{
+		reduceContainerID,
+		reduceSourceID,
+		reduceHostID,
+	}))
+	// Create sink and wrap in `resourceLogs`
+	sink := Output(id, o, []string{formatResourceLogsID}, secrets, op)
+	if strategy != nil {
+		strategy.VisitSink(sink)
+	}
+	return MergeElements(
+		els,
+		[]Element{
+			sink,
+			common.NewEncoding(id, common.CodecJSON),
+			common.NewAcknowledgments(id, strategy),
+			tls.New(id, o.TLS, secrets, op),
+			auth.HTTPAuth(id, o.OTLP.Authentication, secrets),
+		},
+	)
+}
+
+func RouteBySource(id string, inputs []string) Element {
+	// TODO: refactor based on existing map of logSourceTypes?
+	logSources := []string{
+		logSourceContainer,
+		logSourceNode,
+		logSourceAuditd,
+		logSourceKubeAPI,
+		logSourceOpenshiftAPI,
+		logSourceOvn,
+	}
+	// Sort to match the route vrl logic
+	sort.Strings(logSources)
+	routes := map[string]string{}
+	for _, source := range logSources {
+		routes[strings.ToLower(source)] = fmt.Sprintf("'.log_source == \"%s\"'", source)
+	}
+
+	return elements.Route{
+		Desc:        "Route logs separately by log_source",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		Routes:      routes,
+	}
+}
+
+func Output(id string, o obs.OutputSpec, inputs []string, secrets vectorhelpers.Secrets, op Options) *Otlp {
+	return &Otlp{
+		ComponentID: id,
+		Inputs:      vectorhelpers.MakeInputs(inputs...),
+		URI:         o.OTLP.URL,
+		RootMixin:   common.NewRootMixin(nil),
+	}
+}

--- a/internal/generator/vector/output/otlp/otlp_all.toml
+++ b/internal/generator/vector/output/otlp/otlp_all.toml
@@ -1,0 +1,375 @@
+# Route logs separately by log_source
+[transforms.output_otel_collector_reroute]
+type = "route"
+inputs = ["pipeline_my_pipeline_viaq_0"]
+route.auditd = '.log_source == "auditd"'
+route.container = '.log_source == "container"'
+route.kubeapi = '.log_source == "kubeAPI"'
+route.node = '.log_source == "node"'
+route.openshiftapi = '.log_source == "openshiftAPI"'
+route.ovn = '.log_source == "ovn"'
+
+# Normalize container log records to OTLP semantic conventions
+[transforms.output_otel_collector_container]
+type = "remap"
+inputs = ["output_otel_collector_reroute.container"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+  	  {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append container resource attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "k8s.pod.name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+  	{"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
+  	{"key": "k8s.container.name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+  	{"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
+  	{"key": "k8s.namespace.name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+  )
+  # Append kube pod labels
+  if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
+  	    resource.attributes = append(resource.attributes,
+              [{"key": "k8s.pod.label." + key, "value": {"stringValue": value}}]
+  	    )
+      }
+  }
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  # Openshift and kubernetes objects for grouping containers (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  .kubernetes = {
+      "namespace_name": .kubernetes.namespace_name,
+      "pod_name": .kubernetes.pod_name,
+      "container_name": .kubernetes.container_name
+  }
+  . = {
+    "openshift": o,
+    "kubernetes": .kubernetes,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Merge container logs and group by namespace, pod and container
+[transforms.output_otel_collector_groupby_container]
+type = "reduce"
+inputs = ["output_otel_collector_container"]
+expire_after_ms = 15000
+max_events = 250
+group_by = [".openshift.cluster_id",".kubernetes.namespace_name",".kubernetes.pod_name",".kubernetes.container_name"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Normalize node log events to OTLP semantic conventions
+[transforms.output_otel_collector_node]
+type = "remap"
+inputs = ["output_otel_collector_reroute.node"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  # Append log attributes for node logs
+  logAttribute = [
+      "systemd.t.BOOT_ID",
+      "systemd.t.COMM",
+      "systemd.t.CAP_EFFECTIVE",
+      "systemd.t.CMDLINE",
+      "systemd.t.EXE",
+      "systemd.t.GID",
+      "systemd.t.MACHINE_ID",
+      "systemd.t.PID",
+      "systemd.t.SELINUX_CONTEXT",
+      "systemd.t.STREAM_ID",
+      "systemd.t.SYSTEMD_CGROUP",
+      "systemd.t.SYSTEMD_INVOCATION_ID",
+      "systemd.t.SYSTEMD_SLICE",
+      "systemd.t.SYSTEMD_UNIT",
+      "systemd.t.TRANSPORT",
+      "systemd.t.UID",
+      "systemd.u.SYSLOG_FACILITY",
+      "systemd.u.SYSLOG_IDENTIFIER",
+  ]
+  replacements = {
+      "SYSTEMD.CGROUP": "system.cgroup",
+      "SYSTEMD.INVOCATION.ID": "system.invocation.id",
+      "SYSTEMD.SLICE": "system.slice",
+      "SYSTEMD.UNIT": "system.unit",
+      "SYSLOG.FACILITY": "syslog.facility",
+      "SYSLOG.IDENTIFIER": "syslog.identifier",
+      "PID": "syslog.procid"
+  }
+  for_each(logAttribute) -> |_,sub_key| {
+    path = split(sub_key,".")
+    if length(path) > 1 {
+  	sub_key = replace!(path[-1],"_",".")
+    }
+    if get!(replacements, [sub_key]) != null {
+  	sub_key = string!(get!(replacements, [sub_key]))
+    } else {
+  	sub_key = "system." + downcase(sub_key)
+    }
+    r.attributes = append(r.attributes,
+        [{"key": sub_key, "value": {"stringValue": get!(.,path)}}]
+    )
+  }
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit log record to OTLP semantic conventions
+[transforms.output_otel_collector_auditd]
+type = "remap"
+inputs = ["output_otel_collector_reroute.auditd"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append auditd host attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "node.name", "value": {"stringValue": .hostname}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit log kube record to OTLP semantic conventions
+[transforms.output_otel_collector_kubeapi]
+type = "remap"
+inputs = ["output_otel_collector_reroute.kubeapi"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  # Append logRecord attributes
+  r.attributes = append(r.attributes,
+  	[{"key": "url.full", "value": {"stringValue": .requestURI}},
+  	{"key": "http.response.status.code", "value": {"stringValue": to_string!(get!(.,["responseStatus","code"]))}},
+  	{"key": "http.request.method", "value": {"stringValue": .verb}}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit openshiftAPI record to OTLP semantic conventions
+[transforms.output_otel_collector_openshiftapi]
+type = "remap"
+inputs = ["output_otel_collector_reroute.openshiftapi"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  # Append logRecord attributes
+  r.attributes = append(r.attributes,
+  	[{"key": "url.full", "value": {"stringValue": .requestURI}},
+  	{"key": "http.response.status.code", "value": {"stringValue": to_string!(get!(.,["responseStatus","code"]))}},
+  	{"key": "http.request.method", "value": {"stringValue": .verb}}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit log ovn records to OTLP semantic conventions
+[transforms.output_otel_collector_ovn]
+type = "remap"
+inputs = ["output_otel_collector_reroute.ovn"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+  	{"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+  r.attributes = []
+  # Append logRecord attributes
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  # Append logRecord attributes
+  r.attributes = append(r.attributes,
+  	[{"key": "url.full", "value": {"stringValue": .requestURI}},
+  	{"key": "http.response.status.code", "value": {"stringValue": to_string!(get!(.,["responseStatus","code"]))}},
+  	{"key": "http.request.method", "value": {"stringValue": .verb}}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Merge audit api and node logs and group by log_source
+[transforms.output_otel_collector_groupby_source]
+type = "reduce"
+inputs = ["output_otel_collector_kubeapi","output_otel_collector_node","output_otel_collector_openshiftapi","output_otel_collector_ovn"]
+expire_after_ms = 15000
+max_events = 250
+group_by = [".openshift.cluster_id",".openshift.log_source"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Merge auditd host logs and group by hostname
+[transforms.output_otel_collector_groupby_host]
+type = "reduce"
+inputs = ["output_otel_collector_auditd"]
+expire_after_ms = 15000
+max_events = 50
+group_by = [".openshift.cluster_id",".openshift.hostname"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Create new resource object for OTLP JSON payload
+[transforms.output_otel_collector_resource_logs]
+type = "remap"
+inputs = ["output_otel_collector_groupby_container","output_otel_collector_groupby_host","output_otel_collector_groupby_source"]
+source = '''
+  . = {
+        "resource": {
+           "attributes": .resource.attributes,
+        },
+        "scopeLogs": [
+          {"logRecords": .logRecords}
+        ]
+      }
+'''
+
+[sinks.output_otel_collector]
+type = "http"
+inputs = ["output_otel_collector_resource_logs"]
+uri = "http://localhost:4318/v1/logs"
+method = "post"
+payload_prefix = "{\"resourceLogs\":"
+payload_suffix = "}"
+
+[sinks.output_otel_collector.encoding]
+codec = "json"
+except_fields = ["_internal"]

--- a/internal/generator/vector/output/otlp/otlp_test.go
+++ b/internal/generator/vector/output/otlp/otlp_test.go
@@ -1,0 +1,36 @@
+package otlp
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+)
+
+var _ = Describe("Generate vector config", func() {
+	DescribeTable("for OTLP output", func(output obs.OutputSpec, secret helpers.Secrets, op framework.Options, expFile string) {
+		exp, err := tomlContent.ReadFile(expFile)
+		if err != nil {
+			Fail(fmt.Sprintf("Error reading the file %q with exp config: %v", expFile, err))
+		}
+		conf := New(helpers.MakeOutputID(output.Name), output, []string{"pipeline_my_pipeline_viaq_0"}, secret, nil, op) //, includeNS, excludes)
+		Expect(string(exp)).To(EqualConfigFrom(conf))
+	},
+		Entry("with only URL spec'd",
+			obs.OutputSpec{
+				Type: obs.OutputTypeOTLP,
+				Name: "otel-collector",
+				OTLP: &obs.OTLP{
+					URL: "http://localhost:4318/v1/logs",
+				},
+			},
+			nil,
+			framework.NoOptions,
+			"otlp_all.toml",
+		),
+	)
+})

--- a/internal/generator/vector/output/otlp/suite_test.go
+++ b/internal/generator/vector/output/otlp/suite_test.go
@@ -1,0 +1,19 @@
+package otlp
+
+import (
+	"embed"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	//go:embed *.toml
+	tomlContent embed.FS
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][generator][vector][output][otlp] Suite")
+}

--- a/internal/generator/vector/output/otlp/transform.go
+++ b/internal/generator/vector/output/otlp/transform.go
@@ -1,0 +1,253 @@
+package otlp
+
+import (
+	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"strings"
+)
+
+// VRL for OTLP transforms by route
+const (
+	CreateResourceAttributes = `
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append( resource.attributes, 
+    [{"key": "cluster.id", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+)
+`
+	AppendHostAttributes = `
+# Append auditd host attributes
+resource.attributes = append( resource.attributes,
+    [{"key": "node.name", "value": {"stringValue": .hostname}}]
+)
+`
+	AppendContainerAttributes = `
+# Append container resource attributes
+resource.attributes = append( resource.attributes,
+    [{"key": "k8s.pod.name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+    {"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
+    {"key": "k8s.container.name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+    {"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
+    {"key": "k8s.namespace.name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+)
+# Append kube pod labels
+if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {  
+	    resource.attributes = append(resource.attributes,
+            [{"key": "k8s.pod.label." + key, "value": {"stringValue": value}}]
+	    )
+    }
+}
+`
+	CreateLogRecord = `
+# Create logRecord object
+r = {}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+# Convert syslog severity keyword to number, default to 9 (unknown)
+r.severityNumber = to_syslog_severity(.level) ?? 9
+r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+r.attributes = []
+
+# Append logRecord attributes
+r.attributes = append(r.attributes,
+    [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+)
+
+`
+	AppendAPILogRecordAttributes = `
+# Append logRecord attributes
+r.attributes = append(r.attributes,
+	[{"key": "url.full", "value": {"stringValue": .requestURI}},
+	{"key": "http.response.status.code", "value": {"stringValue": to_string!(get!(.,["responseStatus","code"]))}},
+	{"key": "http.request.method", "value": {"stringValue": .verb}}]
+)
+`
+	AppendNodeLogRecordAttributes = `
+# Append log attributes for node logs
+logAttribute = [
+  "systemd.t.BOOT_ID",
+  "systemd.t.COMM",
+  "systemd.t.CAP_EFFECTIVE",
+  "systemd.t.CMDLINE",
+  "systemd.t.EXE",
+  "systemd.t.GID",
+  "systemd.t.MACHINE_ID",
+  "systemd.t.PID",
+  "systemd.t.SELINUX_CONTEXT",
+  "systemd.t.STREAM_ID",
+  "systemd.t.SYSTEMD_CGROUP",
+  "systemd.t.SYSTEMD_INVOCATION_ID",
+  "systemd.t.SYSTEMD_SLICE",
+  "systemd.t.SYSTEMD_UNIT",
+  "systemd.t.TRANSPORT",
+  "systemd.t.UID",
+  "systemd.u.SYSLOG_FACILITY",
+  "systemd.u.SYSLOG_IDENTIFIER",
+]
+replacements = {
+  "SYSTEMD.CGROUP": "system.cgroup",
+  "SYSTEMD.INVOCATION.ID": "system.invocation.id",
+  "SYSTEMD.SLICE": "system.slice",
+  "SYSTEMD.UNIT": "system.unit",
+  "SYSLOG.FACILITY": "syslog.facility",
+  "SYSLOG.IDENTIFIER": "syslog.identifier",
+  "PID": "syslog.procid"
+}
+for_each(logAttribute) -> |_,sub_key| {
+  path = split(sub_key,".")
+  if length(path) > 1 {
+	sub_key = replace!(path[-1],"_",".")
+  }
+  if get!(replacements, [sub_key]) != null {
+	sub_key = string!(get!(replacements, [sub_key]))
+  } else {
+	sub_key = "system." + downcase(sub_key)
+  }
+  r.attributes = append(r.attributes,
+      [{"key": sub_key, "value": {"stringValue": get!(.,path)}}]
+  )
+}
+`
+	FinalObjectWithOpenshiftGrouping = `
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": get!(.,["openshift","cluster_id"])
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+`
+	FinalObjectWithKubeContainerGrouping = `
+# Openshift and kubernetes objects for grouping containers (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "cluster_id": get!(.,["openshift","cluster_id"])
+}
+.kubernetes = {
+    "namespace_name": .kubernetes.namespace_name,
+    "pod_name": .kubernetes.pod_name,
+    "container_name": .kubernetes.container_name
+}
+. = {
+  "openshift": o,
+  "kubernetes": .kubernetes,
+  "resource": resource,
+  "logRecords": r
+}
+`
+)
+
+func containerLogsVRL() string {
+	return strings.Join(helpers.TrimSpaces([]string{
+		CreateResourceAttributes,
+		AppendContainerAttributes,
+		CreateLogRecord,
+		FinalObjectWithKubeContainerGrouping,
+	}), "\n")
+}
+
+func nodeLogsVRL() string {
+	return strings.Join(helpers.TrimSpaces([]string{
+		CreateResourceAttributes,
+		CreateLogRecord,
+		AppendNodeLogRecordAttributes,
+		FinalObjectWithOpenshiftGrouping,
+	}), "\n")
+}
+
+func auditHostLogsVRL() string {
+	return strings.Join(helpers.TrimSpaces([]string{
+		CreateResourceAttributes,
+		AppendHostAttributes,
+		CreateLogRecord,
+		FinalObjectWithOpenshiftGrouping,
+	}), "\n")
+}
+
+func auditAPILogsVRL() string {
+	return strings.Join(helpers.TrimSpaces([]string{
+		CreateResourceAttributes,
+		CreateLogRecord,
+		AppendAPILogRecordAttributes,
+		FinalObjectWithOpenshiftGrouping,
+	}), "\n")
+}
+
+func TransformContainer(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize container log records to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         containerLogsVRL(),
+	}
+}
+
+func TransformJournal(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize node log events to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         nodeLogsVRL(),
+	}
+}
+
+func TransformAuditHost(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize audit log record to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         auditHostLogsVRL(),
+	}
+}
+
+func TransformAuditKube(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize audit log kube record to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         auditAPILogsVRL(),
+	}
+}
+func TransformAuditOpenshift(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize audit openshiftAPI record to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         auditAPILogsVRL(),
+	}
+}
+func TransformAuditOvn(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Normalize audit log ovn records to OTLP semantic conventions",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL:         auditAPILogsVRL(),
+	}
+}
+
+// FormatResourceLog Drops everything except resource.attributes and scopeLogs.logRecords
+func FormatResourceLog(id string, inputs []string) Element {
+	return elements.Remap{
+		Desc:        "Create new resource object for OTLP JSON payload",
+		ComponentID: id,
+		Inputs:      helpers.MakeInputs(inputs...),
+		VRL: strings.TrimSpace(`
+. = {
+      "resource": {
+         "attributes": .resource.attributes,
+      },
+      "scopeLogs": [
+        {"logRecords": .logRecords}
+      ]
+    }
+`),
+	}
+}

--- a/internal/generator/vector/pipeline/adapter.go
+++ b/internal/generator/vector/pipeline/adapter.go
@@ -84,7 +84,6 @@ func NewPipeline(index int, p obs.PipelineSpec, inputs map[string]helpers.InputC
 
 // TODO: add migration to treat like any other
 func addPrefilters(p *Pipeline) {
-
 	prefilters := []string{}
 	if viaq.HasJournalSource(p.inputSpecs) {
 		prefilters = append(prefilters, viaq.ViaqJournal)

--- a/test/framework/functional/constants.go
+++ b/test/framework/functional/constants.go
@@ -42,6 +42,11 @@ var (
 			string(obs.InputTypeAudit):          ApplicationLogFile,
 			string(obs.InputTypeInfrastructure): ApplicationLogFile,
 		},
+		string(obs.OutputTypeOTLP): {
+			string(obs.InputTypeApplication):    ApplicationLogFile,
+			string(obs.InputTypeAudit):          ApplicationLogFile,
+			string(obs.InputTypeInfrastructure): ApplicationLogFile,
+		},
 		string(obs.OutputTypeSyslog): {
 			applicationLog:                      "/tmp/infra.log",
 			auditLog:                            "/tmp/infra.log",

--- a/test/framework/functional/output_otlp.go
+++ b/test/framework/functional/output_otlp.go
@@ -1,0 +1,56 @@
+package functional
+
+import (
+	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	corev1 "k8s.io/api/core/v1"
+	"strings"
+)
+
+const (
+	OTELReceiverConf = `
+exporters:
+  debug:
+    verbosity: detailed
+  file:
+    path: /tmp/app-logs
+    format: json
+    flush_interval: 1s
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "localhost:4318"
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [file,debug]
+`
+	OTELCollectorImage = "quay.io/openshift-logging/opentelemetry-collector:0.96.0"
+)
+
+// TODO: refactor
+func (f *CollectorFunctionalFramework) AddOTELCollector(b *runtime.PodBuilder, outputName string) error {
+	// TODO: add log_type here, or otherwise need a way to write to different file paths
+	// Current paths are all listed the same for type otlp (same as currently http)
+	log.V(3).Info("Adding OTEL collector", "name", outputName)
+	name := strings.ToLower(outputName)
+
+	config := runtime.NewConfigMap(b.Pod.Namespace, name, map[string]string{
+		"config.yaml": OTELReceiverConf,
+	})
+	log.V(2).Info("Creating configmap", "namespace", config.Namespace, "name", config.Name, "config.yaml", OTELReceiverConf)
+	if err := f.Test.Client.Create(config); err != nil {
+		return err
+	}
+
+	log.V(2).Info("Adding container", "name", name, "image", OTELCollectorImage)
+	b.AddContainer(name, OTELCollectorImage).
+		AddVolumeMount(config.Name, "/etc/otel", "", true).
+		WithImagePullPolicy(corev1.PullAlways).
+		End().
+		AddConfigMapVolume(config.Name, config.Name)
+
+	return nil
+}

--- a/test/functional/outputs/otlp/forward_to_otlp_test.go
+++ b/test/functional/outputs/otlp/forward_to_otlp_test.go
@@ -1,0 +1,193 @@
+package otlp
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	"github.com/openshift/cluster-logging-operator/test/helpers/otlp"
+	obstestruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
+	"time"
+)
+
+const (
+	timestamp     = "2023-08-28T12:59:28.573159188+00:00"
+	timestampNano = "1693227568573159188"
+)
+
+var _ = Describe("[Functional][Outputs][OTLP] Functional tests", func() {
+	var (
+		framework    *functional.CollectorFunctionalFramework
+		appNamespace string
+	)
+
+	BeforeEach(func() {
+		framework = functional.NewCollectorFunctionalFramework()
+
+	})
+
+	AfterEach(func() {
+		framework.Cleanup()
+	})
+
+	Context("When forwarding logs to an otel-collector", func() {
+		It("should send application logs with correct grouping and resource attributes", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeApplication).
+				ToOtlpOutput()
+
+			Expect(framework.DeployWithVisitor(func(b *runtime.PodBuilder) error {
+				return framework.AddOTELCollector(b, string(obs.OutputTypeOTLP))
+			})).To(BeNil())
+
+			appNamespace = framework.Pod.Namespace
+
+			// Write message to namespace
+			crioLine := functional.NewCRIOLogMessage(timestamp, "Format me to a container message!", false)
+			Expect(framework.WriteMessagesToNamespace(crioLine, appNamespace, 1)).To(Succeed())
+			crioLine = functional.NewCRIOLogMessage(timestamp, "My second message.", false)
+			Expect(framework.WriteMessagesToNamespace(crioLine, appNamespace, 1)).To(Succeed())
+			crioLine = functional.NewCRIOLogMessage(timestamp, "My third and final message.", false)
+			Expect(framework.WriteMessagesToNamespace(crioLine, appNamespace, 1)).To(Succeed())
+
+			// Read logs
+			raw, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeOTLP))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs for type")
+			Expect(raw).ToNot(BeEmpty())
+
+			logs, err := otlp.ParseLogs(raw[0])
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+			// Access the first (and only) ResourceLog
+			// Inspect resource attributes
+			resourceLog := logs.ResourceLogs[0]
+			resource := resourceLog.Resource
+			namespaceName := resource.FindStringValue(resource.NamespaceNameAttribute())
+			Expect(namespaceName).To(Equal(appNamespace), "Expect namespace name to exist in resource attributes")
+
+			logSource := resource.FindStringValue(resource.LogSourceAttribute())
+			Expect(logSource).To(Equal("container"))
+
+			clusterId := resource.FindStringValue(resource.ClusterIDAttribute())
+			Expect(clusterId).ToNot(BeEmpty(), "Expected cluster.id resource attribute")
+
+			scopeLogs := resourceLog.ScopeLogs
+			Expect(scopeLogs).ToNot(BeEmpty(), "Expected scopeLogs")
+			Expect(scopeLogs).To(HaveLen(1), "Expected a single scopeLog")
+
+			logRecords := scopeLogs[0].LogRecords
+			Expect(logRecords).ToNot(BeEmpty(), "Expected log records for the scope")
+			Expect(logRecords).To(HaveLen(3), "Expected same count as sent for log records")
+
+			// Inspect the first log record for correct fields
+			logRecord := logRecords[0]
+			Expect(logRecord.TimeUnixNano).To(Equal(timestampNano), "Expect timestamp to be converted into unix nano")
+			Expect(logRecord.SeverityNumber).To(Equal(9), "Expect severityNumber to not be parsed to 9")
+			Expect(logRecord.Body.StringValue).ToNot(BeEmpty(), "Expect message to be populated")
+
+			// Ensure we have log.type populated
+			Expect(logRecord.Attributes).ToNot(BeEmpty(), "Expect logRecord attributes to be populated")
+			logType := logRecord.FindStringValue(logRecord.LogTypeAttribute())
+			Expect(logType).To(Equal(string(obs.InputTypeApplication)))
+
+		})
+		It("should send audit logs with correct grouping and resource attributes", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeAudit).
+				ToOtlpOutput()
+
+			Expect(framework.DeployWithVisitor(func(b *runtime.PodBuilder) error {
+				return framework.AddOTELCollector(b, string(obs.OutputTypeOTLP))
+			})).To(BeNil())
+
+			// Log message data
+			nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+			k8sAuditLogLine := fmt.Sprintf(`{"kind":"Event","requestReceivedTimestamp":"%s","level":"Metadata"}`, functional.CRIOTime(nanoTime))
+			Expect(framework.WriteMessagesTok8sAuditLog(k8sAuditLogLine, 3)).To(BeNil())
+
+			// Read line from Log Forward output
+			raw, err := framework.ReadAuditLogsFrom(string(obs.OutputTypeOTLP))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs for type")
+			Expect(raw).ToNot(BeEmpty())
+
+			logs, err := otlp.ParseLogs(raw[0])
+			resourceLog := logs.ResourceLogs[0]
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+			resource := resourceLog.Resource
+			logSource := resource.FindStringValue(resource.LogSourceAttribute())
+			Expect(logSource).To(Equal("kubeAPI"))
+
+			clusterId := resource.FindStringValue(resource.ClusterIDAttribute())
+			Expect(clusterId).ToNot(BeEmpty(), "Expected cluster.id resource attribute")
+
+			scopeLogs := resourceLog.ScopeLogs
+			Expect(scopeLogs).ToNot(BeEmpty(), "Expected scopeLogs")
+			Expect(scopeLogs).To(HaveLen(1), "Expected a single scopeLog")
+
+			logRecords := scopeLogs[0].LogRecords
+			Expect(logRecords).ToNot(BeEmpty(), "Expected log records for the scope")
+			Expect(logRecords).To(HaveLen(3), "Expected same count as sent for log records")
+
+			// Inspect the first log record for correct fields
+			logRecord := logRecords[0]
+			//Expect(logRecord.TimeUnixNano).To(Equal(timestampNano), "Expect timestamp to be converted into unix nano")
+			Expect(logRecord.TimeUnixNano).ToNot(BeEmpty(), "Expect timestamp to be converted into unix nano")
+			Expect(logRecord.Body.StringValue).ToNot(BeEmpty(), "Expect message to be populated")
+
+			// Ensure we have log.type populated
+			Expect(logRecord.Attributes).ToNot(BeEmpty(), "Expect logRecord attributes to be populated")
+			logType := logRecord.FindStringValue(logRecord.LogTypeAttribute())
+			Expect(logType).To(Equal(string(obs.InputTypeAudit)))
+		})
+		It("should send journal logs with correct resource attributes", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeInfrastructure).
+				ToOtlpOutput()
+
+			Expect(framework.DeployWithVisitor(func(b *runtime.PodBuilder) error {
+				return framework.AddOTELCollector(b, string(obs.OutputTypeOTLP))
+			})).To(BeNil())
+
+			// Log message data
+			logline := functional.NewJournalLog(3, "*", "*")
+			Expect(framework.WriteMessagesToInfraJournalLog(logline, 1)).To(BeNil())
+
+			// Read line from Log Forward output
+			raw, err := framework.ReadInfrastructureLogsFrom(string(obs.OutputTypeOTLP))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs for type")
+			Expect(raw).ToNot(BeEmpty())
+
+			logs, err := otlp.ParseLogs(raw[0])
+			resourceLog := logs.ResourceLogs[0]
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+			resource := resourceLog.Resource
+			logSource := resource.FindStringValue(resource.LogSourceAttribute())
+			Expect(logSource).To(Equal("node"))
+
+			clusterId := resource.FindStringValue(resource.ClusterIDAttribute())
+			Expect(clusterId).ToNot(BeEmpty(), "Expected cluster.id resource attribute")
+
+			scopeLogs := resourceLog.ScopeLogs
+			Expect(scopeLogs).ToNot(BeEmpty(), "Expected scopeLogs")
+			Expect(scopeLogs).To(HaveLen(1), "Expected a single scopeLog")
+
+			logRecords := scopeLogs[0].LogRecords
+			Expect(logRecords).ToNot(BeEmpty(), "Expected log records for the scope")
+			Expect(logRecords).To(HaveLen(1), "Expected same count as sent for log records")
+
+			// Inspect the first log record for correct fields
+			logRecord := logRecords[0]
+			Expect(logRecord.TimeUnixNano).ToNot(BeEmpty(), "Expect timestamp to be converted into unix nano")
+			Expect(logRecord.Body.StringValue).ToNot(BeEmpty(), "Expect message to be populated")
+
+			// Ensure we have log.type populated
+			Expect(logRecord.Attributes).ToNot(BeEmpty(), "Expect logRecord attributes to be populated")
+			logType := logRecord.FindStringValue(logRecord.LogTypeAttribute())
+			Expect(logType).To(Equal(string(obs.InputTypeInfrastructure)))
+		})
+	})
+})

--- a/test/functional/outputs/otlp/suite_test.go
+++ b/test/functional/outputs/otlp/suite_test.go
@@ -1,0 +1,13 @@
+package otlp
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[functional][outputs][otlp] Suite")
+}

--- a/test/helpers/otlp/attributes.go
+++ b/test/helpers/otlp/attributes.go
@@ -1,0 +1,51 @@
+package otlp
+
+const (
+	NodeName           = "node.name"
+	ClusterID          = "cluster.id"
+	K8sNamespaceName   = "k8s.namespace.name"
+	K8sPodName         = "k8s.pod.name"
+	K8sContainerName   = "k8s.container.name"
+	OpenshiftLogSource = "openshift.log.source"
+	OpenshiftLogType   = "openshift.log.type"
+)
+
+func (r Resource) NodeNameAttribute() string {
+	return NodeName
+}
+func (r Resource) ClusterIDAttribute() string {
+	return ClusterID
+}
+func (r Resource) NamespaceNameAttribute() string {
+	return K8sNamespaceName
+}
+func (r Resource) PodNameAttribute() string {
+	return K8sPodName
+}
+func (r Resource) ContainerNameAttribute() string {
+	return K8sContainerName
+}
+func (r Resource) LogSourceAttribute() string {
+	return OpenshiftLogSource
+}
+func (l LogRecord) LogTypeAttribute() string {
+	return OpenshiftLogType
+}
+
+func (r Resource) FindStringValue(key string) string {
+	for _, attr := range r.Attributes {
+		if attr.Key == key {
+			return attr.Value.StringValue
+		}
+	}
+	return ""
+}
+
+func (l LogRecord) FindStringValue(key string) string {
+	for _, attr := range l.Attributes {
+		if attr.Key == key {
+			return attr.Value.StringValue
+		}
+	}
+	return ""
+}

--- a/test/helpers/otlp/types.go
+++ b/test/helpers/otlp/types.go
@@ -1,0 +1,78 @@
+package otlp
+
+import (
+	"encoding/json"
+)
+
+type Logs struct {
+	ResourceLogs []ResourceLog `json:"resourceLogs,omitempty"`
+}
+
+type ResourceLog struct {
+	Resource  Resource   `json:"resource,omitempty"`
+	ScopeLogs []ScopeLog `json:"scopeLogs,omitempty"`
+}
+
+type Resource struct {
+	Attributes []Attribute `json:"attributes,omitempty"`
+}
+
+type Attribute struct {
+	Key   string         `json:"key,omitempty"`
+	Value AttributeValue `json:"value,omitempty"`
+}
+
+type Scope struct {
+	Name       string      `json:"name,omitempty"`
+	Version    string      `json:"version,omitempty"`
+	Attributes []Attribute `json:"attributes,omitempty"`
+}
+
+type ScopeLog struct {
+	Scope      Scope       `json:"scope,omitempty"`
+	LogRecords []LogRecord `json:"logRecords,omitempty"`
+}
+
+type LogRecord struct {
+	TimeUnixNano         string      `json:"timeUnixNano,omitempty"`
+	ObservedTimeUnixNano string      `json:"observedTimeUnixNano,omitempty"`
+	SeverityNumber       int         `json:"severityNumber,omitempty"`
+	TraceID              string      `json:"traceId,omitempty"`
+	SpanID               string      `json:"spanId,omitempty"`
+	Body                 StringValue `json:"body,omitempty"`
+	Attributes           []Attribute `json:"attributes,omitempty"`
+}
+
+type AttributeValue struct {
+	StringValue string      `json:"stringValue,omitempty"`
+	Bool        bool        `json:"boolValue,omitempty"`
+	Int         int         `json:"intValue,omitempty"`
+	Float       float64     `json:"doubleValue,omitempty"`
+	Array       ArrayValue  `json:"arrayValue,omitempty"`
+	Map         KVListValue `json:"kvlistValue,omitempty"`
+}
+
+type StringValue struct {
+	StringValue string `json:"stringValue,omitempty"`
+}
+
+type ArrayValue struct {
+	Values []StringValue `json:"values,omitempty"`
+}
+
+type KVListValue struct {
+	Values []AttributeValue `json:"values,omitempty"`
+}
+
+func ParseLogs(in string) (Logs, error) {
+	logs := Logs{}
+	if in == "" {
+		return logs, nil
+	}
+	err := json.Unmarshal([]byte(in), &logs)
+	if err != nil {
+		return logs, err
+	}
+
+	return logs, nil
+}

--- a/test/runtime/observability/cluster_log_forwarder.go
+++ b/test/runtime/observability/cluster_log_forwarder.go
@@ -277,6 +277,19 @@ func (p *PipelineBuilder) ToHttpOutput(visitors ...func(output *obs.OutputSpec))
 	return p.ToOutputWithVisitor(v, string(obs.OutputTypeHTTP))
 }
 
+func (p *PipelineBuilder) ToOtlpOutput(visitors ...func(output *obs.OutputSpec)) *ClusterLogForwarderBuilder {
+	v := func(output *obs.OutputSpec) {
+		output.Name = string(obs.OutputTypeOTLP)
+		output.Type = obs.OutputTypeOTLP
+		output.OTLP = &obs.OTLP{
+			URL: "http://localhost:4318/v1/logs",
+		}
+		for _, v := range visitors {
+			v(output)
+		}
+	}
+	return p.ToOutputWithVisitor(v, string(obs.OutputTypeOTLP))
+}
 func (p *PipelineBuilder) ToAzureMonitorOutput(visitors ...func(output *obs.OutputSpec)) *ClusterLogForwarderBuilder {
 	v := func(output *obs.OutputSpec) {
 		output.Name = string(obs.OutputTypeAzureMonitor)


### PR DESCRIPTION
### Description
Based on previous PR for transforms https://github.com/openshift/cluster-logging-operator/pull/2590

Added the first functional test to send application logs to otel-collector container in the testnamespace.  Can read the log file and parse the attribute keys and values if necessary.   

All is still changing and will be dependent on what we decide is our "resource/stream" for each log_type, and which attributes we send (both in the resource.attributes and logRecord.attributes)

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- Parent task:  https://issues.redhat.com/browse/LOG-5370
- Sub-task: https://issues.redhat.com/browse/LOG-5482 
- Other tasks:  https://issues.redhat.com/browse/LOG-5476 https://issues.redhat.com/browse/LOG-5477 https://issues.redhat.com/browse/LOG-5478 https://issues.redhat.com/browse/LOG-5479 https://issues.redhat.com/browse/LOG-5480
- Enhancement proposal: https://github.com/openshift/enhancements/pull/1618

