### PR TITLE
LOG-5842 Forwarder validation failing on old conditions

### DIFF
--- a/internal/api/observability/conditions.go
+++ b/internal/api/observability/conditions.go
@@ -5,6 +5,7 @@ import (
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclock "k8s.io/utils/clock"
+	"strings"
 )
 
 // clock is used to set status condition timestamps.
@@ -50,4 +51,17 @@ func SetCondition(conditions *[]metav1.Condition, newCond metav1.Condition) bool
 	}
 	*conditions = append(*conditions, newCond)
 	return true
+}
+
+// PruneConditions keeps only those conditions that match names from the spec
+func PruneConditions(conditions *[]metav1.Condition, spec NameList) {
+	keepers := []metav1.Condition{}
+	for _, condition := range *conditions {
+		for _, name := range spec.Names() {
+			if strings.HasSuffix(condition.Type, name) {
+				keepers = append(keepers, condition)
+			}
+		}
+	}
+	*conditions = keepers
 }

--- a/internal/api/observability/filters.go
+++ b/internal/api/observability/filters.go
@@ -10,3 +10,13 @@ func FilterMap(spec obs.ClusterLogForwarderSpec) map[string]*obs.FilterSpec {
 	}
 	return m
 }
+
+type Filters []obs.FilterSpec
+
+// Names returns a slice of filter names
+func (filters Filters) Names() (names []string) {
+	for _, f := range filters {
+		names = append(names, f.Name)
+	}
+	return names
+}

--- a/internal/api/observability/forwarder.go
+++ b/internal/api/observability/forwarder.go
@@ -7,6 +7,11 @@ import (
 	"strings"
 )
 
+// NameList provides a list of names for any resource implementing Names
+type NameList interface {
+	Names() []string
+}
+
 // DeployAsDeployment evaluates the spec to determine if the collector will be deployed as a deployment.
 // Collector is not a daemonset if the only input source is an HTTP receiver
 // Enabled through an annotation

--- a/internal/api/observability/input_types.go
+++ b/internal/api/observability/input_types.go
@@ -23,6 +23,14 @@ func Threshold(ls *obs.LimitSpec) (int64, bool) {
 
 type Inputs []obs.InputSpec
 
+// Names returns a slice of input names
+func (inputs Inputs) Names() (names []string) {
+	for _, i := range inputs {
+		names = append(names, i.Name)
+	}
+	return names
+}
+
 // InputTypes returns a unique set of input types
 func (inputs Inputs) InputTypes() []obs.InputType {
 	types := set.New[obs.InputType]()

--- a/internal/api/observability/output_types.go
+++ b/internal/api/observability/output_types.go
@@ -14,6 +14,14 @@ func OutputTypeUnknown(t obsv1.OutputType) error {
 
 type Outputs []obsv1.OutputSpec
 
+// Names returns a slice of output names
+func (outputs Outputs) Names() (names []string) {
+	for _, o := range outputs {
+		names = append(names, o.Name)
+	}
+	return names
+}
+
 // Map returns a map of output name to output spec
 func (outputs Outputs) Map() map[string]obsv1.OutputSpec {
 	m := map[string]obsv1.OutputSpec{}

--- a/internal/api/observability/pipelines.go
+++ b/internal/api/observability/pipelines.go
@@ -1,0 +1,22 @@
+package observability
+
+import obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+
+type Pipelines []obs.PipelineSpec
+
+// Names returns a slice of pipeline names
+func (pipeline Pipelines) Names() (names []string) {
+	for _, p := range pipeline {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+// Map returns a map of pipeline names to pipeline spec
+func (pipeline Pipelines) Map() map[string]obs.PipelineSpec {
+	m := map[string]obs.PipelineSpec{}
+	for _, p := range pipeline {
+		m[p.Name] = p
+	}
+	return m
+}

--- a/internal/validations/observability/filters/validate.go
+++ b/internal/validations/observability/filters/validate.go
@@ -1,6 +1,7 @@
 package filters
 
 import (
+	"fmt"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
 	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
@@ -10,7 +11,7 @@ func Validate(context internalcontext.ForwarderContext) {
 	filterMap := internalobs.FilterMap(context.Forwarder.Spec)
 	for _, filter := range filterMap {
 		internalobs.SetCondition(&context.Forwarder.Status.Filters,
-			internalobs.NewConditionFromPrefix(obs.ConditionTypeValidFilterPrefix, filter.Name, true, obs.ReasonValidationSuccess, "filter valid"))
+			internalobs.NewConditionFromPrefix(obs.ConditionTypeValidFilterPrefix, filter.Name, true, obs.ReasonValidationSuccess, fmt.Sprintf("filter %q is valid", filter.Name)))
 	}
 
 }

--- a/internal/validations/observability/inputs/validate.go
+++ b/internal/validations/observability/inputs/validate.go
@@ -3,6 +3,7 @@ package inputs
 import (
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
+	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -22,5 +23,8 @@ func Validate(context internalcontext.ForwarderContext) {
 		}
 		results = append(results, conditions...)
 	}
-	context.Forwarder.Status.Inputs = results
+	// Set condition
+	for _, condition := range results {
+		internalobs.SetCondition(&context.Forwarder.Status.Inputs, condition)
+	}
 }

--- a/internal/validations/observability/pipelines/validate.go
+++ b/internal/validations/observability/pipelines/validate.go
@@ -24,7 +24,7 @@ func Validate(context internalcontext.ForwarderContext) {
 				internalobs.NewConditionFromPrefix(obs.ConditionTypeValidPipelinePrefix, pipelineSpec.Name, false, obs.ReasonValidationFailure, strings.Join(messages, ",")))
 		} else {
 			internalobs.SetCondition(&context.Forwarder.Status.Pipelines,
-				internalobs.NewConditionFromPrefix(obs.ConditionTypeValidPipelinePrefix, pipelineSpec.Name, true, obs.ReasonValidationSuccess, "pipeline valid"))
+				internalobs.NewConditionFromPrefix(obs.ConditionTypeValidPipelinePrefix, pipelineSpec.Name, true, obs.ReasonValidationSuccess, fmt.Sprintf("pipeline %q is valid", pipelineSpec.Name)))
 		}
 	}
 


### PR DESCRIPTION
### Description
 Added `removeStaleStatuses` to prune conditions for any resource that may no longer be listed (name change for example).   
I tried to create a test for this, but am not just going to push the fix.   I may come back to this later.   

I also changed the input validation to use SetCondition() like the others, and added name to the other messages to be consistent between all Condition types.

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- https://issues.redhat.com/browse/LOG-5842
