### PR TITLE
LOG-5972: Fix ServiceMonitor for LogFileMetricExporter

### DIFF
--- a/internal/controller/observability/collector.go
+++ b/internal/controller/observability/collector.go
@@ -106,7 +106,8 @@ func ReconcileCollector(context internalcontext.ForwarderContext, pollInterval, 
 		log.Error(err, "collector.ReconcileService")
 		return err
 	}
-	if err := metrics.ReconcileServiceMonitor(context.Client, context.Forwarder.Namespace, resourceNames.CommonName, constants.CollectorName, collector.MetricsPortName, ownerRef); err != nil {
+	metricsSelector := metrics.BuildSelector(constants.CollectorName, resourceNames.CommonName)
+	if err := metrics.ReconcileServiceMonitor(context.Client, context.Forwarder.Namespace, resourceNames.CommonName, ownerRef, metricsSelector, collector.MetricsPortName); err != nil {
 		log.Error(err, "collector.ReconcileServiceMonitor")
 		return err
 	}

--- a/internal/metrics/logfilemetricexporter/factory.go
+++ b/internal/metrics/logfilemetricexporter/factory.go
@@ -19,8 +19,8 @@ import (
 
 const (
 	clusterLoggingPriorityClassName = "system-node-critical"
-	ExporterPort                    = int32(2112)
-	ExporterPortName                = "exporter-port"
+	exporterPort                    = int32(2112)
+	exporterPortName                = "exporter-port"
 	logContainers                   = "varlogcontainers"
 	logContainersValue              = "/var/log/containers"
 	exporterMetricsVolumeName       = "lfme-metrics"
@@ -103,8 +103,8 @@ func newLogMetricsExporterContainer(exporter loggingv1a1.LogFileMetricExporter, 
 
 	exporterContainer.Ports = []v1.ContainerPort{
 		{
-			Name:          ExporterPortName,
-			ContainerPort: ExporterPort,
+			Name:          exporterPortName,
+			ContainerPort: exporterPort,
 			Protocol:      v1.ProtocolTCP,
 		},
 	}

--- a/internal/metrics/logfilemetricexporter/factory_test.go
+++ b/internal/metrics/logfilemetricexporter/factory_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		Expect(serviceInstance.Spec.Ports).ToNot(BeEmpty(), "Exp. to have spec.Ports")
 
 		Expect(serviceInstance.Spec.Ports[0].Port).
-			To(Equal(ExporterPort), fmt.Sprintf("Exp service port of: %v", ExporterPort))
+			To(Equal(exporterPort), fmt.Sprintf("Exp service port of: %v", exporterPort))
 
 		Expect(serviceInstance.Annotations[constants.AnnotationServingCertSecretName]).
 			To(Equal(ExporterMetricsSecretName))
@@ -116,7 +116,7 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		expJobLabel := fmt.Sprintf("monitor-%s", constants.LogfilesmetricexporterName)
 		Expect(smInstance.Spec.JobLabel).To(Equal(expJobLabel))
 		Expect(smInstance.Spec.Endpoints).ToNot(BeEmpty())
-		Expect(smInstance.Spec.Endpoints[0].Port).To(Equal(ExporterPortName))
+		Expect(smInstance.Spec.Endpoints[0].Port).To(Equal(exporterPortName))
 
 		svcURL := fmt.Sprintf("%s.openshift-logging.svc", constants.LogfilesmetricexporterName)
 		Expect(smInstance.Spec.Endpoints[0].TLSConfig.SafeTLSConfig.ServerName).

--- a/internal/metrics/logfilemetricexporter/metric_exporter.go
+++ b/internal/metrics/logfilemetricexporter/metric_exporter.go
@@ -50,12 +50,13 @@ func Reconcile(lfmeInstance *loggingv1alpha1.LogFileMetricExporter,
 		return err
 	}
 
-	if err := network.ReconcileService(requestClient, lfmeInstance.Namespace, resNames.CommonName, lfmeInstance.Name, constants.LogfilesmetricexporterName, ExporterPortName, ExporterMetricsSecretName, ExporterPort, owner, commonLabels); err != nil {
+	if err := network.ReconcileService(requestClient, lfmeInstance.Namespace, resNames.CommonName, lfmeInstance.Name, constants.LogfilesmetricexporterName, exporterPortName, ExporterMetricsSecretName, exporterPort, owner, commonLabels); err != nil {
 		log.Error(err, "logfilemetricexporter.ReconcileService")
 		return err
 	}
 
-	if err := metrics.ReconcileServiceMonitor(requestClient, lfmeInstance.Namespace, resNames.CommonName, constants.LogfilesmetricexporterName, ExporterPortName, owner); err != nil {
+	metricsSelector := metrics.BuildSelector(constants.LogfilesmetricexporterName, lfmeInstance.Name)
+	if err := metrics.ReconcileServiceMonitor(requestClient, lfmeInstance.Namespace, resNames.CommonName, owner, metricsSelector, exporterPortName); err != nil {
 		log.Error(err, "logfilemetricexporter.ReconcileServiceMonitor")
 		return err
 	}

--- a/internal/metrics/logfilemetricexporter/metric_exporter_test.go
+++ b/internal/metrics/logfilemetricexporter/metric_exporter_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		Expect(serviceInstance.Spec.Ports).ToNot(BeEmpty(), "Exp. to have spec.Ports")
 
 		Expect(serviceInstance.Spec.Ports[0].Port).
-			To(Equal(ExporterPort), fmt.Sprintf("Exp service port of: %v", ExporterPort))
+			To(Equal(exporterPort), fmt.Sprintf("Exp service port of: %v", exporterPort))
 
 		Expect(serviceInstance.Annotations[constants.AnnotationServingCertSecretName]).
 			To(Equal(ExporterMetricsSecretName))
@@ -116,7 +116,7 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		expJobLabel := fmt.Sprintf("monitor-%s", constants.LogfilesmetricexporterName)
 		Expect(smInstance.Spec.JobLabel).To(Equal(expJobLabel))
 		Expect(smInstance.Spec.Endpoints).ToNot(BeEmpty())
-		Expect(smInstance.Spec.Endpoints[0].Port).To(Equal(ExporterPortName))
+		Expect(smInstance.Spec.Endpoints[0].Port).To(Equal(exporterPortName))
 
 		svcURL := fmt.Sprintf("%s.openshift-logging.svc", constants.LogfilesmetricexporterName)
 		Expect(smInstance.Spec.Endpoints[0].TLSConfig.SafeTLSConfig.ServerName).

--- a/internal/metrics/service_monitor_test.go
+++ b/internal/metrics/service_monitor_test.go
@@ -37,7 +37,9 @@ var _ = Describe("Reconcile ServiceMonitor", func() {
 		owner       = metav1.OwnerReference{}
 		portName    = "test-port"
 		serviceName = "test-service"
-		component   = "test-component"
+		selector    = map[string]string{
+			constants.LabelK8sComponent: "test-component",
+		}
 
 		serviceMonitorKey = types.NamespacedName{Name: serviceName, Namespace: namespace.Name}
 		smInstance        = &monitoringv1.ServiceMonitor{}
@@ -49,9 +51,10 @@ var _ = Describe("Reconcile ServiceMonitor", func() {
 			reqClient,
 			constants.OpenshiftNS,
 			serviceName,
-			component,
+			owner,
+			selector,
 			portName,
-			owner)).To(Succeed())
+		)).To(Succeed())
 
 		// Get and check the ServiceMonitor
 		Expect(reqClient.Get(context.TODO(), serviceMonitorKey, smInstance)).Should(Succeed())


### PR DESCRIPTION
### Description

Fixes an issue with the selector used for the LFME's ServiceMonitor.

/cc @cahartma
/assign @jcantrill 

### Links

- JIRA: [LOG-5972](https://issues.redhat.com//browse/LOG-5972)
