### PR TITLE
LOG-5790: Allow syslog templating in CLF API syntax

### DIFF
--- a/internal/generator/vector/output/syslog/tcp_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_defaults.toml
@@ -3,12 +3,6 @@ type = "remap"
 inputs = ["application"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
-
-if is_null(.) {
-	.payload_key = .
-} else {
-	.payload_key = .
-}
 '''
 
 [sinks.example]
@@ -24,4 +18,3 @@ rfc = "rfc5424"
 facility = "user"
 severity = "informational"
 add_log_source = false
-payload_key = "payload_key"

--- a/internal/generator/vector/output/syslog/xyz_defaults.toml
+++ b/internal/generator/vector/output/syslog/xyz_defaults.toml
@@ -3,12 +3,6 @@ type = "remap"
 inputs = ["application"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
-
-if is_null(.) {
-	.payload_key = .
-} else {
-	.payload_key = .
-}
 '''
 
 [sinks.example]
@@ -24,4 +18,3 @@ rfc = "rfc5424"
 facility = "user"
 severity = "informational"
 add_log_source = false
-payload_key = "payload_key"


### PR DESCRIPTION
### Description
This PR removes the `payload_key` config if it is not defined by the user.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5790

