### PR TITLE
LOG-5131: Implement telemetry metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	log "github.com/ViaQ/logerr/v2/log/static"
 
 	apis "github.com/openshift/cluster-logging-operator/api"
+	"github.com/openshift/cluster-logging-operator/internal/metrics/telemetry"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/version"
 
@@ -38,6 +39,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
@@ -53,13 +55,8 @@ import (
 	loggingruntime "github.com/openshift/cluster-logging-operator/internal/runtime"
 )
 
-// Change below variables to serve metrics on different host or port.
 var (
 	scheme = apiruntime.NewScheme()
-)
-
-const (
-	UnHealthyStatus = "0"
 )
 
 func init() {
@@ -221,7 +218,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO initialize new telemetry implementation here
+	if err := telemetry.Setup(context.TODO(), mgr.GetClient(), metrics.Registry, version.Version); err != nil {
+		log.Error(err, "Error registering telemetry metrics")
+	}
 
 	log.Info("Starting the Cmd.")
 	// Start the Cmd

--- a/internal/metrics/telemetry/collector.go
+++ b/internal/metrics/telemetry/collector.go
@@ -1,0 +1,146 @@
+package telemetry
+
+import (
+	"context"
+	loggingv1 "github.com/openshift/cluster-logging-operator/api/logging/v1"
+	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/api/logging/v1alpha1"
+	observabilityv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/status"
+
+	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	boolYes = "1"
+	boolNo  = "0"
+)
+
+type telemetryCollector struct {
+	ctx     context.Context
+	client  client.Client
+	version string
+}
+
+func newTelemetryCollector(ctx context.Context, k8sClient client.Client, version string) *telemetryCollector {
+	return &telemetryCollector{
+		ctx:     ctx,
+		client:  k8sClient,
+		version: version,
+	}
+}
+
+var _ prometheus.Collector = &telemetryCollector{}
+
+func (t *telemetryCollector) Describe(descs chan<- *prometheus.Desc) {
+	descs <- logFileMetricExporterInfoDesc
+
+	descs <- forwarderPipelinesDesc
+	descs <- forwarderInputTypeDesc
+	descs <- forwarderOutputTypeDesc
+}
+
+func (t *telemetryCollector) Collect(m chan<- prometheus.Metric) {
+	if err := t.collectForwarder(m); err != nil {
+		log.V(1).Error(err, "Error collecting telemetry for cluster log forwarders")
+	}
+
+	if err := t.collectLogFileMetricExporter(m); err != nil {
+		log.V(1).Error(err, "Error collecting telemetry for LogFileMetricExporter")
+	}
+}
+
+func (t *telemetryCollector) collectForwarder(m chan<- prometheus.Metric) error {
+	clfList := &observabilityv1.ClusterLogForwarderList{}
+	if err := t.client.List(t.ctx, clfList); err != nil {
+		return err
+	}
+
+	for _, clf := range clfList.Items {
+		pipelines := float64(len(clf.Spec.Pipelines))
+		m <- prometheus.MustNewConstMetric(forwarderPipelinesDesc, prometheus.GaugeValue, pipelines,
+			t.version, clf.Namespace, clf.Name)
+
+		inputTypes := map[observabilityv1.InputType]int{}
+		for _, i := range clf.Spec.Inputs {
+			count := inputTypes[i.Type]
+			inputTypes[i.Type] = count + 1
+		}
+
+		for _, p := range clf.Spec.Pipelines {
+			for _, ir := range p.InputRefs {
+				input := observabilityv1.InputType(ir)
+				switch input {
+				case observabilityv1.InputTypeApplication, observabilityv1.InputTypeInfrastructure, observabilityv1.InputTypeAudit:
+					// Treat predefined input references as "input types"
+					count := inputTypes[input]
+					inputTypes[input] = count + 1
+				default:
+				}
+			}
+		}
+
+		for input, c := range inputTypes {
+			m <- prometheus.MustNewConstMetric(forwarderInputTypeDesc, prometheus.GaugeValue, float64(c),
+				t.version, clf.Namespace, clf.Name, string(input))
+		}
+
+		outputTypes := map[observabilityv1.OutputType]int{}
+		for _, o := range clf.Spec.Outputs {
+			count := outputTypes[o.Type]
+			outputTypes[o.Type] = count + 1
+		}
+
+		for output, c := range outputTypes {
+			m <- prometheus.MustNewConstMetric(forwarderOutputTypeDesc, prometheus.GaugeValue, float64(c),
+				t.version, clf.Namespace, clf.Name, string(output))
+		}
+	}
+
+	return nil
+}
+
+func (t *telemetryCollector) collectLogFileMetricExporter(m chan<- prometheus.Metric) error {
+	lfmeList := &loggingv1alpha1.LogFileMetricExporterList{}
+	if err := t.client.List(t.ctx, lfmeList); err != nil {
+		return err
+	}
+
+	deployed := false
+	healthy := false
+
+	for _, lfme := range lfmeList.Items {
+		if lfme.Namespace != constants.OpenshiftNS || lfme.Name != constants.SingletonName {
+			// Only singleton instance is valid
+			continue
+		}
+
+		deployed = true
+		healthy = hasReadyCondition(lfme.Status.Conditions)
+	}
+
+	m <- prometheus.MustNewConstMetric(logFileMetricExporterInfoDesc, prometheus.GaugeValue, 1.0,
+		t.version, boolLabel(deployed), boolLabel(healthy))
+	return nil
+}
+
+func boolLabel(value bool) string {
+	if value {
+		return boolYes
+	}
+
+	return boolNo
+}
+
+func hasReadyCondition(conditions status.Conditions) bool {
+	for _, c := range conditions {
+		if c.Type == loggingv1.ConditionReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/metrics/telemetry/collector_test.go
+++ b/internal/metrics/telemetry/collector_test.go
@@ -1,0 +1,189 @@
+package telemetry
+
+import (
+	"context"
+	"strings"
+
+	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/api/logging/v1alpha1"
+	observabilityv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/status"
+	"github.com/openshift/cluster-logging-operator/internal/validations/clusterlogforwarder/conditions"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testVersion = "test-version"
+)
+
+var (
+	singletonMeta = metav1.ObjectMeta{
+		Name:      constants.SingletonName,
+		Namespace: constants.OpenshiftNS,
+	}
+)
+
+// Test if ServiceMonitor spec is correct or not, also Prometheus Metrics get Registered, Updated, Retrieved properly or not
+var _ = Describe("Telemetry Collector", func() {
+	When("Registering it to a Prometheus registry", func() {
+		It("should not return an error", func() {
+			k8s := fake.NewFakeClient()
+			collector := newTelemetryCollector(context.Background(), k8s, testVersion)
+			registry := prometheus.NewPedanticRegistry()
+
+			err := registry.Register(collector)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	When("Initializing a new collector", func() {
+		Context("with no resources in the Kubernetes cluster", func() {
+			It("should only provide LFME metric", func() {
+				wantMetrics := `# HELP log_file_metric_exporter_info Info metric containing information about usage the file metric exporter. Value is always 1.
+# TYPE log_file_metric_exporter_info gauge
+log_file_metric_exporter_info{deployed="0",healthStatus="0",version="test-version"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient()
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("with observabilityv1 ClusterLogForwarder present", func() {
+			It("should provide CLF and LFME metrics", func() {
+				clf := &observabilityv1.ClusterLogForwarder{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-name",
+					},
+					Spec: observabilityv1.ClusterLogForwarderSpec{
+						Outputs: []observabilityv1.OutputSpec{
+							{
+								Name: "output",
+								Type: observabilityv1.OutputTypeLokiStack,
+							},
+						},
+						Pipelines: []observabilityv1.PipelineSpec{
+							{
+								Name: "pipeline",
+								InputRefs: []string{
+									"application",
+									"infrastructure",
+								},
+								OutputRefs: []string{
+									"output",
+								},
+							},
+						},
+					},
+					Status: observabilityv1.ClusterLogForwarderStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   observabilityv1.ConditionTypeReady,
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				}
+				wantMetrics := `# HELP log_file_metric_exporter_info Info metric containing information about usage the file metric exporter. Value is always 1.
+# TYPE log_file_metric_exporter_info gauge
+log_file_metric_exporter_info{deployed="0",healthStatus="0",version="test-version"} 1
+# HELP log_forwarder_input_type Shows which input types a forwarder uses.
+# TYPE log_forwarder_input_type gauge
+log_forwarder_input_type{input="application",resource_name="test-name",resource_namespace="test-namespace",version="test-version"} 1
+log_forwarder_input_type{input="infrastructure",resource_name="test-name",resource_namespace="test-namespace",version="test-version"} 1
+# HELP log_forwarder_output_type Shows which output types a forwarder uses.
+# TYPE log_forwarder_output_type gauge
+log_forwarder_output_type{output="lokiStack",resource_name="test-name",resource_namespace="test-namespace",version="test-version"} 1
+# HELP log_forwarder_pipelines Metric counting the number of pipelines in a forwarder.
+# TYPE log_forwarder_pipelines gauge
+log_forwarder_pipelines{resource_name="test-name",resource_namespace="test-namespace",version="test-version"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient(clf)
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("with LogFileMetricExporter present", func() {
+			It("should show a ready and deployed exporter", func() {
+				lfme := &loggingv1alpha1.LogFileMetricExporter{
+					ObjectMeta: singletonMeta,
+					Status: loggingv1alpha1.LogFileMetricExporterStatus{
+						Conditions: []status.Condition{
+							conditions.CondReady,
+						},
+					},
+				}
+				wantMetrics := `# HELP log_file_metric_exporter_info Info metric containing information about usage the file metric exporter. Value is always 1.
+# TYPE log_file_metric_exporter_info gauge
+log_file_metric_exporter_info{deployed="1",healthStatus="1",version="test-version"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient(lfme)
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+
+			It("should show an unready status", func() {
+				lfme := &loggingv1alpha1.LogFileMetricExporter{
+					ObjectMeta: singletonMeta,
+				}
+				wantMetrics := `# HELP log_file_metric_exporter_info Info metric containing information about usage the file metric exporter. Value is always 1.
+# TYPE log_file_metric_exporter_info gauge
+log_file_metric_exporter_info{deployed="1",healthStatus="0",version="test-version"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient(lfme)
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+
+			It("should ignore non-singleton instances", func() {
+				lfme := &loggingv1alpha1.LogFileMetricExporter{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-name",
+					},
+				}
+				wantMetrics := `# HELP log_file_metric_exporter_info Info metric containing information about usage the file metric exporter. Value is always 1.
+# TYPE log_file_metric_exporter_info gauge
+log_file_metric_exporter_info{deployed="0",healthStatus="0",version="test-version"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient(lfme)
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+})

--- a/internal/metrics/telemetry/servicemonitor_test.go
+++ b/internal/metrics/telemetry/servicemonitor_test.go
@@ -1,0 +1,33 @@
+package telemetry
+
+import (
+	"os"
+	"path"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ServiceMonitor", func() {
+	var (
+		smYamlFile   string
+		manifestFile string
+	)
+
+	BeforeEach(func() {
+		mdir, _ := os.Getwd()
+		mdir = path.Dir(path.Dir(mdir))
+		smYamlFile = mdir + "/config/prometheus/servicemonitor.yaml"
+		manifestFile = mdir + "/bundle/manifests/cluster-logging-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml"
+	})
+
+	Describe("Testing ServiceMonitor Spec", func() {
+		Context("With config/prometheus/servicemonitor.yaml", func() {
+			It("Should generate bundle/manifests/cluster-logging-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml spec correctly", func() {
+				sm, _ := os.ReadFile(smYamlFile)
+				msm, _ := os.ReadFile(manifestFile)
+				Expect(sm).To(MatchYAML(msm))
+			})
+		})
+	})
+})

--- a/internal/metrics/telemetry/telemetry.go
+++ b/internal/metrics/telemetry/telemetry.go
@@ -1,0 +1,58 @@
+package telemetry
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	metricsPrefix = "log_"
+
+	labelVersion = "version"
+
+	labelResourceNamespace = "resource_namespace"
+	labelResourceName      = "resource_name"
+
+	labelHealthStatus = "healthStatus"
+	labelDeployed     = "deployed"
+
+	labelInput  = "input"
+	labelOutput = "output"
+)
+
+var (
+	logFileMetricExporterInfoDesc = prometheus.NewDesc(
+		metricsPrefix+"file_metric_exporter_info",
+		"Info metric containing information about usage the file metric exporter. Value is always 1.",
+		[]string{labelVersion, labelDeployed, labelHealthStatus}, nil,
+	)
+
+	forwarderPipelinesDesc = prometheus.NewDesc(
+		metricsPrefix+"forwarder_pipelines",
+		"Metric counting the number of pipelines in a forwarder.",
+		[]string{labelVersion, labelResourceNamespace, labelResourceName}, nil,
+	)
+	forwarderInputTypeDesc = prometheus.NewDesc(
+		metricsPrefix+"forwarder_input_type",
+		"Shows which input types a forwarder uses.",
+		[]string{labelVersion, labelResourceNamespace, labelResourceName, labelInput}, nil,
+	)
+	forwarderOutputTypeDesc = prometheus.NewDesc(
+		metricsPrefix+"forwarder_output_type",
+		"Shows which output types a forwarder uses.",
+		[]string{labelVersion, labelResourceNamespace, labelResourceName, labelOutput}, nil,
+	)
+)
+
+// Setup initializes the telemetry collector and registers it with the given Prometheus registry.
+func Setup(ctx context.Context, k8sClient client.Client, registry prometheus.Registerer, version string) error {
+	collector := newTelemetryCollector(ctx, k8sClient, version)
+
+	if err := registry.Register(collector); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/metrics/telemetry/telemetry_test.go
+++ b/internal/metrics/telemetry/telemetry_test.go
@@ -1,0 +1,24 @@
+package telemetry
+
+import (
+	"testing"
+
+	loggingv1alpha1 "github.com/openshift/cluster-logging-operator/api/logging/v1alpha1"
+	observabilityv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/test"
+
+	"k8s.io/client-go/kubernetes/scheme"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func init() {
+	test.Must(loggingv1alpha1.AddToScheme(scheme.Scheme))
+	test.Must(observabilityv1.AddToScheme(scheme.Scheme))
+}
+
+func TestTelemetry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "clo telemetry test")
+}


### PR DESCRIPTION
### Description

This PR implements telemetry metrics for the new cluster-logging-operator release. The `log_file_metric_exporter_info` metric is compatible with telemetry in previous releases, but the telemetry metrics for the ClusterLogForwarder have been changed:

- `log_forwarder_input_type` shows usage information about input types.
- `log_forwarder_output_type` shows usage information about output types.
- `log_forwarder_pipelines` counts the number of pipelines in a forwarder.

The input and output metrics now create a series per used input/output type, so that Prometheus aggregations can be used more easily when querying the metrics, for example to show the percentage of different output types used in clusters.

This PR is an alternative implementation to #2680, which implements a set of metrics compatible with previous releases instead.

### Links

- JIRA: [LOG-5131](https://issues.redhat.com//browse/LOG-5131)
