### PR TITLE
LOG-5978: Remove default values from API definition

### DIFF
--- a/api/observability/v1/input_types.go
+++ b/api/observability/v1/input_types.go
@@ -274,7 +274,6 @@ type ReceiverSpec struct {
 
 	// Port the Receiver listens on. It must be a value between 1024 and 65535
 	//
-	// +kubebuilder:default:=8443
 	// +kubebuilder:validation:Minimum:=1024
 	// +kubebuilder:validation:Maximum:=65535
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Listen Port",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}

--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -200,7 +200,6 @@ type BaseOutputTuningSpec struct {
 // DeliveryMode sets the delivery mode for log forwarding.
 //
 // +kubebuilder:validation:Enum:=atLeastOnce;atMostOnce
-// +kubebuilder:default:=atLeastOnce
 type DeliveryMode string
 
 const (
@@ -299,7 +298,6 @@ type CloudwatchTuningSpec struct {
 	// It is an error if the compression type is not supported by the output.
 	//
 	// +kubebuilder:validation:Enum:=gzip;none;snappy;zlib;zstd
-	// +kubebuilder:default:=none
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
@@ -428,7 +426,6 @@ type ElasticsearchTuningSpec struct {
 	// Compression causes data to be compressed before sending over the network.
 	//
 	// +kubebuilder:validation:Enum:=none;gzip;zlib
-	// +kubebuilder:default:=none
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
@@ -473,7 +470,6 @@ type Elasticsearch struct {
 	//
 	// +kubebuilder:validation:Minimum:=6
 	// +kubebuilder:validation:Maximum:=8
-	// +kubebuilder:default:=8
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ElasticSearch Version",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
 	Version int `json:"version,omitempty"`
 }
@@ -564,7 +560,6 @@ type HTTPTuningSpec struct {
 	// Compression causes data to be compressed before sending over the network.
 	//
 	// +kubebuilder:validation:Enum:=none;gzip;snappy;zlib
-	// +kubebuilder:default:=none
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
@@ -619,7 +614,6 @@ type KafkaTuningSpec struct {
 	// Compression causes data to be compressed before sending over the network.
 	//
 	// +kubebuilder:validation:Enum:=none;snappy;zstd;lz4
-	// +kubebuilder:default:=none
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
@@ -721,7 +715,6 @@ type LokiTuningSpec struct {
 	// Compression causes data to be compressed before sending over the network.
 	//
 	// +kubebuilder:validation:Enum:=none;gzip;snappy
-	// +kubebuilder:default:=snappy
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
@@ -940,7 +933,6 @@ type SplunkTuningSpec struct {
 	// Compression causes data to be compressed before sending over the network.
 	//
 	// +kubebuilder:validation:Enum:=none;gzip
-	// +kubebuilder:default:=none
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression"
 	Compression string `json:"compression,omitempty"`
 }
@@ -1017,7 +1009,6 @@ type Syslog struct {
 	URL string `json:"url"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default:=RFC5424
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Syslog RFC"
 	RFC SyslogRFCType `json:"rfc"`
 
@@ -1030,7 +1021,6 @@ type Syslog struct {
 	//     Emergency Alert Critical Error Warning Notice Informational Debug
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:=informational
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Severity",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Severity string `json:"severity,omitempty"`
 
@@ -1047,7 +1037,6 @@ type Syslog struct {
 	//     local0 local1 local2 local3 local4 local5 local6 local7
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:=user
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Facility",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Facility string `json:"facility,omitempty"`
 
@@ -1170,7 +1159,6 @@ type OTLPTuningSpec struct {
 	// It is an error if the compression type is not supported by the output.
 	//
 	// +kubebuilder:validation:Enum:=gzip;none
-	// +kubebuilder:default:=gzip
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Compression string `json:"compression,omitempty"`
 }

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -654,7 +654,6 @@ spec:
                           - format
                           type: object
                         port:
-                          default: 8443
                           description: Port the Receiver listens on. It must be a
                             value between 1024 and 65535
                           format: int32
@@ -1031,7 +1030,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: none
                               description: Compression causes data to be compressed
                                 before sending over the network. It is an error if
                                 the compression type is not supported by the output.
@@ -1171,7 +1169,6 @@ spec:
                           description: Tuning specs tuning for the output
                           properties:
                             compression:
-                              default: none
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -1214,7 +1211,6 @@ spec:
                           - message: invalid URL
                             rule: isURL(self)
                         version:
-                          default: 8
                           description: 'Version specifies the version of Elasticsearch
                             to be used. Must be one of: 6-8, where 8 is the default'
                           maximum: 8
@@ -1420,7 +1416,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: none
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -1550,7 +1545,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: none
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -1703,7 +1697,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: snappy
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -1898,7 +1891,6 @@ spec:
                           description: Tuning specs tuning for the output
                           properties:
                             compression:
-                              default: snappy
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -2020,7 +2012,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: gzip
                               description: Compression causes data to be compressed
                                 before sending over the network. It is an error if
                                 the compression type is not supported by the output.
@@ -2134,7 +2125,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: none
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -2209,7 +2199,6 @@ spec:
                           - kubernetesMinimal
                           type: string
                         facility:
-                          default: user
                           description: "Facility to set on outgoing syslog records.
                             \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
                             \n The value can be a decimal integer. Facility keywords
@@ -2263,7 +2252,6 @@ spec:
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         rfc:
-                          default: RFC5424
                           description: SyslogRFCType sets which RFC the generated
                             messages conform to.
                           enum:
@@ -2271,7 +2259,6 @@ spec:
                           - RFC5424
                           type: string
                         severity:
-                          default: informational
                           description: "Severity to set on outgoing syslog records.
                             \n Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1
                             \n The value can be a decimal integer or one of these

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -655,7 +655,6 @@ spec:
                           - format
                           type: object
                         port:
-                          default: 8443
                           description: Port the Receiver listens on. It must be a
                             value between 1024 and 65535
                           format: int32
@@ -1032,7 +1031,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: none
                               description: Compression causes data to be compressed
                                 before sending over the network. It is an error if
                                 the compression type is not supported by the output.
@@ -1172,7 +1170,6 @@ spec:
                           description: Tuning specs tuning for the output
                           properties:
                             compression:
-                              default: none
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -1215,7 +1212,6 @@ spec:
                           - message: invalid URL
                             rule: isURL(self)
                         version:
-                          default: 8
                           description: 'Version specifies the version of Elasticsearch
                             to be used. Must be one of: 6-8, where 8 is the default'
                           maximum: 8
@@ -1421,7 +1417,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: none
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -1551,7 +1546,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: none
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -1704,7 +1698,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: snappy
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -1899,7 +1892,6 @@ spec:
                           description: Tuning specs tuning for the output
                           properties:
                             compression:
-                              default: snappy
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -2021,7 +2013,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: gzip
                               description: Compression causes data to be compressed
                                 before sending over the network. It is an error if
                                 the compression type is not supported by the output.
@@ -2135,7 +2126,6 @@ spec:
                           nullable: true
                           properties:
                             compression:
-                              default: none
                               description: Compression causes data to be compressed
                                 before sending over the network.
                               enum:
@@ -2210,7 +2200,6 @@ spec:
                           - kubernetesMinimal
                           type: string
                         facility:
-                          default: user
                           description: "Facility to set on outgoing syslog records.
                             \n Facility values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1.
                             \n The value can be a decimal integer. Facility keywords
@@ -2264,7 +2253,6 @@ spec:
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         rfc:
-                          default: RFC5424
                           description: SyslogRFCType sets which RFC the generated
                             messages conform to.
                           enum:
@@ -2272,7 +2260,6 @@ spec:
                           - RFC5424
                           type: string
                         severity:
-                          default: informational
                           description: "Severity to set on outgoing syslog records.
                             \n Severity values are defined in https://tools.ietf.org/html/rfc5424#section-6.2.1
                             \n The value can be a decimal integer or one of these

--- a/test/e2e/collection/apivalidations/syslog_valid_url_tcp.yaml
+++ b/test/e2e/collection/apivalidations/syslog_valid_url_tcp.yaml
@@ -6,6 +6,7 @@ spec:
   outputs:
     - name: syslog
       syslog:
+        rfc: RFC5424
         url: tcp://someplance:100
       type: syslog
   pipelines:

--- a/test/e2e/collection/apivalidations/syslog_valid_url_tls.yaml
+++ b/test/e2e/collection/apivalidations/syslog_valid_url_tls.yaml
@@ -6,6 +6,7 @@ spec:
   outputs:
     - name: syslog
       syslog:
+        rfc: RFC5424
         url: tls://someplance:100
       type: syslog
   pipelines:

--- a/test/e2e/collection/apivalidations/syslog_valid_url_udp.yaml
+++ b/test/e2e/collection/apivalidations/syslog_valid_url_udp.yaml
@@ -6,6 +6,7 @@ spec:
   outputs:
     - name: syslog
       syslog:
+        rfc: RFC5424
         url: udp://someplance:100
       type: syslog
   pipelines:

--- a/test/e2e/collection/apivalidations/syslog_valid_url_udps.yaml
+++ b/test/e2e/collection/apivalidations/syslog_valid_url_udps.yaml
@@ -6,6 +6,7 @@ spec:
   outputs:
     - name: syslog
       syslog:
+        rfc: RFC5424
         url: udps://someplance:100
       type: syslog
   pipelines:


### PR DESCRIPTION
### Description

This PR removes all `kubebuilder:default` markers except for the `managementState` which is present in all ClusterLogForwarder instances in an effort to fix creation of CLF resources using the OpenShift Console form view.

/cc @cahartma
/assign @jcantrill

### Links

- JIRA: [LOG-5978](https://issues.redhat.com//browse/LOG-5978)
