### PR TITLE
LOG-6044: validation failure when adding a namespace which contains 'kube'

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
@@ -24,7 +24,7 @@ const (
 	allNamespaces = ""
 )
 
-var infraNamespaces = regexp.MustCompile(`^default|openshift.*|kube.*$`)
+var infraNamespaces = regexp.MustCompile(`^default$|^openshift.*$|^kube.*$`)
 
 // ValidateServiceAcccount validates the serviceaccount for the CLF has the needed permissions to collect the desired inputs
 func ValidateServiceAccount(clf loggingv1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *loggingv1.ClusterLogForwarderStatus) {

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account_test.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account_test.go
@@ -255,6 +255,29 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder permissio
 			})
 
 			Context("when service account only has collect-application-logs permission", func() {
+				It("should pass validation for non-infra namespaces", func() {
+					appInput := "my-app"
+					customClf.Spec = loggingv1.ClusterLogForwarderSpec{
+						ServiceAccountName: clfServiceAccount.Name,
+						Inputs: []loggingv1.InputSpec{
+							{
+								Name: appInput,
+								Application: &loggingv1.Application{
+									Namespaces: []string{"sample-kube-namespace", "my-default-ns", "custom-openshift-namespace", "default-custom"},
+								},
+							},
+						},
+						Pipelines: []loggingv1.PipelineSpec{
+							{
+								Name: "pipeline1",
+								InputRefs: []string{
+									appInput,
+								},
+							},
+						},
+					}
+					Expect(ValidateServiceAccount(customClf, k8sAppClient, extras)).To(Succeed(), "should pass validation for non-infra namespaces")
+				})
 				DescribeTable("application input with infrastructure namespaces included", func(infraNS []string) {
 					customClf.Spec = loggingv1.ClusterLogForwarderSpec{
 						ServiceAccountName: clfServiceAccount.Name,


### PR DESCRIPTION
### Description
This PR modifies the regex that determines infrastructure namespaces so that namespaces containing, but not starting with, `kube` or `openshift` are treated as application namespaces. Only the namespace `default` is treated as infrastructure and any other namespace containing `default` is not.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6044
