### PR TITLE
cleanup CI UI. write logs to artifact dir

### DIFF
--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -135,9 +135,9 @@ func (f *CollectorFunctionalFramework) Cleanup() {
 			if err != nil {
 				log.Error(err, "Unable to retrieve logs", "container", container.Name)
 			}
-			fmt.Fprintln(test.Writer(), logs)
+			fmt.Fprintln(f.delayedWriter, logs)
 		}
-		f.delayedWriter.Flush()
+		f.delayedWriter.FlushToArtifactsDir(fmt.Sprintf("%s_%d.log", g.FileName, g.LineNumber))
 	}
 	f.closeClient()
 }


### PR DESCRIPTION
### Description
This PR:
* attempts to cleanup the CI test UI to only display minimal info while preserving logs to artifacts dir

