### PR TITLE
Update example resources distributed with CSV

### DIFF
--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -34,28 +34,10 @@ metadata:
           "apiVersion": "observability.openshift.io/v1",
           "kind": "ClusterLogForwarder",
           "metadata": {
-            "labels": {
-              "app.kubernetes.io/component": "collector",
-              "app.kubernetes.io/instance": "log-collector",
-              "app.kubernetes.io/managed-by": "cluster-logging-operator",
-              "app.kubernetes.io/name": "vector",
-              "app.kubernetes.io/part-of": "cluster-logging"
-            },
-            "name": "log-collector",
-            "namespace": "acme-logging"
+            "name": "logging",
+            "namespace": "openshift-logging"
           },
           "spec": {
-            "inputs": [
-              {
-                "infrastructure": {
-                  "sources": [
-                    "container"
-                  ]
-                },
-                "name": "infra-container",
-                "type": "infrastructure"
-              }
-            ],
             "outputs": [
               {
                 "lokiStack": {
@@ -65,10 +47,10 @@ metadata:
                     }
                   },
                   "target": {
-                    "name": "rh-managed-loki"
+                    "name": "logging-loki"
                   }
                 },
-                "name": "rh-loki",
+                "name": "logging-loki",
                 "tls": {
                   "ca": {
                     "configMapName": "openshift-service-ca.crt",
@@ -81,17 +63,17 @@ metadata:
             "pipelines": [
               {
                 "inputRefs": [
-                  "infra-container",
-                  "audit"
+                  "application",
+                  "infrastructure"
                 ],
                 "name": "logs-to-loki",
                 "outputRefs": [
-                  "rh-loki"
+                  "logging-loki"
                 ]
               }
             ],
             "serviceAccount": {
-              "name": "audit-collector-sa"
+              "name": "log-collector"
             }
           }
         }
@@ -100,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-08-09T16:07:33Z"
+    createdAt: "2024-08-15T13:59:59Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -115,6 +97,14 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=5.8.0-0 <6.0.0'
     operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/initialization-resource: |
+      {
+        "apiVersion": "observability.openshift.io/v1",
+        "kind": "ClusterLogForwarder",
+        "metadata": {
+          "name": "logging"
+        }
+      }
     operatorframework.io/suggested-namespace: openshift-logging
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -20,6 +20,14 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: '>=5.8.0-0 <6.0.0'
     operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/initialization-resource: |
+      {
+        "apiVersion": "observability.openshift.io/v1",
+        "kind": "ClusterLogForwarder",
+        "metadata": {
+          "name": "logging"
+        }
+      }
     operatorframework.io/suggested-namespace: openshift-logging
     operators.openshift.io/infrastructure-features: '["disconnected","proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift

--- a/config/samples/logging_v1alpha1_logfilemetricexporter.yaml
+++ b/config/samples/logging_v1alpha1_logfilemetricexporter.yaml
@@ -1,17 +1,16 @@
-apiVersion: "logging.openshift.io/v1alpha1"
+apiVersion: logging.openshift.io/v1alpha1
 kind: LogFileMetricExporter
 metadata:
   name: instance
   namespace: openshift-logging
 spec:
   tolerations:
-    - key: node-role.kubernetes.io/master
-      operator: Exists
-      effect: NoSchedule
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
   resources:
     limits:
       cpu: 500m
     requests:
       cpu: 200m
       memory: 128Mi
-  

--- a/config/samples/observability_v1_clusterlogforwarder.yaml
+++ b/config/samples/observability_v1_clusterlogforwarder.yaml
@@ -1,39 +1,28 @@
 apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  name: log-collector
-  namespace: acme-logging
-  labels:
-    app.kubernetes.io/name: vector
-    app.kubernetes.io/instance: log-collector
-    app.kubernetes.io/component: collector
-    app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/managed-by: cluster-logging-operator
+  name: logging
+  namespace: openshift-logging
 spec:
-  outputs:
-    - name: rh-loki
-      type: lokiStack
-      lokiStack:
-        authentication:
-          token:
-            from: serviceAccount
-        target:
-          name: rh-managed-loki
-      tls:
-        ca:
-          key: service-ca.crt
-          configMapName: openshift-service-ca.crt
-  inputs:
-    - name: infra-container
-      type: infrastructure
-      infrastructure:
-        sources: [container]
   serviceAccount:
-    name: audit-collector-sa
+    name: log-collector
+  outputs:
+  - name: logging-loki
+    type: lokiStack
+    lokiStack:
+      authentication:
+        token:
+          from: serviceAccount
+      target:
+        name: logging-loki
+    tls:
+      ca:
+        key: service-ca.crt
+        configMapName: openshift-service-ca.crt
   pipelines:
-    - name: logs-to-loki
-      inputRefs:
-        - infra-container
-        - audit
-      outputRefs:
-        - rh-loki
+  - name: logs-to-loki
+    inputRefs:
+    - application
+    - infrastructure
+    outputRefs:
+    - logging-loki

--- a/test/e2e/logfilesmetricexporter/invalid.yaml
+++ b/test/e2e/logfilesmetricexporter/invalid.yaml
@@ -1,13 +1,12 @@
-apiVersion: "logging.openshift.io/v1alpha1"
-kind: "LogFileMetricExporter"
+apiVersion: logging.openshift.io/v1alpha1
+kind: LogFileMetricExporter
 metadata:
-  name: "cluster-log-metrics" # Name must be 'instance'
-  namespace: "openshift-logging"
+  name: cluster-log-metrics # Name must be 'instance'
+  namespace: openshift-logging
 spec:
   resources:
     limits:
-      cpu: "100m"
+      cpu: 100m
     requests:
-      cpu: "100m"
-      memory: "128Mi"
-  
+      cpu: 100m
+      memory: 128Mi

--- a/test/e2e/logfilesmetricexporter/valid.yaml
+++ b/test/e2e/logfilesmetricexporter/valid.yaml
@@ -1,13 +1,12 @@
-apiVersion: "logging.openshift.io/v1alpha1"
-kind: "LogFileMetricExporter"
+apiVersion: logging.openshift.io/v1alpha1
+kind: LogFileMetricExporter
 metadata:
-  name: "instance"
-  namespace: "openshift-logging"
+  name: instance
+  namespace: openshift-logging
 spec:
   resources:
     limits:
-      cpu: "500m"
+      cpu: 500m
     requests:
-      cpu: "200m"
-      memory: "128Mi"
-  
+      cpu: 200m
+      memory: 128Mi


### PR DESCRIPTION
### Description

This PR updates the example files distributed with the CSV. They are used as a starting point when creating a new resource in the OpenShift Console.

I have opted for a "application and infrastructure logs to local LokiStack" configuration for the ClusterLogForwarder. I think ideally we synchronize this with what we list as the "recommended configuration" in the documentation. I've already tried to use the naming conventions we had for the resources in the 5.y docs.

This PR also enables a new feature in the OpenShift Console: It now shows a "ClusterLogForwarder required" warning in the operator details when no resource has been created yet, prompting the user to create one. This button unfortunately does not use the same example file, but we could keep it synchronized manually. Currently I am using a "blank" CLF for that function.

/cc @cahartma
/assign @jcantrill
