### PR TITLE
LOG-5846: fix filter name after migration according to spec

### DIFF
--- a/internal/migrations/observability/api/convert_test.go
+++ b/internal/migrations/observability/api/convert_test.go
@@ -374,7 +374,7 @@ var _ = Describe("#ConvertLoggingToObservability", func() {
 							},
 						},
 						{
-							Name:            "filter-app-logs-" + string(obs.FilterTypeOpenshiftLabels),
+							Name:            "filter-app-logs-" + openshiftLabelsFilterName,
 							Type:            obs.FilterTypeOpenshiftLabels,
 							OpenShiftLabels: map[string]string{"foo": "bar"},
 						},

--- a/internal/migrations/observability/api/filters.go
+++ b/internal/migrations/observability/api/filters.go
@@ -7,7 +7,8 @@ import (
 
 const (
 	parseFilterName                = "converted-filter-parse"
-	detectMultilineErrorFilterName = "converted-filter-detectMultilineError"
+	detectMultilineErrorFilterName = "converted-filter-detect-multiline-error"
+	openshiftLabelsFilterName      = "converted-openshift-labels"
 )
 
 // convertFilters maps logging.Filters to observability.Filters

--- a/internal/migrations/observability/api/filters_test.go
+++ b/internal/migrations/observability/api/filters_test.go
@@ -117,7 +117,7 @@ var _ = Describe("#ConvertFilters", func() {
 		)
 		loggingClfSpec.Filters = []logging.FilterSpec{
 			{
-				Name: "kubeApiAudit",
+				Name: "kube-api-audit",
 				Type: logging.FilterKubeAPIAudit,
 				FilterTypeSpec: logging.FilterTypeSpec{
 					KubeAPIAudit: &logging.KubeAPIAudit{
@@ -171,7 +171,7 @@ var _ = Describe("#ConvertFilters", func() {
 
 		expObsClfFilterSpec := []obs.FilterSpec{
 			{
-				Name: "kubeApiAudit",
+				Name: "kube-api-audit",
 				Type: logging.FilterKubeAPIAudit,
 				KubeAPIAudit: &obs.KubeAPIAudit{
 					Rules: []v1.PolicyRule{{

--- a/internal/migrations/observability/api/pipelines.go
+++ b/internal/migrations/observability/api/pipelines.go
@@ -96,7 +96,7 @@ func generatePipelineFilters(loggingPipelineSpec logging.PipelineSpec, createdFi
 		}
 	}
 	if len(loggingPipelineSpec.Labels) != 0 {
-		openshiftLabelFilterName := fmt.Sprintf("filter-%s-%s", loggingPipelineSpec.Name, string(obs.FilterTypeOpenshiftLabels))
+		openshiftLabelFilterName := fmt.Sprintf("filter-%s-%s", loggingPipelineSpec.Name, openshiftLabelsFilterName)
 		addedFilterRefs = append(addedFilterRefs, openshiftLabelFilterName)
 		obsFilter := &obs.FilterSpec{
 			Type:            obs.FilterTypeOpenshiftLabels,

--- a/internal/migrations/observability/api/pipelines_test.go
+++ b/internal/migrations/observability/api/pipelines_test.go
@@ -27,7 +27,7 @@ var _ = Describe("#ConvertPipelines", func() {
 		Expect(actFilterRefs).To(Equal(expObsFilterRefs))
 	},
 		Entry("should generate detect multiline error as a filter and filterRef", logging.PipelineSpec{
-			Name:                  "detectPipeline",
+			Name:                  "detect-pipeline",
 			DetectMultilineErrors: true,
 		}, []obs.FilterSpec{
 			{
@@ -47,18 +47,18 @@ var _ = Describe("#ConvertPipelines", func() {
 		},
 			[]string{parseFilterName}),
 		Entry("should generate labels as a filter and filterRef", logging.PipelineSpec{
-			Name:   "labelPipeline",
+			Name:   "label-pipeline",
 			Labels: map[string]string{"foo": "bar"},
 		}, []obs.FilterSpec{
 			{
-				Name:            "filter-labelPipeline-openShiftLabels",
+				Name:            "filter-label-pipeline-" + openshiftLabelsFilterName,
 				Type:            obs.FilterTypeOpenshiftLabels,
 				OpenShiftLabels: map[string]string{"foo": "bar"},
 			},
 		},
-			[]string{"filter-labelPipeline-openShiftLabels"}),
+			[]string{"filter-label-pipeline-" + openshiftLabelsFilterName}),
 		Entry("should generate all pipeline filters and filterRefs", logging.PipelineSpec{
-			Name:                  "filterPipeline",
+			Name:                  "filter-pipeline",
 			Labels:                map[string]string{"foo": "bar"},
 			Parse:                 "json",
 			DetectMultilineErrors: true,
@@ -72,12 +72,12 @@ var _ = Describe("#ConvertPipelines", func() {
 				Type: obs.FilterTypeParse,
 			},
 			{
-				Name:            "filter-filterPipeline-openShiftLabels",
+				Name:            "filter-filter-pipeline-" + openshiftLabelsFilterName,
 				Type:            obs.FilterTypeOpenshiftLabels,
 				OpenShiftLabels: map[string]string{"foo": "bar"},
 			},
 		},
-			[]string{detectMultilineErrorFilterName, parseFilterName, "filter-filterPipeline-openShiftLabels"}),
+			[]string{detectMultilineErrorFilterName, parseFilterName, "filter-filter-pipeline-" + openshiftLabelsFilterName}),
 	)
 
 	Context("pipeline with default reference", func() {
@@ -206,7 +206,7 @@ var _ = Describe("#ConvertPipelines", func() {
 				Type: obs.FilterTypeParse,
 			},
 			{
-				Name:            "filter-my-app-default-openShiftLabels",
+				Name:            "filter-my-app-default-" + openshiftLabelsFilterName,
 				Type:            obs.FilterTypeOpenshiftLabels,
 				OpenShiftLabels: map[string]string{"foo": "bar"},
 			},
@@ -228,7 +228,7 @@ var _ = Describe("#ConvertPipelines", func() {
 				Name:       "my-app-default",
 				InputRefs:  []string{logging.InputNameApplication},
 				OutputRefs: []string{"default-lokistack"},
-				FilterRefs: []string{"filter-my-app-default-openShiftLabels"},
+				FilterRefs: []string{"filter-my-app-default-" + openshiftLabelsFilterName},
 			},
 		}
 

--- a/test/functional/inputs/http/http_input_test.go
+++ b/test/functional/inputs/http/http_input_test.go
@@ -178,7 +178,7 @@ var _ = Describe("[Functional][Inputs][Http] Functional tests", func() {
 
 		It("should apply an audit filter", func() {
 			Expect(events.Items[0].Stage).To(Not(Equal(events.Items[1].Stage)))
-			filterName := "auditFilter"
+			filterName := "audit-filter"
 			framework.Forwarder.Spec.Filters = []obs.FilterSpec{
 				{
 					Name: filterName,


### PR DESCRIPTION
### Description
Fix filter name generated during migration process according to specification, must match to the: 
`^[a-z][a-z0-9-]*[a-z0-9]$`
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-5846
- Enhancement proposal:
