### PR TITLE
LOG-5745: Forwarding logs to cloudwatch with groupName {{.kubernetes.namespace_name}}, only container logs can be forwarded.

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -301,9 +301,15 @@ type Cloudwatch struct {
 	Region string `json:"region"`
 
 	// GroupName defines the strategy for grouping logstreams
+	// The GroupName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	// Example:
+	// 1. foo-{.bar||"none"}
+	// 2. {.foo||.bar||"missing"}
+	// 3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
 	//
-	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")*((\|\|)?(\.[a-zA-Z0-9_]+|\.?"[^"]+"))*\})*)*$`
-	// +kubebuilder:default:=`{.log_type||"none"}`
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
 	// +kubebuilder:validation:Required
 	GroupName string `json:"groupName"`
 }

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1045,10 +1045,17 @@ spec:
                           - type
                           type: object
                         groupName:
-                          default: '{.log_type||"none"}'
-                          description: GroupName defines the strategy for grouping
-                            logstreams
-                          pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")*((\|\|)?(\.[a-zA-Z0-9_]+|\.?"[^"]+"))*\})*)*$
+                          description: 'GroupName defines the strategy for grouping
+                            logstreams The GroupName can be a combination of static
+                            and dynamic values consisting of field paths followed
+                            by `||` followed by another field path or a static value.
+                            A dynamic value is encased in single curly brackets `{}`
+                            and MUST end with a static fallback value separated with
+                            `||`. Static values can only contain alphanumeric characters
+                            along with dashes, underscores, dots and forward slashes.
+                            Example: 1. foo-{.bar||"none"} 2. {.foo||.bar||"missing"}
+                            3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}'
+                          pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         region:
                           type: string

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1046,10 +1046,17 @@ spec:
                           - type
                           type: object
                         groupName:
-                          default: '{.log_type||"none"}'
-                          description: GroupName defines the strategy for grouping
-                            logstreams
-                          pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")*((\|\|)?(\.[a-zA-Z0-9_]+|\.?"[^"]+"))*\})*)*$
+                          description: 'GroupName defines the strategy for grouping
+                            logstreams The GroupName can be a combination of static
+                            and dynamic values consisting of field paths followed
+                            by `||` followed by another field path or a static value.
+                            A dynamic value is encased in single curly brackets `{}`
+                            and MUST end with a static fallback value separated with
+                            `||`. Static values can only contain alphanumeric characters
+                            along with dashes, underscores, dots and forward slashes.
+                            Example: 1. foo-{.bar||"none"} 2. {.foo||.bar||"missing"}
+                            3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}'
+                          pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         region:
                           type: string


### PR DESCRIPTION
### Description
This PR fixes the validation for `Cloudwatch's` `groupName`. 
This validation ensures that fallback values are included if `groupName` contains `{}` to indicate dynamic fields. 

A dynamic value MUST end with a static string not just another field.

#### Examples:
Valid:
1. {.foo||"none"}
2. {.foo||.bar||"missing"}
3. {.kubernetes.namespace_name||.log_type||"foo"}

Invalid:
1. {.foo}
2. {.bar||.baz}

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5745

