### PR TITLE
Fix per-tenant label keys not using global default keys

### DIFF
--- a/internal/api/initialize/init_lokiStack_test.go
+++ b/internal/api/initialize/init_lokiStack_test.go
@@ -906,7 +906,11 @@ var _ = Describe("MigrateLokiStack", func() {
 
 	DescribeTable(
 		"LabelKeys logic for LokiStack tenants", func(labelKeys *obs.LokiStackLabelKeys, tenant string, wantKeys []string) {
-			keys := lokiStackLabelKeysForTenant(labelKeys, tenant)
+			testDefaultKeys := []string{
+				"default_one",
+				"default_two",
+			}
+			keys := lokiStackLabelKeysForTenant(labelKeys, tenant, testDefaultKeys)
 			Expect(keys).To(Equal(wantKeys))
 		},
 		Entry(
@@ -944,6 +948,7 @@ var _ = Describe("MigrateLokiStack", func() {
 			"only tenant",
 			&obs.LokiStackLabelKeys{
 				Application: &obs.LokiStackTenantLabelKeys{
+					IgnoreGlobal: true,
 					LabelKeys: []string{
 						"tenant_one",
 						"tenant_two",
@@ -952,6 +957,24 @@ var _ = Describe("MigrateLokiStack", func() {
 			},
 			string(obs.InputTypeApplication),
 			[]string{
+				"tenant_one",
+				"tenant_two",
+			},
+		),
+		Entry(
+			"only tenant but with defaults",
+			&obs.LokiStackLabelKeys{
+				Application: &obs.LokiStackTenantLabelKeys{
+					LabelKeys: []string{
+						"tenant_one",
+						"tenant_two",
+					},
+				},
+			},
+			string(obs.InputTypeApplication),
+			[]string{
+				"default_one",
+				"default_two",
 				"tenant_one",
 				"tenant_two",
 			},

--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -29,7 +29,8 @@ const (
 )
 
 var (
-	defaultLabelKeys = []string{
+	// DefaultLabelKeys contains the log entry keys that are used as Loki stream labels by default.
+	DefaultLabelKeys = []string{
 		logType,
 
 		//container labels
@@ -172,7 +173,7 @@ func lokiLabelKeys(l *obs.Loki) []string {
 	if l != nil && len(l.LabelKeys) != 0 {
 		keys = *sets.NewString(l.LabelKeys...)
 	} else {
-		keys = *sets.NewString(defaultLabelKeys...)
+		keys = *sets.NewString(DefaultLabelKeys...)
 	}
 	// Ensure required tags for serialization
 	keys.Insert(requiredLabelKeys...)

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -31,7 +31,7 @@ var _ = Describe("outputLabelConf", func() {
 	Context("#lokiLabelKeys when LabelKeys", func() {
 		Context("are not spec'd", func() {
 			It("should provide a default set of labels including the required ones", func() {
-				exp := append(defaultLabelKeys, requiredLabelKeys...)
+				exp := append(DefaultLabelKeys, requiredLabelKeys...)
 				sort.Strings(exp)
 				Expect(lokiLabelKeys(loki)).To(BeEquivalentTo(exp))
 			})


### PR DESCRIPTION
### Description

During a discussion I noticed that there is a case, when we need to explicitly pass the default label keys through to the Loki output: when a per-tenant provides custom keys, `ignoreGlobal=false` and there are no global overrides.

This PR adds this case to the implementation.
