### PR TITLE
[LOG-5151] Remove `toml` private data

### DIFF
--- a/must-gather/collection-scripts/gather_cluster_logging_operator_resources
+++ b/must-gather/collection-scripts/gather_cluster_logging_operator_resources
@@ -43,7 +43,7 @@ secret_names=$(oc -n $NAMESPACE get secrets -o custom-columns=:.metadata.name | 
 for name in ${secret_names[@]}; do
   data=$(oc -n $NAMESPACE get secret ${name} -o jsonpath='{.data.vector\.toml}' --ignore-not-found)
   if [ "$data" != "" ] ; then
-    echo $data | base64 -d > ${clo_folder}/${name}_vector.toml 2>&1
+    echo $data | base64 -d | awk '{ if ($1~/access_key/) { print $1 " = xxxxxxxx" } else { print }}' > ${clo_folder}/${name}_vector.toml 2>&1
   fi
 done
 


### PR DESCRIPTION
### Description
Remove `toml` private data based on the example in [LOG-5151](https://issues.redhat.com//browse/LOG-5151).
This complements the PR for removing the RAW `secrets`: PR #2317.


/cc cahartma
/assign cahartma

/cherry-pick 5.9
/cherry-pick 5.8

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5151
