### PR TITLE
LOG-5525: Trigger collector reload on update

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -126,12 +126,18 @@ func New(confHash, clusterID string, collectorSpec logging.CollectionSpec, secre
 func (f *Factory) NewDaemonSet(namespace, name string, trustedCABundle *v1.ConfigMap, tlsProfileSpec configv1.TLSProfileSpec, receiverInputs []string) *apps.DaemonSet {
 	podSpec := f.NewPodSpec(trustedCABundle, f.ForwarderSpec, f.ClusterID, f.TrustedCAHash, tlsProfileSpec, receiverInputs, namespace)
 	ds := factory.NewDaemonSet(name, namespace, f.ResourceNames.CommonName, constants.CollectorName, string(f.CollectorSpec.Type), *podSpec, f.CommonLabelInitializer, f.PodLabelVisitor)
+	ds.Spec.Template.Annotations = map[string]string{
+		constants.AnnotationSecretHash: SecretsHash64a(f.Secrets),
+	}
 	return ds
 }
 
 func (f *Factory) NewDeployment(namespace, name string, trustedCABundle *v1.ConfigMap, tlsProfileSpec configv1.TLSProfileSpec, receiverInputs []string) *apps.Deployment {
 	podSpec := f.NewPodSpec(trustedCABundle, f.ForwarderSpec, f.ClusterID, f.TrustedCAHash, tlsProfileSpec, receiverInputs, namespace)
 	dpl := factory.NewDeployment(namespace, name, f.ResourceNames.CommonName, constants.CollectorName, string(f.CollectorSpec.Type), *podSpec, f.CommonLabelInitializer, f.PodLabelVisitor)
+	dpl.Spec.Template.Annotations = map[string]string{
+		constants.AnnotationSecretHash: SecretsHash64a(f.Secrets),
+	}
 	return dpl
 }
 

--- a/internal/collector/secrets.go
+++ b/internal/collector/secrets.go
@@ -1,0 +1,42 @@
+package collector
+
+import (
+	"fmt"
+	"hash/fnv"
+	v1 "k8s.io/api/core/v1"
+	"sort"
+)
+
+type Secrets map[string]*v1.Secret
+
+func (s Secrets) Names() (names []string) {
+
+	for name := range s {
+		names = append(names, name)
+	}
+	return names
+}
+
+// SecretsHash64a returns an FNV-1a representation of a secret map
+func SecretsHash64a(s Secrets) string {
+	names := s.Names()
+	sort.Strings(names)
+	buffer := fnv.New64a()
+	for _, name := range names {
+		secret := s[name]
+		buffer.Write([]byte(name))
+
+		var keys []string
+		for key := range secret.Data {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			v := secret.Data[k]
+			buffer.Write([]byte(k))
+			buffer.Write(v)
+		}
+	}
+	return fmt.Sprintf("%d", buffer.Sum64())
+}

--- a/internal/constants/annotations.go
+++ b/internal/constants/annotations.go
@@ -26,4 +26,6 @@ const (
 	// instead of a daemonset to support the HCP use case of using the collector for collecting
 	// audit logs via a webhook.
 	AnnotationEnableCollectorAsDeployment = "logging.openshift.io/dev-preview-enable-collector-as-deployment"
+
+	AnnotationSecretHash = "logging.openshift.io/secret-hash"
 )

--- a/internal/utils/comparators/daemonsets/comparator.go
+++ b/internal/utils/comparators/daemonsets/comparator.go
@@ -1,6 +1,7 @@
 package daemonsets
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"reflect"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -27,6 +28,12 @@ func AreSame(current *apps.DaemonSet, desired *apps.DaemonSet) (bool, string) {
 	if !reflect.DeepEqual(current.GetOwnerReferences(), desired.GetOwnerReferences()) {
 		log.V(3).Info("Daemonset ownership change", "name", current.Name)
 		return false, "ownerReference"
+	}
+
+	currentHash := current.Spec.Template.Annotations[constants.AnnotationSecretHash]
+	desiredHash := desired.Spec.Template.Annotations[constants.AnnotationSecretHash]
+	if currentHash != desiredHash {
+		return false, "secretHash"
 	}
 
 	return true, ""

--- a/internal/utils/comparators/daemonsets/comparator_test.go
+++ b/internal/utils/comparators/daemonsets/comparator_test.go
@@ -3,6 +3,7 @@ package daemonsets_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,16 @@ var _ = Describe("daemonset#AreSame", func() {
 		It("should recognize the specs are same", func() {
 			ok, _ := daemonsets.AreSame(current, desired)
 			Expect(ok).To(BeTrue())
+		})
+
+		It("should fail when the secret hash is different", func() {
+			current.Spec.Template.Annotations = map[string]string{
+				constants.AnnotationSecretHash: "foo",
+			}
+			ok, reason := daemonsets.AreSame(current, desired)
+
+			Expect(ok).To(BeFalse())
+			Expect(reason).To(Equal("secretHash"))
 		})
 	})
 

--- a/internal/utils/comparators/deployments/comparator.go
+++ b/internal/utils/comparators/deployments/comparator.go
@@ -1,6 +1,7 @@
 package deployments
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"reflect"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -27,6 +28,12 @@ func AreSame(current *apps.Deployment, desired *apps.Deployment) (bool, string) 
 	if !reflect.DeepEqual(current.GetOwnerReferences(), desired.GetOwnerReferences()) {
 		log.V(3).Info("Deployment ownership change", "name", current.Name)
 		return false, "ownerReference"
+	}
+
+	currentHash := current.Spec.Template.Annotations[constants.AnnotationSecretHash]
+	desiredHash := desired.Spec.Template.Annotations[constants.AnnotationSecretHash]
+	if currentHash != desiredHash {
+		return false, "secretHash"
 	}
 
 	return true, ""

--- a/internal/utils/comparators/deployments/comparator_test.go
+++ b/internal/utils/comparators/deployments/comparator_test.go
@@ -3,6 +3,7 @@ package deployments_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,16 @@ var _ = Describe("deployments#AreSame", func() {
 		It("should recognize the specs are same", func() {
 			ok, _ := deployments.AreSame(current, desired)
 			Expect(ok).To(BeTrue())
+		})
+
+		It("should fail when the secret hash is different", func() {
+			current.Spec.Template.Annotations = map[string]string{
+				constants.AnnotationSecretHash: "foo",
+			}
+			ok, reason := deployments.AreSame(current, desired)
+
+			Expect(ok).To(BeFalse())
+			Expect(reason).To(Equal("secretHash"))
 		})
 	})
 


### PR DESCRIPTION
### Description
This PR:
* adds pod annotation template with hash of secrets
* should cause the collector to reload when the secrets change

### Links
https://issues.redhat.com/browse/LOG-5525
