### PR TITLE
LOG-5983: Remove compat-openssl11 library from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ ENV SRC_DIR=./
 
 RUN INSTALL_PKGS=" \
       openssl \
-      compat-openssl11 \
       rsync \
       file \
       xz \


### PR DESCRIPTION
### Description

This PR removes the `compat-openssl11` package from the built Docker image. As the `oc` binary is also built on RHEL9 this should no longer be necessary. This PR brings the upstream Dockerfile in sync with the midstream one.

/cc @cahartma
/assign @jcantrill

### Links

- JIRA: [LOG-5983](https://issues.redhat.com//browse/LOG-5983)
