### PR TITLE
LOG-5131: Backwards-compatible telemetry implementation for new API

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	log "github.com/ViaQ/logerr/v2/log/static"
 
 	apis "github.com/openshift/cluster-logging-operator/api"
+	"github.com/openshift/cluster-logging-operator/internal/metrics/telemetry"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/version"
 
@@ -38,6 +39,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
@@ -53,13 +55,8 @@ import (
 	loggingruntime "github.com/openshift/cluster-logging-operator/internal/runtime"
 )
 
-// Change below variables to serve metrics on different host or port.
 var (
 	scheme = apiruntime.NewScheme()
-)
-
-const (
-	UnHealthyStatus = "0"
 )
 
 func init() {
@@ -221,7 +218,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO initialize new telemetry implementation here
+	if err := telemetry.Setup(context.TODO(), mgr.GetClient(), metrics.Registry, version.Version); err != nil {
+		log.Error(err, "Error registering telemetry metrics")
+	}
 
 	log.Info("Starting the Cmd.")
 	// Start the Cmd

--- a/internal/metrics/telemetry/cluster_log_forwarder.go
+++ b/internal/metrics/telemetry/cluster_log_forwarder.go
@@ -1,0 +1,44 @@
+package telemetry
+
+import (
+	observabilityv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
+)
+
+func gatherForwarderInfo(forwarder *observabilityv1.ClusterLogForwarder) (pipelines uint, inputs, outputs []string) {
+	inputs = makeZeroStrings(len(forwarderInputTypes))
+	outputs = makeZeroStrings(len(forwarderOutputTypes))
+
+	outputMap := internalobs.Outputs(forwarder.Spec.Outputs).Map()
+
+	activeInputNames := map[string]bool{}
+	activeOutputTypes := map[string]bool{}
+	for _, pipeline := range forwarder.Spec.Pipelines {
+		for _, inputName := range pipeline.InputRefs {
+			activeInputNames[inputName] = true
+		}
+
+		for _, outputName := range pipeline.OutputRefs {
+			output, found := outputMap[outputName]
+			if found {
+				activeOutputTypes[string(output.Type)] = true
+			}
+		}
+	}
+
+	pipelines = uint(len(forwarder.Spec.Pipelines))
+
+	for i, v := range forwarderInputTypes {
+		if activeInputNames[v] {
+			inputs[i] = boolYes
+		}
+	}
+
+	for i, v := range forwarderOutputTypes {
+		if activeOutputTypes[v] {
+			outputs[i] = boolYes
+		}
+	}
+
+	return pipelines, inputs, outputs
+}

--- a/internal/metrics/telemetry/collector.go
+++ b/internal/metrics/telemetry/collector.go
@@ -1,0 +1,147 @@
+package telemetry
+
+import (
+	"context"
+	"strconv"
+
+	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/api/logging/v1alpha1"
+	observabilityv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/status"
+
+	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	boolYes = "1"
+	boolNo  = "0"
+)
+
+type telemetryCollector struct {
+	ctx     context.Context
+	client  client.Client
+	version string
+}
+
+func newTelemetryCollector(ctx context.Context, k8sClient client.Client, version string) *telemetryCollector {
+	return &telemetryCollector{
+		ctx:     ctx,
+		client:  k8sClient,
+		version: version,
+	}
+}
+
+var _ prometheus.Collector = &telemetryCollector{}
+
+func (t *telemetryCollector) Describe(descs chan<- *prometheus.Desc) {
+	descs <- clusterLogForwarderDesc
+	descs <- forwarderInputInfoDesc
+	descs <- forwarderOutputInfoDesc
+	descs <- logFileMetricExporterInfoDesc
+}
+
+func (t *telemetryCollector) Collect(m chan<- prometheus.Metric) {
+	if err := t.collectForwarder(m); err != nil {
+		log.V(1).Error(err, "Error collecting telemetry for cluster log forwarders")
+	}
+
+	if err := t.collectLogFileMetricExporter(m); err != nil {
+		log.V(1).Error(err, "Error collecting telemetry for LogFileMetricExporter")
+	}
+}
+
+func (t *telemetryCollector) collectForwarder(m chan<- prometheus.Metric) error {
+	clfList := &observabilityv1.ClusterLogForwarderList{}
+	if err := t.client.List(t.ctx, clfList); err != nil {
+		return err
+	}
+
+	for _, clf := range clfList.Items {
+		healthy := hasReadyCondition(clf.Status.Conditions)
+		pipelines, inputs, outputs := gatherForwarderInfo(&clf)
+
+		t.collectForwarderMetrics(m, clf.Namespace, clf.Name, healthy, pipelines, inputs, outputs)
+	}
+
+	return nil
+}
+
+func (t *telemetryCollector) collectForwarderMetrics(m chan<- prometheus.Metric, namespace, name string, healthy bool, pipelines uint, inputs, outputs []string) {
+	m <- prometheus.MustNewConstMetric(clusterLogForwarderDesc, prometheus.GaugeValue, 1.0,
+		namespace, name, boolLabel(healthy), uintLabel(pipelines))
+
+	inputLabels := append([]string{namespace, name}, inputs...)
+	m <- prometheus.MustNewConstMetric(forwarderInputInfoDesc, prometheus.GaugeValue, 1.0, inputLabels...)
+
+	outputLabels := append([]string{namespace, name}, outputs...)
+	m <- prometheus.MustNewConstMetric(forwarderOutputInfoDesc, prometheus.GaugeValue, 1.0, outputLabels...)
+}
+
+func (t *telemetryCollector) collectLogFileMetricExporter(m chan<- prometheus.Metric) error {
+	lfmeList := &loggingv1alpha1.LogFileMetricExporterList{}
+	if err := t.client.List(t.ctx, lfmeList); err != nil {
+		return err
+	}
+
+	deployed := false
+	healthy := false
+
+	for _, lfme := range lfmeList.Items {
+		if lfme.Namespace != constants.OpenshiftNS || lfme.Name != constants.SingletonName {
+			// Only singleton instance is valid
+			continue
+		}
+
+		deployed = true
+		healthy = hasLegacyReadyCondition(lfme.Status.Conditions)
+	}
+
+	m <- prometheus.MustNewConstMetric(logFileMetricExporterInfoDesc, prometheus.GaugeValue, 1.0, boolLabel(deployed), boolLabel(healthy))
+	return nil
+}
+
+func boolLabel(value bool) string {
+	if value {
+		return boolYes
+	}
+
+	return boolNo
+}
+
+func uintLabel(value uint) string {
+	return strconv.FormatUint(uint64(value), 10)
+}
+
+func makeZeroStrings(length int) []string {
+	result := make([]string, length)
+	for i := range result {
+		result[i] = boolNo
+	}
+
+	return result
+}
+
+func hasLegacyReadyCondition(conditions status.Conditions) bool {
+	for _, c := range conditions {
+		if c.Type == loggingv1.ConditionReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasReadyCondition(conditions []metav1.Condition) bool {
+	for _, c := range conditions {
+		if c.Type == observabilityv1.ConditionTypeReady && c.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/metrics/telemetry/collector_test.go
+++ b/internal/metrics/telemetry/collector_test.go
@@ -1,0 +1,188 @@
+package telemetry
+
+import (
+	"context"
+	"strings"
+
+	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/api/logging/v1alpha1"
+	observabilityv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/status"
+	"github.com/openshift/cluster-logging-operator/internal/validations/clusterlogforwarder/conditions"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testVersion = "test-version"
+)
+
+var (
+	singletonMeta = metav1.ObjectMeta{
+		Name:      constants.SingletonName,
+		Namespace: constants.OpenshiftNS,
+	}
+)
+
+// Test if ServiceMonitor spec is correct or not, also Prometheus Metrics get Registered, Updated, Retrieved properly or not
+var _ = Describe("Telemetry Collector", func() {
+	When("Registering it to a Prometheus registry", func() {
+		It("should not return an error", func() {
+			k8s := fake.NewFakeClient()
+			collector := newTelemetryCollector(context.Background(), k8s, testVersion)
+			registry := prometheus.NewPedanticRegistry()
+
+			err := registry.Register(collector)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("Initializing a new collector", func() {
+		Context("with no resources in the Kubernetes cluster", func() {
+			It("should only provide LFME metric", func() {
+				wantMetrics := `# HELP log_file_metric_exporter_info Info metric containing information about usage the file metric exporter. Value is always 1.
+# TYPE log_file_metric_exporter_info gauge
+log_file_metric_exporter_info{deployed="0",healthStatus="0"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient()
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("with observabilityv1 ClusterLogForwarder present", func() {
+			It("should provide CLF and LFME metrics", func() {
+				clf := &observabilityv1.ClusterLogForwarder{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-name",
+					},
+					Spec: observabilityv1.ClusterLogForwarderSpec{
+						Outputs: []observabilityv1.OutputSpec{
+							{
+								Name: "output",
+								Type: observabilityv1.OutputTypeLokiStack,
+							},
+						},
+						Pipelines: []observabilityv1.PipelineSpec{
+							{
+								Name: "pipeline",
+								InputRefs: []string{
+									"application",
+									"infrastructure",
+								},
+								OutputRefs: []string{
+									"output",
+								},
+							},
+						},
+					},
+					Status: observabilityv1.ClusterLogForwarderStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   observabilityv1.ConditionTypeReady,
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				}
+				wantMetrics := `# HELP log_file_metric_exporter_info Info metric containing information about usage the file metric exporter. Value is always 1.
+# TYPE log_file_metric_exporter_info gauge
+log_file_metric_exporter_info{deployed="0",healthStatus="0"} 1
+# HELP log_forwarder_input_info Info metric containing information about usage of pre-defined input names. Value is always 1.
+# TYPE log_forwarder_input_info gauge
+log_forwarder_input_info{application="1",audit="0",infrastructure="1",receiver="0",resource_name="test-name",resource_namespace="test-namespace"} 1
+# HELP log_forwarder_output_info Info metric containing information about usage of available output types. Value is always 1.
+# TYPE log_forwarder_output_info gauge
+log_forwarder_output_info{azureMonitor="0",cloudwatch="0",elasticsearch="0",googleCloudLogging="0",http="0",kafka="0",loki="0",lokiStack="1",otlp="0",resource_name="test-name",resource_namespace="test-namespace",splunk="0",syslog="0"} 1
+# HELP log_forwarder_pipeline_info Info metric containing information about deployed forwarders. Value is always 1.
+# TYPE log_forwarder_pipeline_info gauge
+log_forwarder_pipeline_info{healthStatus="1",pipelineInfo="1",resource_name="test-name",resource_namespace="test-namespace"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient(clf)
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("with LogFileMetricExporter present", func() {
+			It("should show a ready and deployed exporter", func() {
+				lfme := &loggingv1alpha1.LogFileMetricExporter{
+					ObjectMeta: singletonMeta,
+					Status: loggingv1alpha1.LogFileMetricExporterStatus{
+						Conditions: []status.Condition{
+							conditions.CondReady,
+						},
+					},
+				}
+				wantMetrics := `# HELP log_file_metric_exporter_info Info metric containing information about usage the file metric exporter. Value is always 1.
+# TYPE log_file_metric_exporter_info gauge
+log_file_metric_exporter_info{deployed="1",healthStatus="1"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient(lfme)
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+
+			It("should show an unready status", func() {
+				lfme := &loggingv1alpha1.LogFileMetricExporter{
+					ObjectMeta: singletonMeta,
+				}
+				wantMetrics := `# HELP log_file_metric_exporter_info Info metric containing information about usage the file metric exporter. Value is always 1.
+# TYPE log_file_metric_exporter_info gauge
+log_file_metric_exporter_info{deployed="1",healthStatus="0"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient(lfme)
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+
+			It("should ignore non-singleton instances", func() {
+				lfme := &loggingv1alpha1.LogFileMetricExporter{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-name",
+					},
+				}
+				wantMetrics := `# HELP log_file_metric_exporter_info Info metric containing information about usage the file metric exporter. Value is always 1.
+# TYPE log_file_metric_exporter_info gauge
+log_file_metric_exporter_info{deployed="0",healthStatus="0"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient(lfme)
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+})

--- a/internal/metrics/telemetry/servicemonitor_test.go
+++ b/internal/metrics/telemetry/servicemonitor_test.go
@@ -1,0 +1,33 @@
+package telemetry
+
+import (
+	"os"
+	"path"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ServiceMonitor", func() {
+	var (
+		smYamlFile   string
+		manifestFile string
+	)
+
+	BeforeEach(func() {
+		mdir, _ := os.Getwd()
+		mdir = path.Dir(path.Dir(mdir))
+		smYamlFile = mdir + "/config/prometheus/servicemonitor.yaml"
+		manifestFile = mdir + "/bundle/manifests/cluster-logging-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml"
+	})
+
+	Describe("Testing ServiceMonitor Spec", func() {
+		Context("With config/prometheus/servicemonitor.yaml", func() {
+			It("Should generate bundle/manifests/cluster-logging-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml spec correctly", func() {
+				sm, _ := os.ReadFile(smYamlFile)
+				msm, _ := os.ReadFile(manifestFile)
+				Expect(sm).To(MatchYAML(msm))
+			})
+		})
+	})
+})

--- a/internal/metrics/telemetry/telemetry.go
+++ b/internal/metrics/telemetry/telemetry.go
@@ -1,0 +1,75 @@
+package telemetry
+
+import (
+	"context"
+
+	observabilityv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	labelResourceNamespace = "resource_namespace"
+	labelResourceName      = "resource_name"
+
+	labelHealthStatus = "healthStatus"
+	labelPipelineInfo = "pipelineInfo"
+	labelDeployed     = "deployed"
+
+	metricsPrefix = "log_"
+)
+
+var (
+	forwarderInputTypes  = convertInputs(observabilityv1.InputTypes)
+	forwarderOutputTypes = convertOutputs(observabilityv1.OutputTypes)
+
+	logFileMetricExporterInfoDesc = prometheus.NewDesc(
+		metricsPrefix+"file_metric_exporter_info",
+		"Info metric containing information about usage the file metric exporter. Value is always 1.",
+		[]string{labelDeployed, labelHealthStatus}, nil,
+	)
+
+	clusterLogForwarderDesc = prometheus.NewDesc(
+		metricsPrefix+"forwarder_pipeline_info",
+		"Info metric containing information about deployed forwarders. Value is always 1.",
+		[]string{labelResourceNamespace, labelResourceName, labelHealthStatus, labelPipelineInfo}, nil,
+	)
+	forwarderInputInfoDesc = prometheus.NewDesc(
+		metricsPrefix+"forwarder_input_info",
+		"Info metric containing information about usage of pre-defined input names. Value is always 1.",
+		append([]string{labelResourceNamespace, labelResourceName}, forwarderInputTypes...), nil,
+	)
+	forwarderOutputInfoDesc = prometheus.NewDesc(
+		metricsPrefix+"forwarder_output_info",
+		"Info metric containing information about usage of available output types. Value is always 1.",
+		append([]string{labelResourceNamespace, labelResourceName}, forwarderOutputTypes...), nil,
+	)
+)
+
+// Setup initializes the telemetry collector and registers it with the given Prometheus registry.
+func Setup(ctx context.Context, k8sClient client.Client, registry prometheus.Registerer, version string) error {
+	collector := newTelemetryCollector(ctx, k8sClient, version)
+
+	if err := registry.Register(collector); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func convertInputs(types []observabilityv1.InputType) []string {
+	result := make([]string, len(types))
+	for i, t := range types {
+		result[i] = string(t)
+	}
+	return result
+}
+
+func convertOutputs(types []observabilityv1.OutputType) []string {
+	result := make([]string, len(types))
+	for i, t := range types {
+		result[i] = string(t)
+	}
+	return result
+}

--- a/internal/metrics/telemetry/telemetry_test.go
+++ b/internal/metrics/telemetry/telemetry_test.go
@@ -1,0 +1,24 @@
+package telemetry
+
+import (
+	"testing"
+
+	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/api/logging/v1alpha1"
+	observabilityv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/test"
+
+	"k8s.io/client-go/kubernetes/scheme"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func init() {
+	test.Must(loggingv1alpha1.AddToScheme(scheme.Scheme))
+	test.Must(observabilityv1.AddToScheme(scheme.Scheme))
+}
+
+func TestTelemetry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "clo telemetry test")
+}


### PR DESCRIPTION
### Description

This PR reintroduces the telemetry metrics in the cluster-logging-operator. The implementation produces a set of metrics compatible with the previous CLO version. The label-set on the info-metrics for inputs/outputs is based on the available types of 6.x, so some labels are missing from the previous version and some are added (for example, the "default" output).

It does not create any metrics for `loggingv1.ClusterLogging` or `loggingv1.ClusterLogForwarder` instances, but the `loggingv1alpha1.LogFileMetricExporter` metric is still present.

### Links

- JIRA: [LOG-5131](https://issues.redhat.com//browse/LOG-5131)
