### PR TITLE
LOG-5787: The migration process doesn't work.

### DIFF
--- a/internal/controller/clusterlogging/clusterlogging_controller.go
+++ b/internal/controller/clusterlogging/clusterlogging_controller.go
@@ -132,6 +132,9 @@ func AnnotateLoggingClusterLoggings(k8sClient client.Client, apiReader client.Re
 		return err
 	}
 	for _, cl := range clList.Items {
+		if cl.Annotations == nil {
+			cl.Annotations = map[string]string{}
+		}
 		cl.Annotations[constants.AnnotationNeedsMigration] = "true"
 		if err := k8sClient.Update(context.TODO(), &cl); err != nil {
 			return err

--- a/internal/controller/forwarding/forwarding_controller.go
+++ b/internal/controller/forwarding/forwarding_controller.go
@@ -142,6 +142,9 @@ func AnnotateLoggingClusterLogForwarders(k8sClient client.Client, apiReader clie
 	}
 
 	for _, clf := range clfList.Items {
+		if clf.Annotations == nil {
+			clf.Annotations = map[string]string{}
+		}
 		clf.Annotations[constants.AnnotationNeedsMigration] = "true"
 		if err := k8sClient.Update(context.TODO(), &clf); err != nil {
 			return err


### PR DESCRIPTION
### Description
This PR adds a nil check for annotations on `ClusterLogging` and `ClusterLogForwarders` and initializes the map if the annotations are empty before marking existing resources.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5787

