### PR TITLE
LOG-5880: output ca-bundle.crt,tls.key,tls.crt,passphrase are not migrated to 6.0

### DIFF
--- a/internal/migrations/observability/api/output_test.go
+++ b/internal/migrations/observability/api/output_test.go
@@ -654,7 +654,8 @@ var _ = Describe("#ConvertOutputs", func() {
 				"test-namespace",
 				"splunk-secret",
 				map[string][]byte{
-					constants.SplunkHECTokenKey: []byte("hec-token"),
+					constants.SplunkHECTokenKey:  []byte("hec-token"),
+					constants.TrustedCABundleKey: []byte("ca"),
 				},
 			)
 
@@ -806,6 +807,14 @@ var _ = Describe("#ConvertOutputs", func() {
 					Authentication: &obs.SplunkAuthentication{
 						Token: &obs.SecretReference{
 							Key:        constants.SplunkHECTokenKey,
+							SecretName: splunkSecret.Name,
+						},
+					},
+				},
+				TLS: &obs.OutputTLSSpec{
+					TLSSpec: obs.TLSSpec{
+						CA: &obs.ValueReference{
+							Key:        constants.TrustedCABundleKey,
 							SecretName: splunkSecret.Name,
 						},
 					},


### PR DESCRIPTION
### Description
This PR fixes migrating TLS settings for outputs. When the secret for that output specs the trusted ca bundle, tls cert & key, or passphrase, the TLS settings will be set accordingly.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5880