### PR TITLE
Improve descriptors for OpenShift Console CLF creation form

### DIFF
--- a/api/observability/v1/clusterlogforwarder_types.go
+++ b/api/observability/v1/clusterlogforwarder_types.go
@@ -21,9 +21,10 @@ import (
 
 // ClusterLogForwarderSpec defines the desired state of ClusterLogForwarder
 type ClusterLogForwarderSpec struct {
-	// Indicator if the resource is 'Managed' or 'Unmanaged' by the operator
+	// Indicator if the resource is 'Managed' or 'Unmanaged' by the operator.
 	//
 	// +kubebuilder:default:=Managed
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Management State"
 	ManagementState ManagementState `json:"managementState,omitempty"`
 
 	// Specification of the Collector deployment to define
@@ -74,6 +75,7 @@ type ClusterLogForwarderSpec struct {
 	// ServiceAccount points to the ServiceAccount resource used by the collector pods.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Service Account"
 	ServiceAccount ServiceAccount `json:"serviceAccount"`
 }
 
@@ -81,7 +83,7 @@ type ServiceAccount struct {
 	// Name of the ServiceAccount to use to deploy the Forwarder.  The ServiceAccount is created by the administrator
 	//
 	// +kubebuilder:validation:Pattern:="^[a-z][a-z0-9-]{2,62}[a-z0-9]$"
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ServiceAccount Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Name string `json:"name"`
 }
 
@@ -118,6 +120,7 @@ type CollectorSpec struct {
 	//
 	// +nullable
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tolerations"
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
@@ -133,20 +136,22 @@ type PipelineSpec struct {
 	//
 	// The following built-in input names are always available:
 	//
-	// `application` selects all logs from application pods.
+	//  - `application` selects all logs from application pods.
 	//
-	// `infrastructure` selects logs from openshift and kubernetes pods and some node logs.
+	//  - `infrastructure` selects logs from openshift and kubernetes pods and some node logs.
 	//
-	// `audit` selects node logs related to security audits.
+	//  - `audit` selects node logs related to security audits.
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems:=1
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Inputs"
 	InputRefs []string `json:"inputRefs"`
 
 	// OutputRefs lists the names (`output.name`) of outputs from this pipeline.
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinItems:=1
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Outputs"
 	OutputRefs []string `json:"outputRefs"`
 
 	// Filters lists the names of filters to be applied to records going through this pipeline.
@@ -155,6 +160,7 @@ type PipelineSpec struct {
 	// If a filter drops a records, subsequent filters are not applied.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Filters"
 	FilterRefs []string `json:"filterRefs,omitempty"`
 }
 
@@ -181,9 +187,13 @@ type ValueReference struct {
 	Key string `json:"key"`
 
 	// ConfigMapName contains the name of the ConfigMap containing the referenced value.
+	//
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ConfigMap Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	ConfigMapName string `json:"configMapName,omitempty"`
 
 	// SecretName contains the name of the Secret containing the referenced value.
+	//
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	SecretName string `json:"secretName,omitempty"`
 }
 
@@ -198,6 +208,7 @@ type SecretReference struct {
 	// SecretName contains the name of the Secret containing the referenced value.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	SecretName string `json:"secretName"`
 }
 
@@ -209,11 +220,13 @@ type BearerToken struct {
 	// From is the source from where to find the token
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Token Source"
 	From BearerTokenFrom `json:"from"`
 
 	// Use Secret if the value should be sourced from a Secret in the same namespace.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Token Secret"
 	Secret *BearerTokenSecretKey `json:"secret,omitempty"`
 }
 
@@ -234,11 +247,13 @@ type BearerTokenSecretKey struct {
 	// Name of the key used to get the value from the referenced Secret.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Key Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Key string `json:"key"`
 
 	// Name of secret
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Name string `json:"name"`
 }
 
@@ -247,21 +262,25 @@ type TLSSpec struct {
 	// CA can be used to specify a custom list of trusted certificate authorities.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Certificate Authority Bundle"
 	CA *ValueReference `json:"ca,omitempty"`
 
 	// Certificate points to the server certificate to use.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Certificate"
 	Certificate *ValueReference `json:"certificate,omitempty"`
 
 	// Key points to the private key of the server certificate.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Certificate Key"
 	Key *SecretReference `json:"key,omitempty"`
 
 	// KeyPassphrase points to the passphrase used to unlock the private key.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Certificate Key Passphrase"
 	KeyPassphrase *SecretReference `json:"keyPassphrase,omitempty"`
 }
 

--- a/api/observability/v1/input_types.go
+++ b/api/observability/v1/input_types.go
@@ -24,7 +24,6 @@ import (
 // +kubebuilder:validation:Enum:=audit;application;infrastructure;receiver
 type InputType string
 
-// Reserved input names.
 const (
 	// InputTypeApplication contains all the non-infrastructure container logs.
 	InputTypeApplication InputType = "application"
@@ -46,7 +45,8 @@ var (
 	ReservedInputTypes = sets.NewString(
 		string(InputTypeApplication),
 		string(InputTypeAudit),
-		string(InputTypeInfrastructure))
+		string(InputTypeInfrastructure),
+	)
 )
 
 // InputSpec defines a selector of log messages for a given log type.
@@ -58,33 +58,39 @@ type InputSpec struct {
 	// Name used to refer to the input of a `pipeline`.
 	//
 	// +kubebuilder:validation:Pattern:="^[a-z][a-z0-9-]*[a-z0-9]$"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Input Name"
 	Name string `json:"name"`
 
 	// Type of output sink.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Input Type"
 	Type InputType `json:"type"`
 
 	// Application, named set of `application` logs that
 	// can specify a set of match criteria
 	//
-	// +kubebuilder:validation:Optional
 	// +nullable
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Application Logs Input"
 	Application *Application `json:"application,omitempty"`
 
 	// Infrastructure, Enables `infrastructure` logs.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Infrastructure Logs Input"
 	Infrastructure *Infrastructure `json:"infrastructure,omitempty"`
 
 	// Audit, enables `audit` logs.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Audit Logs Input"
 	Audit *Audit `json:"audit,omitempty"`
 
 	// Receiver to receive logs from non-cluster sources.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Log Receiver"
 	Receiver *ReceiverSpec `json:"receiver,omitempty"`
 }
 
@@ -94,6 +100,7 @@ type ContainerInputTuningSpec struct {
 	// by this input. This limit is applied per collector deployment.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Per-Container Rate Limit"
 	RateLimitPerContainer *LimitSpec `json:"rateLimitPerContainer,omitempty"`
 }
 
@@ -113,27 +120,35 @@ const (
 // All conditions in the selector must be satisfied (logical AND) to select logs.
 type Application struct {
 	// Selector for logs from pods with matching labels.
+	//
 	// Only messages from pods with these labels are collected.
+	//
 	// If absent or empty, logs are collected regardless of labels.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Pod Selector",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Pod"}
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
 	// Tuning is the container input tuning spec for this container sources
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Input Tuning"
 	Tuning *ContainerInputTuningSpec `json:"tuning,omitempty"`
 
 	// Includes is the set of namespaces and containers to include when collecting logs.
+	//
 	// Note: infrastructure namespaces are still excluded for "*" values unless a qualifying glob pattern is specified.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Include"
 	Includes []NamespaceContainerSpec `json:"includes,omitempty"`
 
 	// Excludes is the set of namespaces and containers to ignore when collecting logs.
+	//
 	// Takes precedence over Includes option.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Exclude"
 	Excludes []NamespaceContainerSpec `json:"excludes,omitempty"`
 }
 
@@ -143,12 +158,14 @@ type NamespaceContainerSpec struct {
 	// Supports glob patterns and presumes "*" if omitted.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Namespace Glob",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Namespace string `json:"namespace,omitempty"`
 
 	// Container spec the containers from which to collect logs
 	// Supports glob patterns and presumes "*" if omitted.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Container Glob",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Container string `json:"container,omitempty"`
 }
 
@@ -182,6 +199,7 @@ type Infrastructure struct {
 	// This field is optional and omission results in the collection of all infrastructure sources.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Log Sources"
 	Sources []InfrastructureSource `json:"sources,omitempty"`
 }
 
@@ -219,6 +237,7 @@ type Audit struct {
 	// This field is optional and its exclusion results in the collection of all audit sources.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Log Sources"
 	Sources []AuditSource `json:"sources,omitempty"`
 }
 
@@ -246,6 +265,7 @@ type ReceiverSpec struct {
 	// Type of Receiver plugin.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Receiver Type"
 	Type ReceiverType `json:"type"`
 
 	// TLS contains settings for controlling options of TLS connections.
@@ -255,6 +275,7 @@ type ReceiverSpec struct {
 	// the collector. The collector is configured to use the public and private key provided by the service
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TLS Options"
 	TLS *InputTLSSpec `json:"tls,omitempty"`
 
 	// Port the Receiver listens on. It must be a value between 1024 and 65535
@@ -262,9 +283,11 @@ type ReceiverSpec struct {
 	// +kubebuilder:default:=8443
 	// +kubebuilder:validation:Minimum:=1024
 	// +kubebuilder:validation:Maximum:=65535
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Listen Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
 	Port int32 `json:"port"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="HTTP Receiver Configuration"
 	HTTP *HTTPReceiver `json:"http,omitempty"`
 }
 
@@ -282,5 +305,6 @@ type HTTPReceiver struct {
 	// Format is the format of incoming log data.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Data Format"
 	Format HTTPReceiverFormat `json:"format"`
 }

--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -59,6 +59,7 @@ var (
 )
 
 // OutputSpec defines a destination for log messages.
+//
 // +kubebuilder:validation:XValidation:rule="self.type != 'azureMonitor' || has(self.azureMonitor)", message="Additional type specific spec is required for the output type"
 // +kubebuilder:validation:XValidation:rule="self.type != 'cloudwatch' || has(self.cloudwatch)", message="Additional type specific spec is required for the output type"
 // +kubebuilder:validation:XValidation:rule="self.type != 'elasticsearch' || has(self.elasticsearch)", message="Additional type specific spec is required for the output type"
@@ -74,16 +75,19 @@ type OutputSpec struct {
 	// Name used to refer to the output from a `pipeline`.
 	//
 	// +kubebuilder:validation:Pattern:="^[a-z][a-z0-9-]*[a-z0-9]$"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Output Name"
 	Name string `json:"name"`
 
 	// Type of output sink.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Output Type"
 	Type OutputType `json:"type"`
 
 	// TLS contains settings for controlling options on TLS client connections.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TLS Options"
 	TLS *OutputTLSSpec `json:"tls,omitempty"`
 
 	// Limit imposes a limit in records-per-second on the total aggregate rate of logs forwarded
@@ -92,39 +96,51 @@ type OutputSpec struct {
 	// Logs may be dropped to enforce the limit. Missing or 0 means no rate limit.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Rate Limiting"
 	Limit *LimitSpec `json:"rateLimit,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Azure Monitor"
 	AzureMonitor *AzureMonitor `json:"azureMonitor,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Amazon CloudWatch"
 	Cloudwatch *Cloudwatch `json:"cloudwatch,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ElasticSearch"
 	Elasticsearch *Elasticsearch `json:"elasticsearch,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Google Cloud Logging"
 	GoogleCloudLogging *GoogleCloudLogging `json:"googleCloudLogging,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="HTTP Output"
 	HTTP *HTTP `json:"http,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Apache Kafka"
 	Kafka *Kafka `json:"kafka,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Grafana Loki"
 	Loki *Loki `json:"loki,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="LokiStack"
 	LokiStack *LokiStack `json:"lokiStack,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Splunk"
 	Splunk *Splunk `json:"splunk,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Syslog Output"
 	Syslog *Syslog `json:"syslog,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OpenTelemetry Output"
 	OTLP *OTLP `json:"otlp,omitempty"`
 }
 
@@ -136,11 +152,13 @@ type OutputTLSSpec struct {
 	// This option is *not* recommended for production configurations.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Skip Certificate Validation",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 
 	// TLSSecurityProfile is the security profile to apply to the output connection.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="TLS Security Profile"
 	TLSSecurityProfile *openshiftv1.TLSSecurityProfile `json:"securityProfile,omitempty"`
 }
 
@@ -151,26 +169,31 @@ type URLSpec struct {
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="isURL(self)", message="invalid URL"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Destination URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	URL string `json:"url"`
 }
 
 // BaseOutputTuningSpec tuning parameters for an output
 type BaseOutputTuningSpec struct {
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Delivery Mode"
 	Delivery DeliveryMode `json:"delivery,omitempty"`
 
 	// MaxWrite limits the maximum payload in terms of bytes of a single "send" to the output.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Batch Size"
 	MaxWrite *resource.Quantity `json:"maxWrite,omitempty"`
 
 	// MinRetryDuration is the minimum time to wait between attempts to retry after delivery a failure.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Minimum Retry Duration"
 	MinRetryDuration *time.Duration `json:"minRetryDuration,omitempty"`
 
 	// MaxRetryDuration is the maximum time to wait between retry attempts after a delivery failure.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Maximum Retry Duration"
 	MaxRetryDuration *time.Duration `json:"maxRetryDuration,omitempty"`
 }
 
@@ -196,20 +219,23 @@ const (
 type HTTPAuthentication struct {
 	// Token specifies a bearer token to be used for authenticating requests.
 	//
-	// +kubebuilder:validation:Optional
 	// +nullable
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Bearer Token"
 	Token *BearerToken `json:"token,omitempty"`
 
 	// Username to use for authenticating requests.
 	//
-	// +kubebuilder:validation:Optional
 	// +nullable
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Username"
 	Username *SecretReference `json:"username,omitempty"`
 
 	// Password to use for authenticating requests.
 	//
-	// +kubebuilder:validation:Optional
 	// +nullable
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Password"
 	Password *SecretReference `json:"password,omitempty"`
 }
 
@@ -217,8 +243,9 @@ type HTTPAuthentication struct {
 type AzureMonitorAuthentication struct {
 	// SharedKey points to the secret containing the shared key used for authenticating requests.
 	//
-	// +kubebuilder:validation:Required
 	// +nullable
+	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Shared Key"
 	SharedKey *SecretReference `json:"sharedKey"`
 }
 
@@ -226,12 +253,14 @@ type AzureMonitor struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Options"
 	Authentication *AzureMonitorAuthentication `json:"authentication"`
 
 	// CustomerId che unique identifier for the Log Analytics workspace.
 	// https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell#request-uri-parameters
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Customer ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	CustomerId string `json:"customerId"`
 
 	// LogType the record type of the data that is being submitted.
@@ -239,23 +268,27 @@ type AzureMonitor struct {
 	// https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell#request-headers
 	//
 	// +kubebuilder:validation:Pattern:="^[a-zA-Z0-9][a-zA-Z0-9_]{0,99}$"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Log Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	LogType string `json:"logType,omitempty"`
 
 	// AzureResourceId the Resource ID of the Azure resource the data should be associated with.
 	// https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell#request-headers
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Azure Resource ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	AzureResourceId string `json:"azureResourceId,omitempty"`
 
 	// Host alternative host for dedicated Azure regions. (for example for China region)
 	// https://docs.azure.cn/en-us/articles/guidance/developerdifferences#check-endpoints-in-azure
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Azure Host",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Host string `json:"host,omitempty"`
 
 	// Tuning specs tuning for the output
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tuning Options"
 	Tuning *BaseOutputTuningSpec `json:"tuning,omitempty"`
 }
 
@@ -267,6 +300,7 @@ type CloudwatchTuningSpec struct {
 	//
 	// +kubebuilder:validation:Enum:=gzip;none;snappy;zlib;zstd
 	// +kubebuilder:default:=none
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
 
@@ -278,32 +312,44 @@ type Cloudwatch struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == '' ||  isURL(self)", message="invalid URL"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Destination URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	URL string `json:"url,omitempty"`
 
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Options"
 	Authentication *CloudwatchAuthentication `json:"authentication"`
 
 	// Tuning specs tuning for the output
 	//
 	// +kubebuilder:validation:Optional
 	// +nullable
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tuning Options"
 	Tuning *CloudwatchTuningSpec `json:"tuning,omitempty"`
 
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Amazon Region",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Region string `json:"region"`
 
 	// GroupName defines the strategy for grouping logstreams
+	//
 	// The GroupName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+	//
 	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	//
 	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	//
 	// Example:
-	// 1. foo-{.bar||"none"}
-	// 2. {.foo||.bar||"missing"}
-	// 3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//
+	//  1. foo-{.bar||"none"}
+	//
+	//  2. {.foo||.bar||"missing"}
+	//
+	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
 	//
 	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Group Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	GroupName string `json:"groupName"`
 }
 
@@ -327,12 +373,14 @@ type CloudwatchAuthentication struct {
 	// Type is the type of cloudwatch authentication to configure
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Type"
 	Type CloudwatchAuthType `json:"type"`
 
 	// AWSAccessKey points to the AWS access key id and secret to be used for authentication.
 	//
 	// +kubebuilder:validation:Optional
 	// +nullable
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Access Key"
 	AWSAccessKey *CloudwatchAWSAccessKey `json:"awsAccessKey,omitempty"`
 
 	// IAMRole points to the secret containing the role ARN to be used for authentication.
@@ -341,6 +389,7 @@ type CloudwatchAuthentication struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +nullable
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Amazon IAM Role"
 	IAMRole *CloudwatchIAMRole `json:"iamRole,omitempty"`
 }
 
@@ -349,11 +398,13 @@ type CloudwatchIAMRole struct {
 	// This is used for authentication in STS-enabled clusters.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="RoleARN Secret"
 	RoleARN SecretReference `json:"roleARN"`
 
 	// Token specifies a bearer token to be used for authenticating requests.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Token"
 	Token BearerToken `json:"token"`
 }
 
@@ -361,11 +412,13 @@ type CloudwatchAWSAccessKey struct {
 	// AccessKeyID points to the AWS access key id to be used for authentication.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret with Access Key ID"
 	KeyID SecretReference `json:"keyID"`
 
 	// AccessKeySecret points to the AWS access key secret to be used for authentication.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret with Access Key Secret"
 	KeySecret SecretReference `json:"keySecret"`
 }
 
@@ -376,6 +429,7 @@ type ElasticsearchTuningSpec struct {
 	//
 	// +kubebuilder:validation:Enum:=none;gzip;zlib
 	// +kubebuilder:default:=none
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
 
@@ -385,25 +439,33 @@ type Elasticsearch struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Options"
 	Authentication *HTTPAuthentication `json:"authentication,omitempty"`
 
 	// Tuning specs tuning for the output
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tuning Options"
 	Tuning *ElasticsearchTuningSpec `json:"tuning,omitempty"`
 
-	// Index is the index for the logs. This supports template syntax
-	// to allow dynamic per-event values.
+	// Index is the index for the logs. This supports template syntax to allow dynamic per-event values.
 	//
 	// The Index can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+	//
 	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	//
 	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	//
 	// Example:
-	// 1. foo-{.bar||"none"}
-	// 2. {.foo||.bar||"missing"}
-	// 3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//
+	//  1. foo-{.bar||"none"}
+	//
+	//  2. {.foo||.bar||"missing"}
+	//
+	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
 	//
 	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Log Index",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Index string `json:"index"`
 
 	// Version specifies the version of Elasticsearch to be used.
@@ -412,6 +474,7 @@ type Elasticsearch struct {
 	// +kubebuilder:validation:Minimum:=6
 	// +kubebuilder:validation:Maximum:=8
 	// +kubebuilder:default:=8
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ElasticSearch Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
 	Version int `json:"version,omitempty"`
 }
 
@@ -420,6 +483,7 @@ type GoogleCloudLoggingAuthentication struct {
 	// Credentials points to the secret containing the `google-application-credentials.json`.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret with Credentials File"
 	Credentials *SecretReference `json:"credentials"`
 }
 
@@ -433,40 +497,52 @@ type GoogleCloudLogging struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Options"
 	Authentication *GoogleCloudLoggingAuthentication `json:"authentication,omitempty"`
 
 	// ID must be one of the required ID fields for the output
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Logging ID"
 	ID GoogleCloudLoggingID `json:"id"`
 
 	// LogID is the log ID to which to publish logs. This identifies log stream.
 	//
 	// The LogID can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+	//
 	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	//
 	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	//
 	// Example:
-	// 1. foo-{.bar||"none"}
-	// 2. {.foo||.bar||"missing"}
-	// 3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//
+	//  1. foo-{.bar||"none"}
+	//
+	//  2. {.foo||.bar||"missing"}
+	//
+	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
 	//
 	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Log Stream ID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	LogID string `json:"logId"`
 
 	// Tuning specs tuning for the output
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tuning Options"
 	Tuning *GoogleCloudLoggingTuningSpec `json:"tuning,omitempty"`
 }
 
 type GoogleCloudLoggingID struct {
 	// Type is the ID type provided
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Logging ID Type"
 	Type GoogleCloudLoggingIDType `json:"type"`
 
 	// Value is the value of the ID
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Logging ID Value",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Value string `json:"value"`
 }
 
@@ -489,6 +565,7 @@ type HTTPTuningSpec struct {
 	//
 	// +kubebuilder:validation:Enum:=none;gzip;snappy;zlib
 	// +kubebuilder:default:=none
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
 
@@ -499,43 +576,51 @@ type HTTP struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Options"
 	Authentication *HTTPAuthentication `json:"authentication,omitempty"`
 
 	// Tuning specs tuning for the output
 	//
-	// +kubebuilder:validation:Optional
 	// +nullable
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tuning Options"
 	Tuning *HTTPTuningSpec `json:"tuning,omitempty"`
 
 	// Headers specify optional headers to be sent with the request
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Headers"
 	Headers map[string]string `json:"headers,omitempty"`
 
 	// Timeout specifies the Http request timeout in seconds. If not set, 10secs is used.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Timeout",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
 	Timeout int `json:"timeout,omitempty"`
 
 	// Method specifies the Http method to be used for sending logs. If not set, 'POST' is used.
 	//
 	// +kubebuilder:validation:Enum:=GET;HEAD;POST;PUT;DELETE;OPTIONS;TRACE;PATCH
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="HTTP Method"
 	Method string `json:"method,omitempty"`
 }
 
 type KafkaTuningSpec struct {
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Delivery Mode"
 	Delivery DeliveryMode `json:"delivery,omitempty"`
 
 	// MaxWrite limits the maximum payload in terms of bytes of a single "send" to the output.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Batch Size"
 	MaxWrite *resource.Quantity `json:"maxWrite,omitempty"`
 
 	// Compression causes data to be compressed before sending over the network.
 	//
 	// +kubebuilder:validation:Enum:=none;snappy;zstd;lz4
 	// +kubebuilder:default:=none
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
 
@@ -544,6 +629,7 @@ type KafkaAuthentication struct {
 	// SASL contains options configuring SASL authentication.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SASL Options"
 	SASL *SASLAuthentication `json:"sasl,omitempty"`
 }
 
@@ -551,16 +637,19 @@ type SASLAuthentication struct {
 	// Username points to the secret to be used as SASL username.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret with Username"
 	Username *SecretReference `json:"username,omitempty"`
 
 	// Username points to the secret to be used as SASL password.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Secret with Password"
 	Password *SecretReference `json:"password,omitempty"`
 
 	// Mechanism sets the SASL mechanism to use.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="SASL Mechanism",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Mechanism string `json:"mechanism,omitempty"`
 }
 
@@ -573,39 +662,53 @@ type Kafka struct {
 	// The 'username@password' part of `url` is ignored.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == '' ||  isURL(self)", message="invalid URL"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Destination URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	URL string `json:"url,omitempty"`
 
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Options"
 	Authentication *KafkaAuthentication `json:"authentication,omitempty"`
 
 	// Tuning specs tuning for the output
 	//
-	// +kubebuilder:validation:Optional
 	// +nullable
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tuning Options"
 	Tuning *KafkaTuningSpec `json:"tuning,omitempty"`
 
 	// Topic specifies the target topic to send logs to. The value when not specified is 'topic'
 	//
 	// The Topic can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
-	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
-	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
-	// Example:
-	// 1. foo-{.bar||"none"}
-	// 2. {.foo||.bar||"missing"}
-	// 3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
 	//
-	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	//
+	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	//
+	// Example:
+	//
+	//  1. foo-{.bar||"none"}
+	//
+	//  2. {.foo||.bar||"missing"}
+	//
+	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Kafka Topic",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Topic string `json:"topic,omitempty"`
 
 	// Brokers specifies the list of broker endpoints of a Kafka cluster.
+	//
 	// The list represents only the initial set used by the collector's Kafka client for the
 	// first connection only. The collector's Kafka client fetches constantly an updated list
 	// from Kafka. These updates are not reconciled back to the collector configuration.
+	//
 	// If none provided the target URL from the OutputSpec is used as fallback.
+	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Kafka Brokers"
 	Brokers []URL `json:"brokers,omitempty"`
 }
 
@@ -619,6 +722,7 @@ type LokiTuningSpec struct {
 	//
 	// +kubebuilder:validation:Enum:=none;gzip;snappy
 	// +kubebuilder:default:=snappy
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
 
@@ -626,13 +730,17 @@ type LokiTuningSpec struct {
 type LokiStackTarget struct {
 	// Namespace of the in-cluster LokiStack resource.
 	//
+	// If unset, this defaults to "openshift-logging".
+	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="LokiStack Namespace",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Namespace string `json:"namespace,omitempty"`
 
 	// Name of the in-cluster LokiStack resource.
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern:="^[a-z][a-z0-9-]{2,62}[a-z0-9]$"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="LokiStack Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Name string `json:"name"`
 }
 
@@ -640,8 +748,9 @@ type LokiStackTarget struct {
 type LokiStackAuthentication struct {
 	// Token specifies a bearer token to be used for authenticating requests.
 	//
-	// +kubebuilder:validation:Required
 	// +nullable
+	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Bearer Token"
 	Token *BearerToken `json:"token"`
 }
 
@@ -650,16 +759,19 @@ type LokiStack struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Options"
 	Authentication *LokiStackAuthentication `json:"authentication"`
 
 	// Target points to the LokiStack resources that should be used as a target for the output.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Target LokiStack Reference"
 	Target LokiStackTarget `json:"target"`
 
 	// Tuning specs tuning for the output
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tuning Options"
 	Tuning *LokiTuningSpec `json:"tuning,omitempty"`
 
 	// LabelKeys can be used to customize which log record keys are mapped to Loki stream labels.
@@ -683,6 +795,7 @@ type LokiStack struct {
 	// Loki queries can also query based on any log record field (not just labels) using query filters.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Stream Label Configuration"
 	LabelKeys *LokiStackLabelKeys `json:"labelKeys,omitempty"`
 }
 
@@ -704,21 +817,25 @@ type LokiStackLabelKeys struct {
 	// where the collector is running and is always present.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Global Configuration"
 	Global []string `json:"global,omitempty"`
 
 	// Application contains the label keys configuration for the "application" tenant.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Application Tenant Configuration"
 	Application *LokiStackTenantLabelKeys `json:"application,omitempty"`
 
 	// Infrastructure contains the label keys configuration for the "infrastructure" tenant.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Infrastructure Tenant Configuration"
 	Infrastructure *LokiStackTenantLabelKeys `json:"infrastructure,omitempty"`
 
 	// Audit contains the label keys configuration for the "audit" tenant.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Audit Tenant Configuration"
 	Audit *LokiStackTenantLabelKeys `json:"audit,omitempty"`
 }
 
@@ -728,13 +845,16 @@ type LokiStackTenantLabelKeys struct {
 	// keys configuration.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Ignore Global Settings",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
 	IgnoreGlobal bool `json:"ignoreGlobal,omitempty"`
 
 	// LabelKeys contains a list of log record keys that are mapped to Loki stream labels.
+	//
 	// By default, this list is combined with the labels specified in the Global configuration.
 	// This behavior can be changed by setting IgnoreGlobal to true.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Label Keys"
 	LabelKeys []string `json:"labelKeys,omitempty"`
 }
 
@@ -743,12 +863,14 @@ type Loki struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Options"
 	Authentication *HTTPAuthentication `json:"authentication,omitempty"`
 
 	// Tuning specs tuning for the output
 	//
-	// +kubebuilder:validation:Optional
 	// +nullable
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tuning Options"
 	Tuning *LokiTuningSpec `json:"tuning,omitempty"`
 
 	URLSpec `json:",inline"`
@@ -787,22 +909,28 @@ type Loki struct {
 	// Loki queries can also query based on any log record field (not just labels) using query filters.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Stream Label Configuration"
 	LabelKeys []string `json:"labelKeys,omitempty"`
 
-	// TenantKey is the tenant for the logs. This supports vector's template syntax
-	// to allow dynamic per-event values.
+	// TenantKey is the tenant for the logs. This supports vector's template syntax to allow dynamic per-event values.
 	//
 	// The TenantKey can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
-	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
-	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
-	// Example:
-	// 1. foo-{.bar||"none"}
-	// 2. {.foo||.bar||"missing"}
-	// 3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
 	//
-	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	//
+	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	//
+	// Example:
+	//
+	//  1. foo-{.bar||"none"}
+	//
+	//  2. {.foo||.bar||"missing"}
+	//
+	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//
 	// +kubebuilder:validation:Optional
-	// +nullable
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tenant Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	TenantKey string `json:"tenantKey,omitempty"`
 }
 
@@ -813,6 +941,7 @@ type SplunkTuningSpec struct {
 	//
 	// +kubebuilder:validation:Enum:=none;gzip
 	// +kubebuilder:default:=none
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
 
@@ -821,6 +950,7 @@ type SplunkAuthentication struct {
 	// Token points to the secret containing the Splunk HEC token used for authenticating requests.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Splunk HEC Token"
 	Token *SecretReference `json:"token"`
 }
 
@@ -830,30 +960,37 @@ type Splunk struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Options"
 	Authentication *SplunkAuthentication `json:"authentication"`
 
 	// Tuning specs tuning for the output
 	//
-	// +kubebuilder:validation:Optional
 	// +nullable
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tuning Options"
 	Tuning *SplunkTuningSpec `json:"tuning,omitempty"`
 
 	URLSpec `json:",inline"`
 
-	// Index is the index for the logs. This supports template syntax
-	// to allow dynamic per-event values.
+	// Index is the index for the logs. This supports template syntax to allow dynamic per-event values.
 	//
 	// The Index can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
-	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
-	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
-	// Example:
-	// 1. foo-{.bar||"none"}
-	// 2. {.foo||.bar||"missing"}
-	// 3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
 	//
-	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	//
+	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	//
+	// Example:
+	//
+	//  1. foo-{.bar||"none"}
+	//
+	//  2. {.foo||.bar||"missing"}
+	//
+	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//
 	// +kubebuilder:validation:Optional
-	// +nullable
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Index",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Index string `json:"index,omitempty"`
 }
 
@@ -876,26 +1013,31 @@ type Syslog struct {
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="isURL(self)", message="invalid URL"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Destination URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	URL string `json:"url"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:=RFC5424
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Syslog RFC"
 	RFC SyslogRFCType `json:"rfc"`
 
 	// Severity to set on outgoing syslog records.
 	//
 	// Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1
+	//
 	// The value can be a decimal integer or one of these case-insensitive keywords:
 	//
 	//     Emergency Alert Critical Error Warning Notice Informational Debug
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=informational
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Severity",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Severity string `json:"severity,omitempty"`
 
 	// Facility to set on outgoing syslog records.
 	//
 	// Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
+	//
 	// The value can be a decimal integer. Facility keywords are not standardized,
 	// this API recognizes at least the following case-insensitive keywords
 	// (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels):
@@ -906,77 +1048,105 @@ type Syslog struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=user
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Facility",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Facility string `json:"facility,omitempty"`
 
-	// PayloadKey specifies record field to use as payload. This supports template syntax
-	// to allow dynamic per-event values.
-
+	// PayloadKey specifies record field to use as payload. This supports template syntax to allow dynamic per-event values.
+	//
 	// The PayloadKey must be a single field path encased in single curly brackets `{}`.
+	//
 	// Field paths must only contain alphanumeric and underscores. Any field with other characters must be quoted.
+	//
 	// If left empty, Syslog will use the whole message as the payload key
 	//
 	// Example:
-	// 1. {.bar}
-	// 2. {.foo.bar.baz}
-	// 3. {.foo.bar."baz/with/slashes"}
 	//
-	// +kubebuilder:validation:Pattern:=`^\{(\.[a-zA-Z0-9_]+|\."[^"]+")(\.[a-zA-Z0-9_]+|\."[^"]+")*\}$`
+	//  1. {.bar}
+	//
+	//  2. {.foo.bar.baz}
+	//
+	//  3. {.foo.bar."baz/with/slashes"}
+	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern:=`^\{(\.[a-zA-Z0-9_]+|\."[^"]+")(\.[a-zA-Z0-9_]+|\."[^"]+")*\}$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Payload Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	PayloadKey string `json:"payloadKey,omitempty"`
 
 	// AppName is APP-NAME part of the syslog-msg header.
+	//
 	// AppName needs to be specified if using rfc5424. The maximum length of the final values is truncated to 48
 	// This supports template syntax to allow dynamic per-event values.
 	//
 	// The AppName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
-	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
-	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
-	// Example:
-	// 1. foo-{.bar||"none"}
-	// 2. {.foo||.bar||"missing"}
-	// 3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
 	//
-	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	//
+	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	//
+	// Example:
+	//
+	//  1. foo-{.bar||"none"}
+	//
+	//  2. {.foo||.bar||"missing"}
+	//
+	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="App Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	// TODO: DETERMIN HOW to default the app name that isnt based on fluentd assumptions of "tag" when this is empty
 	AppName string `json:"appName,omitempty"`
 
-	// ProcID is PROCID part of the syslog-msg header. This supports template syntax
-	// to allow dynamic per-event values.
+	// ProcID is PROCID part of the syslog-msg header. This supports template syntax to allow dynamic per-event values.
 	//
 	// The ProcID can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+	//
 	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	//
 	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	//
 	// Example:
-	// 1. foo-{.bar||"none"}
-	// 2. {.foo||.bar||"missing"}
-	// 3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//
+	//  1. foo-{.bar||"none"}
+	//
+	//  2. {.foo||.bar||"missing"}
+	//
+	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
 	//
 	// ProcID needs to be specified if using rfc5424. The maximum length of the final values is truncated to 128
 	//
-	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="PROCID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	ProcID string `json:"procID,omitempty"`
 
-	// MsgID is MSGID part of the syslog-msg header. This supports template syntax
-	// to allow dynamic per-event values.
+	// MsgID is MSGID part of the syslog-msg header. This supports template syntax to allow dynamic per-event values.
 	//
 	// The MsgID can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+	//
 	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	//
 	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	//
 	// Example:
-	// 1. foo-{.bar||"none"}
-	// 2. {.foo||.bar||"missing"}
-	// 3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//
+	//  1. foo-{.bar||"none"}
+	//
+	//  2. {.foo||.bar||"missing"}
+	//
+	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
 	//
 	// MsgID needs to be specified if using rfc5424.  The maximum length of the final values is truncated to 32
 	//
-	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="MSGID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	MsgID string `json:"msgID,omitempty"`
 
 	// Enrichment is an additional modification the log message before forwarding it to the receiver
+	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enrichment Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Enrichment EnrichmentType `json:"enrichment,omitempty"`
 }
 
@@ -984,7 +1154,7 @@ type Syslog struct {
 type EnrichmentType string
 
 const (
-	// EnrichmentTypeNone add no additional enrichment to the recored
+	// EnrichmentTypeNone add no additional enrichment to the record
 	EnrichmentTypeNone EnrichmentType = "none"
 
 	// EnrichmentTypeKubernetesMinimal adds namespace_name, pod_name, and collector_name to the beginning of the message
@@ -1001,6 +1171,7 @@ type OTLPTuningSpec struct {
 	//
 	// +kubebuilder:validation:Enum:=gzip;none
 	// +kubebuilder:default:=gzip
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Compression string `json:"compression,omitempty"`
 }
 
@@ -1016,16 +1187,19 @@ type OTLP struct {
 	//
 	// +kubebuilder:validation:Pattern:=`^(https?):\/\/\S+\/v1\/logs$`
 	// +kubebuilder:validation:XValidation:rule="isURL(self)", message="invalid URL"
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Destination URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	URL string `json:"url"`
 
 	// Authentication sets credentials for authenticating the requests.
 	//
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Authentication Options"
 	Authentication *HTTPAuthentication `json:"authentication,omitempty"`
 
 	// Tuning specs tuning for the output
 	//
-	// +kubebuilder:validation:Optional
 	// +nullable
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Tuning Options"
 	Tuning *OTLPTuningSpec `json:"tuning,omitempty"`
 }

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-07-18T18:29:26Z"
+    createdAt: "2024-08-09T16:07:33Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -155,110 +155,1230 @@ spec:
         path: collector.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Define the tolerations the collector pods will accept
+        displayName: Tolerations
+        path: collector.tolerations
       - description: Filters are applied to log records passing through a pipeline.
           There are different types of filter that can select and modify log records
           in different ways. See [FilterTypeSpec] for a list of filter types.
         displayName: Log Forwarder Pipeline Filters
         path: filters
+      - description: A drop filter applies a sequence of tests to a log record and
+          drops the record if any test passes. Each test contains a sequence of conditions,
+          all conditions must be true for the test to pass. A DropTestsSpec contains
+          an array of tests which contains an array of conditions
+        displayName: Drop Filters
+        path: filters[0].drop
+      - description: DropConditions is an array of DropCondition which are conditions
+          that are ANDed together
+        displayName: Drop Filter Conditions
+        path: filters[0].drop[0].test
+      - description: 'A dot delimited path to a field in the log record. It must start
+          with a `.`. The path can contain alpha-numeric characters and underscores
+          (a-zA-Z0-9_). If segments contain characters outside of this range, the
+          segment must be quoted. Examples: `.kubernetes.namespace_name`, `.log_type`,
+          ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`'
+        displayName: Field Path
+        path: filters[0].drop[0].test[0].field
+      - description: A regular expression that the field will match. If the value
+          of the field defined in the DropTest matches the regular expression, the
+          log record will be dropped. Must define only one of matches OR notMatches
+        displayName: Drop Match Expression
+        path: filters[0].drop[0].test[0].matches
+      - description: A regular expression that the field does not match. If the value
+          of the field defined in the DropTest does not match the regular expression,
+          the log record will be dropped. Must define only one of matches or notMatches
+        displayName: Keep Match Expression
+        path: filters[0].drop[0].test[0].notMatches
+      - displayName: Kubernetes API Audit Filter
+        path: filters[0].kubeAPIAudit
+      - description: Name used to refer to the filter from a "pipeline".
+        displayName: Filter Name
+        path: filters[0].name
+      - description: Labels applied to log records passing through a pipeline. These
+          labels appear in the `openshift.labels` map in the log record.
+        displayName: Labels
+        path: filters[0].openShiftLabels
+      - description: The PruneFilterSpec consists of two arrays, namely in and notIn,
+          which dictate the fields to be pruned.
+        displayName: Prune Filters
+        path: filters[0].prune
+      - description: "`In` is an array of dot-delimited field paths. Fields included
+          here are removed from the log record. \n Each field path expression must
+          start with a \".\" \n The path can contain alphanumeric characters and underscores
+          (a-zA-Z0-9_). \n If segments contain characters outside of this range, the
+          segment must be quoted otherwise paths do NOT need to be quoted. \n Examples:
+          \n - `.kubernetes.namespace_name` \n - `.log_type` \n - '.kubernetes.labels.foobar'
+          \n - `.kubernetes.labels.\"foo-bar/baz\"` \n NOTE1: `In` CANNOT contain
+          `.log_type` or `.message` as those fields are required and cannot be pruned.
+          \n NOTE2: If this filter is used in a pipeline with GoogleCloudLogging,
+          `.hostname` CANNOT be added to this list as it is a required field."
+        displayName: Fields to be dropped
+        path: filters[0].prune.in
+      - description: "`NotIn` is an array of dot-delimited field paths. All fields
+          besides the ones listed here are removed from the log record. \n Each field
+          path expression must start with a \".\" \n The path can contain alphanumeric
+          characters and underscores (a-zA-Z0-9_). \n If segments contain characters
+          outside of this range, the segment must be quoted otherwise paths do NOT
+          need to be quoted. \n Examples: \n - `.kubernetes.namespace_name` \n - `.log_type`
+          \n - '.kubernetes.labels.foobar' \n - `.kubernetes.labels.\"foo-bar/baz\"`
+          \n NOTE1: `NotIn` MUST contain `.log_type` and `.message` as those fields
+          are required and cannot be pruned. \n NOTE2: If this filter is used in a
+          pipeline with GoogleCloudLogging, `.hostname` MUST be added to this list
+          as it is a required field."
+        displayName: Fields to be kept
+        path: filters[0].prune.notIn
+      - description: Type of filter.
+        displayName: Filter Type
+        path: filters[0].type
       - description: "Inputs are named filters for log messages to be forwarded. \n
           There are three built-in inputs named `application`, `infrastructure` and
           `audit`. You don't need to define inputs here if those are sufficient for
           your needs. See `inputRefs` for more."
         displayName: Log Forwarder Inputs
         path: inputs
+      - description: Application, named set of `application` logs that can specify
+          a set of match criteria
+        displayName: Application Logs Input
+        path: inputs[0].application
+      - description: "Excludes is the set of namespaces and containers to ignore when
+          collecting logs. \n Takes precedence over Includes option."
+        displayName: Exclude
+        path: inputs[0].application.excludes
+      - description: Container spec the containers from which to collect logs Supports
+          glob patterns and presumes "*" if omitted.
+        displayName: Container Glob
+        path: inputs[0].application.excludes[0].container
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Namespace specs the namespace from which to collect logs Supports
+          glob patterns and presumes "*" if omitted.
+        displayName: Namespace Glob
+        path: inputs[0].application.excludes[0].namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Includes is the set of namespaces and containers to include
+          when collecting logs. \n Note: infrastructure namespaces are still excluded
+          for \"*\" values unless a qualifying glob pattern is specified."
+        displayName: Include
+        path: inputs[0].application.includes
+      - description: Container spec the containers from which to collect logs Supports
+          glob patterns and presumes "*" if omitted.
+        displayName: Container Glob
+        path: inputs[0].application.includes[0].container
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Namespace specs the namespace from which to collect logs Supports
+          glob patterns and presumes "*" if omitted.
+        displayName: Namespace Glob
+        path: inputs[0].application.includes[0].namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Selector for logs from pods with matching labels. \n Only messages
+          from pods with these labels are collected. \n If absent or empty, logs are
+          collected regardless of labels."
+        displayName: Pod Selector
+        path: inputs[0].application.selector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Pod
+      - description: Tuning is the container input tuning spec for this container
+          sources
+        displayName: Input Tuning
+        path: inputs[0].application.tuning
+      - description: RateLimitPerContainer is the limit applied to each container
+          by this input. This limit is applied per collector deployment.
+        displayName: Per-Container Rate Limit
+        path: inputs[0].application.tuning.rateLimitPerContainer
       - description: MaxRecordsPerSecond is the maximum number of log records allowed
           per input/output in a pipeline
         displayName: Max Records Per Second
         path: inputs[0].application.tuning.rateLimitPerContainer.maxRecordsPerSecond
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Audit, enables `audit` logs.
+        displayName: Audit Logs Input
+        path: inputs[0].audit
+      - description: Sources defines the list of audit sources to collect. This field
+          is optional and its exclusion results in the collection of all audit sources.
+        displayName: Log Sources
+        path: inputs[0].audit.sources
+      - description: Infrastructure, Enables `infrastructure` logs.
+        displayName: Infrastructure Logs Input
+        path: inputs[0].infrastructure
+      - description: Sources defines the list of infrastructure sources to collect.
+          This field is optional and omission results in the collection of all infrastructure
+          sources.
+        displayName: Log Sources
+        path: inputs[0].infrastructure.sources
+      - description: Name used to refer to the input of a `pipeline`.
+        displayName: Input Name
+        path: inputs[0].name
+      - description: Receiver to receive logs from non-cluster sources.
+        displayName: Log Receiver
+        path: inputs[0].receiver
+      - displayName: HTTP Receiver Configuration
+        path: inputs[0].receiver.http
+      - description: Format is the format of incoming log data.
+        displayName: Data Format
+        path: inputs[0].receiver.http.format
+      - description: Port the Receiver listens on. It must be a value between 1024
+          and 65535
+        displayName: Listen Port
+        path: inputs[0].receiver.port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: "TLS contains settings for controlling options of TLS connections.
+          \n The operator will request certificates from the cluster's cert signing
+          service when TLS is not defined. The certificates are injected into a secret
+          named \"<clusterlogforwarder.name>-<input.name>\" which is mounted into
+          the collector. The collector is configured to use the public and private
+          key provided by the service"
+        displayName: TLS Options
+        path: inputs[0].receiver.tls
+      - description: Type of Receiver plugin.
+        displayName: Receiver Type
+        path: inputs[0].receiver.type
+      - description: Type of output sink.
+        displayName: Input Type
+        path: inputs[0].type
+      - description: Indicator if the resource is 'Managed' or 'Unmanaged' by the
+          operator.
+        displayName: Management State
+        path: managementState
       - description: Outputs are named destinations for log messages.
         displayName: Log Forwarder Outputs
         path: outputs
+      - displayName: Azure Monitor
+        path: outputs[0].azureMonitor
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].azureMonitor.authentication
+      - description: SharedKey points to the secret containing the shared key used
+          for authenticating requests.
+        displayName: Shared Key
+        path: outputs[0].azureMonitor.authentication.sharedKey
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].azureMonitor.authentication.sharedKey.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].azureMonitor.authentication.sharedKey.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: AzureResourceId the Resource ID of the Azure resource the data
+          should be associated with. https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell#request-headers
+        displayName: Azure Resource ID
+        path: outputs[0].azureMonitor.azureResourceId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: CustomerId che unique identifier for the Log Analytics workspace.
+          https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell#request-uri-parameters
+        displayName: Customer ID
+        path: outputs[0].azureMonitor.customerId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Host alternative host for dedicated Azure regions. (for example
+          for China region) https://docs.azure.cn/en-us/articles/guidance/developerdifferences#check-endpoints-in-azure
+        displayName: Azure Host
+        path: outputs[0].azureMonitor.host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: LogType the record type of the data that is being submitted.
+          Can only contain letters, numbers, and underscores (_), and may not exceed
+          100 characters. https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell#request-headers
+        displayName: Log Type
+        path: outputs[0].azureMonitor.logType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].azureMonitor.tuning
+      - displayName: Delivery Mode
+        path: outputs[0].azureMonitor.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].azureMonitor.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].azureMonitor.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].azureMonitor.tuning.minRetryDuration
+      - displayName: Amazon CloudWatch
+        path: outputs[0].cloudwatch
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].cloudwatch.authentication
+      - description: AWSAccessKey points to the AWS access key id and secret to be
+          used for authentication.
+        displayName: Access Key
+        path: outputs[0].cloudwatch.authentication.awsAccessKey
+      - description: AccessKeyID points to the AWS access key id to be used for authentication.
+        displayName: Secret with Access Key ID
+        path: outputs[0].cloudwatch.authentication.awsAccessKey.keyID
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].cloudwatch.authentication.awsAccessKey.keyID.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].cloudwatch.authentication.awsAccessKey.keyID.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: AccessKeySecret points to the AWS access key secret to be used
+          for authentication.
+        displayName: Secret with Access Key Secret
+        path: outputs[0].cloudwatch.authentication.awsAccessKey.keySecret
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].cloudwatch.authentication.awsAccessKey.keySecret.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].cloudwatch.authentication.awsAccessKey.keySecret.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: IAMRole points to the secret containing the role ARN to be used
+          for authentication. This can be used for authentication in STS-enabled clusters
+          when additionally specifying a web identity token
+        displayName: Amazon IAM Role
+        path: outputs[0].cloudwatch.authentication.iamRole
+      - description: RoleARN points to the secret containing the role ARN to be used
+          for authentication. This is used for authentication in STS-enabled clusters.
+        displayName: RoleARN Secret
+        path: outputs[0].cloudwatch.authentication.iamRole.roleARN
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].cloudwatch.authentication.iamRole.roleARN.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].cloudwatch.authentication.iamRole.roleARN.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Token
+        path: outputs[0].cloudwatch.authentication.iamRole.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].cloudwatch.authentication.iamRole.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].cloudwatch.authentication.iamRole.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].cloudwatch.authentication.iamRole.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].cloudwatch.authentication.iamRole.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Type is the type of cloudwatch authentication to configure
+        displayName: Authentication Type
+        path: outputs[0].cloudwatch.authentication.type
+      - description: "GroupName defines the strategy for grouping logstreams \n The
+          GroupName can be a combination of static and dynamic values consisting of
+          field paths followed by `||` followed by another field path or a static
+          value. \n A dynamic value is encased in single curly brackets `{}` and MUST
+          end with a static fallback value separated with `||`. \n Static values can
+          only contain alphanumeric characters along with dashes, underscores, dots
+          and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+          \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Group Name
+        path: outputs[0].cloudwatch.groupName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Amazon Region
+        path: outputs[0].cloudwatch.region
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].cloudwatch.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network. It is an error if the compression type is not supported by
+          the output.
+        displayName: Compression
+        path: outputs[0].cloudwatch.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].cloudwatch.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].cloudwatch.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].cloudwatch.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].cloudwatch.tuning.minRetryDuration
+      - description: "URL to send log records to. \n The 'username@password' part
+          of `url` is ignored."
+        displayName: Destination URL
+        path: outputs[0].cloudwatch.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: ElasticSearch
+        path: outputs[0].elasticsearch
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].elasticsearch.authentication
+      - description: Password to use for authenticating requests.
+        displayName: Password
+        path: outputs[0].elasticsearch.authentication.password
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].elasticsearch.authentication.password.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].elasticsearch.authentication.password.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Bearer Token
+        path: outputs[0].elasticsearch.authentication.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].elasticsearch.authentication.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].elasticsearch.authentication.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].elasticsearch.authentication.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].elasticsearch.authentication.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username to use for authenticating requests.
+        displayName: Username
+        path: outputs[0].elasticsearch.authentication.username
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].elasticsearch.authentication.username.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].elasticsearch.authentication.username.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Index is the index for the logs. This supports template syntax
+          to allow dynamic per-event values. \n The Index can be a combination of
+          static and dynamic values consisting of field paths followed by `||` followed
+          by another field path or a static value. \n A dynamic value is encased in
+          single curly brackets `{}` and MUST end with a static fallback value separated
+          with `||`. \n Static values can only contain alphanumeric characters along
+          with dashes, underscores, dots and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"}
+          \n 2. {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Log Index
+        path: outputs[0].elasticsearch.index
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].elasticsearch.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].elasticsearch.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].elasticsearch.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].elasticsearch.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].elasticsearch.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].elasticsearch.tuning.minRetryDuration
+      - description: URL to send log records to. Basic TLS is enabled if the URL scheme
+          requires it (for example 'https' or 'tls'). The 'username@password' part
+          of `url` is ignored.
+        displayName: Destination URL
+        path: outputs[0].elasticsearch.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'Version specifies the version of Elasticsearch to be used. Must
+          be one of: 6-8, where 8 is the default'
+        displayName: ElasticSearch Version
+        path: outputs[0].elasticsearch.version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - displayName: Google Cloud Logging
+        path: outputs[0].googleCloudLogging
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].googleCloudLogging.authentication
+      - description: Credentials points to the secret containing the `google-application-credentials.json`.
+        displayName: Secret with Credentials File
+        path: outputs[0].googleCloudLogging.authentication.credentials
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].googleCloudLogging.authentication.credentials.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].googleCloudLogging.authentication.credentials.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ID must be one of the required ID fields for the output
+        displayName: Logging ID
+        path: outputs[0].googleCloudLogging.id
+      - description: Type is the ID type provided
+        displayName: Logging ID Type
+        path: outputs[0].googleCloudLogging.id.type
+      - description: Value is the value of the ID
+        displayName: Logging ID Value
+        path: outputs[0].googleCloudLogging.id.value
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "LogID is the log ID to which to publish logs. This identifies
+          log stream. \n The LogID can be a combination of static and dynamic values
+          consisting of field paths followed by `||` followed by another field path
+          or a static value. \n A dynamic value is encased in single curly brackets
+          `{}` and MUST end with a static fallback value separated with `||`. \n Static
+          values can only contain alphanumeric characters along with dashes, underscores,
+          dots and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+          \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Log Stream ID
+        path: outputs[0].googleCloudLogging.logId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].googleCloudLogging.tuning
+      - displayName: Delivery Mode
+        path: outputs[0].googleCloudLogging.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].googleCloudLogging.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].googleCloudLogging.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].googleCloudLogging.tuning.minRetryDuration
+      - displayName: HTTP Output
+        path: outputs[0].http
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].http.authentication
+      - description: Password to use for authenticating requests.
+        displayName: Password
+        path: outputs[0].http.authentication.password
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].http.authentication.password.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].http.authentication.password.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Bearer Token
+        path: outputs[0].http.authentication.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].http.authentication.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].http.authentication.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].http.authentication.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].http.authentication.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username to use for authenticating requests.
+        displayName: Username
+        path: outputs[0].http.authentication.username
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].http.authentication.username.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].http.authentication.username.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Headers specify optional headers to be sent with the request
+        displayName: Headers
+        path: outputs[0].http.headers
+      - description: Method specifies the Http method to be used for sending logs.
+          If not set, 'POST' is used.
+        displayName: HTTP Method
+        path: outputs[0].http.method
+      - description: Timeout specifies the Http request timeout in seconds. If not
+          set, 10secs is used.
+        displayName: Timeout
+        path: outputs[0].http.timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].http.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].http.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].http.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].http.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].http.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].http.tuning.minRetryDuration
+      - description: URL to send log records to. Basic TLS is enabled if the URL scheme
+          requires it (for example 'https' or 'tls'). The 'username@password' part
+          of `url` is ignored.
+        displayName: Destination URL
+        path: outputs[0].http.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Apache Kafka
+        path: outputs[0].kafka
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].kafka.authentication
+      - description: SASL contains options configuring SASL authentication.
+        displayName: SASL Options
+        path: outputs[0].kafka.authentication.sasl
+      - description: Mechanism sets the SASL mechanism to use.
+        displayName: SASL Mechanism
+        path: outputs[0].kafka.authentication.sasl.mechanism
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username points to the secret to be used as SASL password.
+        displayName: Secret with Password
+        path: outputs[0].kafka.authentication.sasl.password
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].kafka.authentication.sasl.password.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].kafka.authentication.sasl.password.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username points to the secret to be used as SASL username.
+        displayName: Secret with Username
+        path: outputs[0].kafka.authentication.sasl.username
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].kafka.authentication.sasl.username.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].kafka.authentication.sasl.username.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Brokers specifies the list of broker endpoints of a Kafka cluster.
+          \n The list represents only the initial set used by the collector's Kafka
+          client for the first connection only. The collector's Kafka client fetches
+          constantly an updated list from Kafka. These updates are not reconciled
+          back to the collector configuration. \n If none provided the target URL
+          from the OutputSpec is used as fallback."
+        displayName: Kafka Brokers
+        path: outputs[0].kafka.brokers
+      - description: "Topic specifies the target topic to send logs to. The value
+          when not specified is 'topic' \n The Topic can be a combination of static
+          and dynamic values consisting of field paths followed by `||` followed by
+          another field path or a static value. \n A dynamic value is encased in single
+          curly brackets `{}` and MUST end with a static fallback value separated
+          with `||`. \n Static values can only contain alphanumeric characters along
+          with dashes, underscores, dots and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"}
+          \n 2. {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Kafka Topic
+        path: outputs[0].kafka.topic
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].kafka.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].kafka.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].kafka.tuning.delivery
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].kafka.tuning.maxWrite
+      - description: "URL to send log records to. \n The 'username@password' part
+          of `url` is ignored."
+        displayName: Destination URL
+        path: outputs[0].kafka.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Grafana Loki
+        path: outputs[0].loki
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].loki.authentication
+      - description: Password to use for authenticating requests.
+        displayName: Password
+        path: outputs[0].loki.authentication.password
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].loki.authentication.password.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].loki.authentication.password.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Bearer Token
+        path: outputs[0].loki.authentication.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].loki.authentication.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].loki.authentication.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].loki.authentication.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].loki.authentication.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username to use for authenticating requests.
+        displayName: Username
+        path: outputs[0].loki.authentication.username
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].loki.authentication.username.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].loki.authentication.username.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "LabelKeys can be used to customize which log record keys are
+          mapped to Loki stream labels. \n If LabelKeys is not set, the default keys
+          are: \n - log_type \n - kubernetes.container_name \n - kubernetes.namespace_name
+          \n - kubernetes.pod_name \n One additional label \"kubernetes_host\" is
+          not part of the label keys configuration. It contains the hostname where
+          the collector is running and is always present. \n Note: Loki label names
+          must match the regular expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\" Log record
+          keys may contain characters like \".\" and \"/\" that are not allowed in
+          Loki labels. Log record keys are translated to Loki labels by replacing
+          any illegal characters with '_'. \n For example the default log record keys
+          translate to these Loki labels: \n - log_type \n - kubernetes_container_name
+          \n - kubernetes_namespace_name \n - kubernetes_pod_name \n Note: the set
+          of labels should be small, Loki imposes limits on the size and number of
+          labels allowed. See https://grafana.com/docs/loki/latest/configuration/#limits_config
+          for more. Loki queries can also query based on any log record field (not
+          just labels) using query filters."
+        displayName: Stream Label Configuration
+        path: outputs[0].loki.labelKeys
+      - description: "TenantKey is the tenant for the logs. This supports vector's
+          template syntax to allow dynamic per-event values. \n The TenantKey can
+          be a combination of static and dynamic values consisting of field paths
+          followed by `||` followed by another field path or a static value. \n A
+          dynamic value is encased in single curly brackets `{}` and MUST end with
+          a static fallback value separated with `||`. \n Static values can only contain
+          alphanumeric characters along with dashes, underscores, dots and forward
+          slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+          \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Tenant Key
+        path: outputs[0].loki.tenantKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].loki.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].loki.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].loki.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].loki.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].loki.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].loki.tuning.minRetryDuration
+      - description: URL to send log records to. Basic TLS is enabled if the URL scheme
+          requires it (for example 'https' or 'tls'). The 'username@password' part
+          of `url` is ignored.
+        displayName: Destination URL
+        path: outputs[0].loki.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: LokiStack
+        path: outputs[0].lokiStack
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].lokiStack.authentication
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Bearer Token
+        path: outputs[0].lokiStack.authentication.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].lokiStack.authentication.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].lokiStack.authentication.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].lokiStack.authentication.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].lokiStack.authentication.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "LabelKeys can be used to customize which log record keys are
+          mapped to Loki stream labels. \n Note: Loki label names must match the regular
+          expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\" Log record keys may contain characters
+          like \".\" and \"/\" that are not allowed in Loki labels. Log record keys
+          are translated to Loki labels by replacing any illegal characters with '_'.
+          \n For example the default log record keys translate to these Loki labels:
+          \n - log_type \n - kubernetes_container_name \n - kubernetes_namespace_name
+          \n - kubernetes_pod_name \n Note: the set of labels should be small, Loki
+          imposes limits on the size and number of labels allowed. See https://grafana.com/docs/loki/latest/configuration/#limits_config
+          for more. Loki queries can also query based on any log record field (not
+          just labels) using query filters."
+        displayName: Stream Label Configuration
+        path: outputs[0].lokiStack.labelKeys
+      - description: Application contains the label keys configuration for the "application"
+          tenant.
+        displayName: Application Tenant Configuration
+        path: outputs[0].lokiStack.labelKeys.application
+      - description: If IgnoreGlobal is true, then the tenant will not use the labels
+          configured in the Global section of the label keys configuration.
+        displayName: Ignore Global Settings
+        path: outputs[0].lokiStack.labelKeys.application.ignoreGlobal
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: "LabelKeys contains a list of log record keys that are mapped
+          to Loki stream labels. \n By default, this list is combined with the labels
+          specified in the Global configuration. This behavior can be changed by setting
+          IgnoreGlobal to true."
+        displayName: Label Keys
+        path: outputs[0].lokiStack.labelKeys.application.labelKeys
+      - description: Audit contains the label keys configuration for the "audit" tenant.
+        displayName: Audit Tenant Configuration
+        path: outputs[0].lokiStack.labelKeys.audit
+      - description: If IgnoreGlobal is true, then the tenant will not use the labels
+          configured in the Global section of the label keys configuration.
+        displayName: Ignore Global Settings
+        path: outputs[0].lokiStack.labelKeys.audit.ignoreGlobal
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: "LabelKeys contains a list of log record keys that are mapped
+          to Loki stream labels. \n By default, this list is combined with the labels
+          specified in the Global configuration. This behavior can be changed by setting
+          IgnoreGlobal to true."
+        displayName: Label Keys
+        path: outputs[0].lokiStack.labelKeys.audit.labelKeys
+      - description: "Global contains a list of record keys which are used for all
+          tenants. \n If LabelKeys is not set, the default keys are: \n - log_type
+          \n - kubernetes.container_name \n - kubernetes.namespace_name \n - kubernetes.pod_name
+          \n One additional label \"kubernetes_host\" is not part of the label keys
+          configuration. It contains the hostname where the collector is running and
+          is always present."
+        displayName: Global Configuration
+        path: outputs[0].lokiStack.labelKeys.global
+      - description: Infrastructure contains the label keys configuration for the
+          "infrastructure" tenant.
+        displayName: Infrastructure Tenant Configuration
+        path: outputs[0].lokiStack.labelKeys.infrastructure
+      - description: If IgnoreGlobal is true, then the tenant will not use the labels
+          configured in the Global section of the label keys configuration.
+        displayName: Ignore Global Settings
+        path: outputs[0].lokiStack.labelKeys.infrastructure.ignoreGlobal
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: "LabelKeys contains a list of log record keys that are mapped
+          to Loki stream labels. \n By default, this list is combined with the labels
+          specified in the Global configuration. This behavior can be changed by setting
+          IgnoreGlobal to true."
+        displayName: Label Keys
+        path: outputs[0].lokiStack.labelKeys.infrastructure.labelKeys
+      - description: Target points to the LokiStack resources that should be used
+          as a target for the output.
+        displayName: Target LokiStack Reference
+        path: outputs[0].lokiStack.target
+      - description: Name of the in-cluster LokiStack resource.
+        displayName: LokiStack Name
+        path: outputs[0].lokiStack.target.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Namespace of the in-cluster LokiStack resource. \n If unset,
+          this defaults to \"openshift-logging\"."
+        displayName: LokiStack Namespace
+        path: outputs[0].lokiStack.target.namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].lokiStack.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].lokiStack.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].lokiStack.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].lokiStack.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].lokiStack.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].lokiStack.tuning.minRetryDuration
+      - description: Name used to refer to the output from a `pipeline`.
+        displayName: Output Name
+        path: outputs[0].name
+      - displayName: OpenTelemetry Output
+        path: outputs[0].otlp
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].otlp.authentication
+      - description: Password to use for authenticating requests.
+        displayName: Password
+        path: outputs[0].otlp.authentication.password
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].otlp.authentication.password.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].otlp.authentication.password.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Bearer Token
+        path: outputs[0].otlp.authentication.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].otlp.authentication.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].otlp.authentication.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].otlp.authentication.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].otlp.authentication.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username to use for authenticating requests.
+        displayName: Username
+        path: outputs[0].otlp.authentication.username
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].otlp.authentication.username.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].otlp.authentication.username.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].otlp.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network. It is an error if the compression type is not supported by
+          the output.
+        displayName: Compression
+        path: outputs[0].otlp.tuning.compression
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Delivery Mode
+        path: outputs[0].otlp.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].otlp.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].otlp.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].otlp.tuning.minRetryDuration
+      - description: "URL to send log records to. \n An absolute URL, with a valid
+          http scheme. Must terminate with `/v1/logs` \n Basic TLS is enabled if the
+          URL scheme requires it (for example 'https'). The 'username@password' part
+          of `url` is ignored."
+        displayName: Destination URL
+        path: outputs[0].otlp.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Limit imposes a limit in records-per-second on the total aggregate
+          rate of logs forwarded to this output from any given collector container.
+          The total log flow from an individual collector container to this output
+          cannot exceed the limit.  Generally, one collector is deployed per cluster
+          node Logs may be dropped to enforce the limit. Missing or 0 means no rate
+          limit.
+        displayName: Rate Limiting
+        path: outputs[0].rateLimit
       - description: MaxRecordsPerSecond is the maximum number of log records allowed
           per input/output in a pipeline
         displayName: Max Records Per Second
         path: outputs[0].rateLimit.maxRecordsPerSecond
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - displayName: Splunk
+        path: outputs[0].splunk
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].splunk.authentication
+      - description: Token points to the secret containing the Splunk HEC token used
+          for authenticating requests.
+        displayName: Splunk HEC Token
+        path: outputs[0].splunk.authentication.token
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].splunk.authentication.token.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].splunk.authentication.token.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Index is the index for the logs. This supports template syntax
+          to allow dynamic per-event values. \n The Index can be a combination of
+          static and dynamic values consisting of field paths followed by `||` followed
+          by another field path or a static value. \n A dynamic value is encased in
+          single curly brackets `{}` and MUST end with a static fallback value separated
+          with `||`. \n Static values can only contain alphanumeric characters along
+          with dashes, underscores, dots and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"}
+          \n 2. {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Index
+        path: outputs[0].splunk.index
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].splunk.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].splunk.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].splunk.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].splunk.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].splunk.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].splunk.tuning.minRetryDuration
+      - description: URL to send log records to. Basic TLS is enabled if the URL scheme
+          requires it (for example 'https' or 'tls'). The 'username@password' part
+          of `url` is ignored.
+        displayName: Destination URL
+        path: outputs[0].splunk.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Syslog Output
+        path: outputs[0].syslog
+      - description: "AppName is APP-NAME part of the syslog-msg header. \n AppName
+          needs to be specified if using rfc5424. The maximum length of the final
+          values is truncated to 48 This supports template syntax to allow dynamic
+          per-event values. \n The AppName can be a combination of static and dynamic
+          values consisting of field paths followed by `||` followed by another field
+          path or a static value. \n A dynamic value is encased in single curly brackets
+          `{}` and MUST end with a static fallback value separated with `||`. \n Static
+          values can only contain alphanumeric characters along with dashes, underscores,
+          dots and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+          \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+          \n TODO: DETERMIN HOW to default the app name that isnt based on fluentd
+          assumptions of \"tag\" when this is empty"
+        displayName: App Name
+        path: outputs[0].syslog.appName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Enrichment is an additional modification the log message before
+          forwarding it to the receiver
+        displayName: Enrichment Type
+        path: outputs[0].syslog.enrichment
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Facility to set on outgoing syslog records. \n Facility values
+          are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1. \n The
+          value can be a decimal integer. Facility keywords are not standardized,
+          this API recognizes at least the following case-insensitive keywords (defined
+          by https://en.wikipedia.org/wiki/Syslog#Facility_Levels): \n kernel user
+          mail daemon auth syslog lpr news uucp cron authpriv ftp ntp security console
+          solaris-cron local0 local1 local2 local3 local4 local5 local6 local7"
+        displayName: Facility
+        path: outputs[0].syslog.facility
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "MsgID is MSGID part of the syslog-msg header. This supports
+          template syntax to allow dynamic per-event values. \n The MsgID can be a
+          combination of static and dynamic values consisting of field paths followed
+          by `||` followed by another field path or a static value. \n A dynamic value
+          is encased in single curly brackets `{}` and MUST end with a static fallback
+          value separated with `||`. \n Static values can only contain alphanumeric
+          characters along with dashes, underscores, dots and forward slashes. \n
+          Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"} \n 3.
+          foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+          \n MsgID needs to be specified if using rfc5424.  The maximum length of
+          the final values is truncated to 32"
+        displayName: MSGID
+        path: outputs[0].syslog.msgID
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "PayloadKey specifies record field to use as payload. This supports
+          template syntax to allow dynamic per-event values. \n The PayloadKey must
+          be a single field path encased in single curly brackets `{}`. \n Field paths
+          must only contain alphanumeric and underscores. Any field with other characters
+          must be quoted. \n If left empty, Syslog will use the whole message as the
+          payload key \n Example: \n 1. {.bar} \n 2. {.foo.bar.baz} \n 3. {.foo.bar.\"baz/with/slashes\"}"
+        displayName: Payload Key
+        path: outputs[0].syslog.payloadKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "ProcID is PROCID part of the syslog-msg header. This supports
+          template syntax to allow dynamic per-event values. \n The ProcID can be
+          a combination of static and dynamic values consisting of field paths followed
+          by `||` followed by another field path or a static value. \n A dynamic value
+          is encased in single curly brackets `{}` and MUST end with a static fallback
+          value separated with `||`. \n Static values can only contain alphanumeric
+          characters along with dashes, underscores, dots and forward slashes. \n
+          Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"} \n 3.
+          foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+          \n ProcID needs to be specified if using rfc5424. The maximum length of
+          the final values is truncated to 128"
+        displayName: PROCID
+        path: outputs[0].syslog.procID
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Syslog RFC
+        path: outputs[0].syslog.rfc
+      - description: "Severity to set on outgoing syslog records. \n Severity values
+          are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1 \n The
+          value can be a decimal integer or one of these case-insensitive keywords:
+          \n Emergency Alert Critical Error Warning Notice Informational Debug"
+        displayName: Severity
+        path: outputs[0].syslog.severity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'An absolute URL, with a scheme. Valid schemes are: `tcp`, `tls`,
+          `udp` and `udps` For example, to send syslog records using secure UDP: url:
+          udps://syslog.example.com:1234'
+        displayName: Destination URL
+        path: outputs[0].syslog.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: TLS contains settings for controlling options on TLS client connections.
+        displayName: TLS Options
+        path: outputs[0].tls
+      - description: CA can be used to specify a custom list of trusted certificate
+          authorities.
+        displayName: Certificate Authority Bundle
+        path: outputs[0].tls.ca
+      - description: ConfigMapName contains the name of the ConfigMap containing the
+          referenced value.
+        displayName: ConfigMap Name
+        path: outputs[0].tls.ca.configMapName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Name of the key used to get the value in either the referenced
@@ -267,34 +1387,108 @@ spec:
         path: outputs[0].tls.ca.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].tls.ca.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Certificate points to the server certificate to use.
+        displayName: Certificate
+        path: outputs[0].tls.certificate
+      - description: ConfigMapName contains the name of the ConfigMap containing the
+          referenced value.
+        displayName: ConfigMap Name
+        path: outputs[0].tls.certificate.configMapName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Name of the key used to get the value in either the referenced
           ConfigMap or Secret.
         displayName: Key Name
         path: outputs[0].tls.certificate.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].tls.certificate.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "If InsecureSkipVerify is true, then the TLS client will be configured
+          to skip validating server certificates. \n This option is *not* recommended
+          for production configurations."
+        displayName: Skip Certificate Validation
+        path: outputs[0].tls.insecureSkipVerify
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Key points to the private key of the server certificate.
+        displayName: Certificate Key
+        path: outputs[0].tls.key
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].tls.key.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].tls.key.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: KeyPassphrase points to the passphrase used to unlock the private
+          key.
+        displayName: Certificate Key Passphrase
+        path: outputs[0].tls.keyPassphrase
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].tls.keyPassphrase.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].tls.keyPassphrase.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: TLSSecurityProfile is the security profile to apply to the output
+          connection.
+        displayName: TLS Security Profile
+        path: outputs[0].tls.securityProfile
+      - description: Type of output sink.
+        displayName: Output Type
+        path: outputs[0].type
       - description: Pipelines forward the messages selected by a set of inputs to
           a set of outputs.
         displayName: Log Forwarder Pipelines
         path: pipelines
+      - description: "Filters lists the names of filters to be applied to records
+          going through this pipeline. \n Each filter is applied in order. If a filter
+          drops a records, subsequent filters are not applied."
+        displayName: Filters
+        path: pipelines[0].filterRefs
+      - description: "InputRefs lists the names (`input.name`) of inputs to this pipeline.
+          \n The following built-in input names are always available: \n - `application`
+          selects all logs from application pods. \n - `infrastructure` selects logs
+          from openshift and kubernetes pods and some node logs. \n - `audit` selects
+          node logs related to security audits."
+        displayName: Inputs
+        path: pipelines[0].inputRefs
       - description: Name of the pipeline
         displayName: Name
         path: pipelines[0].name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: OutputRefs lists the names (`output.name`) of outputs from this
+          pipeline.
+        displayName: Outputs
+        path: pipelines[0].outputRefs
+      - description: ServiceAccount points to the ServiceAccount resource used by
+          the collector pods.
+        displayName: Service Account
+        path: serviceAccount
       - description: Name of the ServiceAccount to use to deploy the Forwarder.  The
           ServiceAccount is created by the administrator
-        displayName: Name
+        displayName: ServiceAccount Name
         path: serviceAccount.name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -377,7 +377,7 @@ spec:
                           type: array
                       type: object
                     name:
-                      description: Name used to refer to the filter from a `pipeline`.
+                      description: Name used to refer to the filter from a "pipeline".
                       pattern: ^[a-z][a-z0-9-]*[a-z0-9]$
                       type: string
                     openShiftLabels:
@@ -392,25 +392,25 @@ spec:
                         in and notIn, which dictate the fields to be pruned.
                       properties:
                         in:
-                          description: '`In` is an array of dot-delimited field paths.
+                          description: "`In` is an array of dot-delimited field paths.
                             Fields included here are removed from the log record.
-                            Each field path expression must start with a `.`. The
-                            path can contain alpha-numeric characters and underscores
-                            (a-zA-Z0-9_). If segments contain characters outside of
-                            this range, the segment must be quoted otherwise paths
-                            do NOT need to be quoted. Examples: `.kubernetes.namespace_name`,
-                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`
-                            NOTE1: `In` CANNOT contain `.log_type` or `.message` as
-                            those fields are required and cannot be pruned. NOTE2:
-                            If this filter is used in a pipeline with GoogleCloudLogging,
-                            `.hostname` CANNOT be added to this list as it is a required
-                            field.'
+                            \n Each field path expression must start with a \".\"
+                            \n The path can contain alphanumeric characters and underscores
+                            (a-zA-Z0-9_). \n If segments contain characters outside
+                            of this range, the segment must be quoted otherwise paths
+                            do NOT need to be quoted. \n Examples: \n - `.kubernetes.namespace_name`
+                            \n - `.log_type` \n - '.kubernetes.labels.foobar' \n -
+                            `.kubernetes.labels.\"foo-bar/baz\"` \n NOTE1: `In` CANNOT
+                            contain `.log_type` or `.message` as those fields are
+                            required and cannot be pruned. \n NOTE2: If this filter
+                            is used in a pipeline with GoogleCloudLogging, `.hostname`
+                            CANNOT be added to this list as it is a required field."
                           items:
-                            description: 'Field Path represents a path to find a value
+                            description: 'FieldPath represents a path to find a value
                               for a given field.  The format must a value that can
                               be converted to a valid collector configuration. It
                               is a dot delimited path to a field in the log record.
-                              It must start with a `.`. The path can contain alpha-numeric
+                              It must start with a `.`. The path can contain alphanumeric
                               characters and underscores (a-zA-Z0-9_). If segments
                               contain characters outside of this range, the segment
                               must be quoted. Examples: `.kubernetes.namespace_name`,
@@ -419,25 +419,26 @@ spec:
                             type: string
                           type: array
                         notIn:
-                          description: '`NotIn` is an array of dot-delimited field
+                          description: "`NotIn` is an array of dot-delimited field
                             paths. All fields besides the ones listed here are removed
-                            from the log record Each field path expression must start
-                            with a `.`. The path can contain alpha-numeric characters
-                            and underscores (a-zA-Z0-9_). If segments contain characters
-                            outside of this range, the segment must be quoted otherwise
-                            paths do NOT need to be quoted. Examples: `.kubernetes.namespace_name`,
-                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`
-                            NOTE1: `NotIn` MUST contain `.log_type` and `.message`
-                            as those fields are required and cannot be pruned. NOTE2:
-                            If this filter is used in a pipeline with GoogleCloudLogging,
+                            from the log record. \n Each field path expression must
+                            start with a \".\" \n The path can contain alphanumeric
+                            characters and underscores (a-zA-Z0-9_). \n If segments
+                            contain characters outside of this range, the segment
+                            must be quoted otherwise paths do NOT need to be quoted.
+                            \n Examples: \n - `.kubernetes.namespace_name` \n - `.log_type`
+                            \n - '.kubernetes.labels.foobar' \n - `.kubernetes.labels.\"foo-bar/baz\"`
+                            \n NOTE1: `NotIn` MUST contain `.log_type` and `.message`
+                            as those fields are required and cannot be pruned. \n
+                            NOTE2: If this filter is used in a pipeline with GoogleCloudLogging,
                             `.hostname` MUST be added to this list as it is a required
-                            field.'
+                            field."
                           items:
-                            description: 'Field Path represents a path to find a value
+                            description: 'FieldPath represents a path to find a value
                               for a given field.  The format must a value that can
                               be converted to a valid collector configuration. It
                               is a dot delimited path to a field in the log record.
-                              It must start with a `.`. The path can contain alpha-numeric
+                              It must start with a `.`. The path can contain alphanumeric
                               characters and underscores (a-zA-Z0-9_). If segments
                               contain characters outside of this range, the segment
                               must be quoted. Examples: `.kubernetes.namespace_name`,
@@ -492,9 +493,9 @@ spec:
                       nullable: true
                       properties:
                         excludes:
-                          description: Excludes is the set of namespaces and containers
-                            to ignore when collecting logs. Takes precedence over
-                            Includes option.
+                          description: "Excludes is the set of namespaces and containers
+                            to ignore when collecting logs. \n Takes precedence over
+                            Includes option."
                           items:
                             properties:
                               container:
@@ -510,10 +511,10 @@ spec:
                             type: object
                           type: array
                         includes:
-                          description: 'Includes is the set of namespaces and containers
-                            to include when collecting logs. Note: infrastructure
-                            namespaces are still excluded for "*" values unless a
-                            qualifying glob pattern is specified.'
+                          description: "Includes is the set of namespaces and containers
+                            to include when collecting logs. \n Note: infrastructure
+                            namespaces are still excluded for \"*\" values unless
+                            a qualifying glob pattern is specified."
                           items:
                             properties:
                               container:
@@ -529,9 +530,10 @@ spec:
                             type: object
                           type: array
                         selector:
-                          description: Selector for logs from pods with matching labels.
-                            Only messages from pods with these labels are collected.
-                            If absent or empty, logs are collected regardless of labels.
+                          description: "Selector for logs from pods with matching
+                            labels. \n Only messages from pods with these labels are
+                            collected. \n If absent or empty, logs are collected regardless
+                            of labels."
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -795,7 +797,7 @@ spec:
               managementState:
                 default: Managed
                 description: Indicator if the resource is 'Managed' or 'Unmanaged'
-                  by the operator
+                  by the operator.
                 enum:
                 - Managed
                 - Unmanaged
@@ -1010,16 +1012,16 @@ spec:
                               authentication
                             rule: self.type != 'iamRole' || has(self.iamRole)
                         groupName:
-                          description: 'GroupName defines the strategy for grouping
-                            logstreams The GroupName can be a combination of static
+                          description: "GroupName defines the strategy for grouping
+                            logstreams \n The GroupName can be a combination of static
                             and dynamic values consisting of field paths followed
                             by `||` followed by another field path or a static value.
-                            A dynamic value is encased in single curly brackets `{}`
-                            and MUST end with a static fallback value separated with
-                            `||`. Static values can only contain alphanumeric characters
-                            along with dashes, underscores, dots and forward slashes.
-                            Example: 1. foo-{.bar||"none"} 2. {.foo||.bar||"missing"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}'
+                            \n A dynamic value is encased in single curly brackets
+                            `{}` and MUST end with a static fallback value separated
+                            with `||`. \n Static values can only contain alphanumeric
+                            characters along with dashes, underscores, dots and forward
+                            slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2.
+                            {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         region:
@@ -1156,13 +1158,13 @@ spec:
                             template syntax to allow dynamic per-event values. \n
                             The Index can be a combination of static and dynamic values
                             consisting of field paths followed by `||` followed by
-                            another field path or a static value. A dynamic value
+                            another field path or a static value. \n A dynamic value
                             is encased in single curly brackets `{}` and MUST end
-                            with a static fallback value separated with `||`. Static
+                            with a static fallback value separated with `||`. \n Static
                             values can only contain alphanumeric characters along
-                            with dashes, underscores, dots and forward slashes. Example:
-                            1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"} 3.
-                            foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+                            with dashes, underscores, dots and forward slashes. \n
+                            Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+                            \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
@@ -1274,12 +1276,12 @@ spec:
                             This identifies log stream. \n The LogID can be a combination
                             of static and dynamic values consisting of field paths
                             followed by `||` followed by another field path or a static
-                            value. A dynamic value is encased in single curly brackets
+                            value. \n A dynamic value is encased in single curly brackets
                             `{}` and MUST end with a static fallback value separated
-                            with `||`. Static values can only contain alphanumeric
+                            with `||`. \n Static values can only contain alphanumeric
                             characters along with dashes, underscores, dots and forward
-                            slashes. Example: 1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+                            slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2.
+                            {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
@@ -1515,14 +1517,14 @@ spec:
                               type: object
                           type: object
                         brokers:
-                          description: Brokers specifies the list of broker endpoints
-                            of a Kafka cluster. The list represents only the initial
+                          description: "Brokers specifies the list of broker endpoints
+                            of a Kafka cluster. \n The list represents only the initial
                             set used by the collector's Kafka client for the first
                             connection only. The collector's Kafka client fetches
                             constantly an updated list from Kafka. These updates are
-                            not reconciled back to the collector configuration. If
-                            none provided the target URL from the OutputSpec is used
-                            as fallback.
+                            not reconciled back to the collector configuration. \n
+                            If none provided the target URL from the OutputSpec is
+                            used as fallback."
                           items:
                             type: string
                             x-kubernetes-validations:
@@ -1534,12 +1536,13 @@ spec:
                             to. The value when not specified is 'topic' \n The Topic
                             can be a combination of static and dynamic values consisting
                             of field paths followed by `||` followed by another field
-                            path or a static value. A dynamic value is encased in
-                            single curly brackets `{}` and MUST end with a static
-                            fallback value separated with `||`. Static values can
+                            path or a static value. \n A dynamic value is encased
+                            in single curly brackets `{}` and MUST end with a static
+                            fallback value separated with `||`. \n Static values can
                             only contain alphanumeric characters along with dashes,
-                            underscores, dots and forward slashes. Example: 1. foo-{.bar||\"none\"}
-                            2. {.foo||.bar||\"missing\"} 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+                            underscores, dots and forward slashes. \n Example: \n
+                            1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+                            \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
@@ -1687,13 +1690,12 @@ spec:
                             values. \n The TenantKey can be a combination of static
                             and dynamic values consisting of field paths followed
                             by `||` followed by another field path or a static value.
-                            A dynamic value is encased in single curly brackets `{}`
-                            and MUST end with a static fallback value separated with
-                            `||`. Static values can only contain alphanumeric characters
-                            along with dashes, underscores, dots and forward slashes.
-                            Example: 1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
-                          nullable: true
+                            \n A dynamic value is encased in single curly brackets
+                            `{}` and MUST end with a static fallback value separated
+                            with `||`. \n Static values can only contain alphanumeric
+                            characters along with dashes, underscores, dots and forward
+                            slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2.
+                            {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
@@ -1817,11 +1819,11 @@ spec:
                                     section of the label keys configuration.
                                   type: boolean
                                 labelKeys:
-                                  description: LabelKeys contains a list of log record
-                                    keys that are mapped to Loki stream labels. By
-                                    default, this list is combined with the labels
+                                  description: "LabelKeys contains a list of log record
+                                    keys that are mapped to Loki stream labels. \n
+                                    By default, this list is combined with the labels
                                     specified in the Global configuration. This behavior
-                                    can be changed by setting IgnoreGlobal to true.
+                                    can be changed by setting IgnoreGlobal to true."
                                   items:
                                     type: string
                                   type: array
@@ -1836,11 +1838,11 @@ spec:
                                     section of the label keys configuration.
                                   type: boolean
                                 labelKeys:
-                                  description: LabelKeys contains a list of log record
-                                    keys that are mapped to Loki stream labels. By
-                                    default, this list is combined with the labels
+                                  description: "LabelKeys contains a list of log record
+                                    keys that are mapped to Loki stream labels. \n
+                                    By default, this list is combined with the labels
                                     specified in the Global configuration. This behavior
-                                    can be changed by setting IgnoreGlobal to true.
+                                    can be changed by setting IgnoreGlobal to true."
                                   items:
                                     type: string
                                   type: array
@@ -1867,11 +1869,11 @@ spec:
                                     section of the label keys configuration.
                                   type: boolean
                                 labelKeys:
-                                  description: LabelKeys contains a list of log record
-                                    keys that are mapped to Loki stream labels. By
-                                    default, this list is combined with the labels
+                                  description: "LabelKeys contains a list of log record
+                                    keys that are mapped to Loki stream labels. \n
+                                    By default, this list is combined with the labels
                                     specified in the Global configuration. This behavior
-                                    can be changed by setting IgnoreGlobal to true.
+                                    can be changed by setting IgnoreGlobal to true."
                                   items:
                                     type: string
                                   type: array
@@ -1886,7 +1888,8 @@ spec:
                               pattern: ^[a-z][a-z0-9-]{2,62}[a-z0-9]$
                               type: string
                             namespace:
-                              description: Namespace of the in-cluster LokiStack resource.
+                              description: "Namespace of the in-cluster LokiStack
+                                resource. \n If unset, this defaults to \"openshift-logging\"."
                               type: string
                           required:
                           - name
@@ -2117,14 +2120,13 @@ spec:
                             template syntax to allow dynamic per-event values. \n
                             The Index can be a combination of static and dynamic values
                             consisting of field paths followed by `||` followed by
-                            another field path or a static value. A dynamic value
+                            another field path or a static value. \n A dynamic value
                             is encased in single curly brackets `{}` and MUST end
-                            with a static fallback value separated with `||`. Static
+                            with a static fallback value separated with `||`. \n Static
                             values can only contain alphanumeric characters along
-                            with dashes, underscores, dots and forward slashes. Example:
-                            1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"} 3.
-                            foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
-                          nullable: true
+                            with dashes, underscores, dots and forward slashes. \n
+                            Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+                            \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
@@ -2183,18 +2185,18 @@ spec:
                       properties:
                         appName:
                           description: "AppName is APP-NAME part of the syslog-msg
-                            header. AppName needs to be specified if using rfc5424.
+                            header. \n AppName needs to be specified if using rfc5424.
                             The maximum length of the final values is truncated to
                             48 This supports template syntax to allow dynamic per-event
                             values. \n The AppName can be a combination of static
                             and dynamic values consisting of field paths followed
                             by `||` followed by another field path or a static value.
-                            A dynamic value is encased in single curly brackets `{}`
-                            and MUST end with a static fallback value separated with
-                            `||`. Static values can only contain alphanumeric characters
-                            along with dashes, underscores, dots and forward slashes.
-                            Example: 1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+                            \n A dynamic value is encased in single curly brackets
+                            `{}` and MUST end with a static fallback value separated
+                            with `||`. \n Static values can only contain alphanumeric
+                            characters along with dashes, underscores, dots and forward
+                            slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2.
+                            {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
                             \n TODO: DETERMIN HOW to default the app name that isnt
                             based on fluentd assumptions of \"tag\" when this is empty"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
@@ -2210,7 +2212,7 @@ spec:
                           default: user
                           description: "Facility to set on outgoing syslog records.
                             \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
-                            The value can be a decimal integer. Facility keywords
+                            \n The value can be a decimal integer. Facility keywords
                             are not standardized, this API recognizes at least the
                             following case-insensitive keywords (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels):
                             \n kernel user mail daemon auth syslog lpr news uucp cron
@@ -2222,24 +2224,26 @@ spec:
                             This supports template syntax to allow dynamic per-event
                             values. \n The MsgID can be a combination of static and
                             dynamic values consisting of field paths followed by `||`
-                            followed by another field path or a static value. A dynamic
-                            value is encased in single curly brackets `{}` and MUST
-                            end with a static fallback value separated with `||`.
-                            Static values can only contain alphanumeric characters
+                            followed by another field path or a static value. \n A
+                            dynamic value is encased in single curly brackets `{}`
+                            and MUST end with a static fallback value separated with
+                            `||`. \n Static values can only contain alphanumeric characters
                             along with dashes, underscores, dots and forward slashes.
-                            Example: 1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+                            \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+                            \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
                             \n MsgID needs to be specified if using rfc5424.  The
                             maximum length of the final values is truncated to 32"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         payloadKey:
-                          description: "The PayloadKey must be a single field path
-                            encased in single curly brackets `{}`. Field paths must
-                            only contain alphanumeric and underscores. Any field with
-                            other characters must be quoted. If left empty, Syslog
-                            will use the whole message as the payload key \n Example:
-                            1. {.bar} 2. {.foo.bar.baz} 3. {.foo.bar.\"baz/with/slashes\"}"
+                          description: "PayloadKey specifies record field to use as
+                            payload. This supports template syntax to allow dynamic
+                            per-event values. \n The PayloadKey must be a single field
+                            path encased in single curly brackets `{}`. \n Field paths
+                            must only contain alphanumeric and underscores. Any field
+                            with other characters must be quoted. \n If left empty,
+                            Syslog will use the whole message as the payload key \n
+                            Example: \n 1. {.bar} \n 2. {.foo.bar.baz} \n 3. {.foo.bar.\"baz/with/slashes\"}"
                           pattern: ^\{(\.[a-zA-Z0-9_]+|\."[^"]+")(\.[a-zA-Z0-9_]+|\."[^"]+")*\}$
                           type: string
                         procID:
@@ -2247,13 +2251,13 @@ spec:
                             This supports template syntax to allow dynamic per-event
                             values. \n The ProcID can be a combination of static and
                             dynamic values consisting of field paths followed by `||`
-                            followed by another field path or a static value. A dynamic
-                            value is encased in single curly brackets `{}` and MUST
-                            end with a static fallback value separated with `||`.
-                            Static values can only contain alphanumeric characters
+                            followed by another field path or a static value. \n A
+                            dynamic value is encased in single curly brackets `{}`
+                            and MUST end with a static fallback value separated with
+                            `||`. \n Static values can only contain alphanumeric characters
                             along with dashes, underscores, dots and forward slashes.
-                            Example: 1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+                            \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+                            \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
                             \n ProcID needs to be specified if using rfc5424. The
                             maximum length of the final values is truncated to 128"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
@@ -2270,9 +2274,9 @@ spec:
                           default: informational
                           description: "Severity to set on outgoing syslog records.
                             \n Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1
-                            The value can be a decimal integer or one of these case-insensitive
-                            keywords: \n Emergency Alert Critical Error Warning Notice
-                            Informational Debug"
+                            \n The value can be a decimal integer or one of these
+                            case-insensitive keywords: \n Emergency Alert Critical
+                            Error Warning Notice Informational Debug"
                           type: string
                         url:
                           description: 'An absolute URL, with a scheme. Valid schemes
@@ -2551,10 +2555,10 @@ spec:
                     inputRefs:
                       description: "InputRefs lists the names (`input.name`) of inputs
                         to this pipeline. \n The following built-in input names are
-                        always available: \n `application` selects all logs from application
-                        pods. \n `infrastructure` selects logs from openshift and
-                        kubernetes pods and some node logs. \n `audit` selects node
-                        logs related to security audits."
+                        always available: \n - `application` selects all logs from
+                        application pods. \n - `infrastructure` selects logs from
+                        openshift and kubernetes pods and some node logs. \n - `audit`
+                        selects node logs related to security audits."
                       items:
                         type: string
                       minItems: 1

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -378,7 +378,7 @@ spec:
                           type: array
                       type: object
                     name:
-                      description: Name used to refer to the filter from a `pipeline`.
+                      description: Name used to refer to the filter from a "pipeline".
                       pattern: ^[a-z][a-z0-9-]*[a-z0-9]$
                       type: string
                     openShiftLabels:
@@ -393,25 +393,25 @@ spec:
                         in and notIn, which dictate the fields to be pruned.
                       properties:
                         in:
-                          description: '`In` is an array of dot-delimited field paths.
+                          description: "`In` is an array of dot-delimited field paths.
                             Fields included here are removed from the log record.
-                            Each field path expression must start with a `.`. The
-                            path can contain alpha-numeric characters and underscores
-                            (a-zA-Z0-9_). If segments contain characters outside of
-                            this range, the segment must be quoted otherwise paths
-                            do NOT need to be quoted. Examples: `.kubernetes.namespace_name`,
-                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`
-                            NOTE1: `In` CANNOT contain `.log_type` or `.message` as
-                            those fields are required and cannot be pruned. NOTE2:
-                            If this filter is used in a pipeline with GoogleCloudLogging,
-                            `.hostname` CANNOT be added to this list as it is a required
-                            field.'
+                            \n Each field path expression must start with a \".\"
+                            \n The path can contain alphanumeric characters and underscores
+                            (a-zA-Z0-9_). \n If segments contain characters outside
+                            of this range, the segment must be quoted otherwise paths
+                            do NOT need to be quoted. \n Examples: \n - `.kubernetes.namespace_name`
+                            \n - `.log_type` \n - '.kubernetes.labels.foobar' \n -
+                            `.kubernetes.labels.\"foo-bar/baz\"` \n NOTE1: `In` CANNOT
+                            contain `.log_type` or `.message` as those fields are
+                            required and cannot be pruned. \n NOTE2: If this filter
+                            is used in a pipeline with GoogleCloudLogging, `.hostname`
+                            CANNOT be added to this list as it is a required field."
                           items:
-                            description: 'Field Path represents a path to find a value
+                            description: 'FieldPath represents a path to find a value
                               for a given field.  The format must a value that can
                               be converted to a valid collector configuration. It
                               is a dot delimited path to a field in the log record.
-                              It must start with a `.`. The path can contain alpha-numeric
+                              It must start with a `.`. The path can contain alphanumeric
                               characters and underscores (a-zA-Z0-9_). If segments
                               contain characters outside of this range, the segment
                               must be quoted. Examples: `.kubernetes.namespace_name`,
@@ -420,25 +420,26 @@ spec:
                             type: string
                           type: array
                         notIn:
-                          description: '`NotIn` is an array of dot-delimited field
+                          description: "`NotIn` is an array of dot-delimited field
                             paths. All fields besides the ones listed here are removed
-                            from the log record Each field path expression must start
-                            with a `.`. The path can contain alpha-numeric characters
-                            and underscores (a-zA-Z0-9_). If segments contain characters
-                            outside of this range, the segment must be quoted otherwise
-                            paths do NOT need to be quoted. Examples: `.kubernetes.namespace_name`,
-                            `.log_type`, ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`
-                            NOTE1: `NotIn` MUST contain `.log_type` and `.message`
-                            as those fields are required and cannot be pruned. NOTE2:
-                            If this filter is used in a pipeline with GoogleCloudLogging,
+                            from the log record. \n Each field path expression must
+                            start with a \".\" \n The path can contain alphanumeric
+                            characters and underscores (a-zA-Z0-9_). \n If segments
+                            contain characters outside of this range, the segment
+                            must be quoted otherwise paths do NOT need to be quoted.
+                            \n Examples: \n - `.kubernetes.namespace_name` \n - `.log_type`
+                            \n - '.kubernetes.labels.foobar' \n - `.kubernetes.labels.\"foo-bar/baz\"`
+                            \n NOTE1: `NotIn` MUST contain `.log_type` and `.message`
+                            as those fields are required and cannot be pruned. \n
+                            NOTE2: If this filter is used in a pipeline with GoogleCloudLogging,
                             `.hostname` MUST be added to this list as it is a required
-                            field.'
+                            field."
                           items:
-                            description: 'Field Path represents a path to find a value
+                            description: 'FieldPath represents a path to find a value
                               for a given field.  The format must a value that can
                               be converted to a valid collector configuration. It
                               is a dot delimited path to a field in the log record.
-                              It must start with a `.`. The path can contain alpha-numeric
+                              It must start with a `.`. The path can contain alphanumeric
                               characters and underscores (a-zA-Z0-9_). If segments
                               contain characters outside of this range, the segment
                               must be quoted. Examples: `.kubernetes.namespace_name`,
@@ -493,9 +494,9 @@ spec:
                       nullable: true
                       properties:
                         excludes:
-                          description: Excludes is the set of namespaces and containers
-                            to ignore when collecting logs. Takes precedence over
-                            Includes option.
+                          description: "Excludes is the set of namespaces and containers
+                            to ignore when collecting logs. \n Takes precedence over
+                            Includes option."
                           items:
                             properties:
                               container:
@@ -511,10 +512,10 @@ spec:
                             type: object
                           type: array
                         includes:
-                          description: 'Includes is the set of namespaces and containers
-                            to include when collecting logs. Note: infrastructure
-                            namespaces are still excluded for "*" values unless a
-                            qualifying glob pattern is specified.'
+                          description: "Includes is the set of namespaces and containers
+                            to include when collecting logs. \n Note: infrastructure
+                            namespaces are still excluded for \"*\" values unless
+                            a qualifying glob pattern is specified."
                           items:
                             properties:
                               container:
@@ -530,9 +531,10 @@ spec:
                             type: object
                           type: array
                         selector:
-                          description: Selector for logs from pods with matching labels.
-                            Only messages from pods with these labels are collected.
-                            If absent or empty, logs are collected regardless of labels.
+                          description: "Selector for logs from pods with matching
+                            labels. \n Only messages from pods with these labels are
+                            collected. \n If absent or empty, logs are collected regardless
+                            of labels."
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -796,7 +798,7 @@ spec:
               managementState:
                 default: Managed
                 description: Indicator if the resource is 'Managed' or 'Unmanaged'
-                  by the operator
+                  by the operator.
                 enum:
                 - Managed
                 - Unmanaged
@@ -1011,16 +1013,16 @@ spec:
                               authentication
                             rule: self.type != 'iamRole' || has(self.iamRole)
                         groupName:
-                          description: 'GroupName defines the strategy for grouping
-                            logstreams The GroupName can be a combination of static
+                          description: "GroupName defines the strategy for grouping
+                            logstreams \n The GroupName can be a combination of static
                             and dynamic values consisting of field paths followed
                             by `||` followed by another field path or a static value.
-                            A dynamic value is encased in single curly brackets `{}`
-                            and MUST end with a static fallback value separated with
-                            `||`. Static values can only contain alphanumeric characters
-                            along with dashes, underscores, dots and forward slashes.
-                            Example: 1. foo-{.bar||"none"} 2. {.foo||.bar||"missing"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}'
+                            \n A dynamic value is encased in single curly brackets
+                            `{}` and MUST end with a static fallback value separated
+                            with `||`. \n Static values can only contain alphanumeric
+                            characters along with dashes, underscores, dots and forward
+                            slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2.
+                            {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         region:
@@ -1157,13 +1159,13 @@ spec:
                             template syntax to allow dynamic per-event values. \n
                             The Index can be a combination of static and dynamic values
                             consisting of field paths followed by `||` followed by
-                            another field path or a static value. A dynamic value
+                            another field path or a static value. \n A dynamic value
                             is encased in single curly brackets `{}` and MUST end
-                            with a static fallback value separated with `||`. Static
+                            with a static fallback value separated with `||`. \n Static
                             values can only contain alphanumeric characters along
-                            with dashes, underscores, dots and forward slashes. Example:
-                            1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"} 3.
-                            foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+                            with dashes, underscores, dots and forward slashes. \n
+                            Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+                            \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
@@ -1275,12 +1277,12 @@ spec:
                             This identifies log stream. \n The LogID can be a combination
                             of static and dynamic values consisting of field paths
                             followed by `||` followed by another field path or a static
-                            value. A dynamic value is encased in single curly brackets
+                            value. \n A dynamic value is encased in single curly brackets
                             `{}` and MUST end with a static fallback value separated
-                            with `||`. Static values can only contain alphanumeric
+                            with `||`. \n Static values can only contain alphanumeric
                             characters along with dashes, underscores, dots and forward
-                            slashes. Example: 1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+                            slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2.
+                            {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
@@ -1516,14 +1518,14 @@ spec:
                               type: object
                           type: object
                         brokers:
-                          description: Brokers specifies the list of broker endpoints
-                            of a Kafka cluster. The list represents only the initial
+                          description: "Brokers specifies the list of broker endpoints
+                            of a Kafka cluster. \n The list represents only the initial
                             set used by the collector's Kafka client for the first
                             connection only. The collector's Kafka client fetches
                             constantly an updated list from Kafka. These updates are
-                            not reconciled back to the collector configuration. If
-                            none provided the target URL from the OutputSpec is used
-                            as fallback.
+                            not reconciled back to the collector configuration. \n
+                            If none provided the target URL from the OutputSpec is
+                            used as fallback."
                           items:
                             type: string
                             x-kubernetes-validations:
@@ -1535,12 +1537,13 @@ spec:
                             to. The value when not specified is 'topic' \n The Topic
                             can be a combination of static and dynamic values consisting
                             of field paths followed by `||` followed by another field
-                            path or a static value. A dynamic value is encased in
-                            single curly brackets `{}` and MUST end with a static
-                            fallback value separated with `||`. Static values can
+                            path or a static value. \n A dynamic value is encased
+                            in single curly brackets `{}` and MUST end with a static
+                            fallback value separated with `||`. \n Static values can
                             only contain alphanumeric characters along with dashes,
-                            underscores, dots and forward slashes. Example: 1. foo-{.bar||\"none\"}
-                            2. {.foo||.bar||\"missing\"} 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+                            underscores, dots and forward slashes. \n Example: \n
+                            1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+                            \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
@@ -1688,13 +1691,12 @@ spec:
                             values. \n The TenantKey can be a combination of static
                             and dynamic values consisting of field paths followed
                             by `||` followed by another field path or a static value.
-                            A dynamic value is encased in single curly brackets `{}`
-                            and MUST end with a static fallback value separated with
-                            `||`. Static values can only contain alphanumeric characters
-                            along with dashes, underscores, dots and forward slashes.
-                            Example: 1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
-                          nullable: true
+                            \n A dynamic value is encased in single curly brackets
+                            `{}` and MUST end with a static fallback value separated
+                            with `||`. \n Static values can only contain alphanumeric
+                            characters along with dashes, underscores, dots and forward
+                            slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2.
+                            {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
@@ -1818,11 +1820,11 @@ spec:
                                     section of the label keys configuration.
                                   type: boolean
                                 labelKeys:
-                                  description: LabelKeys contains a list of log record
-                                    keys that are mapped to Loki stream labels. By
-                                    default, this list is combined with the labels
+                                  description: "LabelKeys contains a list of log record
+                                    keys that are mapped to Loki stream labels. \n
+                                    By default, this list is combined with the labels
                                     specified in the Global configuration. This behavior
-                                    can be changed by setting IgnoreGlobal to true.
+                                    can be changed by setting IgnoreGlobal to true."
                                   items:
                                     type: string
                                   type: array
@@ -1837,11 +1839,11 @@ spec:
                                     section of the label keys configuration.
                                   type: boolean
                                 labelKeys:
-                                  description: LabelKeys contains a list of log record
-                                    keys that are mapped to Loki stream labels. By
-                                    default, this list is combined with the labels
+                                  description: "LabelKeys contains a list of log record
+                                    keys that are mapped to Loki stream labels. \n
+                                    By default, this list is combined with the labels
                                     specified in the Global configuration. This behavior
-                                    can be changed by setting IgnoreGlobal to true.
+                                    can be changed by setting IgnoreGlobal to true."
                                   items:
                                     type: string
                                   type: array
@@ -1868,11 +1870,11 @@ spec:
                                     section of the label keys configuration.
                                   type: boolean
                                 labelKeys:
-                                  description: LabelKeys contains a list of log record
-                                    keys that are mapped to Loki stream labels. By
-                                    default, this list is combined with the labels
+                                  description: "LabelKeys contains a list of log record
+                                    keys that are mapped to Loki stream labels. \n
+                                    By default, this list is combined with the labels
                                     specified in the Global configuration. This behavior
-                                    can be changed by setting IgnoreGlobal to true.
+                                    can be changed by setting IgnoreGlobal to true."
                                   items:
                                     type: string
                                   type: array
@@ -1887,7 +1889,8 @@ spec:
                               pattern: ^[a-z][a-z0-9-]{2,62}[a-z0-9]$
                               type: string
                             namespace:
-                              description: Namespace of the in-cluster LokiStack resource.
+                              description: "Namespace of the in-cluster LokiStack
+                                resource. \n If unset, this defaults to \"openshift-logging\"."
                               type: string
                           required:
                           - name
@@ -2118,14 +2121,13 @@ spec:
                             template syntax to allow dynamic per-event values. \n
                             The Index can be a combination of static and dynamic values
                             consisting of field paths followed by `||` followed by
-                            another field path or a static value. A dynamic value
+                            another field path or a static value. \n A dynamic value
                             is encased in single curly brackets `{}` and MUST end
-                            with a static fallback value separated with `||`. Static
+                            with a static fallback value separated with `||`. \n Static
                             values can only contain alphanumeric characters along
-                            with dashes, underscores, dots and forward slashes. Example:
-                            1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"} 3.
-                            foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
-                          nullable: true
+                            with dashes, underscores, dots and forward slashes. \n
+                            Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+                            \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
@@ -2184,18 +2186,18 @@ spec:
                       properties:
                         appName:
                           description: "AppName is APP-NAME part of the syslog-msg
-                            header. AppName needs to be specified if using rfc5424.
+                            header. \n AppName needs to be specified if using rfc5424.
                             The maximum length of the final values is truncated to
                             48 This supports template syntax to allow dynamic per-event
                             values. \n The AppName can be a combination of static
                             and dynamic values consisting of field paths followed
                             by `||` followed by another field path or a static value.
-                            A dynamic value is encased in single curly brackets `{}`
-                            and MUST end with a static fallback value separated with
-                            `||`. Static values can only contain alphanumeric characters
-                            along with dashes, underscores, dots and forward slashes.
-                            Example: 1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+                            \n A dynamic value is encased in single curly brackets
+                            `{}` and MUST end with a static fallback value separated
+                            with `||`. \n Static values can only contain alphanumeric
+                            characters along with dashes, underscores, dots and forward
+                            slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2.
+                            {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
                             \n TODO: DETERMIN HOW to default the app name that isnt
                             based on fluentd assumptions of \"tag\" when this is empty"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
@@ -2211,7 +2213,7 @@ spec:
                           default: user
                           description: "Facility to set on outgoing syslog records.
                             \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
-                            The value can be a decimal integer. Facility keywords
+                            \n The value can be a decimal integer. Facility keywords
                             are not standardized, this API recognizes at least the
                             following case-insensitive keywords (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels):
                             \n kernel user mail daemon auth syslog lpr news uucp cron
@@ -2223,24 +2225,26 @@ spec:
                             This supports template syntax to allow dynamic per-event
                             values. \n The MsgID can be a combination of static and
                             dynamic values consisting of field paths followed by `||`
-                            followed by another field path or a static value. A dynamic
-                            value is encased in single curly brackets `{}` and MUST
-                            end with a static fallback value separated with `||`.
-                            Static values can only contain alphanumeric characters
+                            followed by another field path or a static value. \n A
+                            dynamic value is encased in single curly brackets `{}`
+                            and MUST end with a static fallback value separated with
+                            `||`. \n Static values can only contain alphanumeric characters
                             along with dashes, underscores, dots and forward slashes.
-                            Example: 1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+                            \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+                            \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
                             \n MsgID needs to be specified if using rfc5424.  The
                             maximum length of the final values is truncated to 32"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         payloadKey:
-                          description: "The PayloadKey must be a single field path
-                            encased in single curly brackets `{}`. Field paths must
-                            only contain alphanumeric and underscores. Any field with
-                            other characters must be quoted. If left empty, Syslog
-                            will use the whole message as the payload key \n Example:
-                            1. {.bar} 2. {.foo.bar.baz} 3. {.foo.bar.\"baz/with/slashes\"}"
+                          description: "PayloadKey specifies record field to use as
+                            payload. This supports template syntax to allow dynamic
+                            per-event values. \n The PayloadKey must be a single field
+                            path encased in single curly brackets `{}`. \n Field paths
+                            must only contain alphanumeric and underscores. Any field
+                            with other characters must be quoted. \n If left empty,
+                            Syslog will use the whole message as the payload key \n
+                            Example: \n 1. {.bar} \n 2. {.foo.bar.baz} \n 3. {.foo.bar.\"baz/with/slashes\"}"
                           pattern: ^\{(\.[a-zA-Z0-9_]+|\."[^"]+")(\.[a-zA-Z0-9_]+|\."[^"]+")*\}$
                           type: string
                         procID:
@@ -2248,13 +2252,13 @@ spec:
                             This supports template syntax to allow dynamic per-event
                             values. \n The ProcID can be a combination of static and
                             dynamic values consisting of field paths followed by `||`
-                            followed by another field path or a static value. A dynamic
-                            value is encased in single curly brackets `{}` and MUST
-                            end with a static fallback value separated with `||`.
-                            Static values can only contain alphanumeric characters
+                            followed by another field path or a static value. \n A
+                            dynamic value is encased in single curly brackets `{}`
+                            and MUST end with a static fallback value separated with
+                            `||`. \n Static values can only contain alphanumeric characters
                             along with dashes, underscores, dots and forward slashes.
-                            Example: 1. foo-{.bar||\"none\"} 2. {.foo||.bar||\"missing\"}
-                            3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+                            \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+                            \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
                             \n ProcID needs to be specified if using rfc5424. The
                             maximum length of the final values is truncated to 128"
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
@@ -2271,9 +2275,9 @@ spec:
                           default: informational
                           description: "Severity to set on outgoing syslog records.
                             \n Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1
-                            The value can be a decimal integer or one of these case-insensitive
-                            keywords: \n Emergency Alert Critical Error Warning Notice
-                            Informational Debug"
+                            \n The value can be a decimal integer or one of these
+                            case-insensitive keywords: \n Emergency Alert Critical
+                            Error Warning Notice Informational Debug"
                           type: string
                         url:
                           description: 'An absolute URL, with a scheme. Valid schemes
@@ -2552,10 +2556,10 @@ spec:
                     inputRefs:
                       description: "InputRefs lists the names (`input.name`) of inputs
                         to this pipeline. \n The following built-in input names are
-                        always available: \n `application` selects all logs from application
-                        pods. \n `infrastructure` selects logs from openshift and
-                        kubernetes pods and some node logs. \n `audit` selects node
-                        logs related to security audits."
+                        always available: \n - `application` selects all logs from
+                        application pods. \n - `infrastructure` selects logs from
+                        openshift and kubernetes pods and some node logs. \n - `audit`
+                        selects node logs related to security audits."
                       items:
                         type: string
                       minItems: 1

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -60,110 +60,1230 @@ spec:
         path: collector.resources
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+      - description: Define the tolerations the collector pods will accept
+        displayName: Tolerations
+        path: collector.tolerations
       - description: Filters are applied to log records passing through a pipeline.
           There are different types of filter that can select and modify log records
           in different ways. See [FilterTypeSpec] for a list of filter types.
         displayName: Log Forwarder Pipeline Filters
         path: filters
+      - description: A drop filter applies a sequence of tests to a log record and
+          drops the record if any test passes. Each test contains a sequence of conditions,
+          all conditions must be true for the test to pass. A DropTestsSpec contains
+          an array of tests which contains an array of conditions
+        displayName: Drop Filters
+        path: filters[0].drop
+      - description: DropConditions is an array of DropCondition which are conditions
+          that are ANDed together
+        displayName: Drop Filter Conditions
+        path: filters[0].drop[0].test
+      - description: 'A dot delimited path to a field in the log record. It must start
+          with a `.`. The path can contain alpha-numeric characters and underscores
+          (a-zA-Z0-9_). If segments contain characters outside of this range, the
+          segment must be quoted. Examples: `.kubernetes.namespace_name`, `.log_type`,
+          ''.kubernetes.labels.foobar'', `.kubernetes.labels."foo-bar/baz"`'
+        displayName: Field Path
+        path: filters[0].drop[0].test[0].field
+      - description: A regular expression that the field will match. If the value
+          of the field defined in the DropTest matches the regular expression, the
+          log record will be dropped. Must define only one of matches OR notMatches
+        displayName: Drop Match Expression
+        path: filters[0].drop[0].test[0].matches
+      - description: A regular expression that the field does not match. If the value
+          of the field defined in the DropTest does not match the regular expression,
+          the log record will be dropped. Must define only one of matches or notMatches
+        displayName: Keep Match Expression
+        path: filters[0].drop[0].test[0].notMatches
+      - displayName: Kubernetes API Audit Filter
+        path: filters[0].kubeAPIAudit
+      - description: Name used to refer to the filter from a "pipeline".
+        displayName: Filter Name
+        path: filters[0].name
+      - description: Labels applied to log records passing through a pipeline. These
+          labels appear in the `openshift.labels` map in the log record.
+        displayName: Labels
+        path: filters[0].openShiftLabels
+      - description: The PruneFilterSpec consists of two arrays, namely in and notIn,
+          which dictate the fields to be pruned.
+        displayName: Prune Filters
+        path: filters[0].prune
+      - description: "`In` is an array of dot-delimited field paths. Fields included
+          here are removed from the log record. \n Each field path expression must
+          start with a \".\" \n The path can contain alphanumeric characters and underscores
+          (a-zA-Z0-9_). \n If segments contain characters outside of this range, the
+          segment must be quoted otherwise paths do NOT need to be quoted. \n Examples:
+          \n - `.kubernetes.namespace_name` \n - `.log_type` \n - '.kubernetes.labels.foobar'
+          \n - `.kubernetes.labels.\"foo-bar/baz\"` \n NOTE1: `In` CANNOT contain
+          `.log_type` or `.message` as those fields are required and cannot be pruned.
+          \n NOTE2: If this filter is used in a pipeline with GoogleCloudLogging,
+          `.hostname` CANNOT be added to this list as it is a required field."
+        displayName: Fields to be dropped
+        path: filters[0].prune.in
+      - description: "`NotIn` is an array of dot-delimited field paths. All fields
+          besides the ones listed here are removed from the log record. \n Each field
+          path expression must start with a \".\" \n The path can contain alphanumeric
+          characters and underscores (a-zA-Z0-9_). \n If segments contain characters
+          outside of this range, the segment must be quoted otherwise paths do NOT
+          need to be quoted. \n Examples: \n - `.kubernetes.namespace_name` \n - `.log_type`
+          \n - '.kubernetes.labels.foobar' \n - `.kubernetes.labels.\"foo-bar/baz\"`
+          \n NOTE1: `NotIn` MUST contain `.log_type` and `.message` as those fields
+          are required and cannot be pruned. \n NOTE2: If this filter is used in a
+          pipeline with GoogleCloudLogging, `.hostname` MUST be added to this list
+          as it is a required field."
+        displayName: Fields to be kept
+        path: filters[0].prune.notIn
+      - description: Type of filter.
+        displayName: Filter Type
+        path: filters[0].type
       - description: "Inputs are named filters for log messages to be forwarded. \n
           There are three built-in inputs named `application`, `infrastructure` and
           `audit`. You don't need to define inputs here if those are sufficient for
           your needs. See `inputRefs` for more."
         displayName: Log Forwarder Inputs
         path: inputs
+      - description: Application, named set of `application` logs that can specify
+          a set of match criteria
+        displayName: Application Logs Input
+        path: inputs[0].application
+      - description: "Excludes is the set of namespaces and containers to ignore when
+          collecting logs. \n Takes precedence over Includes option."
+        displayName: Exclude
+        path: inputs[0].application.excludes
+      - description: Container spec the containers from which to collect logs Supports
+          glob patterns and presumes "*" if omitted.
+        displayName: Container Glob
+        path: inputs[0].application.excludes[0].container
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Namespace specs the namespace from which to collect logs Supports
+          glob patterns and presumes "*" if omitted.
+        displayName: Namespace Glob
+        path: inputs[0].application.excludes[0].namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Includes is the set of namespaces and containers to include
+          when collecting logs. \n Note: infrastructure namespaces are still excluded
+          for \"*\" values unless a qualifying glob pattern is specified."
+        displayName: Include
+        path: inputs[0].application.includes
+      - description: Container spec the containers from which to collect logs Supports
+          glob patterns and presumes "*" if omitted.
+        displayName: Container Glob
+        path: inputs[0].application.includes[0].container
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Namespace specs the namespace from which to collect logs Supports
+          glob patterns and presumes "*" if omitted.
+        displayName: Namespace Glob
+        path: inputs[0].application.includes[0].namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Selector for logs from pods with matching labels. \n Only messages
+          from pods with these labels are collected. \n If absent or empty, logs are
+          collected regardless of labels."
+        displayName: Pod Selector
+        path: inputs[0].application.selector
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Pod
+      - description: Tuning is the container input tuning spec for this container
+          sources
+        displayName: Input Tuning
+        path: inputs[0].application.tuning
+      - description: RateLimitPerContainer is the limit applied to each container
+          by this input. This limit is applied per collector deployment.
+        displayName: Per-Container Rate Limit
+        path: inputs[0].application.tuning.rateLimitPerContainer
       - description: MaxRecordsPerSecond is the maximum number of log records allowed
           per input/output in a pipeline
         displayName: Max Records Per Second
         path: inputs[0].application.tuning.rateLimitPerContainer.maxRecordsPerSecond
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Audit, enables `audit` logs.
+        displayName: Audit Logs Input
+        path: inputs[0].audit
+      - description: Sources defines the list of audit sources to collect. This field
+          is optional and its exclusion results in the collection of all audit sources.
+        displayName: Log Sources
+        path: inputs[0].audit.sources
+      - description: Infrastructure, Enables `infrastructure` logs.
+        displayName: Infrastructure Logs Input
+        path: inputs[0].infrastructure
+      - description: Sources defines the list of infrastructure sources to collect.
+          This field is optional and omission results in the collection of all infrastructure
+          sources.
+        displayName: Log Sources
+        path: inputs[0].infrastructure.sources
+      - description: Name used to refer to the input of a `pipeline`.
+        displayName: Input Name
+        path: inputs[0].name
+      - description: Receiver to receive logs from non-cluster sources.
+        displayName: Log Receiver
+        path: inputs[0].receiver
+      - displayName: HTTP Receiver Configuration
+        path: inputs[0].receiver.http
+      - description: Format is the format of incoming log data.
+        displayName: Data Format
+        path: inputs[0].receiver.http.format
+      - description: Port the Receiver listens on. It must be a value between 1024
+          and 65535
+        displayName: Listen Port
+        path: inputs[0].receiver.port
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: "TLS contains settings for controlling options of TLS connections.
+          \n The operator will request certificates from the cluster's cert signing
+          service when TLS is not defined. The certificates are injected into a secret
+          named \"<clusterlogforwarder.name>-<input.name>\" which is mounted into
+          the collector. The collector is configured to use the public and private
+          key provided by the service"
+        displayName: TLS Options
+        path: inputs[0].receiver.tls
+      - description: Type of Receiver plugin.
+        displayName: Receiver Type
+        path: inputs[0].receiver.type
+      - description: Type of output sink.
+        displayName: Input Type
+        path: inputs[0].type
+      - description: Indicator if the resource is 'Managed' or 'Unmanaged' by the
+          operator.
+        displayName: Management State
+        path: managementState
       - description: Outputs are named destinations for log messages.
         displayName: Log Forwarder Outputs
         path: outputs
+      - displayName: Azure Monitor
+        path: outputs[0].azureMonitor
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].azureMonitor.authentication
+      - description: SharedKey points to the secret containing the shared key used
+          for authenticating requests.
+        displayName: Shared Key
+        path: outputs[0].azureMonitor.authentication.sharedKey
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].azureMonitor.authentication.sharedKey.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].azureMonitor.authentication.sharedKey.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: AzureResourceId the Resource ID of the Azure resource the data
+          should be associated with. https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell#request-headers
+        displayName: Azure Resource ID
+        path: outputs[0].azureMonitor.azureResourceId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: CustomerId che unique identifier for the Log Analytics workspace.
+          https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell#request-uri-parameters
+        displayName: Customer ID
+        path: outputs[0].azureMonitor.customerId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Host alternative host for dedicated Azure regions. (for example
+          for China region) https://docs.azure.cn/en-us/articles/guidance/developerdifferences#check-endpoints-in-azure
+        displayName: Azure Host
+        path: outputs[0].azureMonitor.host
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: LogType the record type of the data that is being submitted.
+          Can only contain letters, numbers, and underscores (_), and may not exceed
+          100 characters. https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell#request-headers
+        displayName: Log Type
+        path: outputs[0].azureMonitor.logType
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].azureMonitor.tuning
+      - displayName: Delivery Mode
+        path: outputs[0].azureMonitor.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].azureMonitor.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].azureMonitor.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].azureMonitor.tuning.minRetryDuration
+      - displayName: Amazon CloudWatch
+        path: outputs[0].cloudwatch
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].cloudwatch.authentication
+      - description: AWSAccessKey points to the AWS access key id and secret to be
+          used for authentication.
+        displayName: Access Key
+        path: outputs[0].cloudwatch.authentication.awsAccessKey
+      - description: AccessKeyID points to the AWS access key id to be used for authentication.
+        displayName: Secret with Access Key ID
+        path: outputs[0].cloudwatch.authentication.awsAccessKey.keyID
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].cloudwatch.authentication.awsAccessKey.keyID.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].cloudwatch.authentication.awsAccessKey.keyID.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: AccessKeySecret points to the AWS access key secret to be used
+          for authentication.
+        displayName: Secret with Access Key Secret
+        path: outputs[0].cloudwatch.authentication.awsAccessKey.keySecret
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].cloudwatch.authentication.awsAccessKey.keySecret.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].cloudwatch.authentication.awsAccessKey.keySecret.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: IAMRole points to the secret containing the role ARN to be used
+          for authentication. This can be used for authentication in STS-enabled clusters
+          when additionally specifying a web identity token
+        displayName: Amazon IAM Role
+        path: outputs[0].cloudwatch.authentication.iamRole
+      - description: RoleARN points to the secret containing the role ARN to be used
+          for authentication. This is used for authentication in STS-enabled clusters.
+        displayName: RoleARN Secret
+        path: outputs[0].cloudwatch.authentication.iamRole.roleARN
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].cloudwatch.authentication.iamRole.roleARN.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].cloudwatch.authentication.iamRole.roleARN.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Token
+        path: outputs[0].cloudwatch.authentication.iamRole.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].cloudwatch.authentication.iamRole.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].cloudwatch.authentication.iamRole.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].cloudwatch.authentication.iamRole.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].cloudwatch.authentication.iamRole.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Type is the type of cloudwatch authentication to configure
+        displayName: Authentication Type
+        path: outputs[0].cloudwatch.authentication.type
+      - description: "GroupName defines the strategy for grouping logstreams \n The
+          GroupName can be a combination of static and dynamic values consisting of
+          field paths followed by `||` followed by another field path or a static
+          value. \n A dynamic value is encased in single curly brackets `{}` and MUST
+          end with a static fallback value separated with `||`. \n Static values can
+          only contain alphanumeric characters along with dashes, underscores, dots
+          and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+          \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Group Name
+        path: outputs[0].cloudwatch.groupName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Amazon Region
+        path: outputs[0].cloudwatch.region
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].cloudwatch.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network. It is an error if the compression type is not supported by
+          the output.
+        displayName: Compression
+        path: outputs[0].cloudwatch.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].cloudwatch.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].cloudwatch.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].cloudwatch.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].cloudwatch.tuning.minRetryDuration
+      - description: "URL to send log records to. \n The 'username@password' part
+          of `url` is ignored."
+        displayName: Destination URL
+        path: outputs[0].cloudwatch.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: ElasticSearch
+        path: outputs[0].elasticsearch
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].elasticsearch.authentication
+      - description: Password to use for authenticating requests.
+        displayName: Password
+        path: outputs[0].elasticsearch.authentication.password
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].elasticsearch.authentication.password.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].elasticsearch.authentication.password.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Bearer Token
+        path: outputs[0].elasticsearch.authentication.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].elasticsearch.authentication.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].elasticsearch.authentication.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].elasticsearch.authentication.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].elasticsearch.authentication.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username to use for authenticating requests.
+        displayName: Username
+        path: outputs[0].elasticsearch.authentication.username
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].elasticsearch.authentication.username.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].elasticsearch.authentication.username.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Index is the index for the logs. This supports template syntax
+          to allow dynamic per-event values. \n The Index can be a combination of
+          static and dynamic values consisting of field paths followed by `||` followed
+          by another field path or a static value. \n A dynamic value is encased in
+          single curly brackets `{}` and MUST end with a static fallback value separated
+          with `||`. \n Static values can only contain alphanumeric characters along
+          with dashes, underscores, dots and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"}
+          \n 2. {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Log Index
+        path: outputs[0].elasticsearch.index
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].elasticsearch.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].elasticsearch.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].elasticsearch.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].elasticsearch.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].elasticsearch.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].elasticsearch.tuning.minRetryDuration
+      - description: URL to send log records to. Basic TLS is enabled if the URL scheme
+          requires it (for example 'https' or 'tls'). The 'username@password' part
+          of `url` is ignored.
+        displayName: Destination URL
+        path: outputs[0].elasticsearch.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'Version specifies the version of Elasticsearch to be used. Must
+          be one of: 6-8, where 8 is the default'
+        displayName: ElasticSearch Version
+        path: outputs[0].elasticsearch.version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - displayName: Google Cloud Logging
+        path: outputs[0].googleCloudLogging
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].googleCloudLogging.authentication
+      - description: Credentials points to the secret containing the `google-application-credentials.json`.
+        displayName: Secret with Credentials File
+        path: outputs[0].googleCloudLogging.authentication.credentials
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].googleCloudLogging.authentication.credentials.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].googleCloudLogging.authentication.credentials.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: ID must be one of the required ID fields for the output
+        displayName: Logging ID
+        path: outputs[0].googleCloudLogging.id
+      - description: Type is the ID type provided
+        displayName: Logging ID Type
+        path: outputs[0].googleCloudLogging.id.type
+      - description: Value is the value of the ID
+        displayName: Logging ID Value
+        path: outputs[0].googleCloudLogging.id.value
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "LogID is the log ID to which to publish logs. This identifies
+          log stream. \n The LogID can be a combination of static and dynamic values
+          consisting of field paths followed by `||` followed by another field path
+          or a static value. \n A dynamic value is encased in single curly brackets
+          `{}` and MUST end with a static fallback value separated with `||`. \n Static
+          values can only contain alphanumeric characters along with dashes, underscores,
+          dots and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+          \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Log Stream ID
+        path: outputs[0].googleCloudLogging.logId
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].googleCloudLogging.tuning
+      - displayName: Delivery Mode
+        path: outputs[0].googleCloudLogging.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].googleCloudLogging.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].googleCloudLogging.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].googleCloudLogging.tuning.minRetryDuration
+      - displayName: HTTP Output
+        path: outputs[0].http
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].http.authentication
+      - description: Password to use for authenticating requests.
+        displayName: Password
+        path: outputs[0].http.authentication.password
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].http.authentication.password.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].http.authentication.password.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Bearer Token
+        path: outputs[0].http.authentication.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].http.authentication.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].http.authentication.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].http.authentication.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].http.authentication.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username to use for authenticating requests.
+        displayName: Username
+        path: outputs[0].http.authentication.username
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].http.authentication.username.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].http.authentication.username.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Headers specify optional headers to be sent with the request
+        displayName: Headers
+        path: outputs[0].http.headers
+      - description: Method specifies the Http method to be used for sending logs.
+          If not set, 'POST' is used.
+        displayName: HTTP Method
+        path: outputs[0].http.method
+      - description: Timeout specifies the Http request timeout in seconds. If not
+          set, 10secs is used.
+        displayName: Timeout
+        path: outputs[0].http.timeout
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].http.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].http.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].http.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].http.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].http.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].http.tuning.minRetryDuration
+      - description: URL to send log records to. Basic TLS is enabled if the URL scheme
+          requires it (for example 'https' or 'tls'). The 'username@password' part
+          of `url` is ignored.
+        displayName: Destination URL
+        path: outputs[0].http.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Apache Kafka
+        path: outputs[0].kafka
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].kafka.authentication
+      - description: SASL contains options configuring SASL authentication.
+        displayName: SASL Options
+        path: outputs[0].kafka.authentication.sasl
+      - description: Mechanism sets the SASL mechanism to use.
+        displayName: SASL Mechanism
+        path: outputs[0].kafka.authentication.sasl.mechanism
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username points to the secret to be used as SASL password.
+        displayName: Secret with Password
+        path: outputs[0].kafka.authentication.sasl.password
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].kafka.authentication.sasl.password.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].kafka.authentication.sasl.password.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username points to the secret to be used as SASL username.
+        displayName: Secret with Username
+        path: outputs[0].kafka.authentication.sasl.username
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].kafka.authentication.sasl.username.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].kafka.authentication.sasl.username.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Brokers specifies the list of broker endpoints of a Kafka cluster.
+          \n The list represents only the initial set used by the collector's Kafka
+          client for the first connection only. The collector's Kafka client fetches
+          constantly an updated list from Kafka. These updates are not reconciled
+          back to the collector configuration. \n If none provided the target URL
+          from the OutputSpec is used as fallback."
+        displayName: Kafka Brokers
+        path: outputs[0].kafka.brokers
+      - description: "Topic specifies the target topic to send logs to. The value
+          when not specified is 'topic' \n The Topic can be a combination of static
+          and dynamic values consisting of field paths followed by `||` followed by
+          another field path or a static value. \n A dynamic value is encased in single
+          curly brackets `{}` and MUST end with a static fallback value separated
+          with `||`. \n Static values can only contain alphanumeric characters along
+          with dashes, underscores, dots and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"}
+          \n 2. {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Kafka Topic
+        path: outputs[0].kafka.topic
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].kafka.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].kafka.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].kafka.tuning.delivery
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].kafka.tuning.maxWrite
+      - description: "URL to send log records to. \n The 'username@password' part
+          of `url` is ignored."
+        displayName: Destination URL
+        path: outputs[0].kafka.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Grafana Loki
+        path: outputs[0].loki
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].loki.authentication
+      - description: Password to use for authenticating requests.
+        displayName: Password
+        path: outputs[0].loki.authentication.password
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].loki.authentication.password.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].loki.authentication.password.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Bearer Token
+        path: outputs[0].loki.authentication.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].loki.authentication.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].loki.authentication.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].loki.authentication.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].loki.authentication.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username to use for authenticating requests.
+        displayName: Username
+        path: outputs[0].loki.authentication.username
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].loki.authentication.username.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].loki.authentication.username.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "LabelKeys can be used to customize which log record keys are
+          mapped to Loki stream labels. \n If LabelKeys is not set, the default keys
+          are: \n - log_type \n - kubernetes.container_name \n - kubernetes.namespace_name
+          \n - kubernetes.pod_name \n One additional label \"kubernetes_host\" is
+          not part of the label keys configuration. It contains the hostname where
+          the collector is running and is always present. \n Note: Loki label names
+          must match the regular expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\" Log record
+          keys may contain characters like \".\" and \"/\" that are not allowed in
+          Loki labels. Log record keys are translated to Loki labels by replacing
+          any illegal characters with '_'. \n For example the default log record keys
+          translate to these Loki labels: \n - log_type \n - kubernetes_container_name
+          \n - kubernetes_namespace_name \n - kubernetes_pod_name \n Note: the set
+          of labels should be small, Loki imposes limits on the size and number of
+          labels allowed. See https://grafana.com/docs/loki/latest/configuration/#limits_config
+          for more. Loki queries can also query based on any log record field (not
+          just labels) using query filters."
+        displayName: Stream Label Configuration
+        path: outputs[0].loki.labelKeys
+      - description: "TenantKey is the tenant for the logs. This supports vector's
+          template syntax to allow dynamic per-event values. \n The TenantKey can
+          be a combination of static and dynamic values consisting of field paths
+          followed by `||` followed by another field path or a static value. \n A
+          dynamic value is encased in single curly brackets `{}` and MUST end with
+          a static fallback value separated with `||`. \n Static values can only contain
+          alphanumeric characters along with dashes, underscores, dots and forward
+          slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+          \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Tenant Key
+        path: outputs[0].loki.tenantKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].loki.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].loki.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].loki.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].loki.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].loki.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].loki.tuning.minRetryDuration
+      - description: URL to send log records to. Basic TLS is enabled if the URL scheme
+          requires it (for example 'https' or 'tls'). The 'username@password' part
+          of `url` is ignored.
+        displayName: Destination URL
+        path: outputs[0].loki.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: LokiStack
+        path: outputs[0].lokiStack
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].lokiStack.authentication
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Bearer Token
+        path: outputs[0].lokiStack.authentication.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].lokiStack.authentication.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].lokiStack.authentication.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].lokiStack.authentication.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].lokiStack.authentication.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "LabelKeys can be used to customize which log record keys are
+          mapped to Loki stream labels. \n Note: Loki label names must match the regular
+          expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\" Log record keys may contain characters
+          like \".\" and \"/\" that are not allowed in Loki labels. Log record keys
+          are translated to Loki labels by replacing any illegal characters with '_'.
+          \n For example the default log record keys translate to these Loki labels:
+          \n - log_type \n - kubernetes_container_name \n - kubernetes_namespace_name
+          \n - kubernetes_pod_name \n Note: the set of labels should be small, Loki
+          imposes limits on the size and number of labels allowed. See https://grafana.com/docs/loki/latest/configuration/#limits_config
+          for more. Loki queries can also query based on any log record field (not
+          just labels) using query filters."
+        displayName: Stream Label Configuration
+        path: outputs[0].lokiStack.labelKeys
+      - description: Application contains the label keys configuration for the "application"
+          tenant.
+        displayName: Application Tenant Configuration
+        path: outputs[0].lokiStack.labelKeys.application
+      - description: If IgnoreGlobal is true, then the tenant will not use the labels
+          configured in the Global section of the label keys configuration.
+        displayName: Ignore Global Settings
+        path: outputs[0].lokiStack.labelKeys.application.ignoreGlobal
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: "LabelKeys contains a list of log record keys that are mapped
+          to Loki stream labels. \n By default, this list is combined with the labels
+          specified in the Global configuration. This behavior can be changed by setting
+          IgnoreGlobal to true."
+        displayName: Label Keys
+        path: outputs[0].lokiStack.labelKeys.application.labelKeys
+      - description: Audit contains the label keys configuration for the "audit" tenant.
+        displayName: Audit Tenant Configuration
+        path: outputs[0].lokiStack.labelKeys.audit
+      - description: If IgnoreGlobal is true, then the tenant will not use the labels
+          configured in the Global section of the label keys configuration.
+        displayName: Ignore Global Settings
+        path: outputs[0].lokiStack.labelKeys.audit.ignoreGlobal
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: "LabelKeys contains a list of log record keys that are mapped
+          to Loki stream labels. \n By default, this list is combined with the labels
+          specified in the Global configuration. This behavior can be changed by setting
+          IgnoreGlobal to true."
+        displayName: Label Keys
+        path: outputs[0].lokiStack.labelKeys.audit.labelKeys
+      - description: "Global contains a list of record keys which are used for all
+          tenants. \n If LabelKeys is not set, the default keys are: \n - log_type
+          \n - kubernetes.container_name \n - kubernetes.namespace_name \n - kubernetes.pod_name
+          \n One additional label \"kubernetes_host\" is not part of the label keys
+          configuration. It contains the hostname where the collector is running and
+          is always present."
+        displayName: Global Configuration
+        path: outputs[0].lokiStack.labelKeys.global
+      - description: Infrastructure contains the label keys configuration for the
+          "infrastructure" tenant.
+        displayName: Infrastructure Tenant Configuration
+        path: outputs[0].lokiStack.labelKeys.infrastructure
+      - description: If IgnoreGlobal is true, then the tenant will not use the labels
+          configured in the Global section of the label keys configuration.
+        displayName: Ignore Global Settings
+        path: outputs[0].lokiStack.labelKeys.infrastructure.ignoreGlobal
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: "LabelKeys contains a list of log record keys that are mapped
+          to Loki stream labels. \n By default, this list is combined with the labels
+          specified in the Global configuration. This behavior can be changed by setting
+          IgnoreGlobal to true."
+        displayName: Label Keys
+        path: outputs[0].lokiStack.labelKeys.infrastructure.labelKeys
+      - description: Target points to the LokiStack resources that should be used
+          as a target for the output.
+        displayName: Target LokiStack Reference
+        path: outputs[0].lokiStack.target
+      - description: Name of the in-cluster LokiStack resource.
+        displayName: LokiStack Name
+        path: outputs[0].lokiStack.target.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Namespace of the in-cluster LokiStack resource. \n If unset,
+          this defaults to \"openshift-logging\"."
+        displayName: LokiStack Namespace
+        path: outputs[0].lokiStack.target.namespace
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].lokiStack.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].lokiStack.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].lokiStack.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].lokiStack.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].lokiStack.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].lokiStack.tuning.minRetryDuration
+      - description: Name used to refer to the output from a `pipeline`.
+        displayName: Output Name
+        path: outputs[0].name
+      - displayName: OpenTelemetry Output
+        path: outputs[0].otlp
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].otlp.authentication
+      - description: Password to use for authenticating requests.
+        displayName: Password
+        path: outputs[0].otlp.authentication.password
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].otlp.authentication.password.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].otlp.authentication.password.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Token specifies a bearer token to be used for authenticating
+          requests.
+        displayName: Bearer Token
+        path: outputs[0].otlp.authentication.token
+      - description: From is the source from where to find the token
+        displayName: Token Source
+        path: outputs[0].otlp.authentication.token.from
+      - description: Use Secret if the value should be sourced from a Secret in the
+          same namespace.
+        displayName: Token Secret
+        path: outputs[0].otlp.authentication.token.secret
+      - description: Name of the key used to get the value from the referenced Secret.
+        displayName: Key Name
+        path: outputs[0].otlp.authentication.token.secret.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Name of secret
+        displayName: Secret Name
+        path: outputs[0].otlp.authentication.token.secret.name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Username to use for authenticating requests.
+        displayName: Username
+        path: outputs[0].otlp.authentication.username
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].otlp.authentication.username.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].otlp.authentication.username.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].otlp.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network. It is an error if the compression type is not supported by
+          the output.
+        displayName: Compression
+        path: outputs[0].otlp.tuning.compression
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Delivery Mode
+        path: outputs[0].otlp.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].otlp.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].otlp.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].otlp.tuning.minRetryDuration
+      - description: "URL to send log records to. \n An absolute URL, with a valid
+          http scheme. Must terminate with `/v1/logs` \n Basic TLS is enabled if the
+          URL scheme requires it (for example 'https'). The 'username@password' part
+          of `url` is ignored."
+        displayName: Destination URL
+        path: outputs[0].otlp.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Limit imposes a limit in records-per-second on the total aggregate
+          rate of logs forwarded to this output from any given collector container.
+          The total log flow from an individual collector container to this output
+          cannot exceed the limit.  Generally, one collector is deployed per cluster
+          node Logs may be dropped to enforce the limit. Missing or 0 means no rate
+          limit.
+        displayName: Rate Limiting
+        path: outputs[0].rateLimit
       - description: MaxRecordsPerSecond is the maximum number of log records allowed
           per input/output in a pipeline
         displayName: Max Records Per Second
         path: outputs[0].rateLimit.maxRecordsPerSecond
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - displayName: Splunk
+        path: outputs[0].splunk
+      - description: Authentication sets credentials for authenticating the requests.
+        displayName: Authentication Options
+        path: outputs[0].splunk.authentication
+      - description: Token points to the secret containing the Splunk HEC token used
+          for authenticating requests.
+        displayName: Splunk HEC Token
+        path: outputs[0].splunk.authentication.token
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].splunk.authentication.token.key
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].splunk.authentication.token.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Index is the index for the logs. This supports template syntax
+          to allow dynamic per-event values. \n The Index can be a combination of
+          static and dynamic values consisting of field paths followed by `||` followed
+          by another field path or a static value. \n A dynamic value is encased in
+          single curly brackets `{}` and MUST end with a static fallback value separated
+          with `||`. \n Static values can only contain alphanumeric characters along
+          with dashes, underscores, dots and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"}
+          \n 2. {.foo||.bar||\"missing\"} \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}"
+        displayName: Index
+        path: outputs[0].splunk.index
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Tuning specs tuning for the output
+        displayName: Tuning Options
+        path: outputs[0].splunk.tuning
+      - description: Compression causes data to be compressed before sending over
+          the network.
+        displayName: Compression
+        path: outputs[0].splunk.tuning.compression
+      - displayName: Delivery Mode
+        path: outputs[0].splunk.tuning.delivery
+      - description: MaxRetryDuration is the maximum time to wait between retry attempts
+          after a delivery failure.
+        displayName: Maximum Retry Duration
+        path: outputs[0].splunk.tuning.maxRetryDuration
+      - description: MaxWrite limits the maximum payload in terms of bytes of a single
+          "send" to the output.
+        displayName: Batch Size
+        path: outputs[0].splunk.tuning.maxWrite
+      - description: MinRetryDuration is the minimum time to wait between attempts
+          to retry after delivery a failure.
+        displayName: Minimum Retry Duration
+        path: outputs[0].splunk.tuning.minRetryDuration
+      - description: URL to send log records to. Basic TLS is enabled if the URL scheme
+          requires it (for example 'https' or 'tls'). The 'username@password' part
+          of `url` is ignored.
+        displayName: Destination URL
+        path: outputs[0].splunk.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Syslog Output
+        path: outputs[0].syslog
+      - description: "AppName is APP-NAME part of the syslog-msg header. \n AppName
+          needs to be specified if using rfc5424. The maximum length of the final
+          values is truncated to 48 This supports template syntax to allow dynamic
+          per-event values. \n The AppName can be a combination of static and dynamic
+          values consisting of field paths followed by `||` followed by another field
+          path or a static value. \n A dynamic value is encased in single curly brackets
+          `{}` and MUST end with a static fallback value separated with `||`. \n Static
+          values can only contain alphanumeric characters along with dashes, underscores,
+          dots and forward slashes. \n Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"}
+          \n 3. foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+          \n TODO: DETERMIN HOW to default the app name that isnt based on fluentd
+          assumptions of \"tag\" when this is empty"
+        displayName: App Name
+        path: outputs[0].syslog.appName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Enrichment is an additional modification the log message before
+          forwarding it to the receiver
+        displayName: Enrichment Type
+        path: outputs[0].syslog.enrichment
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "Facility to set on outgoing syslog records. \n Facility values
+          are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1. \n The
+          value can be a decimal integer. Facility keywords are not standardized,
+          this API recognizes at least the following case-insensitive keywords (defined
+          by https://en.wikipedia.org/wiki/Syslog#Facility_Levels): \n kernel user
+          mail daemon auth syslog lpr news uucp cron authpriv ftp ntp security console
+          solaris-cron local0 local1 local2 local3 local4 local5 local6 local7"
+        displayName: Facility
+        path: outputs[0].syslog.facility
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "MsgID is MSGID part of the syslog-msg header. This supports
+          template syntax to allow dynamic per-event values. \n The MsgID can be a
+          combination of static and dynamic values consisting of field paths followed
+          by `||` followed by another field path or a static value. \n A dynamic value
+          is encased in single curly brackets `{}` and MUST end with a static fallback
+          value separated with `||`. \n Static values can only contain alphanumeric
+          characters along with dashes, underscores, dots and forward slashes. \n
+          Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"} \n 3.
+          foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+          \n MsgID needs to be specified if using rfc5424.  The maximum length of
+          the final values is truncated to 32"
+        displayName: MSGID
+        path: outputs[0].syslog.msgID
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "PayloadKey specifies record field to use as payload. This supports
+          template syntax to allow dynamic per-event values. \n The PayloadKey must
+          be a single field path encased in single curly brackets `{}`. \n Field paths
+          must only contain alphanumeric and underscores. Any field with other characters
+          must be quoted. \n If left empty, Syslog will use the whole message as the
+          payload key \n Example: \n 1. {.bar} \n 2. {.foo.bar.baz} \n 3. {.foo.bar.\"baz/with/slashes\"}"
+        displayName: Payload Key
+        path: outputs[0].syslog.payloadKey
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "ProcID is PROCID part of the syslog-msg header. This supports
+          template syntax to allow dynamic per-event values. \n The ProcID can be
+          a combination of static and dynamic values consisting of field paths followed
+          by `||` followed by another field path or a static value. \n A dynamic value
+          is encased in single curly brackets `{}` and MUST end with a static fallback
+          value separated with `||`. \n Static values can only contain alphanumeric
+          characters along with dashes, underscores, dots and forward slashes. \n
+          Example: \n 1. foo-{.bar||\"none\"} \n 2. {.foo||.bar||\"missing\"} \n 3.
+          foo.{.bar.baz||.qux.quux.corge||.grault||\"nil\"}-waldo.fred{.plugh||\"none\"}
+          \n ProcID needs to be specified if using rfc5424. The maximum length of
+          the final values is truncated to 128"
+        displayName: PROCID
+        path: outputs[0].syslog.procID
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - displayName: Syslog RFC
+        path: outputs[0].syslog.rfc
+      - description: "Severity to set on outgoing syslog records. \n Severity values
+          are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1 \n The
+          value can be a decimal integer or one of these case-insensitive keywords:
+          \n Emergency Alert Critical Error Warning Notice Informational Debug"
+        displayName: Severity
+        path: outputs[0].syslog.severity
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: 'An absolute URL, with a scheme. Valid schemes are: `tcp`, `tls`,
+          `udp` and `udps` For example, to send syslog records using secure UDP: url:
+          udps://syslog.example.com:1234'
+        displayName: Destination URL
+        path: outputs[0].syslog.url
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: TLS contains settings for controlling options on TLS client connections.
+        displayName: TLS Options
+        path: outputs[0].tls
+      - description: CA can be used to specify a custom list of trusted certificate
+          authorities.
+        displayName: Certificate Authority Bundle
+        path: outputs[0].tls.ca
+      - description: ConfigMapName contains the name of the ConfigMap containing the
+          referenced value.
+        displayName: ConfigMap Name
+        path: outputs[0].tls.ca.configMapName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: Name of the key used to get the value in either the referenced
@@ -172,34 +1292,108 @@ spec:
         path: outputs[0].tls.ca.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].tls.ca.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Certificate points to the server certificate to use.
+        displayName: Certificate
+        path: outputs[0].tls.certificate
+      - description: ConfigMapName contains the name of the ConfigMap containing the
+          referenced value.
+        displayName: ConfigMap Name
+        path: outputs[0].tls.certificate.configMapName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Name of the key used to get the value in either the referenced
           ConfigMap or Secret.
         displayName: Key Name
         path: outputs[0].tls.certificate.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].tls.certificate.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "If InsecureSkipVerify is true, then the TLS client will be configured
+          to skip validating server certificates. \n This option is *not* recommended
+          for production configurations."
+        displayName: Skip Certificate Validation
+        path: outputs[0].tls.insecureSkipVerify
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Key points to the private key of the server certificate.
+        displayName: Certificate Key
+        path: outputs[0].tls.key
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].tls.key.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].tls.key.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: KeyPassphrase points to the passphrase used to unlock the private
+          key.
+        displayName: Certificate Key Passphrase
+        path: outputs[0].tls.keyPassphrase
       - description: Key contains the name of the key inside the referenced Secret.
         displayName: Key Name
         path: outputs[0].tls.keyPassphrase.key
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: SecretName contains the name of the Secret containing the referenced
+          value.
+        displayName: Secret Name
+        path: outputs[0].tls.keyPassphrase.secretName
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: TLSSecurityProfile is the security profile to apply to the output
+          connection.
+        displayName: TLS Security Profile
+        path: outputs[0].tls.securityProfile
+      - description: Type of output sink.
+        displayName: Output Type
+        path: outputs[0].type
       - description: Pipelines forward the messages selected by a set of inputs to
           a set of outputs.
         displayName: Log Forwarder Pipelines
         path: pipelines
+      - description: "Filters lists the names of filters to be applied to records
+          going through this pipeline. \n Each filter is applied in order. If a filter
+          drops a records, subsequent filters are not applied."
+        displayName: Filters
+        path: pipelines[0].filterRefs
+      - description: "InputRefs lists the names (`input.name`) of inputs to this pipeline.
+          \n The following built-in input names are always available: \n - `application`
+          selects all logs from application pods. \n - `infrastructure` selects logs
+          from openshift and kubernetes pods and some node logs. \n - `audit` selects
+          node logs related to security audits."
+        displayName: Inputs
+        path: pipelines[0].inputRefs
       - description: Name of the pipeline
         displayName: Name
         path: pipelines[0].name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: OutputRefs lists the names (`output.name`) of outputs from this
+          pipeline.
+        displayName: Outputs
+        path: pipelines[0].outputRefs
+      - description: ServiceAccount points to the ServiceAccount resource used by
+          the collector pods.
+        displayName: Service Account
+        path: serviceAccount
       - description: Name of the ServiceAccount to use to deploy the Forwarder.  The
           ServiceAccount is created by the administrator
-        displayName: Name
+        displayName: ServiceAccount Name
         path: serviceAccount.name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text

--- a/docs/reference/operator/api_logging_v1alpha1.adoc
+++ b/docs/reference/operator/api_logging_v1alpha1.adoc
@@ -1099,6 +1099,7 @@ More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-co
 
 === .spec.collection.logs.fluentd.resources.claims[]
 
+<<<<<<< HEAD
 Type:: array
 
 [options="header"]
@@ -2318,12 +2319,15 @@ Type:: object
 
 === .status.conditions[]
 
+=======
+>>>>>>> bffb95011 (Improve descriptors for OpenShift Console CLF creation form)
 Type:: array
 
 [options="header"]
 |======================
 |Property|Type|Description
 
+<<<<<<< HEAD
 |lastTransitionTime|string|  lastTransitionTime is the last time the condition transitioned from one status to another.
 This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
 |message|string|  message is a human readable message indicating details about the transition.
@@ -2344,3 +2348,1219 @@ useful (see .node.status.conditions), the ability to deconflict is important.
 The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
 |======================
 
+=======
+|name|string|  Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.
+|======================
+
+=== .spec.collection.logs.fluentd.resources.limits
+
+Type:: object
+
+=== .spec.collection.logs.fluentd.resources.requests
+
+Type:: object
+
+=== .spec.collection.logs.fluentd.tolerations[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|effect|string|  *(optional)* Effect indicates the taint effect to match. Empty means match all taint effects.
+When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+|key|string|  *(optional)* Key is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+|operator|string|  *(optional)* Operator represents a key&#39;s relationship to the value.
+Valid operators are Exists and Equal. Defaults to Equal.
+Exists is equivalent to wildcard for value, so that a pod can
+tolerate all taints of a particular category.
+|tolerationSeconds|int|  *(optional)* TolerationSeconds represents the period of time the toleration (which must be
+of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+it is not set, which means tolerate the taint forever (do not evict). Zero and
+negative values will be treated as 0 (evict immediately) by the system.
+|value|string|  *(optional)* Value is the taint value the toleration matches to.
+If the operator is Exists, the value should be empty, otherwise just a regular string.
+|======================
+
+=== .spec.collection.logs.fluentd.tolerations[].tolerationSeconds
+
+Type:: int
+
+=== .spec.curation
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
+This is the struct that will contain information pertinent to Log curation (Curator)
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|curator|object|  The specification of curation to configure
+|type|string|  The kind of curation to configure
+|======================
+
+=== .spec.curation.curator
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|nodeSelector|object|  Define which Nodes the Pods are scheduled on.
+
+|resources|object|  *(optional)* The resource requirements for Curator
+
+|schedule|string|  The cron schedule that the Curator job is run. Defaults to &#34;30 3 * * *&#34;
+|tolerations|array|  
+|======================
+
+=== .spec.curation.curator.nodeSelector
+
+Type:: object
+
+=== .spec.curation.curator.resources
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|claims|array|  *(optional)* Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+
+|limits|object|  *(optional)* Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|requests|object|  *(optional)* Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|======================
+
+=== .spec.curation.curator.resources.claims[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|name|string|  Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.
+|======================
+
+=== .spec.curation.curator.resources.limits
+
+Type:: object
+
+=== .spec.curation.curator.resources.requests
+
+Type:: object
+
+=== .spec.curation.curator.tolerations[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|effect|string|  *(optional)* Effect indicates the taint effect to match. Empty means match all taint effects.
+When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+|key|string|  *(optional)* Key is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+|operator|string|  *(optional)* Operator represents a key&#39;s relationship to the value.
+Valid operators are Exists and Equal. Defaults to Equal.
+Exists is equivalent to wildcard for value, so that a pod can
+tolerate all taints of a particular category.
+|tolerationSeconds|int|  *(optional)* TolerationSeconds represents the period of time the toleration (which must be
+of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+it is not set, which means tolerate the taint forever (do not evict). Zero and
+negative values will be treated as 0 (evict immediately) by the system.
+|value|string|  *(optional)* Value is the taint value the toleration matches to.
+If the operator is Exists, the value should be empty, otherwise just a regular string.
+|======================
+
+=== .spec.curation.curator.tolerations[].tolerationSeconds
+
+Type:: int
+
+=== .spec.forwarder
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
+ForwarderSpec contains global tuning parameters for specific forwarder implementations.
+This field is not required for general use, it allows performance tuning by users
+familiar with the underlying forwarder technology.
+Currently supported: `fluentd`.
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|fluentd|object|  
+|======================
+
+=== .spec.forwarder.fluentd
+
+FluentdForwarderSpec represents the configuration for forwarders of type fluentd.
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|buffer|object|  
+|inFile|object|  
+|======================
+
+=== .spec.forwarder.fluentd.buffer
+
+FluentdBufferSpec represents a subset of fluentd buffer parameters to tune
+the buffer configuration for all fluentd outputs. It supports a subset of
+parameters to configure buffer and queue sizing, flush operations and retry
+flushing.
+
+For general parameters refer to:
+https://docs.fluentd.org/configuration/buffer-section#buffering-parameters
+
+For flush parameters refer to:
+https://docs.fluentd.org/configuration/buffer-section#flushing-parameters
+
+For retry parameters refer to:
+https://docs.fluentd.org/configuration/buffer-section#retries-parameters
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|chunkLimitSize|string|  *(optional)* ChunkLimitSize represents the maximum size of each chunk. Events will be
+written into chunks until the size of chunks become this size.
+
+|flushInterval|string|  *(optional)* FlushInterval represents the time duration to wait between two consecutive flush
+operations. Takes only effect used together with `flushMode: interval`.
+
+|flushMode|string|  *(optional)* FlushMode represents the mode of the flushing thread to write chunks. The mode
+allows lazy (if `time` parameter set), per interval or immediate flushing.
+
+|flushThreadCount|int|  *(optional)* FlushThreadCount reprents the number of threads used by the fluentd buffer
+plugin to flush/write chunks in parallel.
+
+|overflowAction|string|  *(optional)* OverflowAction represents the action for the fluentd buffer plugin to
+execute when a buffer queue is full. (Default: block)
+
+|retryMaxInterval|string|  *(optional)* RetryMaxInterval represents the maximum time interval for exponential backoff
+between retries. Takes only effect if used together with `retryType: exponential_backoff`.
+
+|retryTimeout|string|  *(optional)* RetryTimeout represents the maximum time interval to attempt retries before giving up
+and the record is disguarded.  If unspecified, the default will be used
+
+|retryType|string|  *(optional)* RetryType represents the type of retrying flush operations. Flush operations can
+be retried either periodically or by applying exponential backoff.
+
+|retryWait|string|  *(optional)* RetryWait represents the time duration between two consecutive retries to flush
+buffers for periodic retries or a constant factor of time on retries with exponential
+backoff.
+
+|totalLimitSize|string|  *(optional)* TotalLimitSize represents the threshold of node space allowed per fluentd
+buffer to allocate. Once this threshold is reached, all append operations
+will fail with error (and data will be lost).
+
+|======================
+
+=== .spec.forwarder.fluentd.inFile
+
+FluentdInFileSpec represents a subset of fluentd in-tail plugin parameters
+to tune the configuration for all fluentd in-tail inputs.
+
+For general parameters refer to:
+https://docs.fluentd.org/input/tail#parameters
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|readLinesLimit|int|  *(optional)* ReadLinesLimit represents the number of lines to read with each I/O operation
+|======================
+
+=== .spec.logStore
+
+The LogStoreSpec contains information about how logs are stored.
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|elasticsearch|object| **(DEPRECATED)** Specification of the Elasticsearch Log Store component
+|lokistack|object|  LokiStack contains information about which LokiStack to use for log storage if Type is set to LogStoreTypeLokiStack.
+
+The cluster-logging-operator does not create or manage the referenced LokiStack.
+|retentionPolicy|object| **(DEPRECATED)** *(optional)* Retention policy defines the maximum age for an Elasticsearch index after which it should be deleted
+
+|type|string|  The Type of Log Storage to configure. The operator currently supports either using ElasticSearch
+managed by elasticsearch-operator or Loki managed by loki-operator (LokiStack) as a default log store.
+
+When using ElasticSearch as a log store this operator also manages the ElasticSearch deployment.
+
+When using LokiStack as a log store this operator does not manage the LokiStack, but only creates
+configuration referencing an existing LokiStack deployment. The user is responsible for creating and
+managing the LokiStack himself.
+
+|======================
+
+=== .spec.logStore.elasticsearch
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|nodeCount|int|  Number of nodes to deploy for Elasticsearch
+|nodeSelector|object|  Define which Nodes the Pods are scheduled on.
+
+|proxy|object|  Specification of the Elasticsearch Proxy component
+|redundancyPolicy|string|  *(optional)* 
+|resources|object|  *(optional)* The resource requirements for Elasticsearch
+
+|storage|object|  *(optional)* The storage specification for Elasticsearch data nodes
+
+|tolerations|array|  
+|======================
+
+=== .spec.logStore.elasticsearch.nodeSelector
+
+Type:: object
+
+=== .spec.logStore.elasticsearch.proxy
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|resources|object|  
+|======================
+
+=== .spec.logStore.elasticsearch.proxy.resources
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|claims|array|  *(optional)* Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+
+|limits|object|  *(optional)* Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|requests|object|  *(optional)* Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|======================
+
+=== .spec.logStore.elasticsearch.proxy.resources.claims[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|name|string|  Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.
+|======================
+
+=== .spec.logStore.elasticsearch.proxy.resources.limits
+
+Type:: object
+
+=== .spec.logStore.elasticsearch.proxy.resources.requests
+
+Type:: object
+
+=== .spec.logStore.elasticsearch.resources
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|claims|array|  *(optional)* Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+
+|limits|object|  *(optional)* Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|requests|object|  *(optional)* Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|======================
+
+=== .spec.logStore.elasticsearch.resources.claims[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|name|string|  Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.
+|======================
+
+=== .spec.logStore.elasticsearch.resources.limits
+
+Type:: object
+
+=== .spec.logStore.elasticsearch.resources.requests
+
+Type:: object
+
+=== .spec.logStore.elasticsearch.storage
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|size|object|  The max storage capacity for the node to provision.
+|storageClassName|string|  *(optional)* The name of the storage class to use with creating the node&#39;s PVC.
+More info: https://kubernetes.io/docs/concepts/storage/storage-classes/
+|======================
+
+=== .spec.logStore.elasticsearch.storage.size
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|Format|string|  Change Format at will. See the comment for Canonicalize for
+more details.
+|d|object|  d is the quantity in inf.Dec form if d.Dec != nil
+|i|int|  i is the quantity in int64 scaled form, if d.Dec == nil
+|s|string|  s is the generated value of this quantity to avoid recalculation
+|======================
+
+=== .spec.logStore.elasticsearch.storage.size.d
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|Dec|object|  
+|======================
+
+=== .spec.logStore.elasticsearch.storage.size.d.Dec
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|scale|int|  
+|unscaled|object|  
+|======================
+
+=== .spec.logStore.elasticsearch.storage.size.d.Dec.unscaled
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|abs|Word|  sign
+|neg|bool|  
+|======================
+
+=== .spec.logStore.elasticsearch.storage.size.d.Dec.unscaled.abs
+
+Type:: Word
+
+=== .spec.logStore.elasticsearch.storage.size.i
+
+Type:: int
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|scale|int|  
+|value|int|  
+|======================
+
+=== .spec.logStore.elasticsearch.tolerations[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|effect|string|  *(optional)* Effect indicates the taint effect to match. Empty means match all taint effects.
+When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+|key|string|  *(optional)* Key is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+|operator|string|  *(optional)* Operator represents a key&#39;s relationship to the value.
+Valid operators are Exists and Equal. Defaults to Equal.
+Exists is equivalent to wildcard for value, so that a pod can
+tolerate all taints of a particular category.
+|tolerationSeconds|int|  *(optional)* TolerationSeconds represents the period of time the toleration (which must be
+of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+it is not set, which means tolerate the taint forever (do not evict). Zero and
+negative values will be treated as 0 (evict immediately) by the system.
+|value|string|  *(optional)* Value is the taint value the toleration matches to.
+If the operator is Exists, the value should be empty, otherwise just a regular string.
+|======================
+
+=== .spec.logStore.elasticsearch.tolerations[].tolerationSeconds
+
+Type:: int
+
+=== .spec.logStore.lokistack
+
+LokiStackStoreSpec is used to set up cluster-logging to use a LokiStack as logging storage.
+It points to an existing LokiStack in the same namespace.
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|name|string|  Name of the LokiStack resource.
+
+|======================
+
+=== .spec.logStore.retentionPolicy
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|application|object|  
+|audit|object|  
+|infra|object|  
+|======================
+
+=== .spec.logStore.retentionPolicy.application
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|diskThresholdPercent|int|  *(optional)* The threshold percentage of ES disk usage that when reached, old indices should be deleted (e.g. 75)
+|maxAge|string|  *(optional)* 
+|namespaceSpec|array|  *(optional)* The per namespace specification to delete documents older than a given minimum age
+|pruneNamespacesInterval|string|  *(optional)* How often to run a new prune-namespaces job
+|======================
+
+=== .spec.logStore.retentionPolicy.application.namespaceSpec[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|minAge|string|  *(optional)* Delete the records matching the namespaces which are older than this MinAge (e.g. 1d)
+|namespace|string|  Target Namespace to delete logs older than MinAge (defaults to 7d)
+Can be one namespace name or a prefix (e.g., &#34;openshift-&#34; covers all namespaces with this prefix)
+|======================
+
+=== .spec.logStore.retentionPolicy.audit
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|diskThresholdPercent|int|  *(optional)* The threshold percentage of ES disk usage that when reached, old indices should be deleted (e.g. 75)
+|maxAge|string|  *(optional)* 
+|namespaceSpec|array|  *(optional)* The per namespace specification to delete documents older than a given minimum age
+|pruneNamespacesInterval|string|  *(optional)* How often to run a new prune-namespaces job
+|======================
+
+=== .spec.logStore.retentionPolicy.audit.namespaceSpec[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|minAge|string|  *(optional)* Delete the records matching the namespaces which are older than this MinAge (e.g. 1d)
+|namespace|string|  Target Namespace to delete logs older than MinAge (defaults to 7d)
+Can be one namespace name or a prefix (e.g., &#34;openshift-&#34; covers all namespaces with this prefix)
+|======================
+
+=== .spec.logStore.retentionPolicy.infra
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|diskThresholdPercent|int|  *(optional)* The threshold percentage of ES disk usage that when reached, old indices should be deleted (e.g. 75)
+|maxAge|string|  *(optional)* 
+|namespaceSpec|array|  *(optional)* The per namespace specification to delete documents older than a given minimum age
+|pruneNamespacesInterval|string|  *(optional)* How often to run a new prune-namespaces job
+|======================
+
+=== .spec.logStore.retentionPolicy.infra.namespaceSpec[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|minAge|string|  *(optional)* Delete the records matching the namespaces which are older than this MinAge (e.g. 1d)
+|namespace|string|  Target Namespace to delete logs older than MinAge (defaults to 7d)
+Can be one namespace name or a prefix (e.g., &#34;openshift-&#34; covers all namespaces with this prefix)
+|======================
+
+=== .spec.visualization
+
+This is the struct that will contain information pertinent to Log visualization (Kibana)
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|kibana|object| **(DEPRECATED)** *(optional)* Specification of the Kibana Visualization component
+
+|nodeSelector|object|  Define which Nodes the Pods are scheduled on.
+
+|ocpConsole|object|  *(optional)* OCPConsole is the specification for the OCP console plugin
+
+|tolerations|array|  *(optional)* Define the tolerations the Pods will accept
+|type|string|  The type of Visualization to configure
+
+|======================
+
+=== .spec.visualization.kibana
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|nodeSelector|object| **(DEPRECATED)** Define which Nodes the Pods are scheduled on.
+
+|proxy|object|  Specification of the Kibana Proxy component
+|replicas|int|  *(optional)* Number of instances to deploy for a Kibana deployment
+|resources|object|  *(optional)* The resource requirements for Kibana
+
+|tolerations|array| **(DEPRECATED)** Define the tolerations the Pods will accept
+
+|======================
+
+=== .spec.visualization.kibana.nodeSelector
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
+Type:: object
+
+=== .spec.visualization.kibana.proxy
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|resources|object|  
+|======================
+
+=== .spec.visualization.kibana.proxy.resources
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|claims|array|  *(optional)* Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+
+|limits|object|  *(optional)* Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|requests|object|  *(optional)* Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|======================
+
+=== .spec.visualization.kibana.proxy.resources.claims[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|name|string|  Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.
+|======================
+
+=== .spec.visualization.kibana.proxy.resources.limits
+
+Type:: object
+
+=== .spec.visualization.kibana.proxy.resources.requests
+
+Type:: object
+
+=== .spec.visualization.kibana.replicas
+
+Type:: int
+
+=== .spec.visualization.kibana.resources
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|claims|array|  *(optional)* Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+
+|limits|object|  *(optional)* Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|requests|object|  *(optional)* Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|======================
+
+=== .spec.visualization.kibana.resources.claims[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|name|string|  Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.
+|======================
+
+=== .spec.visualization.kibana.resources.limits
+
+Type:: object
+
+=== .spec.visualization.kibana.resources.requests
+
+Type:: object
+
+=== .spec.visualization.kibana.tolerations[]
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|effect|string|  *(optional)* Effect indicates the taint effect to match. Empty means match all taint effects.
+When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+|key|string|  *(optional)* Key is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+|operator|string|  *(optional)* Operator represents a key&#39;s relationship to the value.
+Valid operators are Exists and Equal. Defaults to Equal.
+Exists is equivalent to wildcard for value, so that a pod can
+tolerate all taints of a particular category.
+|tolerationSeconds|int|  *(optional)* TolerationSeconds represents the period of time the toleration (which must be
+of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+it is not set, which means tolerate the taint forever (do not evict). Zero and
+negative values will be treated as 0 (evict immediately) by the system.
+|value|string|  *(optional)* Value is the taint value the toleration matches to.
+If the operator is Exists, the value should be empty, otherwise just a regular string.
+|======================
+
+=== .spec.visualization.kibana.tolerations[].tolerationSeconds
+
+Type:: int
+
+=== .spec.visualization.nodeSelector
+
+Type:: object
+
+=== .spec.visualization.ocpConsole
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|logsLimit|int|  *(optional)* LogsLimit is the max number of entries returned for a query.
+
+|timeout|string|  *(optional)* Timeout is the max duration before a query timeout
+
+|======================
+
+=== .spec.visualization.tolerations[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|effect|string|  *(optional)* Effect indicates the taint effect to match. Empty means match all taint effects.
+When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+|key|string|  *(optional)* Key is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+|operator|string|  *(optional)* Operator represents a key&#39;s relationship to the value.
+Valid operators are Exists and Equal. Defaults to Equal.
+Exists is equivalent to wildcard for value, so that a pod can
+tolerate all taints of a particular category.
+|tolerationSeconds|int|  *(optional)* TolerationSeconds represents the period of time the toleration (which must be
+of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+it is not set, which means tolerate the taint forever (do not evict). Zero and
+negative values will be treated as 0 (evict immediately) by the system.
+|value|string|  *(optional)* Value is the taint value the toleration matches to.
+If the operator is Exists, the value should be empty, otherwise just a regular string.
+|======================
+
+=== .spec.visualization.tolerations[].tolerationSeconds
+
+Type:: int
+
+=== .status
+
+ClusterLoggingStatus defines the observed state of ClusterLogging
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|collection|object| **(DEPRECATED)** *(optional)* Deprecated.
+|conditions|object|  *(optional)* 
+|curation|object| **(DEPRECATED)** *(optional)* 
+|logStore|object|  *(optional)* 
+|visualization|object|  *(optional)* 
+|======================
+
+=== .status.collection
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|logs|object|  *(optional)* 
+|======================
+
+=== .status.collection.logs
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|fluentdStatus|object|  *(optional)* 
+|======================
+
+=== .status.collection.logs.fluentdStatus
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|clusterCondition|object|  *(optional)* 
+|daemonSet|string|  *(optional)* 
+|nodes|object|  *(optional)* 
+|pods|string|  *(optional)* 
+|======================
+
+=== .status.collection.logs.fluentdStatus.clusterCondition
+
+`operator-sdk generate crds` does not allow map-of-slice, must use a named type.
+
+Type:: object
+
+=== .status.collection.logs.fluentdStatus.nodes
+
+Type:: object
+
+=== .status.conditions
+
+Type:: object
+
+=== .status.curation
+
+[IMPORTANT]
+====
+This API key has been deprecated and is planned for removal in a future release. For more information, see the release notes for logging on Red{nbsp}Hat OpenShift.
+====
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|curatorStatus|array|  *(optional)* 
+|======================
+
+=== .status.curation.curatorStatus[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|clusterCondition|object|  *(optional)* 
+|cronJobs|string|  *(optional)* 
+|schedules|string|  *(optional)* 
+|suspended|bool|  *(optional)* 
+|======================
+
+=== .status.curation.curatorStatus[].clusterCondition
+
+`operator-sdk generate crds` does not allow map-of-slice, must use a named type.
+
+Type:: object
+
+=== .status.logStore
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|elasticsearchStatus|array|  *(optional)* 
+|======================
+
+=== .status.logStore.elasticsearchStatus[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|cluster|object|  *(optional)* 
+|clusterConditions|object|  *(optional)* 
+|clusterHealth|string|  *(optional)* 
+|clusterName|string|  *(optional)* 
+|deployments|array|  *(optional)* 
+|nodeConditions|object|  *(optional)* 
+|nodeCount|int|  *(optional)* 
+|pods|object|  *(optional)* 
+|replicaSets|array|  *(optional)* 
+|shardAllocationEnabled|string|  *(optional)* 
+|statefulSets|array|  *(optional)* 
+|======================
+
+=== .status.logStore.elasticsearchStatus[].cluster
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|activePrimaryShards|int|  The number of Active Primary Shards for the Elasticsearch Cluster
+|activeShards|int|  The number of Active Shards for the Elasticsearch Cluster
+|initializingShards|int|  The number of Initializing Shards for the Elasticsearch Cluster
+|numDataNodes|int|  The number of Data Nodes for the Elasticsearch Cluster
+|numNodes|int|  The number of Nodes for the Elasticsearch Cluster
+|pendingTasks|int|  
+|relocatingShards|int|  The number of Relocating Shards for the Elasticsearch Cluster
+|status|string|  The current Status of the Elasticsearch Cluster
+|unassignedShards|int|  The number of Unassigned Shards for the Elasticsearch Cluster
+|======================
+
+=== .status.logStore.elasticsearchStatus[].clusterConditions
+
+Type:: object
+
+=== .status.logStore.elasticsearchStatus[].deployments[]
+
+Type:: array
+
+=== .status.logStore.elasticsearchStatus[].nodeConditions
+
+Type:: object
+
+=== .status.logStore.elasticsearchStatus[].pods
+
+Type:: object
+
+=== .status.logStore.elasticsearchStatus[].replicaSets[]
+
+Type:: array
+
+=== .status.logStore.elasticsearchStatus[].statefulSets[]
+
+Type:: array
+
+=== .status.visualization
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|kibanaStatus|array|  *(optional)* 
+|======================
+
+=== .status.visualization.kibanaStatus[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|clusterCondition|object|  *(optional)* 
+|deployment|string|  *(optional)* 
+|pods|string|  *(optional)* The status for each of the Kibana pods for the Visualization component
+|replicaSets|array|  *(optional)* 
+|replicas|int|  *(optional)* 
+|======================
+
+=== .status.visualization.kibanaStatus[].clusterCondition
+
+Type:: object
+
+=== .status.visualization.kibanaStatus[].replicaSets[]
+
+Type:: array
+
+[id="logging-6-x-reference-LogFileMetricExporter"]
+== LogFileMetricExporter
+
+A Log File Metric Exporter instance. LogFileMetricExporter is the Schema for the logFileMetricExporters API
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|spec|object|  
+|status|object|  
+|======================
+
+=== .spec
+
+LogFileMetricExporterSpec defines the desired state of LogFileMetricExporter
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|nodeSelector|object|  *(optional)* Define which Nodes the Pods are scheduled on.
+|resources|object|  *(optional)* The resource requirements for the LogFileMetricExporter
+|tolerations|array|  *(optional)* Define the tolerations the Pods will accept
+|======================
+
+=== .spec.nodeSelector
+
+Type:: object
+
+=== .spec.resources
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|claims|array|  *(optional)* Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+
+|limits|object|  *(optional)* Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|requests|object|  *(optional)* Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+|======================
+
+=== .spec.resources.claims[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|name|string|  Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.
+|======================
+
+=== .spec.resources.limits
+
+Type:: object
+
+=== .spec.resources.requests
+
+Type:: object
+
+=== .spec.tolerations[]
+
+Type:: array
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|effect|string|  *(optional)* Effect indicates the taint effect to match. Empty means match all taint effects.
+When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+|key|string|  *(optional)* Key is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+|operator|string|  *(optional)* Operator represents a key&#39;s relationship to the value.
+Valid operators are Exists and Equal. Defaults to Equal.
+Exists is equivalent to wildcard for value, so that a pod can
+tolerate all taints of a particular category.
+|tolerationSeconds|int|  *(optional)* TolerationSeconds represents the period of time the toleration (which must be
+of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+it is not set, which means tolerate the taint forever (do not evict). Zero and
+negative values will be treated as 0 (evict immediately) by the system.
+|value|string|  *(optional)* Value is the taint value the toleration matches to.
+If the operator is Exists, the value should be empty, otherwise just a regular string.
+|======================
+
+=== .spec.tolerations[].tolerationSeconds
+
+Type:: int
+
+=== .status
+
+LogFileMetricExporterStatus defines the observed state of LogFileMetricExporter
+
+Type:: object
+
+[options="header"]
+|======================
+|Property|Type|Description
+
+|conditions|object|  Conditions of the Log File Metrics Exporter.
+|======================
+
+=== .status.conditions
+
+Type:: object
+>>>>>>> bffb95011 (Improve descriptors for OpenShift Console CLF creation form)

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -53,7 +53,7 @@ There are three built-in inputs named `application`, `infrastructure` and
 `audit`. You don&#39;t need to define inputs here if those are sufficient for
 your needs. See `inputRefs` for more.
 
-|managementState|string|  Indicator if the resource is &#39;Managed&#39; or &#39;Unmanaged&#39; by the operator
+|managementState|string|  Indicator if the resource is &#39;Managed&#39; or &#39;Unmanaged&#39; by the operator.
 
 |outputs|array|  Outputs are named destinations for log messages.
 
@@ -173,7 +173,7 @@ Each test contains a sequence of conditions, all conditions must be true for the
 A DropTestsSpec contains an array of tests which contains an array of conditions
 
 |kubeAPIAudit|object|  
-|name|string|  Name used to refer to the filter from a `pipeline`.
+|name|string|  Name used to refer to the filter from a &#34;pipeline&#34;.
 
 |openShiftLabels|object|  Labels applied to log records passing through a pipeline.
 These labels appear in the `openshift.labels` map in the log record.
@@ -417,28 +417,56 @@ Type:: object
 |Property|Type|Description
 
 |in|array|  `In` is an array of dot-delimited field paths. Fields included here are removed from the log record.
-Each field path expression must start with a `.`.
-The path can contain alpha-numeric characters and underscores (a-zA-Z0-9_).
+
+Each field path expression must start with a &#34;.&#34;
+
+The path can contain alphanumeric characters and underscores (a-zA-Z0-9_).
+
 If segments contain characters outside of this range, the segment must be quoted otherwise paths do NOT need to be quoted.
-Examples: `.kubernetes.namespace_name`, `.log_type`, &#39;.kubernetes.labels.foobar&#39;, `.kubernetes.labels.&#34;foo-bar/baz&#34;`
+
+Examples:
+
+- `.kubernetes.namespace_name`
+
+- `.log_type`
+
+- &#39;.kubernetes.labels.foobar&#39;
+
+- `.kubernetes.labels.&#34;foo-bar/baz&#34;`
+
 NOTE1: `In` CANNOT contain `.log_type` or `.message` as those fields are required and cannot be pruned.
+
 NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` CANNOT be added to this list as it is a required field.
 
-|notIn|array|  `NotIn` is an array of dot-delimited field paths. All fields besides the ones listed here are removed from the log record
-Each field path expression must start with a `.`.
-The path can contain alpha-numeric characters and underscores (a-zA-Z0-9_).
+|notIn|array|  `NotIn` is an array of dot-delimited field paths. All fields besides the ones listed here are removed from the log record.
+
+Each field path expression must start with a &#34;.&#34;
+
+The path can contain alphanumeric characters and underscores (a-zA-Z0-9_).
+
 If segments contain characters outside of this range, the segment must be quoted otherwise paths do NOT need to be quoted.
-Examples: `.kubernetes.namespace_name`, `.log_type`, &#39;.kubernetes.labels.foobar&#39;, `.kubernetes.labels.&#34;foo-bar/baz&#34;`
+
+Examples:
+
+- `.kubernetes.namespace_name`
+
+- `.log_type`
+
+- &#39;.kubernetes.labels.foobar&#39;
+
+- `.kubernetes.labels.&#34;foo-bar/baz&#34;`
+
 NOTE1: `NotIn` MUST contain `.log_type` and `.message` as those fields are required and cannot be pruned.
+
 NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` MUST be added to this list as it is a required field.
 
 |======================
 
 === .spec.filters[].prune.in[]
 
-Field Path represents a path to find a value for a given field.  The format must a value that can be converted to a
+FieldPath represents a path to find a value for a given field.  The format must a value that can be converted to a
 valid collector configuration. It is a dot delimited path to a field in the log record. It must start with a `.`.
-The path can contain alpha-numeric characters and underscores (a-zA-Z0-9_).
+The path can contain alphanumeric characters and underscores (a-zA-Z0-9_).
 If segments contain characters outside of this range, the segment must be quoted.
 Examples: `.kubernetes.namespace_name`, `.log_type`, &#39;.kubernetes.labels.foobar&#39;, `.kubernetes.labels.&#34;foo-bar/baz&#34;`
 
@@ -446,9 +474,9 @@ Type:: array
 
 === .spec.filters[].prune.notIn[]
 
-Field Path represents a path to find a value for a given field.  The format must a value that can be converted to a
+FieldPath represents a path to find a value for a given field.  The format must a value that can be converted to a
 valid collector configuration. It is a dot delimited path to a field in the log record. It must start with a `.`.
-The path can contain alpha-numeric characters and underscores (a-zA-Z0-9_).
+The path can contain alphanumeric characters and underscores (a-zA-Z0-9_).
 If segments contain characters outside of this range, the segment must be quoted.
 Examples: `.kubernetes.namespace_name`, `.log_type`, &#39;.kubernetes.labels.foobar&#39;, `.kubernetes.labels.&#34;foo-bar/baz&#34;`
 
@@ -491,13 +519,17 @@ Type:: object
 |Property|Type|Description
 
 |excludes|array|  Excludes is the set of namespaces and containers to ignore when collecting logs.
+
 Takes precedence over Includes option.
 
 |includes|array|  Includes is the set of namespaces and containers to include when collecting logs.
+
 Note: infrastructure namespaces are still excluded for &#34;*&#34; values unless a qualifying glob pattern is specified.
 
 |selector|object|  Selector for logs from pods with matching labels.
+
 Only messages from pods with these labels are collected.
+
 If absent or empty, logs are collected regardless of labels.
 
 |tuning|object|  Tuning is the container input tuning spec for this container sources
@@ -712,9 +744,11 @@ Type:: object
 |Property|Type|Description
 
 |configMapName|string|  ConfigMapName contains the name of the ConfigMap containing the referenced value.
+
 |key|string|  Name of the key used to get the value in either the referenced ConfigMap or Secret.
 
 |secretName|string|  SecretName contains the name of the Secret containing the referenced value.
+
 |======================
 
 === .spec.inputs[].receiver.tls.certificate
@@ -728,9 +762,11 @@ Type:: object
 |Property|Type|Description
 
 |configMapName|string|  ConfigMapName contains the name of the ConfigMap containing the referenced value.
+
 |key|string|  Name of the key used to get the value in either the referenced ConfigMap or Secret.
 
 |secretName|string|  SecretName contains the name of the Secret containing the referenced value.
+
 |======================
 
 === .spec.inputs[].receiver.tls.key
@@ -962,12 +998,19 @@ Type:: object
 |authentication|object|  Authentication sets credentials for authenticating the requests.
 
 |groupName|string|  GroupName defines the strategy for grouping logstreams
+
 The GroupName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+
 A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+
 Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+
 Example:
+
 1. foo-{.bar||&#34;none&#34;}
+
 2. {.foo||.bar||&#34;missing&#34;}
+
 3. foo.{.bar.baz||.qux.quux.corge||.grault||&#34;nil&#34;}-waldo.fred{.plugh||&#34;none&#34;}
 
 |region|string|  
@@ -1141,15 +1184,20 @@ The &#39;username@password&#39; part of `url` is ignored.
 
 |authentication|object|  Authentication sets credentials for authenticating the requests.
 
-|index|string|  Index is the index for the logs. This supports template syntax
-to allow dynamic per-event values.
+|index|string|  Index is the index for the logs. This supports template syntax to allow dynamic per-event values.
 
 The Index can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+
 A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+
 Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+
 Example:
+
 1. foo-{.bar||&#34;none&#34;}
+
 2. {.foo||.bar||&#34;missing&#34;}
+
 3. foo.{.bar.baz||.qux.quux.corge||.grault||&#34;nil&#34;}-waldo.fred{.plugh||&#34;none&#34;}
 
 |tuning|object|  Tuning specs tuning for the output
@@ -1278,11 +1326,17 @@ Type:: object
 |logId|string|  LogID is the log ID to which to publish logs. This identifies log stream.
 
 The LogID can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+
 A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+
 Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+
 Example:
+
 1. foo-{.bar||&#34;none&#34;}
+
 2. {.foo||.bar||&#34;missing&#34;}
+
 3. foo.{.bar.baz||.qux.quux.corge||.grault||&#34;nil&#34;}-waldo.fred{.plugh||&#34;none&#34;}
 
 |tuning|object|  Tuning specs tuning for the output
@@ -1493,18 +1547,27 @@ Type:: object
 |authentication|object|  Authentication sets credentials for authenticating the requests.
 
 |brokers|array|  Brokers specifies the list of broker endpoints of a Kafka cluster.
+
 The list represents only the initial set used by the collector&#39;s Kafka client for the
 first connection only. The collector&#39;s Kafka client fetches constantly an updated list
 from Kafka. These updates are not reconciled back to the collector configuration.
+
 If none provided the target URL from the OutputSpec is used as fallback.
+
 |topic|string|  Topic specifies the target topic to send logs to. The value when not specified is &#39;topic&#39;
 
 The Topic can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+
 A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+
 Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+
 Example:
+
 1. foo-{.bar||&#34;none&#34;}
+
 2. {.foo||.bar||&#34;missing&#34;}
+
 3. foo.{.bar.baz||.qux.quux.corge||.grault||&#34;nil&#34;}-waldo.fred{.plugh||&#34;none&#34;}
 
 |tuning|object|  Tuning specs tuning for the output
@@ -1710,15 +1773,20 @@ Note: the set of labels should be small, Loki imposes limits on the size and num
 See https://grafana.com/docs/loki/latest/configuration/#limits_config for more.
 Loki queries can also query based on any log record field (not just labels) using query filters.
 
-|tenantKey|string|  TenantKey is the tenant for the logs. This supports vector&#39;s template syntax
-to allow dynamic per-event values.
+|tenantKey|string|  TenantKey is the tenant for the logs. This supports vector&#39;s template syntax to allow dynamic per-event values.
 
 The TenantKey can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+
 A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+
 Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+
 Example:
+
 1. foo-{.bar||&#34;none&#34;}
+
 2. {.foo||.bar||&#34;missing&#34;}
+
 3. foo.{.bar.baz||.qux.quux.corge||.grault||&#34;nil&#34;}-waldo.fred{.plugh||&#34;none&#34;}
 
 |tuning|object|  Tuning specs tuning for the output
@@ -1960,6 +2028,7 @@ Type:: object
 keys configuration.
 
 |labelKeys|array|  LabelKeys contains a list of log record keys that are mapped to Loki stream labels.
+
 By default, this list is combined with the labels specified in the Global configuration.
 This behavior can be changed by setting IgnoreGlobal to true.
 
@@ -1983,6 +2052,7 @@ Type:: object
 keys configuration.
 
 |labelKeys|array|  LabelKeys contains a list of log record keys that are mapped to Loki stream labels.
+
 By default, this list is combined with the labels specified in the Global configuration.
 This behavior can be changed by setting IgnoreGlobal to true.
 
@@ -2010,6 +2080,7 @@ Type:: object
 keys configuration.
 
 |labelKeys|array|  LabelKeys contains a list of log record keys that are mapped to Loki stream labels.
+
 By default, this list is combined with the labels specified in the Global configuration.
 This behavior can be changed by setting IgnoreGlobal to true.
 
@@ -2032,6 +2103,8 @@ Type:: object
 |name|string|  Name of the in-cluster LokiStack resource.
 
 |namespace|string|  Namespace of the in-cluster LokiStack resource.
+
+If unset, this defaults to &#34;openshift-logging&#34;.
 
 |======================
 
@@ -2210,15 +2283,20 @@ The &#39;username@password&#39; part of `url` is ignored.
 
 |authentication|object|  Authentication sets credentials for authenticating the requests.
 
-|index|string|  Index is the index for the logs. This supports template syntax
-to allow dynamic per-event values.
+|index|string|  Index is the index for the logs. This supports template syntax to allow dynamic per-event values.
 
 The Index can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+
 A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+
 Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+
 Example:
+
 1. foo-{.bar||&#34;none&#34;}
+
 2. {.foo||.bar||&#34;missing&#34;}
+
 3. foo.{.bar.baz||.qux.quux.corge||.grault||&#34;nil&#34;}-waldo.fred{.plugh||&#34;none&#34;}
 
 |tuning|object|  Tuning specs tuning for the output
@@ -2285,22 +2363,31 @@ Type:: object
 |Property|Type|Description
 
 |appName|string|  AppName is APP-NAME part of the syslog-msg header.
+
 AppName needs to be specified if using rfc5424. The maximum length of the final values is truncated to 48
 This supports template syntax to allow dynamic per-event values.
 
 The AppName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+
 A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+
 Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+
 Example:
+
 1. foo-{.bar||&#34;none&#34;}
+
 2. {.foo||.bar||&#34;missing&#34;}
+
 3. foo.{.bar.baz||.qux.quux.corge||.grault||&#34;nil&#34;}-waldo.fred{.plugh||&#34;none&#34;}
 
 TODO: DETERMIN HOW to default the app name that isnt based on fluentd assumptions of &#34;tag&#34; when this is empty
 |enrichment|string|  Enrichment is an additional modification the log message before forwarding it to the receiver
+
 |facility|string|  Facility to set on outgoing syslog records.
 
 Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
+
 The value can be a decimal integer. Facility keywords are not standardized,
 this API recognizes at least the following case-insensitive keywords
 (defined by https://en.wikipedia.org/wiki/Syslog#Facility_Levels):
@@ -2311,37 +2398,54 @@ uucp cron authpriv ftp ntp security console solaris-cron
 
 local0 local1 local2 local3 local4 local5 local6 local7
 
-|msgID|string|  MsgID is MSGID part of the syslog-msg header. This supports template syntax
-to allow dynamic per-event values.
+|msgID|string|  MsgID is MSGID part of the syslog-msg header. This supports template syntax to allow dynamic per-event values.
 
 The MsgID can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+
 A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+
 Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+
 Example:
+
 1. foo-{.bar||&#34;none&#34;}
+
 2. {.foo||.bar||&#34;missing&#34;}
+
 3. foo.{.bar.baz||.qux.quux.corge||.grault||&#34;nil&#34;}-waldo.fred{.plugh||&#34;none&#34;}
 
 MsgID needs to be specified if using rfc5424.  The maximum length of the final values is truncated to 32
 
-|payloadKey|string|  The PayloadKey must be a single field path encased in single curly brackets `{}`.
+|payloadKey|string|  PayloadKey specifies record field to use as payload. This supports template syntax to allow dynamic per-event values.
+
+The PayloadKey must be a single field path encased in single curly brackets `{}`.
+
 Field paths must only contain alphanumeric and underscores. Any field with other characters must be quoted.
+
 If left empty, Syslog will use the whole message as the payload key
 
 Example:
+
 1. {.bar}
+
 2. {.foo.bar.baz}
+
 3. {.foo.bar.&#34;baz/with/slashes&#34;}
 
-|procID|string|  ProcID is PROCID part of the syslog-msg header. This supports template syntax
-to allow dynamic per-event values.
+|procID|string|  ProcID is PROCID part of the syslog-msg header. This supports template syntax to allow dynamic per-event values.
 
 The ProcID can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+
 A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+
 Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+
 Example:
+
 1. foo-{.bar||&#34;none&#34;}
+
 2. {.foo||.bar||&#34;missing&#34;}
+
 3. foo.{.bar.baz||.qux.quux.corge||.grault||&#34;nil&#34;}-waldo.fred{.plugh||&#34;none&#34;}
 
 ProcID needs to be specified if using rfc5424. The maximum length of the final values is truncated to 128
@@ -2350,6 +2454,7 @@ ProcID needs to be specified if using rfc5424. The maximum length of the final v
 |severity|string|  Severity to set on outgoing syslog records.
 
 Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1
+
 The value can be a decimal integer or one of these case-insensitive keywords:
 
 Emergency Alert Critical Error Warning Notice Informational Debug
@@ -2599,11 +2704,11 @@ If a filter drops a records, subsequent filters are not applied.
 
 The following built-in input names are always available:
 
-`application` selects all logs from application pods.
+- `application` selects all logs from application pods.
 
-`infrastructure` selects logs from openshift and kubernetes pods and some node logs.
+- `infrastructure` selects logs from openshift and kubernetes pods and some node logs.
 
-`audit` selects node logs related to security audits.
+- `audit` selects node logs related to security audits.
 
 |name|string|  Name of the pipeline
 


### PR DESCRIPTION
### Description

This PR adds `operator-sdk` markers to all fields in the new API improving the UI in the OpenShift Console "form view" for creating a new ClusterLogForwarder instance.

I've also tried to improve the formatting of the field comments for display in the console, especially for comments containing multiple paragraphs and lists.
 
/cc @cahartma
/assign @jcantrill
