### PR TITLE
LOG-5993: Sort names of secrets / configmaps so that order is stable

### DIFF
--- a/internal/api/observability/configmap.go
+++ b/internal/api/observability/configmap.go
@@ -1,6 +1,10 @@
 package observability
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 type ConfigMaps map[string]*corev1.ConfigMap
 
@@ -8,5 +12,7 @@ func (c ConfigMaps) Names() (names []string) {
 	for name := range c {
 		names = append(names, name)
 	}
+
+	sort.Strings(names)
 	return names
 }

--- a/internal/api/observability/secrets.go
+++ b/internal/api/observability/secrets.go
@@ -2,11 +2,13 @@ package observability
 
 import (
 	"fmt"
+	"hash/fnv"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
-	"hash/fnv"
-	corev1 "k8s.io/api/core/v1"
-	"sort"
 )
 
 // NewSecretReference returns a SecretReference with the given key name and secret
@@ -23,7 +25,6 @@ type Secrets map[string]*corev1.Secret
 // Hash64a returns an FNV-1a representation of the secrets
 func (s Secrets) Hash64a() string {
 	names := s.Names()
-	sort.Strings(names)
 	buffer := fnv.New64a()
 	for _, name := range names {
 		secret := s[name]
@@ -45,10 +46,11 @@ func (s Secrets) Hash64a() string {
 }
 
 func (s Secrets) Names() (names []string) {
-
 	for name := range s {
 		names = append(names, name)
 	}
+
+	sort.Strings(names)
 	return names
 }
 


### PR DESCRIPTION
### Description

This sorts the slices returned by `Names()` for both secrets and configmaps so that the ordering is stable.

/cc @cahartma
/assign @jcantrill

### Links

- JIRA: [LOG-5993](https://issues.redhat.com//browse/LOG-5993)
