### PR TITLE
LOG-5885: New CLF raises ClusterRoleMissing after migration

### DIFF
--- a/internal/controller/clusterlogging/clusterlogging_controller.go
+++ b/internal/controller/clusterlogging/clusterlogging_controller.go
@@ -2,9 +2,10 @@ package clusterlogging
 
 import (
 	"context"
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/cluster-logging-operator/internal/api/initialize"
 
@@ -97,7 +98,10 @@ func (r *ReconcileClusterLogging) Reconcile(ctx context.Context, request ctrl.Re
 	}
 
 	// Convert to observability.ClusterLogForwarder
-	obsClf := api.ConvertLoggingToObservability(r.Client, instance, clf, outputSecrets)
+	obsClf, err := api.ConvertLoggingToObservability(r.Client, instance, clf, outputSecrets)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	// Fix indices for default elasticsearch to be `app-write`, `infra-write`, `audit-write`
 	obsClf.Spec = initialize.DefaultElasticsearch(obsClf.Spec)
 

--- a/internal/controller/forwarding/forwarding_controller.go
+++ b/internal/controller/forwarding/forwarding_controller.go
@@ -93,7 +93,10 @@ func (r *ReconcileForwarder) Reconcile(ctx context.Context, request ctrl.Request
 	}
 
 	// Convert to observability.ClusterLogForwarder
-	obsClf := api.ConvertLoggingToObservability(r.Client, clInstance, instance, outputSecrets)
+	obsClf, err := api.ConvertLoggingToObservability(r.Client, clInstance, instance, outputSecrets)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	// Fix indices for default elasticsearch to be `app-write`, `infra-write`, `audit-write`
 	obsClf.Spec = initialize.DefaultElasticsearch(obsClf.Spec)
 

--- a/internal/migrations/observability/api/convert_test.go
+++ b/internal/migrations/observability/api/convert_test.go
@@ -402,7 +402,8 @@ var _ = Describe("#ConvertLoggingToObservability", func() {
 
 			expObsVisit(expObsClf)
 
-			actObsClfSpec := ConvertLoggingToObservability(k8sClient, loggingCl, loggingClf, outputSecrets)
+			actObsClfSpec, err := ConvertLoggingToObservability(k8sClient, loggingCl, loggingClf, outputSecrets)
+			Expect(err).To(BeNil())
 			Expect(actObsClfSpec.Spec.ServiceAccount).To(Equal(expObsClf.Spec.ServiceAccount))
 			Expect(actObsClfSpec.Spec.Collector).To(Equal(expObsClf.Spec.Collector))
 			Expect(actObsClfSpec.Spec.Inputs).To(Equal(expObsClf.Spec.Inputs))

--- a/internal/migrations/observability/api/permissions.go
+++ b/internal/migrations/observability/api/permissions.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CreateLogCollectorSAPermissions(k8sClient client.Client) error {
+	for _, inputType := range obs.ReservedInputTypes.List() {
+		name := fmt.Sprintf("%s-collect-%s-logs", constants.CollectorServiceAccountName, inputType)
+		current := &rbacv1.ClusterRoleBinding{}
+		key := client.ObjectKey{Name: name}
+
+		// Check if CRB exists
+		if err := k8sClient.Get(context.TODO(), key, current); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to get ClusterRoleBinding: %w", err)
+			}
+			// Create the CRB if it doesn't exist
+			crb := NewLogCollectorClusterRoleBinding(name, inputType)
+			if err := k8sClient.Create(context.TODO(), crb); err != nil {
+				return fmt.Errorf("error  creating ClusterRoleBinding: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func NewLogCollectorClusterRoleBinding(name, input string) *rbacv1.ClusterRoleBinding {
+	return runtime.NewClusterRoleBinding(name,
+		rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     fmt.Sprintf("collect-%s-logs", input),
+		},
+		rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Name:      constants.CollectorServiceAccountName,
+			Namespace: constants.OpenshiftNS,
+		},
+	)
+}

--- a/internal/migrations/observability/api/permissions_test.go
+++ b/internal/migrations/observability/api/permissions_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/test"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("LogCollector Service Account Permissions", func() {
+	var (
+		k8sClient = fake.NewFakeClient() //nolint
+	)
+	It("should stub a well-formed clusterrolebinding", func() {
+		Expect(test.YAMLString(NewLogCollectorClusterRoleBinding("foo-crb", string(obs.InputTypeApplication)))).To(MatchYAML(
+			`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: foo-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: collect-application-logs
+subjects:
+- kind: ServiceAccount
+  name: logcollector
+  namespace: openshift-logging
+`))
+	})
+
+	It("should create new ClusterRoleBindings for all input types", func() {
+		err := CreateLogCollectorSAPermissions(k8sClient)
+		Expect(err).To(BeNil())
+
+		// Check for CRB Creation
+		for _, inputType := range obs.ReservedInputTypes.List() {
+			name := fmt.Sprintf("%s-collect-%s-logs", constants.CollectorServiceAccountName, inputType)
+			current := &rbacv1.ClusterRoleBinding{}
+			key := client.ObjectKey{Name: name}
+			err := k8sClient.Get(context.TODO(), key, current)
+			Expect(err).To(BeNil())
+			Expect(current.RoleRef.Name).To(Equal(fmt.Sprintf("collect-%s-logs", inputType)))
+			Expect(current.Subjects[0].Name).To(Equal(constants.CollectorServiceAccountName))
+		}
+	})
+
+})


### PR DESCRIPTION
### Description
This PR adds the required `logcollector` service account permissions upon migration of a legacy CL and/or CLF.
The `logcollector` service account is permitted to collect all 3 log types:
1. application
2. audit
3. infrastructure

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5885

