### PR TITLE
LOG-5899: The migration doesn't work when the default log store is logging-managed elasticsearch

### DIFF
--- a/api/logging/v1/clusterlogging_types.go
+++ b/api/logging/v1/clusterlogging_types.go
@@ -229,11 +229,11 @@ type RetentionPoliciesSpec struct {
 
 type RetentionPolicySpec struct {
 	// +optional
-	MaxAge elasticsearch.TimeUnit `json:"maxAge"`
+	MaxAge elasticsearch.TimeUnit `json:"maxAge,omitempty"`
 
 	// How often to run a new prune-namespaces job
 	// +optional
-	PruneNamespacesInterval elasticsearch.TimeUnit `json:"pruneNamespacesInterval"`
+	PruneNamespacesInterval elasticsearch.TimeUnit `json:"pruneNamespacesInterval,omitempty"`
 
 	// The per namespace specification to delete documents older than a given minimum age
 	// +optional


### PR DESCRIPTION
### Description
This PR fixes migration of a CL resource by adding `omitempty` to `pruneNamespacesInterval`. The problem was the `retentionPolicy` and marshaling of the object. 

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5899

