### PR TITLE
LOG-6034: tune audit sources to release file handles

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -18,6 +18,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_host_meta]
 type = "remap"
@@ -33,6 +36,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_kube_meta]
 type = "remap"
@@ -48,6 +54,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_openshift_meta]
 type = "remap"
@@ -63,6 +72,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_ovn_meta]
 type = "remap"

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -18,6 +18,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_host_meta]
 type = "remap"
@@ -33,6 +36,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_kube_meta]
 type = "remap"
@@ -48,6 +54,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_openshift_meta]
 type = "remap"
@@ -63,6 +72,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_ovn_meta]
 type = "remap"

--- a/internal/generator/vector/input/audit.toml
+++ b/internal/generator/vector/input/audit.toml
@@ -4,6 +4,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_host_meta]
 type = "remap"
@@ -19,6 +22,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_kube_meta]
 type = "remap"
@@ -34,6 +40,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_openshift_meta]
 type = "remap"
@@ -49,6 +58,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_audit_ovn_meta]
 type = "remap"

--- a/internal/generator/vector/input/audit_host.toml
+++ b/internal/generator/vector/input/audit_host.toml
@@ -4,6 +4,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_myaudit_host_meta]
 type = "remap"

--- a/internal/generator/vector/input/audit_kube.toml
+++ b/internal/generator/vector/input/audit_kube.toml
@@ -4,6 +4,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_myaudit_kube_meta]
 type = "remap"

--- a/internal/generator/vector/input/audit_openshift.toml
+++ b/internal/generator/vector/input/audit_openshift.toml
@@ -4,6 +4,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_myaudit_openshift_meta]
 type = "remap"

--- a/internal/generator/vector/input/audit_ovn.toml
+++ b/internal/generator/vector/input/audit_ovn.toml
@@ -4,6 +4,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 
 [transforms.input_myaudit_ovn_meta]
 type = "remap"

--- a/internal/generator/vector/source/audit_logs.go
+++ b/internal/generator/vector/source/audit_logs.go
@@ -12,6 +12,9 @@ type = "file"
 include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 {{end}}`
 
 type HostAuditLog = framework.ConfLiteral
@@ -24,6 +27,9 @@ type = "file"
 include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/audit.log","/var/log/oauth-server/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 {{end}}
 `
 
@@ -37,6 +43,9 @@ type = "file"
 include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 {{end}}
 `
 
@@ -50,6 +59,9 @@ type = "file"
 include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
+ignore_older_secs = 3600
+max_read_bytes = 3145728
+rotate_wait_secs = 5
 {{end}}
 `
 


### PR DESCRIPTION
### Description
This PR modifies audit sources:
* with max read bytes
* ignore files older then one hour
* release rotated files after 5s

### Links
https://issues.redhat.com/browse/LOG-6034
Forward port of #2768 