### PR TITLE
LOG-5920: 'maxWrite' and 'delivery' tuning options are missing under collector config for kafka

### DIFF
--- a/internal/api/observability/tuning.go
+++ b/internal/api/observability/tuning.go
@@ -42,6 +42,8 @@ func NewTuning(spec obs.OutputSpec) Tuning {
 		}
 	case obs.OutputTypeKafka:
 		if spec.Kafka != nil && spec.Kafka.Tuning != nil {
+			t.Delivery = spec.Kafka.Tuning.Delivery
+			t.MaxWrite = spec.Kafka.Tuning.MaxWrite
 			t.Compression = spec.Kafka.Tuning.Compression
 		}
 	case obs.OutputTypeLoki:

--- a/internal/api/observability/tuning_test.go
+++ b/internal/api/observability/tuning_test.go
@@ -1,6 +1,8 @@
 package observability_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -8,7 +10,6 @@ import (
 	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"time"
 )
 
 var _ = Describe("Output", func() {
@@ -22,6 +23,10 @@ var _ = Describe("Output", func() {
 			MaxWrite:         utils.GetPtr(resource.MustParse("1250G")),
 			MaxRetryDuration: utils.GetPtr(time.Second),
 			MinRetryDuration: utils.GetPtr(3 * time.Second),
+		}
+		kafkaBaseSpec = &obs.BaseOutputTuningSpec{
+			Delivery: obs.DeliveryModeAtLeastOnce,
+			MaxWrite: utils.GetPtr(resource.MustParse("1250G")),
 		}
 	)
 
@@ -86,10 +91,12 @@ var _ = Describe("Output", func() {
 			Type: obs.OutputTypeKafka,
 			Kafka: &obs.Kafka{
 				Tuning: &obs.KafkaTuningSpec{
+					Delivery:    obs.DeliveryModeAtLeastOnce,
+					MaxWrite:    utils.GetPtr(resource.MustParse("1250G")),
 					Compression: compression,
 				},
 			},
-		}, nil, compression),
+		}, kafkaBaseSpec, compression),
 		Entry("with Loki", obs.OutputSpec{
 			Type: obs.OutputTypeLoki,
 			Loki: &obs.Loki{


### PR DESCRIPTION
### Description
This PR fixes Kafka tune settings for `delivery` and `maxWrite` so they generate in the `vector.toml`

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5920

