### PR TITLE
LOG-5906: Fix metrics ServiceMonitor label selector

### DIFF
--- a/internal/collector/input_service.go
+++ b/internal/collector/input_service.go
@@ -38,7 +38,7 @@ func RemoveOrphanedInputServices(client kubernetes.Client, reader kubernetes.Rea
 
 	for _, receiverType := range obs.ReceiverTypes {
 		// Get list of input services by label/ namespace
-		services, err := service.List(reader, namespace, constants.LabelsLoggingInputServiceType, string(receiverType))
+		services, err := service.List(reader, namespace, constants.LabelLoggingInputServiceType, string(receiverType))
 		if err != nil {
 			return err
 		}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -79,7 +79,11 @@ const (
 	LabelK8sManagedBy = "app.kubernetes.io/managed-by" // The tool being used to manage the operation of an application (string)
 	LabelK8sCreatedBy = "app.kubernetes.io/created-by" // The controller/user who created this resource (string)
 
-	LabelsLoggingInputServiceType = "logging.observability.openshift.io/input-service-type"
+	LabelLoggingServiceType      = "logging.observability.openshift.io/service-type"
+	LabelLoggingInputServiceType = "logging.observability.openshift.io/input-service-type"
+
+	ServiceTypeMetrics = "metrics"
+	ServiceTypeInput   = "input"
 
 	ClusterLogging         = "cluster-logging"
 	ClusterLoggingOperator = "cluster-logging-operator"

--- a/internal/metrics/service_monitor.go
+++ b/internal/metrics/service_monitor.go
@@ -50,9 +50,9 @@ func NewServiceMonitor(namespace, name, component, portName string, owner metav1
 		Endpoints: endpoint,
 		Selector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"logging-infra":             "support",
-				constants.LabelK8sInstance:  name,
-				constants.LabelK8sComponent: component,
+				constants.LabelLoggingServiceType: constants.ServiceTypeMetrics,
+				constants.LabelK8sInstance:        name,
+				constants.LabelK8sComponent:       component,
 			},
 		},
 		NamespaceSelector: monitoringv1.NamespaceSelector{


### PR DESCRIPTION
### Description

I noticed that I did not get any collector metrics anymore in the dashboard after a recent update. This PR should fix the selector used in the ServiceMonitor for picking up the collector metrics.

I have added a new label describing the "service type" of the created Service resources. It looked to me as if we have two types: metrics and input services.
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma
/assign @jcantrill

### Links

- JIRA: LOG-5906
