### PR TITLE
Fix reconcile errors when resource is deleted

### DIFF
--- a/internal/controller/logfilemetricsexporter/logfilemetricsexporter_controller.go
+++ b/internal/controller/logfilemetricsexporter/logfilemetricsexporter_controller.go
@@ -60,6 +60,11 @@ func (r *ReconcileLogFileMetricExporter) Reconcile(ctx context.Context, request 
 		return ctrl.Result{}, nil
 	}
 
+	if lfmeInstance.DeletionTimestamp != nil {
+		// Resource is being deleted, no further reconciliation
+		return ctrl.Result{}, nil
+	}
+
 	// Validate LogFileMetricExporter instance
 	if err, _ := logfilemetricsexporter.Validate(lfmeInstance); err != nil {
 		condition := condNotReady(loggingv1alpha1.ReasonInvalid, "validation failed: %v", err)


### PR DESCRIPTION
### Description

This PR adds code to the operator's controllers, so that changes on deleted and "soon to be deleted" resources do not cause reconciliation runs (or even loops) anymore.

/cc @cahartma
/assign @jcantrill
