### PR TITLE
LOG-5922: fix the default ES secret

### DIFF
--- a/internal/migrations/observability/api/convert_test.go
+++ b/internal/migrations/observability/api/convert_test.go
@@ -52,15 +52,15 @@ var _ = Describe("#ConvertLoggingToObservability", func() {
 							TLSSpec: obs.TLSSpec{
 								CA: &obs.ValueReference{
 									Key:        constants.TrustedCABundleKey,
-									SecretName: constants.ElasticsearchName,
+									SecretName: constants.CollectorSecretName,
 								},
 								Certificate: &obs.ValueReference{
 									Key:        constants.ClientCertKey,
-									SecretName: constants.ElasticsearchName,
+									SecretName: constants.CollectorSecretName,
 								},
 								Key: &obs.SecretReference{
 									Key:        constants.ClientPrivateKey,
-									SecretName: constants.ElasticsearchName,
+									SecretName: constants.CollectorSecretName,
 								},
 							},
 						},
@@ -430,15 +430,15 @@ var _ = Describe("#ConvertLoggingToObservability", func() {
 							TLSSpec: obs.TLSSpec{
 								CA: &obs.ValueReference{
 									Key:        constants.TrustedCABundleKey,
-									SecretName: constants.ElasticsearchName,
+									SecretName: constants.CollectorSecretName,
 								},
 								Certificate: &obs.ValueReference{
 									Key:        constants.ClientCertKey,
-									SecretName: constants.ElasticsearchName,
+									SecretName: constants.CollectorSecretName,
 								},
 								Key: &obs.SecretReference{
 									Key:        constants.ClientPrivateKey,
-									SecretName: constants.ElasticsearchName,
+									SecretName: constants.CollectorSecretName,
 								},
 							},
 						},

--- a/internal/migrations/observability/api/outputs/managedlogstores/managed_logstores.go
+++ b/internal/migrations/observability/api/outputs/managedlogstores/managed_logstores.go
@@ -35,15 +35,15 @@ func GenerateDefaultOutput(logStoreSpec *logging.LogStoreSpec) *obs.OutputSpec {
 				TLSSpec: obs.TLSSpec{
 					CA: &obs.ValueReference{
 						Key:        constants.TrustedCABundleKey,
-						SecretName: constants.ElasticsearchName,
+						SecretName: constants.CollectorSecretName,
 					},
 					Certificate: &obs.ValueReference{
 						Key:        constants.ClientCertKey,
-						SecretName: constants.ElasticsearchName,
+						SecretName: constants.CollectorSecretName,
 					},
 					Key: &obs.SecretReference{
 						Key:        constants.ClientPrivateKey,
-						SecretName: constants.ElasticsearchName,
+						SecretName: constants.CollectorSecretName,
 					},
 				},
 			},

--- a/internal/migrations/observability/api/outputs/managedlogstores/managed_logstores_test.go
+++ b/internal/migrations/observability/api/outputs/managedlogstores/managed_logstores_test.go
@@ -30,15 +30,15 @@ var _ = Describe("#MapManagedLogStores", func() {
 				TLSSpec: obs.TLSSpec{
 					CA: &obs.ValueReference{
 						Key:        constants.TrustedCABundleKey,
-						SecretName: constants.ElasticsearchName,
+						SecretName: constants.CollectorSecretName,
 					},
 					Certificate: &obs.ValueReference{
 						Key:        constants.ClientCertKey,
-						SecretName: constants.ElasticsearchName,
+						SecretName: constants.CollectorSecretName,
 					},
 					Key: &obs.SecretReference{
 						Key:        constants.ClientPrivateKey,
-						SecretName: constants.ElasticsearchName,
+						SecretName: constants.CollectorSecretName,
 					},
 				},
 			},


### PR DESCRIPTION
### Description
This PR:
* fixes the secret for default ES after migration to use the same secrets used in 5.9

### Links
https://issues.redhat.com/browse/LOG-5922
