### PR TITLE
LOG-4745: Default collector resources when undefined

### DIFF
--- a/internal/api/initialize/init_resources.go
+++ b/internal/api/initialize/init_resources.go
@@ -1,0 +1,37 @@
+package initialize
+
+import (
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var (
+
+	//https://vector.dev/docs/reference/configuration/sources/kubernetes_logs/#resource-limits
+
+	DefaultRequestMemory = resource.MustParse("64Mi")
+	DefaultRequestCpu    = resource.MustParse("500m")
+	DefaultLimitMemory   = resource.MustParse("1024Mi")
+	DefaultLimitCpu      = resource.MustParse("6000m")
+)
+
+func Resources(forwarder obs.ClusterLogForwarder, options utils.Options) obs.ClusterLogForwarder {
+	if forwarder.Spec.Collector == nil {
+		forwarder.Spec.Collector = &obs.CollectorSpec{}
+	}
+	if forwarder.Spec.Collector.Resources == nil {
+		forwarder.Spec.Collector.Resources = &corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: DefaultLimitMemory,
+				corev1.ResourceCPU:    DefaultLimitCpu,
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: DefaultRequestMemory,
+				corev1.ResourceCPU:    DefaultRequestCpu,
+			},
+		}
+	}
+	return forwarder
+}

--- a/internal/api/initialize/init_resources_test.go
+++ b/internal/api/initialize/init_resources_test.go
@@ -1,0 +1,60 @@
+package initialize
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var _ = Describe("#Resources", func() {
+	var (
+		forwarder    obs.ClusterLogForwarder
+		expResources = &v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("1024Mi"),
+				v1.ResourceCPU:    resource.MustParse("6000m"),
+			},
+			Requests: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("64Mi"),
+				v1.ResourceCPU:    resource.MustParse("500m"),
+			},
+		}
+	)
+
+	BeforeEach(func() {
+		forwarder = obs.ClusterLogForwarder{
+			Spec: obs.ClusterLogForwarderSpec{},
+		}
+	})
+
+	It("should apply the default resources when collector is not defined", func() {
+		forwarder := Resources(forwarder, utils.NoOptions)
+		Expect(forwarder.Spec.Collector.Resources).To(Equal(expResources))
+	})
+	It("should apply the default resources when resources are not defined", func() {
+		forwarder.Spec.Collector = &obs.CollectorSpec{}
+		forwarder := Resources(forwarder, utils.NoOptions)
+		Expect(forwarder.Spec.Collector.Resources).To(Equal(expResources))
+	})
+	It("should apply the spec'd resources when defined", func() {
+		resources := &v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("1024Mi"),
+				v1.ResourceCPU:    resource.MustParse("6000m"),
+			},
+			Requests: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("64Mi"),
+				v1.ResourceCPU:    resource.MustParse("500m"),
+			},
+		}
+		forwarder.Spec.Collector = &obs.CollectorSpec{
+			Resources: resources,
+		}
+		forwarder := Resources(forwarder, utils.NoOptions)
+		Expect(forwarder.Spec.Collector.Resources).To(Equal(resources))
+	})
+
+})

--- a/internal/api/initialize/initializations.go
+++ b/internal/api/initialize/initializations.go
@@ -14,6 +14,7 @@ const (
 
 // clfInitializers are the set of rules for initializing the ClusterLogForwarder spec
 var clfInitializers = []func(spec obs.ClusterLogForwarder, migrateContext utils.Options) obs.ClusterLogForwarder{
+	Resources,
 	MigrateLokiStack,
 	MigrateInputs,
 }


### PR DESCRIPTION
### Description
This PR:
* defaults the collector resources (e.g. memory,cpu) when the collector or collector resources are undefined
* defaults values as suggested by vector [upstream](https://vector.dev/docs/reference/configuration/sources/kubernetes_logs/#resource-limits)

### Links
https://issues.redhat.com/browse/LOG-4745

cc @cahartma @xperimental @Clee2691 
