### PR TITLE
LOG-3432: Remove collector error alerts

### DIFF
--- a/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -17,38 +17,6 @@ spec:
       labels:
         service: collector
         severity: critical
-    - alert: CollectorHighErrorRate
-      annotations:
-        message: '{{ $value }}% of records have resulted in an error by {{ $labels.namespace
-          }}/{{ $labels.pod }} collector component.'
-        summary: '{{ $labels.namespace }}/{{ $labels.pod }} collector component errors
-          are high'
-      expr: |
-        100 * (
-            collector:log_num_errors:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
-          /
-            collector:received_events:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
-          ) > 0.001
-      for: 15m
-      labels:
-        service: collector
-        severity: critical
-    - alert: CollectorVeryHighErrorRate
-      annotations:
-        message: '{{ $value }}% of records have resulted in an error by {{ $labels.namespace
-          }}/{{ $labels.pod }} collector component.'
-        summary: '{{ $labels.namespace }}/{{ $labels.pod }} collector component errors
-          are very high'
-      expr: |
-        100 * (
-            collector:log_num_errors:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
-          /
-            collector:received_events:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
-          ) > 0.05
-      for: 15m
-      labels:
-        service: collector
-        severity: critical
     - alert: ElasticsearchDeprecation
       annotations:
         message: In Red Hat OpenShift Logging Operator 6.0, support for the Red Hat

--- a/config/prometheus/collector_alerts.yaml
+++ b/config/prometheus/collector_alerts.yaml
@@ -17,34 +17,6 @@ spec:
       labels:
         service: collector
         severity: critical
-    - alert: CollectorHighErrorRate
-      annotations:
-        message: "{{ $value }}% of records have resulted in an error by {{ $labels.namespace }}/{{ $labels.pod }} collector component."
-        summary: "{{ $labels.namespace }}/{{ $labels.pod }} collector component errors are high"
-      expr: |
-        100 * (
-            collector:log_num_errors:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
-          /
-            collector:received_events:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
-          ) > 0.001
-      for: 15m
-      labels:
-        service: collector
-        severity: critical
-    - alert: CollectorVeryHighErrorRate
-      annotations:
-        message: "{{ $value }}% of records have resulted in an error by {{ $labels.namespace }}/{{ $labels.pod }} collector component."
-        summary: "{{ $labels.namespace }}/{{ $labels.pod }} collector component errors are very high"
-      expr: |
-        100 * (
-            collector:log_num_errors:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
-          /
-            collector:received_events:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
-          ) > 0.05
-      for: 15m
-      labels:
-        service: collector
-        severity: critical
     - alert: ElasticsearchDeprecation
       annotations:
         message: "In Red Hat OpenShift Logging Operator 6.0, support for the Red Hat Elasticsearch Operator has been removed. Bug fixes and support are provided only through the end of the 5.9 lifecycle. As an alternative to the Elasticsearch Operator, you can use the Loki Operator instead."


### PR DESCRIPTION
### Description
This PR:
* removes the collector error alerts until they can be replace with a version that is reliable and created based upon concrete requirements

### Links
https://issues.redhat.com/browse/LOG-3432