### PR TITLE
LOG-5862: Validation rule causing  error on install

### DIFF
--- a/api/observability/v1/clusterlogforwarder_types.go
+++ b/api/observability/v1/clusterlogforwarder_types.go
@@ -300,8 +300,8 @@ type ClusterLogForwarderStatus struct {
 //
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories=observability,shortName=clf
-// +kubebuilder:validation:XValidation:rule="matches(self.metadata.name,'^[a-z][a-z0-9-]{1,61}[a-z0-9]$')",message="Name must be a valid DNS1035 label"
+// +kubebuilder:resource:categories=observability,shortName=obsclf;clf
+// +kubebuilder:validation:XValidation:rule="self.metadata.name.matches('^[a-z][a-z0-9-]{1,61}[a-z0-9]$')",message="Name must be a valid DNS1035 label"
 type ClusterLogForwarder struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: ClusterLogForwarderList
     plural: clusterlogforwarders
     shortNames:
+    - obsclf
     - clf
     singular: clusterlogforwarder
   scope: Namespaced
@@ -2822,7 +2823,7 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: Name must be a valid DNS1035 label
-          rule: matches(self.metadata.name,'^[a-z][a-z0-9-]{1,61}[a-z0-9]$')
+          rule: self.metadata.name.matches('^[a-z][a-z0-9-]{1,61}[a-z0-9]$')
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -15,6 +15,7 @@ spec:
     listKind: ClusterLogForwarderList
     plural: clusterlogforwarders
     shortNames:
+    - obsclf
     - clf
     singular: clusterlogforwarder
   scope: Namespaced
@@ -2823,7 +2824,7 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: Name must be a valid DNS1035 label
-          rule: matches(self.metadata.name,'^[a-z][a-z0-9-]{1,61}[a-z0-9]$')
+          rule: self.metadata.name.matches('^[a-z][a-z0-9-]{1,61}[a-z0-9]$')
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
### Description
The validation error can also be verified by trying to applying the CRD to the cluster.   I was not able to reproduce the `"CRD is not present"` errors, but I am assuming the first (validation) error is causing the requirementStatus to fail as well.

Also adding a shortname back into the CRD.  In case of upgrade scenario, user can now use `obsclf` (until we remove the old CRD)

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- https://issues.redhat.com/browse/LOG-5862