### PR TITLE
LOG-5640: Add validation to reject when CW outputs spec different IAM Role

### DIFF
--- a/internal/validations/observability/outputs/cloudwatch_test.go
+++ b/internal/validations/observability/outputs/cloudwatch_test.go
@@ -1,92 +1,78 @@
 package outputs
 
 import (
+	"github.com/golang-collections/collections/set"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("validating CloudWatch auth", func() {
 	Context("#ValidateCloudWatchAuth", func() {
 
-		It("should skip validation when not CloudWatch", func() {
-			spec := obs.OutputSpec{
-				Name: "myoutput",
-				Type: obs.OutputTypeLoki,
+		var (
+			myRoleArn    = "arn:aws:iam::123456789012:role/my-role-to-assume"
+			otherRoleArn = "arn:aws:iam::123456789012:role/other-role-to-assume"
+			spec         = obs.OutputSpec{
+				Name: "output",
+				Type: obs.OutputTypeCloudwatch,
+				Cloudwatch: &obs.Cloudwatch{
+					Authentication: &obs.CloudwatchAuthentication{
+						Type: obs.CloudwatchAuthTypeIAMRole,
+						IAMRole: &obs.CloudwatchIAMRole{
+							RoleARN: &obs.SecretReference{
+								SecretName: "foo",
+								Key:        constants.AWSCredentialsKey,
+							},
+						},
+					},
+				},
 			}
-			Expect(ValidateCloudWatchAuth(spec)).To(BeEmpty())
+
+			fooSecret = &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "foo",
+				},
+				Data: map[string][]byte{
+					constants.AWSCredentialsKey: []byte(myRoleArn),
+				},
+			}
+			context = internalcontext.ForwarderContext{
+				Forwarder: &obs.ClusterLogForwarder{
+					Spec: obs.ClusterLogForwarderSpec{
+						Outputs: []obs.OutputSpec{spec},
+					},
+				},
+				Secrets: map[string]*corev1.Secret{
+					fooSecret.Name: fooSecret,
+				},
+			}
+		)
+
+		It("should fail validation if meet different Role ARN", func() {
+			roleARNs := set.New(otherRoleArn)
+			context.AdditionalContext = utils.Options{
+				RoleARNsOpt: roleARNs,
+			}
+			res := ValidateCloudWatchAuth(spec, context)
+			Expect(res).ToNot(BeEmpty())
+			Expect(len(res)).To(BeEquivalentTo(1))
+			Expect(res[0]).To(BeEquivalentTo(ErrVariousRoleARNAuth))
 		})
 
-		DescribeTable("when using accessKey", func(auth *obs.CloudwatchAWSAccessKey, match types.GomegaMatcher) {
-			spec := obs.OutputSpec{
-				Name: "myoutput",
-				Type: obs.OutputTypeCloudwatch,
-				Cloudwatch: &obs.Cloudwatch{
-					Authentication: &obs.CloudwatchAuthentication{
-						Type:         obs.CloudwatchAuthTypeAccessKey,
-						AWSAccessKey: auth,
-					},
-				},
+		It("should pass validation if Role ARNs are equals", func() {
+			roleARNs := set.New(myRoleArn)
+			context.AdditionalContext = utils.Options{
+				RoleARNsOpt: roleARNs,
 			}
-			cond := ValidateCloudWatchAuth(spec)
-			Expect(cond).To(match)
-		},
-			Entry("should fail when not defined", nil, ContainElement(MatchRegexp(`AccessKey is nil`))),
-			Entry("should fail when the KeyID is not defined", &obs.CloudwatchAWSAccessKey{
-				KeySecret: &obs.SecretReference{},
-			}, ContainElement(MatchRegexp(`KeyID.*`))),
-			Entry("should fail when the KeySecret is not defined", &obs.CloudwatchAWSAccessKey{
-				KeyID: &obs.SecretReference{},
-			}, ContainElement(MatchRegexp(`KeySecret.*`))),
-			Entry("should pass when all required fields are defined",
-				&obs.CloudwatchAWSAccessKey{
-					KeyID:     &obs.SecretReference{},
-					KeySecret: &obs.SecretReference{},
-				},
-				BeEmpty()),
-		)
-		DescribeTable("when using IAMRole", func(auth *obs.CloudwatchIAMRole, match types.GomegaMatcher) {
-			spec := obs.OutputSpec{
-				Name: "myoutput",
-				Type: obs.OutputTypeCloudwatch,
-				Cloudwatch: &obs.Cloudwatch{
-					Authentication: &obs.CloudwatchAuthentication{
-						Type:    obs.CloudwatchAuthTypeIAMRole,
-						IAMRole: auth,
-					},
-				},
-			}
-			cond := ValidateCloudWatchAuth(spec)
-			Expect(cond).To(match)
-		},
-			Entry("should fail when not defined", nil, ContainElement(MatchRegexp(`IAMRole is nil`))),
-			Entry("should fail when the role_arn is not defined", &obs.CloudwatchIAMRole{
-				Token: &obs.BearerToken{},
-			}, ContainElement(MatchRegexp(`RoleARN.*`))),
-			Entry("should pass when the role_arn is defined without a token", &obs.CloudwatchIAMRole{
-				RoleARN: &obs.SecretReference{},
-			}, BeEmpty()),
-			Entry("should fail when the token is sourced from a secret without the secreting being defined", &obs.CloudwatchIAMRole{
-				RoleARN: &obs.SecretReference{},
-				Token: &obs.BearerToken{
-					From: obs.BearerTokenFromSecret,
-				},
-			}, ContainElement(MatchRegexp(`Secret for token.*`))),
-			Entry("should pass when the token is from a secret and role_arn are defined", &obs.CloudwatchIAMRole{
-				RoleARN: &obs.SecretReference{},
-				Token: &obs.BearerToken{
-					From:   obs.BearerTokenFromSecret,
-					Secret: &obs.BearerTokenSecretKey{},
-				},
-			}, BeEmpty()),
-			Entry("should pass when the token is from a serviceaccount and role are defined", &obs.CloudwatchIAMRole{
-				RoleARN: &obs.SecretReference{},
-				Token: &obs.BearerToken{
-					From: obs.BearerTokenFromServiceAccount,
-				},
-			}, BeEmpty()),
-		)
+			res := ValidateCloudWatchAuth(spec, context)
+			Expect(res).To(BeEmpty())
+		})
+
 	})
 })

--- a/internal/validations/observability/outputs/validate.go
+++ b/internal/validations/observability/outputs/validate.go
@@ -2,7 +2,7 @@ package outputs
 
 import (
 	"fmt"
-	obsv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
 	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
 	"github.com/openshift/cluster-logging-operator/internal/validations/observability/common"
@@ -18,20 +18,20 @@ func Validate(context internalcontext.ForwarderContext) {
 		messages := common.ValidateValueReference(configs, context.Secrets, context.ConfigMaps)
 		// Validate by output type
 		switch out.Type {
-		case obsv1.OutputTypeCloudwatch:
-			messages = append(messages, ValidateCloudWatchAuth(out)...)
-		case obsv1.OutputTypeHTTP:
+		case obs.OutputTypeCloudwatch:
+			messages = append(messages, ValidateCloudWatchAuth(out, context)...)
+		case obs.OutputTypeHTTP:
 			messages = append(messages, validateHttpContentTypeHeaders(out)...)
-		case obsv1.OutputTypeOTLP:
+		case obs.OutputTypeOTLP:
 			messages = append(messages, ValidateOtlpAnnotation(context)...)
 		}
 		// Set condition
 		if len(messages) > 0 {
 			internalobs.SetCondition(&context.Forwarder.Status.Outputs,
-				internalobs.NewConditionFromPrefix(obsv1.ConditionTypeValidOutputPrefix, out.Name, false, obsv1.ReasonValidationFailure, strings.Join(messages, ",")))
+				internalobs.NewConditionFromPrefix(obs.ConditionTypeValidOutputPrefix, out.Name, false, obs.ReasonValidationFailure, strings.Join(messages, ",")))
 		} else {
 			internalobs.SetCondition(&context.Forwarder.Status.Outputs,
-				internalobs.NewConditionFromPrefix(obsv1.ConditionTypeValidOutputPrefix, out.Name, true, obsv1.ReasonValidationSuccess, fmt.Sprintf("output %q is valid", out.Name)))
+				internalobs.NewConditionFromPrefix(obs.ConditionTypeValidOutputPrefix, out.Name, true, obs.ReasonValidationSuccess, fmt.Sprintf("output %q is valid", out.Name)))
 		}
 	}
 }

--- a/internal/validations/observability/outputs/validate_test.go
+++ b/internal/validations/observability/outputs/validate_test.go
@@ -1,0 +1,139 @@
+package outputs
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Validating multiple CloudWatch outputs auth", func() {
+
+	var (
+		foo = "foo"
+		bar = "bar"
+
+		myRoleArn    = "arn:aws:iam::123456789012:role/my-role-to-assume"
+		otherRoleArn = "arn:aws:iam::123456789012:role/other-role-to-assume"
+
+		fooSecret = &corev1.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      foo,
+				Namespace: constants.OpenshiftNS,
+			},
+			Data: map[string][]byte{
+				constants.AWSSecretAccessKey: []byte("some-key"),
+				constants.AWSAccessKeyID:     []byte("some-key-id"),
+				constants.AWSCredentialsKey:  []byte(myRoleArn),
+			},
+		}
+
+		barSecret = &corev1.Secret{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      bar,
+				Namespace: constants.OpenshiftNS,
+			},
+			Data: map[string][]byte{
+				constants.AWSSecretAccessKey: []byte("other-key"),
+				constants.AWSAccessKeyID:     []byte("other-key-id"),
+				constants.AWSCredentialsKey:  []byte(otherRoleArn),
+			},
+		}
+	)
+
+	// Helper function to create context
+	createContext := func(outputs []obs.OutputSpec) internalcontext.ForwarderContext {
+		return internalcontext.ForwarderContext{
+			Forwarder: &obs.ClusterLogForwarder{
+				Spec: obs.ClusterLogForwarderSpec{
+					Outputs: outputs,
+				},
+			},
+			Secrets: map[string]*corev1.Secret{
+				fooSecret.Name: fooSecret,
+				barSecret.Name: barSecret,
+			},
+			AdditionalContext: utils.Options{},
+		}
+	}
+
+	// Helper function to create CloudWatch output spec with AccessKey auth
+	createAccessKeySpec := func(name, secretName string) obs.OutputSpec {
+		return obs.OutputSpec{
+			Name: name,
+			Type: obs.OutputTypeCloudwatch,
+			Cloudwatch: &obs.Cloudwatch{
+				Authentication: &obs.CloudwatchAuthentication{
+					Type: obs.CloudwatchAuthTypeAccessKey,
+					AWSAccessKey: &obs.CloudwatchAWSAccessKey{
+						KeySecret: &obs.SecretReference{
+							SecretName: secretName,
+							Key:        constants.AWSSecretAccessKey,
+						},
+						KeyID: &obs.SecretReference{
+							SecretName: secretName,
+							Key:        constants.AWSAccessKeyID,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// Helper function to create CloudWatch output spec with IAMRole auth
+	createIAMRoleSpec := func(name, secretName string) obs.OutputSpec {
+		return obs.OutputSpec{
+			Name: name,
+			Type: obs.OutputTypeCloudwatch,
+			Cloudwatch: &obs.Cloudwatch{
+				Authentication: &obs.CloudwatchAuthentication{
+					Type: obs.CloudwatchAuthTypeIAMRole,
+					IAMRole: &obs.CloudwatchIAMRole{
+						RoleARN: &obs.SecretReference{
+							SecretName: secretName,
+							Key:        constants.AWSCredentialsKey,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	Context("", func() {
+		DescribeTable("",
+			func(outputs []obs.OutputSpec, expectedMessages []string) {
+				context := createContext(outputs)
+				Validate(context)
+				Expect(context.Forwarder.Status.Outputs).To(HaveLen(len(outputs)))
+				for i, message := range expectedMessages {
+					Expect(context.Forwarder.Status.Outputs[i].Message).To(ContainSubstring(message))
+				}
+			},
+			Entry("should accept multiple CloudWatch outputs with different static keys",
+				[]obs.OutputSpec{createAccessKeySpec("output1", foo), createAccessKeySpec("output2", bar)},
+				[]string{"is valid", "is valid"},
+			),
+			Entry("should accept CloudWatch outputs with one static key and one IAM role",
+				[]obs.OutputSpec{createAccessKeySpec("output1", foo), createIAMRoleSpec("output2", foo)},
+				[]string{"is valid", "is valid"},
+			),
+			Entry("should accept multiple CloudWatch outputs with same IAM role",
+				[]obs.OutputSpec{createIAMRoleSpec("output1", foo), createIAMRoleSpec("output2", foo)},
+				[]string{"is valid", "is valid"},
+			),
+			Entry("should reject multiple CloudWatch outputs with different IAM roles",
+				[]obs.OutputSpec{createIAMRoleSpec("output1", foo), createIAMRoleSpec("output2", bar)},
+				[]string{"is valid", ErrVariousRoleARNAuth},
+			),
+			Entry("should reject multiple CloudWatch outputs with different IAM roles and static key",
+				[]obs.OutputSpec{createIAMRoleSpec("output1", foo), createAccessKeySpec("output2", bar), createIAMRoleSpec("output3", bar)},
+				[]string{"is valid", "is valid", ErrVariousRoleARNAuth},
+			),
+		)
+	})
+})


### PR DESCRIPTION
### Description

- added validation to reject when CW outputs spec different IAM Role
- removed not needed code in favor of kubebuilder validation, introduced #2651

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5804
- Enhancement proposal:
