### PR TITLE
LOG-6207: enable stream (stdout/stderr) information in logs for Vector

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -80,6 +80,9 @@ const (
 	SyslogReceiverPort = 10514
 
 	VolumeNameTrustedCA = "trusted-ca"
+
+	STDOUT = "stdout"
+	STDERR = "stderr"
 )
 
 var ExtraNoProxyList = []string{ElasticsearchFQDN}

--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -341,7 +341,7 @@ if .log_source == "container" {
   del(._partial)
   del(.file)
   del(.source_type)
-  del(.stream)
+  .kubernetes.container_iostream = del(.stream)
   del(.kubernetes.pod_ips)
   del(.kubernetes.node_labels)
   del(.timestamp_end)

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -375,7 +375,7 @@ if .log_source == "container" {
   del(._partial)
   del(.file)
   del(.source_type)
-  del(.stream)
+  .kubernetes.container_iostream = del(.stream)
   del(.kubernetes.pod_ips)
   del(.kubernetes.node_labels)
   del(.timestamp_end)

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -141,7 +141,7 @@ if .log_source == "container" {
   del(._partial)
   del(.file)
   del(.source_type)
-  del(.stream)
+  .kubernetes.container_iostream = del(.stream)
   del(.kubernetes.pod_ips)
   del(.kubernetes.node_labels)
   del(.timestamp_end)

--- a/internal/generator/vector/filter/multilineexception/filter.go
+++ b/internal/generator/vector/filter/multilineexception/filter.go
@@ -27,7 +27,7 @@ func (d DetectExceptions) Template() string {
 type = "detect_exceptions"
 inputs = {{.Inputs}}
 languages = ["All"]
-group_by = ["kubernetes.namespace_name","kubernetes.pod_name","kubernetes.container_name", "kubernetes.pod_id"]
+group_by = ["kubernetes.namespace_name","kubernetes.pod_name","kubernetes.container_name", "kubernetes.pod_id", "stream"]
 expire_after_ms = 2000
 multiline_flush_interval_ms = 1000
 {{end}}`

--- a/internal/generator/vector/filter/openshift/viaq/filter.go
+++ b/internal/generator/vector/filter/openshift/viaq/filter.go
@@ -43,7 +43,7 @@ if .log_source == "%s" {
 		RemovePartial,
 		RemoveFile,
 		RemoveSourceType,
-		RemoveStream,
+		HandleStream,
 		RemovePodIPs,
 		RemoveNodeLabels,
 		RemoveTimestampEnd,

--- a/internal/generator/vector/filter/openshift/viaq/normalize.go
+++ b/internal/generator/vector/filter/openshift/viaq/normalize.go
@@ -80,7 +80,7 @@ if starts_with(pod_name, "eventrouter-") {
   }
 }
 `
-	RemoveStream       = `del(.stream)`
+	HandleStream       = `.kubernetes.container_iostream = del(.stream)`
 	RemovePodIPs       = `del(.kubernetes.pod_ips)`
 	RemoveNodeLabels   = `del(.kubernetes.node_labels)`
 	RemoveTimestampEnd = `del(.timestamp_end)`

--- a/internal/generator/vector/output/otlp/otlp_all.toml
+++ b/internal/generator/vector/output/otlp/otlp_all.toml
@@ -60,7 +60,8 @@ source = '''
   r.attributes = append(r.attributes,
       [{"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
       {"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
-      {"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
+      {"key": "k8s.node.name", "value": {"stringValue": .hostname}},
+      {"key": "log.iostream", "value": {"stringValue": get!(.,["kubernetes","container_iostream"])}}]
   )
   if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
       r.attributes = append(r.attributes,

--- a/internal/generator/vector/output/otlp/otlp_tuning.toml
+++ b/internal/generator/vector/output/otlp/otlp_tuning.toml
@@ -60,7 +60,8 @@ source = '''
   r.attributes = append(r.attributes,
       [{"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
       {"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
-      {"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
+      {"key": "k8s.node.name", "value": {"stringValue": .hostname}},
+      {"key": "log.iostream", "value": {"stringValue": get!(.,["kubernetes","container_iostream"])}}]
   )
   if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
       r.attributes = append(r.attributes,

--- a/internal/generator/vector/output/otlp/otlp_with_auth_basic.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_basic.toml
@@ -60,7 +60,8 @@ source = '''
   r.attributes = append(r.attributes,
       [{"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
       {"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
-      {"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
+      {"key": "k8s.node.name", "value": {"stringValue": .hostname}},
+      {"key": "log.iostream", "value": {"stringValue": get!(.,["kubernetes","container_iostream"])}}]
   )
   if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
       r.attributes = append(r.attributes,

--- a/internal/generator/vector/output/otlp/otlp_with_auth_sa_token.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_sa_token.toml
@@ -60,7 +60,8 @@ source = '''
   r.attributes = append(r.attributes,
       [{"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
       {"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
-      {"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
+      {"key": "k8s.node.name", "value": {"stringValue": .hostname}},
+      {"key": "log.iostream", "value": {"stringValue": get!(.,["kubernetes","container_iostream"])}}]
   )
   if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
       r.attributes = append(r.attributes,

--- a/internal/generator/vector/output/otlp/otlp_with_auth_token.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_token.toml
@@ -60,7 +60,8 @@ source = '''
   r.attributes = append(r.attributes,
       [{"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
       {"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
-      {"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
+      {"key": "k8s.node.name", "value": {"stringValue": .hostname}},
+      {"key": "log.iostream", "value": {"stringValue": get!(.,["kubernetes","container_iostream"])}}]
   )
   if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
       r.attributes = append(r.attributes,

--- a/internal/generator/vector/output/otlp/transform.go
+++ b/internal/generator/vector/output/otlp/transform.go
@@ -67,7 +67,8 @@ if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value
 r.attributes = append(r.attributes,
     [{"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
     {"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
-    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}},
+    {"key": "log.iostream", "value": {"stringValue": get!(.,["kubernetes","container_iostream"])}}]
 )
 if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
     r.attributes = append(r.attributes,

--- a/internal/generator/vector/pipeline/adapter_test_drop_filter.toml
+++ b/internal/generator/vector/pipeline/adapter_test_drop_filter.toml
@@ -87,7 +87,7 @@ if .log_source == "container" {
   del(._partial)
   del(.file)
   del(.source_type)
-  del(.stream)
+  .kubernetes.container_iostream = del(.stream)
   del(.kubernetes.pod_ips)
   del(.kubernetes.node_labels)
   del(.timestamp_end)

--- a/internal/generator/vector/pipeline/adapter_test_prune_inNotIn_filter.toml
+++ b/internal/generator/vector/pipeline/adapter_test_prune_inNotIn_filter.toml
@@ -79,7 +79,7 @@ if .log_source == "container" {
   del(._partial)
   del(.file)
   del(.source_type)
-  del(.stream)
+  .kubernetes.container_iostream = del(.stream)
   del(.kubernetes.pod_ips)
   del(.kubernetes.node_labels)
   del(.timestamp_end)

--- a/internal/generator/vector/pipeline/adapter_test_prune_inOnly_filter.toml
+++ b/internal/generator/vector/pipeline/adapter_test_prune_inOnly_filter.toml
@@ -79,7 +79,7 @@ if .log_source == "container" {
   del(._partial)
   del(.file)
   del(.source_type)
-  del(.stream)
+  .kubernetes.container_iostream = del(.stream)
   del(.kubernetes.pod_ips)
   del(.kubernetes.node_labels)
   del(.timestamp_end)

--- a/internal/generator/vector/pipeline/adapter_test_prune_notIn_only_filter.toml
+++ b/internal/generator/vector/pipeline/adapter_test_prune_notIn_only_filter.toml
@@ -79,7 +79,7 @@ if .log_source == "container" {
   del(._partial)
   del(.file)
   del(.source_type)
-  del(.stream)
+  .kubernetes.container_iostream = del(.stream)
   del(.kubernetes.pod_ips)
   del(.kubernetes.node_labels)
   del(.timestamp_end)

--- a/test/framework/functional/factory.go
+++ b/test/framework/functional/factory.go
@@ -2,6 +2,7 @@ package functional
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"strings"
 	"time"
 )
@@ -35,12 +36,16 @@ func NewFullCRIOLogMessage(timestamp, message string) string {
 	return NewCRIOLogMessage(timestamp, message, false)
 }
 
-func NewCRIOLogMessage(timestamp, message string, partial bool) string {
+func NewCRIOLogMessageWithStream(timestamp, stream, message string, partial bool) string {
 	fullOrPartial := "F"
 	if partial {
 		fullOrPartial = "P"
 	}
-	return fmt.Sprintf("%s stdout %s %s", timestamp, fullOrPartial, message)
+	return fmt.Sprintf("%s %s %s %s", timestamp, stream, fullOrPartial, message)
+}
+
+func NewCRIOLogMessage(timestamp, message string, partial bool) string {
+	return NewCRIOLogMessageWithStream(timestamp, constants.STDOUT, message, partial)
 }
 
 // CRIOTime returns the CRIO string format of time t.

--- a/test/framework/functional/message_templates.go
+++ b/test/framework/functional/message_templates.go
@@ -31,6 +31,7 @@ var (
 		FlatLabels:       []string{"*"},
 		NamespaceLabels:  map[string]string{"*": "*"},
 		Annotations:      map[string]string{"*": "*"},
+		ContainerStream:  "stdout",
 	}
 	templateForInfraKubernetes = types.Kubernetes{
 		ContainerID:       "**optional**",

--- a/test/functional/normalization/message_format_test.go
+++ b/test/functional/normalization/message_format_test.go
@@ -77,14 +77,22 @@ var _ = Describe("[Functional][LogForwarding][Normalization] tests for message f
 		outputLogTemplate.Message = fmt.Sprintf("regex:^%s.*$", message)
 		outputLogTemplate.Level = "*"
 
-		// Write log line as input
+		// Write log line as stdout
 		applicationLogLine := fmt.Sprintf("%s stdout F %s $n", timestamp, message)
+		Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 1)).To(BeNil())
+
+		// Write log line as stderr
+		applicationLogLine = fmt.Sprintf("%s stderr F %s $n", timestamp, message)
 		Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 1)).To(BeNil())
 
 		logs, err := framework.ReadApplicationLogsFrom(string(obs.OutputTypeElasticsearch))
 		Expect(err).To(BeNil(), "Expected no errors reading the logs")
 		// Compare to expected template
 		outputTestLog := logs[0]
+		Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
+
+		outputLogTemplate.Kubernetes.ContainerStream = "stderr"
+		outputTestLog = logs[1]
 		Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 	})
 

--- a/test/helpers/types/types.go
+++ b/test/helpers/types/types.go
@@ -116,6 +116,10 @@ type Kubernetes struct {
 	// NamespaceLabels are the labels present on the pod namespace
 	// +optional
 	NamespaceLabels map[string]string `json:"namespace_labels,omitempty"`
+
+	// The name of the stream the log line was submitted to (e.g.: stdout, stderr)
+	// +optional
+	ContainerStream string `json:"container_iostream,omitempty"`
 }
 
 type Collector struct {


### PR DESCRIPTION
### Description
This PR introduces handling of `kubernetes_log` `stream` field (e.g., stdout, stderr). https://vector.dev/docs/reference/configuration/sources/kubernetes_logs/#line-fields

- moved the original `stream` field to `kubernetes.stream` to better align with the log event structure
- added `kubernetes.stream` to the group_by parameter of the Detect Multiline Exceptions filter, ensures that exception detection is correctly handled 
- included `kubernetes.stream `in the group_by parameter for the OTLP output, to improves the granularity of log data sent through OTLP by differentiating between different streams.
- modified the functional tests to verify that log events are handled correctly for both stdout and stderr outputs. 


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-6207
- Enhancement proposal:
