### PR TITLE
LOG-5866: tune audit sources to release file handles

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -13,6 +13,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_host_viaq]
 type = "remap"
@@ -47,6 +50,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_kube_viaq]
 type = "remap"
@@ -65,6 +71,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_openshift_viaq]
 type = "remap"
@@ -83,6 +92,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_ovn_viaq]
 type = "remap"

--- a/internal/generator/vector/conf/complex_drop_filter.toml
+++ b/internal/generator/vector/conf/complex_drop_filter.toml
@@ -13,6 +13,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_host_viaq]
 type = "remap"
@@ -47,6 +50,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_kube_viaq]
 type = "remap"
@@ -65,6 +71,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_openshift_viaq]
 type = "remap"
@@ -83,6 +92,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_ovn_viaq]
 type = "remap"

--- a/internal/generator/vector/conf/complex_es_no_ver.toml
+++ b/internal/generator/vector/conf/complex_es_no_ver.toml
@@ -116,6 +116,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_host_viaq]
 type = "remap"
@@ -150,6 +153,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_kube_viaq]
 type = "remap"
@@ -168,6 +174,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_openshift_viaq]
 type = "remap"
@@ -186,6 +195,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_ovn_viaq]
 type = "remap"

--- a/internal/generator/vector/conf/complex_es_v6.toml
+++ b/internal/generator/vector/conf/complex_es_v6.toml
@@ -116,6 +116,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_host_viaq]
 type = "remap"
@@ -150,6 +153,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_kube_viaq]
 type = "remap"
@@ -168,6 +174,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_openshift_viaq]
 type = "remap"
@@ -186,6 +195,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_ovn_viaq]
 type = "remap"

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -13,6 +13,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_host_viaq]
 type = "remap"
@@ -47,6 +50,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_kube_viaq]
 type = "remap"
@@ -65,6 +71,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_openshift_viaq]
 type = "remap"
@@ -83,6 +92,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_ovn_viaq]
 type = "remap"

--- a/internal/generator/vector/conf/complex_otel.toml
+++ b/internal/generator/vector/conf/complex_otel.toml
@@ -13,6 +13,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_host_viaq]
 type = "remap"
@@ -47,6 +50,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_kube_viaq]
 type = "remap"
@@ -65,6 +71,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_openshift_viaq]
 type = "remap"
@@ -83,6 +92,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_ovn_viaq]
 type = "remap"

--- a/internal/generator/vector/conf/complex_prune_filter.toml
+++ b/internal/generator/vector/conf/complex_prune_filter.toml
@@ -13,6 +13,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_host_viaq]
 type = "remap"
@@ -47,6 +50,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_kube_viaq]
 type = "remap"
@@ -65,6 +71,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_openshift_viaq]
 type = "remap"
@@ -83,6 +92,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_ovn_viaq]
 type = "remap"

--- a/internal/generator/vector/input/viaq_audit.toml
+++ b/internal/generator/vector/input/viaq_audit.toml
@@ -4,6 +4,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_host_viaq]
 type = "remap"
@@ -38,6 +41,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_kube_viaq]
 type = "remap"
@@ -56,6 +62,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_openshift_viaq]
 type = "remap"
@@ -74,6 +83,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_audit_ovn_viaq]
 type = "remap"

--- a/internal/generator/vector/input/viaq_audit_host.toml
+++ b/internal/generator/vector/input/viaq_audit_host.toml
@@ -4,6 +4,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_myaudit_host_viaq]
 type = "remap"

--- a/internal/generator/vector/input/viaq_audit_kube.toml
+++ b/internal/generator/vector/input/viaq_audit_kube.toml
@@ -4,6 +4,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_myaudit_kube_viaq]
 type = "remap"

--- a/internal/generator/vector/input/viaq_audit_openshift.toml
+++ b/internal/generator/vector/input/viaq_audit_openshift.toml
@@ -4,6 +4,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_myaudit_openshift_viaq]
 type = "remap"

--- a/internal/generator/vector/input/viaq_audit_ovn.toml
+++ b/internal/generator/vector/input/viaq_audit_ovn.toml
@@ -4,6 +4,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 
 [transforms.input_myaudit_ovn_viaq]
 type = "remap"

--- a/internal/generator/vector/source/audit_logs.go
+++ b/internal/generator/vector/source/audit_logs.go
@@ -12,6 +12,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 {{end}}`
 
 type HostAuditLog = framework.ConfLiteral
@@ -24,6 +27,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 {{end}}
 `
 
@@ -37,6 +43,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 {{end}}
 `
 
@@ -50,6 +59,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_ms = 5000
 {{end}}
 `
 


### PR DESCRIPTION
### Description
This PR modifies audit sources:
* with max read bytes
* ignore files older then one hour
* release rotated files after 5s

### Links
https://issues.redhat.com/browse/LOG-5866
