### PR TITLE
LOG-5909: Some configurations in otlp.tuning are not added into vector.toml

### DIFF
--- a/internal/generator/vector/output/azuremonitor/azm_tuning.toml
+++ b/internal/generator/vector/output/azuremonitor/azm_tuning.toml
@@ -1,0 +1,22 @@
+
+[sinks.output_azure_monitor_logs]
+type = "azure_monitor_logs"
+inputs = ["pipelineName"]
+customer_id = "6vzw6sHc-0bba-6sHc-4b6c-8bz7sr5eggRt"
+log_type = "myLogType"
+shared_key = "SECRET[kubernetes_secret.azure-monitor-secret/shared_key]"
+
+[sinks.output_azure_monitor_logs.encoding]
+except_fields = ["_internal"]
+
+[sinks.output_azure_monitor_logs.batch]
+max_bytes = 10000000
+
+[sinks.output_azure_monitor_logs.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.output_azure_monitor_logs.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35

--- a/internal/generator/vector/output/cloudwatch/cw_with_tuning.toml
+++ b/internal/generator/vector/output/cloudwatch/cw_with_tuning.toml
@@ -1,0 +1,58 @@
+# Cloudwatch Stream Names
+[transforms.cw_normalize_streams]
+type = "remap"
+inputs = ["cw-forward"]
+source = '''
+  .stream_name = "default"
+  if ( .log_type == "audit" ) {
+   .stream_name = (.hostname +"."+ downcase(.log_source)) ?? .stream_name
+  }
+  if ( .log_source == "container" ) {
+    k = .kubernetes
+    .stream_name = (k.namespace_name+"_"+k.pod_name+"_"+k.container_name) ?? .stream_name
+  }
+  if ( .log_type == "infrastructure" ) {
+   .stream_name = ( .hostname + "." + .stream_name ) ?? .stream_name
+  }
+  if ( .log_source == "node" ) {
+   .stream_name =  ( .hostname + ".journal.system" ) ?? .stream_name
+  }
+  del(.tag)
+  del(.source_type)
+'''
+
+# Cloudwatch Groupname
+[transforms.cw_group_name]
+type = "remap"
+inputs = ["cw_normalize_streams"]
+source = '''
+._internal.cw_group_name = to_string!(.log_type||"missing")
+'''
+
+# Cloudwatch Logs
+[sinks.cw]
+type = "aws_cloudwatch_logs"
+inputs = ["cw_group_name"]
+region = "us-east-test"
+compression = "none"
+group_name = "{{ _internal.cw_group_name }}"
+stream_name = "{{ stream_name }}"
+auth.access_key_id = "SECRET[kubernetes_secret.vector-cw-secret/aws_access_key_id]"
+auth.secret_access_key = "SECRET[kubernetes_secret.vector-cw-secret/aws_secret_access_key]"
+healthcheck.enabled = false
+
+[sinks.cw.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.cw.batch]
+max_bytes = 10000000
+
+[sinks.cw.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.cw.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35

--- a/internal/generator/vector/output/elasticsearch/es_with_tune.toml
+++ b/internal/generator/vector/output/elasticsearch/es_with_tune.toml
@@ -1,0 +1,30 @@
+# Elasticsearch Index
+[transforms.es_1_index]
+type = "remap"
+inputs = ["application"]
+source = '''
+._internal.es_1_index = to_string!(.log_type||"none")
+'''
+
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["es_1_index"]
+endpoints = ["https://es.svc.infra.cluster:9200"]
+bulk.index = "{{ _internal.es_1_index }}"
+bulk.action = "create"
+api_version = "v8"
+
+[sinks.es_1.encoding]
+except_fields = ["_internal"]
+
+[sinks.es_1.batch]
+max_bytes = 10000000
+
+[sinks.es_1.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.es_1.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35

--- a/internal/generator/vector/output/gcl/gcl_with_tuning.toml
+++ b/internal/generator/vector/output/gcl/gcl_with_tuning.toml
@@ -1,0 +1,34 @@
+# GoogleCloudLogging LogID
+[transforms.gcl_1_log_id]
+type = "remap"
+inputs = ["application"]
+source = '''
+._internal.gcl_1_log_id = "vector-1"
+'''
+
+[sinks.gcl_1]
+type = "gcp_stackdriver_logs"
+inputs = ["gcl_1_log_id"]
+billing_account_id = "billing-1"
+credentials_path = "/var/run/ocp-collector/secrets/gcl-1/google-application-credentials.json"
+log_id = "{{ _internal.gcl_1_log_id }}"
+severity_key = "level"
+
+[sinks.gcl_1.resource]
+type = "k8s_node"
+node_name = "{{hostname}}"
+
+[sinks.gcl_1.encoding]
+except_fields = ["_internal"]
+
+[sinks.gcl_1.batch]
+max_bytes = 10000000
+
+[sinks.gcl_1.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.gcl_1.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35

--- a/internal/generator/vector/output/http/http_with_tuning.toml
+++ b/internal/generator/vector/output/http/http_with_tuning.toml
@@ -1,0 +1,29 @@
+[sinks.http_receiver]
+type = "http"
+inputs = ["application"]
+uri = "https://my-logstore.com"
+method = "post"
+
+[sinks.http_receiver.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.http_receiver.batch]
+max_bytes = 10000000
+
+[sinks.http_receiver.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.http_receiver.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35
+headers = {"h1"="v1","h2"="v2"}
+
+[sinks.http_receiver.auth]
+strategy = "basic"
+user = "SECRET[kubernetes_secret.http-receiver/username]"
+password = "SECRET[kubernetes_secret.http-receiver/password]"
+
+

--- a/internal/generator/vector/output/kafka/kafka_test.go
+++ b/internal/generator/vector/output/kafka/kafka_test.go
@@ -10,8 +10,11 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/test/helpers/outputs/adapter/fake"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var _ = Describe("Generate vector config", func() {
@@ -20,6 +23,7 @@ var _ = Describe("Generate vector config", func() {
 	)
 
 	var (
+		adapter fake.Output
 		tlsSpec = &obs.OutputTLSSpec{
 			TLSSpec: obs.TLSSpec{
 				CA: &obs.ValueReference{
@@ -70,7 +74,7 @@ var _ = Describe("Generate vector config", func() {
 		}
 	)
 
-	DescribeTable("for kafka output", func(expFile string, op framework.Options, tlsSpec *obs.OutputTLSSpec, visit func(spec *obs.OutputSpec)) {
+	DescribeTable("for kafka output", func(expFile string, op framework.Options, tune bool, visit func(spec *obs.OutputSpec)) {
 		exp, err := tomlContent.ReadFile(expFile)
 		if err != nil {
 			Fail(fmt.Sprintf("Error reading the file %q with exp config: %v", expFile, err))
@@ -79,39 +83,50 @@ var _ = Describe("Generate vector config", func() {
 		if visit != nil {
 			visit(&outputSpec)
 		}
-		conf := New(helpers.MakeID(outputSpec.Name), outputSpec, []string{"pipeline_1", "pipeline_2"}, secrets, nil, op)
+		if tune {
+			adapter = *fake.NewOutput(outputSpec, secrets, framework.NoOptions)
+		}
+		conf := New(helpers.MakeID(outputSpec.Name), outputSpec, []string{"pipeline_1", "pipeline_2"}, secrets, adapter, op)
 		Expect(string(exp)).To(EqualConfigFrom(conf))
 	},
-		Entry("with plaintext sasl, to single topic", "kafka_sasl_plaintext_single_topic.toml", framework.NoOptions, nil, func(spec *obs.OutputSpec) {
+		Entry("with plaintext sasl, to single topic", "kafka_sasl_plaintext_single_topic.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Kafka.Authentication = &obs.KafkaAuthentication{
 				SASL: saslAuth,
 			}
 		}),
-		Entry("with plaintext sasl, to single topic", "kafka_sasl_with_tls_single_topic.toml", framework.NoOptions, nil, func(spec *obs.OutputSpec) {
+		Entry("with plaintext sasl, to single topic", "kafka_sasl_with_tls_single_topic.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Kafka.Authentication = &obs.KafkaAuthentication{
 				SASL: saslAuth,
 			}
 			spec.TLS = tlsSpec
 		}),
-		Entry("with tls sasl, with SCRAM-SHA-256 mechanism to single topic", "kafka_insecure_skipverify.toml", framework.NoOptions, nil, func(spec *obs.OutputSpec) {
+		Entry("with tls sasl, with SCRAM-SHA-256 mechanism to single topic", "kafka_insecure_skipverify.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Kafka.URL = "tls://broker1-kafka.svc.messaging.cluster.local:9092/mytopic"
 			spec.Kafka.Topic = ""
 			spec.TLS = tlsSpec
 			tlsSpec.InsecureSkipVerify = true
 
 		}),
-		Entry("without security", "kafka_no_security.toml", framework.NoOptions, nil, func(spec *obs.OutputSpec) {
+		Entry("without security", "kafka_no_security.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Kafka.URL = "tcp://broker1-kafka.svc.messaging.cluster.local:9092/topic"
 			spec.Kafka.Topic = ""
 		}),
-		Entry("without custom topic template", "kafka_custom_topic.toml", framework.NoOptions, nil, func(spec *obs.OutputSpec) {
+		Entry("without custom topic template", "kafka_custom_topic.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Kafka.URL = "tcp://broker1-kafka.svc.messaging.cluster.local:9092"
 			spec.Kafka.Topic = `foo-bar{.log_type||"none"}`
 		}),
-		Entry("with NOT tls brokers", "kafka_not_tls_brokers.toml", framework.NoOptions, nil, func(spec *obs.OutputSpec) {
+		Entry("with NOT tls brokers", "kafka_not_tls_brokers.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Kafka.URL = ""
 			spec.Kafka.Topic = ""
 			spec.Kafka.Brokers = []obs.URL{`tcp://broker1:9092`, `tcp://broker2:9092`, `tcp://broker3:9092`}
+		}),
+		Entry("with tuning", "kafka_tuning.toml", framework.NoOptions, true, func(spec *obs.OutputSpec) {
+			spec.Kafka.URL = "tcp://broker1-kafka.svc.messaging.cluster.local:9092/topic"
+			spec.Kafka.Topic = ""
+			spec.Kafka.Tuning = &obs.KafkaTuningSpec{
+				Delivery: obs.DeliveryModeAtLeastOnce,
+				MaxWrite: utils.GetPtr(resource.MustParse("10M")),
+			}
 		}),
 	)
 })

--- a/internal/generator/vector/output/kafka/kafka_tuning.toml
+++ b/internal/generator/vector/output/kafka/kafka_tuning.toml
@@ -1,0 +1,27 @@
+# Kafka Topic
+[transforms.kafka_receiver_topic]
+type = "remap"
+inputs = ["pipeline_1","pipeline_2"]
+source = '''
+._internal.kafka_receiver_topic = "topic"
+'''
+
+[sinks.kafka_receiver]
+type = "kafka"
+inputs = ["kafka_receiver_topic"]
+bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
+topic = "{{ _internal.kafka_receiver_topic }}"
+healthcheck.enabled = false
+
+[sinks.kafka_receiver.encoding]
+codec = "json"
+timestamp_format = "rfc3339"
+except_fields = ["_internal"]
+
+[sinks.kafka_receiver.batch]
+max_bytes = 10000000
+
+[sinks.kafka_receiver.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -4,20 +4,23 @@ import (
 	_ "embed"
 	"fmt"
 	"sort"
-	"strings"
+	"time"
 
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
-	"github.com/openshift/cluster-logging-operator/internal/tls"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	testhelpers "github.com/openshift/cluster-logging-operator/test/helpers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/test/helpers/outputs/adapter/fake"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var _ = Describe("outputLabelConf", func() {
@@ -56,6 +59,7 @@ var _ = Describe("Generate vector config", func() {
 	)
 
 	var (
+		adapter fake.Output
 		secrets = map[string]*corev1.Secret{
 			secretName: {
 				Data: map[string][]byte{
@@ -100,8 +104,14 @@ var _ = Describe("Generate vector config", func() {
 				},
 			}
 		}
+		baseTune = &obs.BaseOutputTuningSpec{
+			Delivery:         obs.DeliveryModeAtLeastOnce,
+			MaxWrite:         utils.GetPtr(resource.MustParse("10M")),
+			MaxRetryDuration: utils.GetPtr(time.Duration(35)),
+			MinRetryDuration: utils.GetPtr(time.Duration(20)),
+		}
 	)
-	DescribeTable("for Loki output", func(expFile string, op framework.Options, visit func(spec *obs.OutputSpec)) {
+	DescribeTable("for Loki output", func(expFile string, op framework.Options, tune bool, visit func(spec *obs.OutputSpec)) {
 		exp, err := tomlContent.ReadFile(expFile)
 		if err != nil {
 			Fail(fmt.Sprintf("Error reading the file %q with exp config: %v", expFile, err))
@@ -110,17 +120,20 @@ var _ = Describe("Generate vector config", func() {
 		if visit != nil {
 			visit(&outputSpec)
 		}
-		conf := New(helpers.MakeID(outputSpec.Name), outputSpec, []string{"application"}, secrets, nil, op)
+		if tune {
+			adapter = *fake.NewOutput(outputSpec, secrets, framework.NoOptions)
+		}
+		conf := New(helpers.MakeID(outputSpec.Name), outputSpec, []string{"application"}, secrets, adapter, op)
 		Expect(string(exp)).To(EqualConfigFrom(conf))
 	},
-		Entry("with default labels", "with_default_labels.toml", framework.NoOptions, func(spec *obs.OutputSpec) {}),
-		Entry("with custom labels", "with_custom_labels.toml", framework.NoOptions, func(spec *obs.OutputSpec) {
+		Entry("with default labels", "with_default_labels.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {}),
+		Entry("with custom labels", "with_custom_labels.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Loki.LabelKeys = []string{"kubernetes.labels.app", "kubernetes.container_name"}
 		}),
-		Entry("with tenant id", "with_tenant_id.toml", framework.NoOptions, func(spec *obs.OutputSpec) {
+		Entry("with tenant id", "with_tenant_id.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Loki.TenantKey = `foo-{.foo.bar.baz||"none"}`
 		}),
-		Entry("with custom bearer token", "with_custom_bearer_token.toml", framework.NoOptions, func(spec *obs.OutputSpec) {
+		Entry("with custom bearer token", "with_custom_bearer_token.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Loki.Authentication = &obs.HTTPAuthentication{
 				Token: &obs.BearerToken{
 					From: obs.BearerTokenFromSecret,
@@ -133,14 +146,14 @@ var _ = Describe("Generate vector config", func() {
 		}),
 		Entry("with custom bearer token", "with_sa_token.toml", framework.Options{
 			framework.OptionServiceAccountTokenSecretName: "my-service-account-token",
-		}, func(spec *obs.OutputSpec) {
+		}, false, func(spec *obs.OutputSpec) {
 			spec.Loki.Authentication = &obs.HTTPAuthentication{
 				Token: &obs.BearerToken{
 					From: obs.BearerTokenFromServiceAccount,
 				},
 			}
 		}),
-		Entry("with username/password token", "with_username_password.toml", framework.NoOptions, func(spec *obs.OutputSpec) {
+		Entry("with username/password token", "with_username_password.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Loki.Authentication = &obs.HTTPAuthentication{
 				Username: &obs.SecretReference{
 					Key:        constants.ClientUsername,
@@ -152,7 +165,7 @@ var _ = Describe("Generate vector config", func() {
 				},
 			}
 		}),
-		Entry("with TLS insecureSkipVerify=true", "with_insecure.toml", framework.NoOptions, func(spec *obs.OutputSpec) {
+		Entry("with TLS insecureSkipVerify=true", "with_insecure.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.TLS = &obs.OutputTLSSpec{
 				InsecureSkipVerify: true,
 				TLSSpec: obs.TLSSpec{
@@ -163,20 +176,22 @@ var _ = Describe("Generate vector config", func() {
 				},
 			}
 		}),
-		Entry("with TLS insecureSkipVerify=true, no certificate in secret", "with_insecure_nocert.toml", framework.NoOptions, func(spec *obs.OutputSpec) {
+		Entry("with TLS insecureSkipVerify=true, no certificate in secret", "with_insecure_nocert.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.TLS = &obs.OutputTLSSpec{
 				InsecureSkipVerify: true,
 			}
 		}),
-		Entry("with TLS", "with_tls.toml", framework.NoOptions, func(spec *obs.OutputSpec) {
+		Entry("with TLS", "with_tls.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.TLS = tlsSpec
 		}),
-		Entry("with TLS config with default minTLSVersion & ciphers", "with_default_tls.toml", framework.Options{
-			framework.MinTLSVersion: string(tls.DefaultMinTLSVersion),
-			framework.Ciphers:       strings.Join(tls.DefaultTLSCiphers, ","),
-		}, func(spec *obs.OutputSpec) {
+		Entry("with TLS config with default minTLSVersion & ciphers", "with_default_tls.toml", testhelpers.FrameworkOptionWithDefaultTLSCiphers, false, func(spec *obs.OutputSpec) {
 			spec.TLS = &obs.OutputTLSSpec{
 				InsecureSkipVerify: false,
+			}
+		}),
+		Entry("with tuning", "with_tuning.toml", framework.NoOptions, true, func(spec *obs.OutputSpec) {
+			spec.Loki.Tuning = &obs.LokiTuningSpec{
+				BaseOutputTuningSpec: *baseTune,
 			}
 		}),
 	)

--- a/internal/generator/vector/output/loki/with_tuning.toml
+++ b/internal/generator/vector/output/loki/with_tuning.toml
@@ -1,0 +1,52 @@
+[transforms.loki_receiver_remap]
+type = "remap"
+inputs = ["application"]
+source = '''
+  del(.tag)
+'''
+
+[transforms.loki_receiver_remap_label]
+type = "remap"
+inputs = ["loki_receiver_remap"]
+source = '''
+if !exists(.kubernetes.namespace_name) {
+  .kubernetes.namespace_name = ""
+}
+if !exists(.kubernetes.pod_name) {
+  .kubernetes.pod_name = ""
+}
+if !exists(.kubernetes.container_name) {
+  .kubernetes.container_name = ""
+}
+'''
+
+[sinks.loki_receiver]
+type = "loki"
+inputs = ["loki_receiver_remap_label"]
+endpoint = "https://logs-us-west1.grafana.net"
+out_of_order_action = "accept"
+healthcheck.enabled = false
+
+[sinks.loki_receiver.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.loki_receiver.batch]
+max_bytes = 10000000
+
+[sinks.loki_receiver.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.loki_receiver.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35
+
+[sinks.loki_receiver.labels]
+kubernetes_container_name = "{{kubernetes.container_name}}"
+kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
+kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
+kubernetes_pod_name = "{{kubernetes.pod_name}}"
+log_type = "{{log_type}}"
+

--- a/internal/generator/vector/output/otlp/otlp.go
+++ b/internal/generator/vector/output/otlp/otlp.go
@@ -2,6 +2,9 @@ package otlp
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/api/observability"
 	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
@@ -12,8 +15,6 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common/auth"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common/tls"
-	"sort"
-	"strings"
 )
 
 type Otlp struct {
@@ -122,6 +123,9 @@ func New(id string, o obs.OutputSpec, inputs []string, secrets observability.Sec
 			sink,
 			common.NewEncoding(id, common.CodecJSON),
 			common.NewAcknowledgments(id, strategy),
+			common.NewBatch(id, strategy),
+			common.NewBuffer(id, strategy),
+			common.NewRequest(id, strategy),
 			tls.New(id, o.TLS, secrets, op),
 			auth.HTTPAuth(id, o.OTLP.Authentication, secrets, op),
 		},

--- a/internal/generator/vector/output/otlp/otlp_test.go
+++ b/internal/generator/vector/output/otlp/otlp_test.go
@@ -2,6 +2,8 @@ package otlp
 
 import (
 	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -9,29 +11,64 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/api/observability"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/test/helpers/outputs/adapter/fake"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var _ = Describe("Generate vector config", func() {
-	DescribeTable("for OTLP output", func(output obs.OutputSpec, secret observability.Secrets, op framework.Options, expFile string) {
-		exp, err := tomlContent.ReadFile(expFile)
-		if err != nil {
-			Fail(fmt.Sprintf("Error reading the file %q with exp config: %v", expFile, err))
-		}
-		conf := New(helpers.MakeOutputID(output.Name), output, []string{"pipeline_my_pipeline_viaq_0"}, secret, nil, op) //, includeNS, excludes)
-		Expect(string(exp)).To(EqualConfigFrom(conf))
-	},
-		Entry("with only URL spec'd",
-			obs.OutputSpec{
+	var (
+		adapter    fake.Output
+		initOutput = func() obs.OutputSpec {
+			return obs.OutputSpec{
 				Type: obs.OutputTypeOTLP,
 				Name: "otel-collector",
 				OTLP: &obs.OTLP{
 					URL: "http://localhost:4318/v1/logs",
 				},
-			},
+			}
+		}
+		baseTune = &obs.BaseOutputTuningSpec{
+			Delivery:         obs.DeliveryModeAtLeastOnce,
+			MaxWrite:         utils.GetPtr(resource.MustParse("10M")),
+			MaxRetryDuration: utils.GetPtr(time.Duration(35)),
+			MinRetryDuration: utils.GetPtr(time.Duration(20)),
+		}
+	)
+
+	DescribeTable("for OTLP output", func(secret observability.Secrets, op framework.Options, tune bool, visit func(spec *obs.OutputSpec), expFile string) {
+		exp, err := tomlContent.ReadFile(expFile)
+		if err != nil {
+			Fail(fmt.Sprintf("Error reading the file %q with exp config: %v", expFile, err))
+		}
+		outputSpec := initOutput()
+		if visit != nil {
+			visit(&outputSpec)
+		}
+		if tune {
+			adapter = *fake.NewOutput(outputSpec, secret, framework.NoOptions)
+		}
+		conf := New(helpers.MakeOutputID(outputSpec.Name), outputSpec, []string{"pipeline_my_pipeline_viaq_0"}, secret, adapter, op)
+		Expect(string(exp)).To(EqualConfigFrom(conf))
+	},
+		Entry("with only URL spec'd",
 			nil,
 			framework.NoOptions,
+			false,
+			nil,
 			"otlp_all.toml",
+		),
+		Entry("with tuning",
+			nil,
+			framework.NoOptions,
+			true,
+			func(spec *obs.OutputSpec) {
+				spec.OTLP.Tuning = &obs.OTLPTuningSpec{
+					BaseOutputTuningSpec: *baseTune,
+				}
+			},
+			"otlp_tuning.toml",
 		),
 	)
 })

--- a/internal/generator/vector/output/otlp/otlp_tuning.toml
+++ b/internal/generator/vector/output/otlp/otlp_tuning.toml
@@ -1,0 +1,404 @@
+# Route logs separately by log_source
+[transforms.output_otel_collector_reroute]
+type = "route"
+inputs = ["pipeline_my_pipeline_viaq_0"]
+route.auditd = '.log_source == "auditd"'
+route.container = '.log_source == "container"'
+route.kubeapi = '.log_source == "kubeAPI"'
+route.node = '.log_source == "node"'
+route.openshiftapi = '.log_source == "openshiftAPI"'
+route.ovn = '.log_source == "ovn"'
+
+# Normalize container log records to OTLP semantic conventions
+[transforms.output_otel_collector_container]
+type = "remap"
+inputs = ["output_otel_collector_reroute.container"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+      {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append container resource attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "k8s.pod.name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+      {"key": "k8s.container.name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+      {"key": "k8s.namespace.name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  # Create body from original message or structured
+  value = .message
+  if (value == null) { value = encode_json(.structured) }
+  r.body = {"stringValue": string!(value)}
+  # Create logRecord attributes
+  r.attributes = []
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    r.attributes = append(r.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+  }}
+  # Append kube pod labels
+  r.attributes = append(r.attributes,
+      [{"key": "k8s.pod.uid", "value": {"stringValue": get!(.,["kubernetes","pod_id"])}},
+      {"key": "k8s.container.id", "value": {"stringValue": get!(.,["kubernetes","container_id"])}},
+      {"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
+  )
+  if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
+      r.attributes = append(r.attributes,
+          [{"key": "k8s.pod.label." + key, "value": {"stringValue": value}}]
+      )
+  }}
+  # Openshift and kubernetes objects for grouping containers (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  .kubernetes = {
+      "namespace_name": .kubernetes.namespace_name,
+      "pod_name": .kubernetes.pod_name,
+      "container_name": .kubernetes.container_name
+  }
+  . = {
+    "openshift": o,
+    "kubernetes": .kubernetes,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Merge container logs and group by namespace, pod and container
+[transforms.output_otel_collector_groupby_container]
+type = "reduce"
+inputs = ["output_otel_collector_container"]
+expire_after_ms = 15000
+max_events = 250
+group_by = [".openshift.cluster_id",".kubernetes.namespace_name",".kubernetes.pod_name",".kubernetes.container_name"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Normalize node log events to OTLP semantic conventions
+[transforms.output_otel_collector_node]
+type = "remap"
+inputs = ["output_otel_collector_reroute.node"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+      {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  # Create body from original message or structured
+  value = .message
+  if (value == null) { value = encode_json(.structured) }
+  r.body = {"stringValue": string!(value)}
+  # Create logRecord attributes
+  r.attributes = []
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    r.attributes = append(r.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+  }}
+  # Append log attributes for node logs
+  r.attributes = append(r.attributes,
+	[{"key": "syslog.facility", "value": {"stringValue": to_string!(get!(.,["systemd","u","SYSLOG_FACILITY"]))}},
+	{"key": "service.name", "value": {"stringValue": to_string!(get!(.,["systemd","u","SYSLOG_IDENTIFIER"]))}},
+	{"key": "process.command", "value": {"stringValue": to_string!(get!(.,["systemd","t","COMM"]))}},
+	{"key": "process.command_line", "value": {"stringValue": to_string!(get!(.,["systemd","t","CMDLINE"]))}},
+	{"key": "process.executable.path", "value": {"stringValue": to_string!(get!(.,["systemd","t","EXE"]))}},
+	{"key": "process.gid", "value": {"stringValue": to_string!(get!(.,["systemd","t","GID"]))}},
+	{"key": "host.id", "value": {"stringValue": to_string!(get!(.,["systemd","t","MACHINE_ID"]))}},
+	{"key": "host.name", "value": {"stringValue": .hostname}},
+	{"key": "process.pid", "value": {"stringValue": to_string!(get!(.,["systemd","t","PID"]))}},
+	{"key": "process.user.id", "value": {"stringValue": to_string!(get!(.,["systemd","t","UID"]))}}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit log record to OTLP semantic conventions
+[transforms.output_otel_collector_auditd]
+type = "remap"
+inputs = ["output_otel_collector_reroute.auditd"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+      {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append auditd host attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  # Create body from internal message
+  r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+  # Create logRecord attributes
+  r.attributes = []
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    r.attributes = append(r.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+  }}
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit log kube record to OTLP semantic conventions
+[transforms.output_otel_collector_kubeapi]
+type = "remap"
+inputs = ["output_otel_collector_reroute.kubeapi"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+      {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  # Create body from internal message
+  r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+  # Create logRecord attributes
+  r.attributes = []
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+      r.attributes = append(r.attributes,
+          [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+      )
+  }}
+  # Append API logRecord attributes
+  parts = split(to_string!(.requestURI), "?")
+  r.attributes = append(r.attributes,
+      [{"key": "http.response.status.code", "value": {"stringValue": to_string!(get!(.,["responseStatus","code"]))}},
+      {"key": "http.request.method_original", "value": {"stringValue": .verb}},
+      {"key": "user.name", "value": {"stringValue": get!(.,["user","username"])}},
+      {"key": "user_agent.original", "value": {"stringValue": .userAgent }},
+      {"key": "url.domain", "value": {"stringValue": .hostname }},
+      {"key": "url.path", "value": {"stringValue": parts[0] }},
+      {"key": "url.query", "value": {"stringValue": parts[1] }}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit openshiftAPI record to OTLP semantic conventions
+[transforms.output_otel_collector_openshiftapi]
+type = "remap"
+inputs = ["output_otel_collector_reroute.openshiftapi"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+      {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  # Create body from internal message
+  r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+  # Create logRecord attributes
+  r.attributes = []
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    r.attributes = append(r.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+  }}
+  # Append API logRecord attributes
+  parts = split(to_string!(.requestURI), "?")
+  r.attributes = append(r.attributes,
+      [{"key": "http.response.status.code", "value": {"stringValue": to_string!(get!(.,["responseStatus","code"]))}},
+      {"key": "http.request.method_original", "value": {"stringValue": .verb}},
+      {"key": "user.name", "value": {"stringValue": get!(.,["user","username"])}},
+      {"key": "user_agent.original", "value": {"stringValue": .userAgent }},
+      {"key": "url.domain", "value": {"stringValue": .hostname }},
+      {"key": "url.path", "value": {"stringValue": parts[0] }},
+      {"key": "url.query", "value": {"stringValue": parts[1] }}]
+  )
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Normalize audit log ovn records to OTLP semantic conventions
+[transforms.output_otel_collector_ovn]
+type = "remap"
+inputs = ["output_otel_collector_reroute.ovn"]
+source = '''
+  # Create base resource attributes
+  resource.attributes = []
+  resource.attributes = append( resource.attributes,
+      [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
+      {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Create logRecord object
+  r = {}
+  r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+  r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+  # Convert syslog severity keyword to number, default to 9 (unknown)
+  r.severityNumber = to_syslog_severity(.level) ?? 9
+  # Create body from original message or structured
+  value = .message
+  if (value == null) { value = encode_json(.structured) }
+  r.body = {"stringValue": string!(value)}
+  # Create logRecord attributes
+  r.attributes = []
+  r.attributes = append(r.attributes,
+      [{"key": "openshift.log.type", "value": {"stringValue": .log_type}}]
+  )
+  if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    r.attributes = append(r.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+  }}
+  # Openshift object for grouping (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "hostname": .hostname,
+      "cluster_id": get!(.,["openshift","cluster_id"])
+  }
+  . = {
+    "openshift": o,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Merge audit api and node logs and group by log_source
+[transforms.output_otel_collector_groupby_source]
+type = "reduce"
+inputs = ["output_otel_collector_kubeapi","output_otel_collector_node","output_otel_collector_openshiftapi","output_otel_collector_ovn"]
+expire_after_ms = 15000
+max_events = 250
+group_by = [".openshift.cluster_id",".openshift.log_source"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Merge auditd host logs and group by hostname
+[transforms.output_otel_collector_groupby_host]
+type = "reduce"
+inputs = ["output_otel_collector_auditd"]
+expire_after_ms = 15000
+max_events = 50
+group_by = [".openshift.cluster_id",".openshift.hostname"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Create new resource object for OTLP JSON payload
+[transforms.output_otel_collector_resource_logs]
+type = "remap"
+inputs = ["output_otel_collector_groupby_container","output_otel_collector_groupby_host","output_otel_collector_groupby_source"]
+source = '''
+  . = {
+        "resource": {
+           "attributes": .resource.attributes,
+        },
+        "scopeLogs": [
+          {"logRecords": .logRecords}
+        ]
+      }
+'''
+
+[sinks.output_otel_collector]
+type = "http"
+inputs = ["output_otel_collector_resource_logs"]
+uri = "http://localhost:4318/v1/logs"
+method = "post"
+payload_prefix = "{\"resourceLogs\":"
+payload_suffix = "}"
+
+[sinks.output_otel_collector.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.output_otel_collector.batch]
+max_bytes = 10000000
+
+[sinks.output_otel_collector.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.output_otel_collector.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35

--- a/internal/generator/vector/output/splunk/splunk_tune.toml
+++ b/internal/generator/vector/output/splunk/splunk_tune.toml
@@ -1,0 +1,36 @@
+# Ensure timestamp field well formatted for Splunk
+[transforms.splunk_hec_timestamp]
+type = "remap"
+inputs = ["pipelineName"]
+source = '''
+ts, err = parse_timestamp(.@timestamp,"%+")
+if err != null {
+	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
+} else {
+	.@timestamp = ts
+}
+
+'''
+[sinks.splunk_hec]
+type = "splunk_hec_logs"
+inputs = ["splunk_hec_timestamp"]
+endpoint = "https://splunk-web:8088/endpoint"
+compression = "none"
+default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
+timestamp_key = "@timestamp"
+
+[sinks.splunk_hec.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.splunk_hec.batch]
+max_bytes = 10000000
+
+[sinks.splunk_hec.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.splunk_hec.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35

--- a/test/helpers/outputs/adapter/fake/adapter.go
+++ b/test/helpers/outputs/adapter/fake/adapter.go
@@ -1,0 +1,25 @@
+package fake
+
+import (
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
+	generator "github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Output is an adapter between CLF and Config generation
+type Output struct {
+	spec    obs.OutputSpec
+	op      generator.Options
+	secrets map[string]*corev1.Secret
+	tuning  internalobs.Tuning
+}
+
+func NewOutput(spec obs.OutputSpec, secrets map[string]*corev1.Secret, op generator.Options) *Output {
+	return &Output{
+		spec:    spec,
+		op:      op,
+		secrets: secrets,
+		tuning:  internalobs.NewTuning(spec),
+	}
+}

--- a/test/helpers/outputs/adapter/fake/config_strategy.go
+++ b/test/helpers/outputs/adapter/fake/config_strategy.go
@@ -1,0 +1,59 @@
+package fake
+
+import (
+	"time"
+
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
+)
+
+const (
+	minBufferSize   = 268435488
+	buffertTypeDisk = "disk"
+)
+
+func (o Output) VisitSink(s common.SinkConfig) {
+	if o.tuning.Compression != "" {
+		s.SetCompression(o.tuning.Compression)
+	}
+}
+
+func (o Output) VisitAcknowledgements(a common.Acknowledgments) common.Acknowledgments {
+	return a
+}
+
+func (o Output) VisitBatch(b common.Batch) common.Batch {
+	if o.tuning.MaxWrite != nil && !o.tuning.MaxWrite.IsZero() {
+		b.MaxBytes.Value = o.tuning.MaxWrite.Value()
+	}
+	return b
+}
+
+func (o Output) VisitRequest(r common.Request) common.Request {
+	var duration time.Duration
+	if o.tuning.MinRetryDuration != nil && o.tuning.MinRetryDuration.Seconds() > 0 {
+		// time.Duration is default nanosecond. Convert to seconds first.
+		duration = *o.tuning.MinRetryDuration * time.Second
+		r.RetryInitialBackoffSec.Value = duration.Seconds()
+	}
+	if o.tuning.MaxRetryDuration != nil && o.tuning.MaxRetryDuration.Seconds() > 0 {
+		duration = *o.tuning.MaxRetryDuration * time.Second
+		r.RetryMaxDurationSec.Value = duration.Seconds()
+	}
+
+	return r
+}
+
+// VisitBuffer modifies the buffer behavior depending upon the value
+// of the tuning.Delivery mode
+func (o Output) VisitBuffer(b common.Buffer) common.Buffer {
+	switch o.tuning.Delivery {
+	case obs.DeliveryModeAtLeastOnce:
+		b.WhenFull.Value = common.BufferWhenFullBlock
+		b.Type.Value = buffertTypeDisk
+		b.MaxSize.Value = minBufferSize
+	case obs.DeliveryModeAtMostOnce:
+		b.WhenFull.Value = common.BufferWhenFullDropNewest
+	}
+	return b
+}


### PR DESCRIPTION
### Description
This PR adds the appropriate tuning sections for the `OTLP` output. In addition, it adds unit tests for the tuning section for all output types.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-5909
