### PR TITLE
LOG-5810: fix cloudwatch stream names

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -146,6 +146,7 @@ source = '''
 if .log_type == "audit" && .log_source == "auditd" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   del(.file)
   del(.source_type)
   match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
@@ -172,6 +173,7 @@ if .log_type == "audit" && .log_source == "auditd" {
 if .log_type == "audit" && .log_source == "kubeAPI" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   del(.file)
   del(.source_type)
   . = merge(., parse_json!(string!(.message))) ?? .
@@ -183,6 +185,7 @@ if .log_type == "audit" && .log_source == "kubeAPI" {
 if .log_type == "audit" && .log_source == "openshiftAPI" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   del(.file)
   del(.source_type)
   . = merge(., parse_json!(string!(.message))) ?? .
@@ -194,6 +197,7 @@ if .log_type == "audit" && .log_source == "openshiftAPI" {
 if .log_type == "audit" && .log_source == "ovn" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   del(.file)
   del(.source_type)
   if !exists(.level) {
@@ -222,6 +226,7 @@ if .log_type == "audit" && .log_source == "ovn" {
 if .log_source == "container" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
    if !exists(.level) {
     .level = "default"
     if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {
@@ -295,6 +300,7 @@ if .log_source == "container" {
 if .log_source == "node" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   .tag = ".journal.system"
 
   del(.source_type)

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -180,6 +180,7 @@ source = '''
 if .log_type == "audit" && .log_source == "auditd" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   del(.file)
   del(.source_type)
   match1 = parse_regex(.message, r'type=(?P<type>[^ ]+)') ?? {}
@@ -206,6 +207,7 @@ if .log_type == "audit" && .log_source == "auditd" {
 if .log_type == "audit" && .log_source == "kubeAPI" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   del(.file)
   del(.source_type)
   . = merge(., parse_json!(string!(.message))) ?? .
@@ -217,6 +219,7 @@ if .log_type == "audit" && .log_source == "kubeAPI" {
 if .log_type == "audit" && .log_source == "openshiftAPI" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   del(.file)
   del(.source_type)
   . = merge(., parse_json!(string!(.message))) ?? .
@@ -228,6 +231,7 @@ if .log_type == "audit" && .log_source == "openshiftAPI" {
 if .log_type == "audit" && .log_source == "ovn" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   del(.file)
   del(.source_type)
   if !exists(.level) {
@@ -256,6 +260,7 @@ if .log_type == "audit" && .log_source == "ovn" {
 if .log_source == "container" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
    if !exists(.level) {
     .level = "default"
     if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {
@@ -329,6 +334,7 @@ if .log_source == "container" {
 if .log_source == "node" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   .tag = ".journal.system"
 
   del(.source_type)

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -67,6 +67,7 @@ source = '''
 if .log_source == "container" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
    if !exists(.level) {
     .level = "default"
     if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {

--- a/internal/generator/vector/filter/openshift/viaq/common.go
+++ b/internal/generator/vector/filter/openshift/viaq/common.go
@@ -3,5 +3,8 @@ package viaq
 const (
 	ClusterID         = `.openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"`
 	FixTimestampField = `ts = del(.timestamp); if !exists(."@timestamp") {."@timestamp" = ts}`
-	InternalContext   = `._internal.message = .message`
+	InternalContext   = `
+._internal.message = .message
+._internal.file = .file
+`
 )

--- a/internal/generator/vector/output/cloudwatch/cloudwatch.go
+++ b/internal/generator/vector/output/cloudwatch/cloudwatch.go
@@ -138,9 +138,8 @@ func NormalizeStreamName(componentID string, inputs []string) Element {
 	vrl := strings.TrimSpace(`
 .stream_name = "default"
 
-if (.file != null) {
- .file = "kubernetes" + replace!(.file, "/", ".")
- .stream_name = del(.file)
+if ( ._internal.file != null) {
+ .stream_name = "kubernetes" + replace!(._internal.file, "/", ".")
 }
 
 if ( .log_type == "audit" ) {

--- a/internal/generator/vector/output/cloudwatch/cw_groupname_with_aws_credentials.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_groupname_with_aws_credentials.toml
@@ -5,9 +5,8 @@ inputs = ["cw-forward"]
 source = '''
   .stream_name = "default"
 
-  if (.file != null) {
-   .file = "kubernetes" + replace!(.file, "/", ".")
-   .stream_name = del(.file)
+  if ( ._internal.file != null) {
+   .stream_name = "kubernetes" + replace!(._internal.file, "/", ".")
   }
 
   if ( .log_type == "audit" ) {

--- a/internal/generator/vector/output/cloudwatch/cw_with_groupname.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_groupname.toml
@@ -5,9 +5,8 @@ inputs = ["cw-forward"]
 source = '''
   .stream_name = "default"
 
-  if (.file != null) {
-   .file = "kubernetes" + replace!(.file, "/", ".")
-   .stream_name = del(.file)
+  if ( ._internal.file != null) {
+   .stream_name = "kubernetes" + replace!(._internal.file, "/", ".")
   }
 
   if ( .log_type == "audit" ) {

--- a/internal/generator/vector/output/cloudwatch/cw_with_tls_and_default_mintls_ciphers.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_tls_and_default_mintls_ciphers.toml
@@ -5,9 +5,8 @@ inputs = ["cw-forward"]
 source = '''
   .stream_name = "default"
 
-  if (.file != null) {
-   .file = "kubernetes" + replace!(.file, "/", ".")
-   .stream_name = del(.file)
+  if ( ._internal.file != null) {
+   .stream_name = "kubernetes" + replace!(._internal.file, "/", ".")
   }
 
   if ( .log_type == "audit" ) {

--- a/internal/generator/vector/output/cloudwatch/cw_with_tls_spec.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_tls_spec.toml
@@ -5,9 +5,8 @@ inputs = ["cw-forward"]
 source = '''
   .stream_name = "default"
 
-  if (.file != null) {
-   .file = "kubernetes" + replace!(.file, "/", ".")
-   .stream_name = del(.file)
+  if ( ._internal.file != null) {
+   .stream_name = "kubernetes" + replace!(._internal.file, "/", ".")
   }
 
   if ( .log_type == "audit" ) {

--- a/internal/generator/vector/output/cloudwatch/cw_with_tls_spec_insecure_verify.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_tls_spec_insecure_verify.toml
@@ -5,9 +5,8 @@ inputs = ["cw-forward"]
 source = '''
   .stream_name = "default"
 
-  if (.file != null) {
-   .file = "kubernetes" + replace!(.file, "/", ".")
-   .stream_name = del(.file)
+  if ( ._internal.file != null) {
+   .stream_name = "kubernetes" + replace!(._internal.file, "/", ".")
   }
 
   if ( .log_type == "audit" ) {

--- a/internal/generator/vector/output/cloudwatch/cw_with_url.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_url.toml
@@ -5,9 +5,8 @@ inputs = ["cw-forward"]
 source = '''
   .stream_name = "default"
 
-  if (.file != null) {
-   .file = "kubernetes" + replace!(.file, "/", ".")
-   .stream_name = del(.file)
+  if ( ._internal.file != null) {
+   .stream_name = "kubernetes" + replace!(._internal.file, "/", ".")
   }
 
   if ( .log_type == "audit" ) {

--- a/internal/generator/vector/pipeline/adapter_test_drop_filter.toml
+++ b/internal/generator/vector/pipeline/adapter_test_drop_filter.toml
@@ -13,6 +13,7 @@ source = '''
 if .log_source == "container" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
    if !exists(.level) {
     .level = "default"
     if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {
@@ -86,6 +87,7 @@ if .log_source == "container" {
 if .log_source == "node" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   .tag = ".journal.system"
 
   del(.source_type)

--- a/internal/generator/vector/pipeline/adapter_test_kube_api_filter.toml
+++ b/internal/generator/vector/pipeline/adapter_test_kube_api_filter.toml
@@ -5,6 +5,7 @@ source = '''
 if .log_type == "audit" && .log_source == "kubeAPI" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
   del(.file)
   del(.source_type)
   . = merge(., parse_json!(string!(.message))) ?? .

--- a/internal/generator/vector/pipeline/adapter_test_prune_inNotIn_filter.toml
+++ b/internal/generator/vector/pipeline/adapter_test_prune_inNotIn_filter.toml
@@ -5,6 +5,7 @@ source = '''
 if .log_source == "container" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
    if !exists(.level) {
     .level = "default"
     if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {

--- a/internal/generator/vector/pipeline/adapter_test_prune_inOnly_filter.toml
+++ b/internal/generator/vector/pipeline/adapter_test_prune_inOnly_filter.toml
@@ -5,6 +5,7 @@ source = '''
 if .log_source == "container" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
    if !exists(.level) {
     .level = "default"
     if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {

--- a/internal/generator/vector/pipeline/adapter_test_prune_notIn_only_filter.toml
+++ b/internal/generator/vector/pipeline/adapter_test_prune_notIn_only_filter.toml
@@ -5,6 +5,7 @@ source = '''
 if .log_source == "container" {
   .openshift.cluster_id = "${OPENSHIFT_CLUSTER_ID:-}"
   ._internal.message = .message
+  ._internal.file = .file
    if !exists(.level) {
     .level = "default"
     if match!(.message, r'Warning|WARN|^W[0-9]+|level=warn|Value:warn|"level":"warn"|<warn>') {


### PR DESCRIPTION
### Description
All app logs in cloudwatch had their stream_name set to default.    This was caused by the `del(.file)` we are putting in each log_type filter.     I've created `._internal.file` to store the filename and modified the cloudwatch stream_name assignment.   
Two small changes, then the remaining files are .toml files for testing.

note: No records are dropped if either of these fields (.file, .message) is not present.  I am curious though, what other sinks could have been sending .file previously?  other output types?



/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
https://issues.redhat.com/browse/LOG-5807
