### PR TITLE
LOG-5890: Migrating syslog output failed due to syslog.rfc: Unsupported value

### DIFF
--- a/internal/migrations/observability/api/output_test.go
+++ b/internal/migrations/observability/api/output_test.go
@@ -609,34 +609,92 @@ var _ = Describe("#ConvertOutputs", func() {
 
 			Expect(mapSplunk(loggingOutSpec, secret)).To(Equal(expObsSplunk))
 		})
-		It("should map logging.Syslog to obs.Syslog", func() {
-			loggingOutSpec := logging.OutputSpec{
-				URL: url,
-				OutputTypeSpec: logging.OutputTypeSpec{
-					Syslog: &logging.Syslog{
-						RFC:        "RFC3164",
-						Severity:   "error",
-						Facility:   "foo",
-						PayloadKey: "bar",
-						AppName:    "app",
-						ProcID:     "123",
-						MsgID:      "12345",
+		Context("syslog", func() {
+			It("should map logging.Syslog to obs.Syslog", func() {
+				loggingOutSpec := logging.OutputSpec{
+					URL: url,
+					OutputTypeSpec: logging.OutputTypeSpec{
+						Syslog: &logging.Syslog{
+							RFC:        "RFC3164",
+							Severity:   "error",
+							Facility:   "foo",
+							PayloadKey: "bar",
+							AppName:    "app",
+							ProcID:     "123",
+							MsgID:      "12345",
+						},
 					},
-				},
-			}
+				}
 
-			expObsSyslog := &obs.Syslog{
-				URL:        url,
-				RFC:        "RFC3164",
-				Severity:   "error",
-				Facility:   "foo",
-				PayloadKey: "{.bar}",
-				AppName:    "app",
-				ProcID:     "123",
-				MsgID:      "12345",
-			}
+				expObsSyslog := &obs.Syslog{
+					URL:        url,
+					RFC:        "RFC3164",
+					Severity:   "error",
+					Facility:   "foo",
+					PayloadKey: "{.bar}",
+					AppName:    "app",
+					ProcID:     "123",
+					MsgID:      "12345",
+				}
 
-			Expect(mapSyslog(loggingOutSpec)).To(Equal(expObsSyslog))
+				Expect(mapSyslog(loggingOutSpec)).To(Equal(expObsSyslog))
+			})
+
+			It("should map logging.Syslog to obs.Syslog when RFC is not specified", func() {
+				loggingOutSpec := logging.OutputSpec{
+					URL: url,
+					OutputTypeSpec: logging.OutputTypeSpec{
+						Syslog: &logging.Syslog{
+							Severity:   "error",
+							Facility:   "foo",
+							PayloadKey: "bar",
+							AppName:    "app",
+							ProcID:     "123",
+							MsgID:      "12345",
+						},
+					},
+				}
+
+				expObsSyslog := &obs.Syslog{
+					URL:        url,
+					RFC:        obs.SyslogRFC5424,
+					Severity:   "error",
+					Facility:   "foo",
+					PayloadKey: "{.bar}",
+					AppName:    "app",
+					ProcID:     "123",
+					MsgID:      "12345",
+				}
+
+				Expect(mapSyslog(loggingOutSpec)).To(Equal(expObsSyslog))
+			})
+
+			It("should map logging.Syslog to obs.Syslog and default values when facility & severity are not spec'd", func() {
+				loggingOutSpec := logging.OutputSpec{
+					URL: url,
+					OutputTypeSpec: logging.OutputTypeSpec{
+						Syslog: &logging.Syslog{
+							PayloadKey: "bar",
+							AppName:    "app",
+							ProcID:     "123",
+							MsgID:      "12345",
+						},
+					},
+				}
+
+				expObsSyslog := &obs.Syslog{
+					URL:        url,
+					RFC:        obs.SyslogRFC5424,
+					Severity:   "informational",
+					Facility:   "user",
+					PayloadKey: "{.bar}",
+					AppName:    "app",
+					ProcID:     "123",
+					MsgID:      "12345",
+				}
+
+				Expect(mapSyslog(loggingOutSpec)).To(Equal(expObsSyslog))
+			})
 		})
 	})
 

--- a/internal/migrations/observability/api/outputs.go
+++ b/internal/migrations/observability/api/outputs.go
@@ -596,7 +596,10 @@ func mapSplunk(loggingOutSpec logging.OutputSpec, secret *corev1.Secret) *obs.Sp
 
 func mapSyslog(loggingOutSpec logging.OutputSpec) *obs.Syslog {
 	obsSyslog := &obs.Syslog{
-		URL: loggingOutSpec.URL,
+		URL:      loggingOutSpec.URL,
+		RFC:      obs.SyslogRFC5424,
+		Facility: "user",
+		Severity: "informational",
 	}
 
 	loggingSyslog := loggingOutSpec.Syslog
@@ -604,9 +607,17 @@ func mapSyslog(loggingOutSpec logging.OutputSpec) *obs.Syslog {
 		return obsSyslog
 	}
 
-	obsSyslog.RFC = obs.SyslogRFCType(loggingSyslog.RFC)
-	obsSyslog.Facility = loggingSyslog.Facility
-	obsSyslog.Severity = loggingSyslog.Severity
+	if loggingSyslog.RFC != "" {
+		obsSyslog.RFC = obs.SyslogRFCType(loggingSyslog.RFC)
+	}
+
+	if loggingSyslog.Facility != "" {
+		obsSyslog.Facility = loggingSyslog.Facility
+	}
+
+	if loggingSyslog.Severity != "" {
+		obsSyslog.Severity = loggingSyslog.Severity
+	}
 
 	if loggingSyslog.AddLogSource {
 		obsSyslog.Enrichment = obs.EnrichmentTypeKubernetesMinimal


### PR DESCRIPTION
### Description
This PR fixes migrating a syslog output that doesn't spec an `RFC` value. It will default to `RFC5424`. Additonally, this PR refactors migration to default values for `facility` & `severity` if none are specified as specified by the API.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5890
