### PR TITLE
LOG-5745: Only container logs can be forwarded with groupName {{.kubernetesnamespace_name}} to CloudWatch

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -302,8 +302,8 @@ type Cloudwatch struct {
 
 	// GroupName defines the strategy for grouping logstreams
 	//
-	// +kubebuilder:validation:Pattern:=`^([a-zA-Z0-9-_.\/])*(\{\{[ ]?\.[a-zA-Z0-9_.]+?[ ]?\}\}([a-zA-Z0-9-_.\/])*)*([a-zA-Z0-9-_.\/])*$`
-	// +kubebuilder:default:="{{.log_type}}"
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")*((\|\|)?(\.[a-zA-Z0-9_]+|\.?"[^"]+"))*\})*)*$`
+	// +kubebuilder:default:=`{.log_type||"none"}`
 	// +kubebuilder:validation:Required
 	GroupName string `json:"groupName"`
 }

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1045,11 +1045,10 @@ spec:
                           - type
                           type: object
                         groupName:
-                          default: '{{.log_type}}'
+                          default: '{.log_type||"none"}'
                           description: GroupName defines the strategy for grouping
                             logstreams
-                          pattern: ^([a-zA-Z0-9-_.\/])*(\{\{[ ]?\.[a-zA-Z0-9_.]+?[
-                            ]?\}\}([a-zA-Z0-9-_.\/])*)*([a-zA-Z0-9-_.\/])*$
+                          pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")*((\|\|)?(\.[a-zA-Z0-9_]+|\.?"[^"]+"))*\})*)*$
                           type: string
                         region:
                           type: string

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1046,11 +1046,10 @@ spec:
                           - type
                           type: object
                         groupName:
-                          default: '{{.log_type}}'
+                          default: '{.log_type||"none"}'
                           description: GroupName defines the strategy for grouping
                             logstreams
-                          pattern: ^([a-zA-Z0-9-_.\/])*(\{\{[ ]?\.[a-zA-Z0-9_.]+?[
-                            ]?\}\}([a-zA-Z0-9-_.\/])*)*([a-zA-Z0-9-_.\/])*$
+                          pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")*((\|\|)?(\.[a-zA-Z0-9_]+|\.?"[^"]+"))*\})*)*$
                           type: string
                         region:
                           type: string

--- a/internal/generator/vector/output/cloudwatch/cloudwatch_test.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch_test.go
@@ -122,20 +122,20 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 			conf := New(outputSpec.Name, outputSpec, []string{"cw-forward"}, secrets, nil, op)
 			Expect(string(exp)).To(EqualConfigFrom(conf))
 		},
-			Entry("when groupName is spec'd", "{{.log_type}}-foo", func(spec *obs.OutputSpec) {},
+			Entry("when groupName is spec'd", `{.log_type||"missing"}-foo`, func(spec *obs.OutputSpec) {},
 				framework.NoOptions, "cw_with_groupname.toml"),
-			Entry("when URL is spec'd", "{{.log_type}}", func(spec *obs.OutputSpec) {
+			Entry("when URL is spec'd", `{.log_type||"missing"}`, func(spec *obs.OutputSpec) {
 				spec.Cloudwatch.URL = "http://mylogreceiver"
 			}, framework.NoOptions, "cw_with_url.toml"),
-			Entry("when minTLS and ciphers is spec'd", "{{.log_type}}", nil, testhelpers.FrameworkOptionWithDefaultTLSCiphers, "cw_with_tls_and_default_mintls_ciphers.toml"),
-			Entry("when tls is spec'd", "{{.log_type}}", func(spec *obs.OutputSpec) {
+			Entry("when minTLS and ciphers is spec'd", `{.log_type||"missing"}`, nil, testhelpers.FrameworkOptionWithDefaultTLSCiphers, "cw_with_tls_and_default_mintls_ciphers.toml"),
+			Entry("when tls is spec'd", `{.log_type||"missing"}`, func(spec *obs.OutputSpec) {
 				spec.TLS = tlsSpec
 			}, framework.NoOptions, "cw_with_tls_spec.toml"),
-			Entry("when tls is spec'd with insecure verify", "{{.log_type}}", func(spec *obs.OutputSpec) {
+			Entry("when tls is spec'd with insecure verify", `{.log_type||"missing"}`, func(spec *obs.OutputSpec) {
 				spec.TLS = tlsSpec
 				spec.TLS.InsecureSkipVerify = true
 			}, framework.NoOptions, "cw_with_tls_spec_insecure_verify.toml"),
-			Entry("when aws credentials are provided", "app-{{.log_type}}", func(spec *obs.OutputSpec) {
+			Entry("when aws credentials are provided", `app-{.log_type||"missing"}`, func(spec *obs.OutputSpec) {
 				spec.Cloudwatch.Authentication = &obs.CloudwatchAuthentication{
 					Type: obs.CloudwatchAuthTypeIAMRole,
 					IAMRole: &obs.CloudwatchIAMRole{
@@ -236,7 +236,5 @@ var _ = Describe("Generating vector config for cloudwatch output", func() {
 					},
 				}, ""),
 		)
-
 	})
-
 })

--- a/internal/generator/vector/output/cloudwatch/cw_groupname_with_aws_credentials.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_groupname_with_aws_credentials.toml
@@ -24,9 +24,17 @@ source = '''
   del(.source_type)
 '''
 
-[transforms.cw_dedot]
+# Cloudwatch Groupname
+[transforms.cw_group_name]
 type = "remap"
 inputs = ["cw_normalize_streams"]
+source = '''
+._internal.cw_groupname = "app-" + to_string!(.log_type||"missing")
+'''
+
+[transforms.cw_dedot]
+type = "remap"
+inputs = ["cw_group_name"]
 source = '''
   .openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
   if exists(.kubernetes.namespace_labels) {
@@ -54,7 +62,7 @@ type = "aws_cloudwatch_logs"
 inputs = ["cw_dedot"]
 region = "us-east-test"
 compression = "none"
-group_name = "app-{{.log_type}}"
+group_name = "{{ _internal.cw_groupname }}"
 stream_name = "{{ stream_name }}"
 healthcheck.enabled = false
 

--- a/internal/generator/vector/output/cloudwatch/cw_with_groupname.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_groupname.toml
@@ -24,9 +24,17 @@ source = '''
   del(.source_type)
 '''
 
-[transforms.cw_dedot]
+# Cloudwatch Groupname
+[transforms.cw_group_name]
 type = "remap"
 inputs = ["cw_normalize_streams"]
+source = '''
+._internal.cw_groupname = to_string!(.log_type||"missing") + "-foo"
+'''
+
+[transforms.cw_dedot]
+type = "remap"
+inputs = ["cw_group_name"]
 source = '''
   .openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
   if exists(.kubernetes.namespace_labels) {
@@ -54,7 +62,7 @@ type = "aws_cloudwatch_logs"
 inputs = ["cw_dedot"]
 region = "us-east-test"
 compression = "none"
-group_name = "{{.log_type}}-foo"
+group_name = "{{ _internal.cw_groupname }}"
 stream_name = "{{ stream_name }}"
 auth.access_key_id = "SECRET[kubernetes_secret.vector-cw-secret/aws_access_key_id]"
 auth.secret_access_key = "SECRET[kubernetes_secret.vector-cw-secret/aws_secret_access_key]"

--- a/internal/generator/vector/output/cloudwatch/cw_with_tls_and_default_mintls_ciphers.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_tls_and_default_mintls_ciphers.toml
@@ -24,9 +24,17 @@ source = '''
   del(.source_type)
 '''
 
-[transforms.cw_dedot]
+# Cloudwatch Groupname
+[transforms.cw_group_name]
 type = "remap"
 inputs = ["cw_normalize_streams"]
+source = '''
+._internal.cw_groupname = to_string!(.log_type||"missing")
+'''
+
+[transforms.cw_dedot]
+type = "remap"
+inputs = ["cw_group_name"]
 source = '''
   .openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
   if exists(.kubernetes.namespace_labels) {
@@ -54,7 +62,7 @@ type = "aws_cloudwatch_logs"
 inputs = ["cw_dedot"]
 region = "us-east-test"
 compression = "none"
-group_name = "{{.log_type}}"
+group_name = "{{ _internal.cw_groupname }}"
 stream_name = "{{ stream_name }}"
 auth.access_key_id = "SECRET[kubernetes_secret.vector-cw-secret/aws_access_key_id]"
 auth.secret_access_key = "SECRET[kubernetes_secret.vector-cw-secret/aws_secret_access_key]"

--- a/internal/generator/vector/output/cloudwatch/cw_with_tls_spec.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_tls_spec.toml
@@ -24,9 +24,17 @@ source = '''
   del(.source_type)
 '''
 
-[transforms.cw_dedot]
+# Cloudwatch Groupname
+[transforms.cw_group_name]
 type = "remap"
 inputs = ["cw_normalize_streams"]
+source = '''
+._internal.cw_groupname = to_string!(.log_type||"missing")
+'''
+
+[transforms.cw_dedot]
+type = "remap"
+inputs = ["cw_group_name"]
 source = '''
   .openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
   if exists(.kubernetes.namespace_labels) {
@@ -54,7 +62,7 @@ type = "aws_cloudwatch_logs"
 inputs = ["cw_dedot"]
 region = "us-east-test"
 compression = "none"
-group_name = "{{.log_type}}"
+group_name = "{{ _internal.cw_groupname }}"
 stream_name = "{{ stream_name }}"
 auth.access_key_id = "SECRET[kubernetes_secret.vector-cw-secret/aws_access_key_id]"
 auth.secret_access_key = "SECRET[kubernetes_secret.vector-cw-secret/aws_secret_access_key]"

--- a/internal/generator/vector/output/cloudwatch/cw_with_tls_spec_insecure_verify.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_tls_spec_insecure_verify.toml
@@ -24,9 +24,17 @@ source = '''
   del(.source_type)
 '''
 
-[transforms.cw_dedot]
+# Cloudwatch Groupname
+[transforms.cw_group_name]
 type = "remap"
 inputs = ["cw_normalize_streams"]
+source = '''
+._internal.cw_groupname = to_string!(.log_type||"missing")
+'''
+
+[transforms.cw_dedot]
+type = "remap"
+inputs = ["cw_group_name"]
 source = '''
   .openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
   if exists(.kubernetes.namespace_labels) {
@@ -54,7 +62,7 @@ type = "aws_cloudwatch_logs"
 inputs = ["cw_dedot"]
 region = "us-east-test"
 compression = "none"
-group_name = "{{.log_type}}"
+group_name = "{{ _internal.cw_groupname }}"
 stream_name = "{{ stream_name }}"
 auth.access_key_id = "SECRET[kubernetes_secret.vector-cw-secret/aws_access_key_id]"
 auth.secret_access_key = "SECRET[kubernetes_secret.vector-cw-secret/aws_secret_access_key]"

--- a/internal/generator/vector/output/cloudwatch/cw_with_url.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_url.toml
@@ -24,9 +24,17 @@ source = '''
   del(.source_type)
 '''
 
-[transforms.cw_dedot]
+# Cloudwatch Groupname
+[transforms.cw_group_name]
 type = "remap"
 inputs = ["cw_normalize_streams"]
+source = '''
+._internal.cw_groupname = to_string!(.log_type||"missing")
+'''
+
+[transforms.cw_dedot]
+type = "remap"
+inputs = ["cw_group_name"]
 source = '''
   .openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
   if exists(.kubernetes.namespace_labels) {
@@ -54,7 +62,7 @@ type = "aws_cloudwatch_logs"
 inputs = ["cw_dedot"]
 region = "us-east-test"
 compression = "none"
-group_name = "{{.log_type}}"
+group_name = "{{ _internal.cw_groupname }}"
 stream_name = "{{ stream_name }}"
 auth.access_key_id = "SECRET[kubernetes_secret.vector-cw-secret/aws_access_key_id]"
 auth.secret_access_key = "SECRET[kubernetes_secret.vector-cw-secret/aws_secret_access_key]"

--- a/internal/generator/vector/output/common/template/suite_test.go
+++ b/internal/generator/vector/output/common/template/suite_test.go
@@ -1,0 +1,13 @@
+package template_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][generator][vector][output][common][template] Suite")
+}

--- a/internal/generator/vector/output/common/template/template.go
+++ b/internal/generator/vector/output/common/template/template.go
@@ -1,0 +1,86 @@
+package template
+
+import (
+	_ "embed"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"text/template"
+
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
+	vectorhelpers "github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+)
+
+var (
+	//go:embed template.vrl.tmpl
+	templateVRLTmplStr   string
+	pathRegex            = regexp.MustCompile(`\{([^{}]+)\}`)
+	splitRegex           = regexp.MustCompile(`to_string!\(([^)]+)\)`)
+	GroupNameVRLTemplate = template.Must(template.New("template VRL").Parse(templateVRLTmplStr))
+)
+
+type Template struct {
+	Field     string
+	VRLString string
+}
+
+func TemplateRemap(componentID string, inputs []string, userTemplate, field, description string) framework.Element {
+	// Generate template
+	w := &strings.Builder{}
+
+	_ = GroupNameVRLTemplate.Execute(w,
+		Template{
+			Field:     field,
+			VRLString: TransformUserTemplateToVRL(userTemplate),
+		},
+	)
+
+	return elements.Remap{
+		Desc:        description,
+		ComponentID: componentID,
+		Inputs:      vectorhelpers.MakeInputs(inputs...),
+		VRL:         w.String(),
+	}
+}
+
+// TransformUserTemplateToVRL converts the user entered template to VRL compatible syntax
+// Example: foo-{.log_type||"none"} -> "foo-" + to_string!(.log_type||"none")
+func TransformUserTemplateToVRL(groupName string) string {
+	// Finds and replaces expressions defined in `{}` with to_string!()
+	replacedGroupName := pathRegex.ReplaceAllStringFunc(groupName, func(match string) string {
+		matches := pathRegex.FindStringSubmatch(match)
+		replaced := fmt.Sprintf("to_string!(%s)", matches[1])
+		return replaced
+	})
+
+	// Finding all matches of to_string!() returning their start + end indices
+	matchedIndices := splitRegex.FindAllStringSubmatchIndex(replacedGroupName, -1)
+	if len(matchedIndices) == 0 {
+		return fmt.Sprintf("%q", groupName)
+	}
+
+	var result []string
+	lastIndex := 0
+	// Make the final resulting array with the appropriate pieces so that it can be concatenated together with `+`
+	for _, match := range matchedIndices {
+		// Append the part before the match. Check if empty string so we don't concat it
+		partBeforeMatch := replacedGroupName[lastIndex:match[0]]
+		if partBeforeMatch != "" {
+			result = append(result, fmt.Sprintf("%q", partBeforeMatch))
+		}
+
+		// Append the to_string!() group
+		result = append(result, replacedGroupName[match[0]:match[1]])
+		lastIndex = match[1]
+	}
+	// Append the remaining part of the string after the last match making sure it isn't the empty string
+	endOfString := replacedGroupName[lastIndex:]
+	if endOfString != "" {
+		result = append(result, fmt.Sprintf("%q", endOfString))
+	}
+
+	// Join array with `+`
+	return strings.Join(result, " + ")
+}

--- a/internal/generator/vector/output/common/template/template.vrl.tmpl
+++ b/internal/generator/vector/output/common/template/template.vrl.tmpl
@@ -1,0 +1,1 @@
+._internal.{{.Field}} = {{.VRLString}}

--- a/internal/generator/vector/output/common/template/template_test.go
+++ b/internal/generator/vector/output/common/template/template_test.go
@@ -1,0 +1,23 @@
+package template
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+)
+
+var _ = Describe("Vector Output Template", func() {
+	Context("GroupNames", func() {
+		DescribeTable("transforms cloudwatch group name to VRL compatible string", func(expVRL, groupNameString string) {
+			Expect(TransformUserTemplateToVRL(groupNameString)).To(EqualTrimLines(expVRL))
+		},
+			Entry("should transform group name with static and dynamic values into VRL compatible syntax",
+				`"foo-" + to_string!(.log_type||"none") + "." + to_string!(.bar.foo.test||"missing) + "_" + to_string!(.log_type||"none")`,
+				`foo-{.log_type||"none"}.{.bar.foo.test||"missing}_{.log_type||"none"}`),
+
+			Entry("should only add quotes and not transform group name if using only a static value", `"foobar-myindex"`, `foobar-myindex`),
+			Entry("should transform group_name if only a dynamic value is defined", `to_string!(.foo.bar||"missing")`, `{.foo.bar||"missing"}`),
+		)
+	})
+})

--- a/test/functional/outputs/cloudwatch/forward_to_cloudwatch_test.go
+++ b/test/functional/outputs/cloudwatch/forward_to_cloudwatch_test.go
@@ -87,6 +87,44 @@ var _ = Describe("[Functional][Outputs][CloudWatch] Forward Output to CloudWatch
 			Expect(logs).To(HaveLen(numOfLogs))
 		})
 
+		It("should be able to read messages from custom defined log group name", func() {
+			cwGroupName := `foo-{.log_type||"none"}`
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(logging.InputNameApplication).
+				ToCloudwatchOutput(*obsCwAuth, func(output *obs.OutputSpec) {
+					output.Cloudwatch.GroupName = cwGroupName
+				})
+			framework.Secrets = append(framework.Secrets, secret)
+
+			Expect(framework.Deploy()).To(BeNil())
+
+			Expect(framework.WritesNApplicationLogsOfSize(numOfLogs, logSize, 0)).To(BeNil())
+			time.Sleep(10 * time.Second)
+
+			logs, err := framework.ReadLogsFromCloudwatchByGroupName("foo-application")
+			Expect(err).To(BeNil())
+			Expect(logs).To(HaveLen(numOfLogs))
+		})
+
+		It("should be able to read messages from custom defined log group name with missing field", func() {
+			cwGroupName := `foo-{.fieldnotfound||"missing"}`
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(logging.InputNameApplication).
+				ToCloudwatchOutput(*obsCwAuth, func(output *obs.OutputSpec) {
+					output.Cloudwatch.GroupName = cwGroupName
+				})
+			framework.Secrets = append(framework.Secrets, secret)
+
+			Expect(framework.Deploy()).To(BeNil())
+
+			Expect(framework.WritesNApplicationLogsOfSize(numOfLogs, logSize, 0)).To(BeNil())
+			time.Sleep(10 * time.Second)
+
+			logs, err := framework.ReadLogsFromCloudwatchByGroupName("foo-missing")
+			Expect(err).To(BeNil())
+			Expect(logs).To(HaveLen(numOfLogs))
+		})
+
 		It("should be able to forward by user-defined pod labels", func() {
 			var (
 				labelKey   = "env1"

--- a/test/runtime/observability/cluster_log_forwarder.go
+++ b/test/runtime/observability/cluster_log_forwarder.go
@@ -173,7 +173,7 @@ func (p *PipelineBuilder) ToCloudwatchOutput(auth obs.CloudwatchAuthentication, 
 		output.Cloudwatch = &obs.Cloudwatch{
 			URL:            "https://localhost:5000",
 			Region:         "us-east-1",
-			GroupName:      "group-prefix.{{.log_type}}",
+			GroupName:      `group-prefix.{.log_type||"none"}`,
 			Authentication: &auth,
 		}
 		for _, v := range visitors {


### PR DESCRIPTION
### Description
This PR addresses missing fields when templating the `groupName` for `Cloudwatch`. This now allows a fallback value to be defined in case a field is missing.

The syntax allows for static values as well as path expressions enclosed in single curly brackets `{}`. There must be a fallback value when using path expressions and can be expressed with `||` followed by another path expression or a static value in quotes.

Examples:

- foo
- {.foo||"none"}
- foo_{.bar||"none"}
- foo_bar{.baz."foo/bar"||.foo||"missing"}

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5745

