### PR TITLE
LOG-5921: 'Could not generate topic for healthcheck' warnings on collector when forwarding to kafka topics

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -399,6 +399,7 @@ type = "kafka"
 inputs = ["output_kafka_receiver_topic"]
 bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
 topic = "{{ _internal.output_kafka_receiver_topic }}"
+healthcheck.enabled = false
 
 [sinks.output_kafka_receiver.encoding]
 codec = "json"

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -426,6 +426,7 @@ type = "kafka"
 inputs = ["output_kafka_receiver_topic"]
 bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
 topic = "{{ _internal.output_kafka_receiver_topic }}"
+healthcheck.enabled = false
 
 [sinks.output_kafka_receiver.encoding]
 codec = "json"

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -158,6 +158,7 @@ type = "kafka"
 inputs = ["output_kafka_receiver_topic"]
 bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
 topic = "{{ _internal.output_kafka_receiver_topic }}"
+healthcheck.enabled = false
 
 [sinks.output_kafka_receiver.encoding]
 codec = "json"

--- a/internal/generator/vector/output/kafka/kafka.go
+++ b/internal/generator/vector/output/kafka/kafka.go
@@ -41,6 +41,7 @@ type = "kafka"
 inputs = {{.Inputs}}
 bootstrap_servers = {{.BootstrapServers}}
 topic = "{{"{{"}} _internal.{{.Topic}} {{"}}"}}"
+healthcheck.enabled = false
 {{.Compression}}
 {{end}}
 `

--- a/internal/generator/vector/output/kafka/kafka_custom_topic.toml
+++ b/internal/generator/vector/output/kafka/kafka_custom_topic.toml
@@ -11,6 +11,7 @@ type = "kafka"
 inputs = ["kafka_receiver_topic"]
 bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
 topic = "{{ _internal.kafka_receiver_topic }}"
+healthcheck.enabled = false
 
 [sinks.kafka_receiver.encoding]
 codec = "json"

--- a/internal/generator/vector/output/kafka/kafka_insecure_skipverify.toml
+++ b/internal/generator/vector/output/kafka/kafka_insecure_skipverify.toml
@@ -11,6 +11,7 @@ type = "kafka"
 inputs = ["kafka_receiver_topic"]
 bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
 topic = "{{ _internal.kafka_receiver_topic }}"
+healthcheck.enabled = false
 
 [sinks.kafka_receiver.encoding]
 codec = "json"

--- a/internal/generator/vector/output/kafka/kafka_multi_brokers_with_tls_single_topic.toml
+++ b/internal/generator/vector/output/kafka/kafka_multi_brokers_with_tls_single_topic.toml
@@ -11,6 +11,7 @@ type = "kafka"
 inputs = ["kafka_receiver_topic"]
 bootstrap_servers = "broker1:9092,broker2:9092,broker3:9092"
 topic = "{{ _internal.kafka_receiver_topic }}"
+healthcheck.enabled = false
 
 [sinks.kafka_receiver.encoding]
 codec = "json"

--- a/internal/generator/vector/output/kafka/kafka_no_security.toml
+++ b/internal/generator/vector/output/kafka/kafka_no_security.toml
@@ -11,6 +11,7 @@ type = "kafka"
 inputs = ["kafka_receiver_topic"]
 bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
 topic = "{{ _internal.kafka_receiver_topic }}"
+healthcheck.enabled = false
 
 [sinks.kafka_receiver.encoding]
 codec = "json"

--- a/internal/generator/vector/output/kafka/kafka_sasl_plaintext_single_topic.toml
+++ b/internal/generator/vector/output/kafka/kafka_sasl_plaintext_single_topic.toml
@@ -11,6 +11,7 @@ type = "kafka"
 inputs = ["kafka_receiver_topic"]
 bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
 topic = "{{ _internal.kafka_receiver_topic }}"
+healthcheck.enabled = false
 
 [sinks.kafka_receiver.encoding]
 codec = "json"

--- a/internal/generator/vector/output/kafka/kafka_sasl_scram_with_tls.toml
+++ b/internal/generator/vector/output/kafka/kafka_sasl_scram_with_tls.toml
@@ -11,6 +11,7 @@ type = "kafka"
 inputs = ["kafka_receiver_topic"]
 bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
 topic = "{{ _internal.kafka_receiver_topic }}"
+healthcheck.enabled = false
 
 [sinks.kafka_receiver.encoding]
 codec = "json"

--- a/internal/generator/vector/output/kafka/kafka_sasl_with_tls_single_topic.toml
+++ b/internal/generator/vector/output/kafka/kafka_sasl_with_tls_single_topic.toml
@@ -11,6 +11,7 @@ type = "kafka"
 inputs = ["kafka_receiver_topic"]
 bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
 topic = "{{ _internal.kafka_receiver_topic }}"
+healthcheck.enabled = false
 
 [sinks.kafka_receiver.encoding]
 codec = "json"


### PR DESCRIPTION
### Description
This PR removes the `healthchecks` for the Kafka sink as we do not claim to support `healthchecks`.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5921