### PR TITLE
LOG-5787: The migration process doesn't work.

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -102,6 +102,8 @@ const (
 	// AnnotationCRConverted is the annotation specifying whether a ClusterLogging and/or
 	// logging.ClusterLogForwarder has been converted to observability.ClusterLogForwarder
 	AnnotationCRConverted = "logging.openshift.io/converted"
+	// AnnotationNeedsMigration is the annotation to mark an existing resource for migration
+	AnnotationNeedsMigration = "logging.openshift.io/needs-migrations"
 
 	// K8s recommended label names: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 	LabelK8sName      = "app.kubernetes.io/name"       // The name of the application (string)

--- a/internal/controller/event_filter.go
+++ b/internal/controller/event_filter.go
@@ -1,36 +1,53 @@
 package controller
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// IgnoreMigratedResources filters and ignores events for the specified annotation
-// It also ignores create events
-func IgnoreMigratedResources(annotation string) predicate.Predicate {
+// IgnoreMigratedResources filters and ignores events related to migration from logging.openshift.io to observability.openshift.io
+// It ignores create events except for the initial start up when existing resources are available.
+func IgnoreMigratedResources() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			// Ignore if generation does not change (status updates)
 			if e.ObjectOld.GetGeneration() == e.ObjectNew.GetGeneration() {
 				return false
 			}
-			if status, ok := e.ObjectNew.GetAnnotations()[annotation]; ok {
+
+			// Ignore already converted resources
+			if status, ok := e.ObjectNew.GetAnnotations()[constants.AnnotationCRConverted]; ok {
 				return !(status == "true")
 			}
-			return true
+
+			// Only allow updates to existing resources
+			// Example: If a user removes fluentDForward from an existing resource, should convert to the new API
+			// Disallows when a user creates a new resource and update it
+			if needsMigration, ok := e.ObjectNew.GetAnnotations()[constants.AnnotationNeedsMigration]; ok {
+				return needsMigration == "true"
+			}
+
+			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			if status, ok := e.Object.GetAnnotations()[annotation]; ok {
+			if status, ok := e.Object.GetAnnotations()[constants.AnnotationCRConverted]; ok {
 				return !(status == "true")
 			}
 			return true
 		},
 		// Do not allow create events to trigger
 		CreateFunc: func(e event.CreateEvent) bool {
+			// When operator starts up, existing resources generate a "create" event
+			// ensure only existing resources get migrated through an annotation
+			if needsMigration, ok := e.Object.GetAnnotations()[constants.AnnotationNeedsMigration]; ok {
+				return needsMigration == "true"
+			}
 			return false
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			if status, ok := e.Object.GetAnnotations()[annotation]; ok {
+			if status, ok := e.Object.GetAnnotations()[constants.AnnotationCRConverted]; ok {
 				return !(status == "true")
 			}
 			return true


### PR DESCRIPTION
### Description
This PR addresses the migration of `logging.openshift.io` resources to the new `observability.openshift.io` API during the operator upgrade process.

When the operator starts, existing logging CLs and CLFs trigger a create event, prompting the operator to mark them with an annotation. This ensures that the controller will reconcile and migrate these resources to the new API.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5787

