### PR TITLE
Updated LokiStack CR to use configmap openshift-service-ca.crt for CA certificate

### DIFF
--- a/docs/administration/upgrade/to_v6.0.adoc
+++ b/docs/administration/upgrade/to_v6.0.adoc
@@ -303,7 +303,7 @@ spec:
     tls:
       ca:
         key: service-ca.crt
-        secretName: logcollector-token
+        configMapName: openshift-service-ca.crt
   pipelines:
   - outputRefs:
     - default-lokistack


### PR DESCRIPTION


As per current config, it is preposed to use secret "logcollector-token" secret to retrieve service-ca.crt but configmap named openshift-service-ca.crt which is part of RHOCP aldready holds the same service CA certificate. It is better to use this as it is provided by platform by default and it also holds updated service CA, if the service-ca operator rotates the certificate.

### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: NA
- Enhancement proposal:
