### PR TITLE
LOG-6069: Enable http/https proxy support for HTTP output.

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -617,12 +617,18 @@ type HTTP struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Timeout",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
 	Timeout int `json:"timeout,omitempty"`
 
-	// Method specifies the Http method to be used for sending logs. If not set, 'POST' is used.
+	// Method specifies the HTTP method to be used for sending logs. If not set, 'POST' is used.
 	//
 	// +kubebuilder:validation:Enum:=GET;HEAD;POST;PUT;DELETE;OPTIONS;TRACE;PATCH
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="HTTP Method"
 	Method string `json:"method,omitempty"`
+
+	// ProxyURL URL of a HTTP or HTTPS proxy to be used instead of direct connection.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == '' ||  isURL(self)", message="invalid URL"
+	ProxyURL string `json:"proxyURL,omitempty"`
 }
 
 type KafkaTuningSpec struct {

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,6 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-10-25T13:58:52Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -880,7 +879,7 @@ spec:
       - description: Headers specify optional headers to be sent with the request
         displayName: Headers
         path: outputs[0].http.headers
-      - description: Method specifies the Http method to be used for sending logs.
+      - description: Method specifies the HTTP method to be used for sending logs.
           If not set, 'POST' is used.
         displayName: HTTP Method
         path: outputs[0].http.method

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1456,7 +1456,7 @@ spec:
                             with the request
                           type: object
                         method:
-                          description: Method specifies the Http method to be used
+                          description: Method specifies the HTTP method to be used
                             for sending logs. If not set, 'POST' is used.
                           enum:
                           - GET
@@ -1468,6 +1468,13 @@ spec:
                           - TRACE
                           - PATCH
                           type: string
+                        proxyURL:
+                          description: ProxyURL URL of a HTTP or HTTPS proxy to be
+                            used instead of direct connection.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: invalid URL
+                            rule: self == '' ||  isURL(self)
                         timeout:
                           description: Timeout specifies the Http request timeout
                             in seconds. If not set, 10secs is used.

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1456,7 +1456,7 @@ spec:
                             with the request
                           type: object
                         method:
-                          description: Method specifies the Http method to be used
+                          description: Method specifies the HTTP method to be used
                             for sending logs. If not set, 'POST' is used.
                           enum:
                           - GET
@@ -1468,6 +1468,13 @@ spec:
                           - TRACE
                           - PATCH
                           type: string
+                        proxyURL:
+                          description: ProxyURL URL of a HTTP or HTTPS proxy to be
+                            used instead of direct connection.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: invalid URL
+                            rule: self == '' ||  isURL(self)
                         timeout:
                           description: Timeout specifies the Http request timeout
                             in seconds. If not set, 10secs is used.

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -803,7 +803,7 @@ spec:
       - description: Headers specify optional headers to be sent with the request
         displayName: Headers
         path: outputs[0].http.headers
-      - description: Method specifies the Http method to be used for sending logs.
+      - description: Method specifies the HTTP method to be used for sending logs.
           If not set, 'POST' is used.
         displayName: HTTP Method
         path: outputs[0].http.method

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -811,24 +811,37 @@ Type:: array
 |======================
 |Property|Type|Description
 
-|azureMonitor|object|  
-|cloudwatch|object|  
-|elasticsearch|object|  
-|googleCloudLogging|object|  
-|http|object|  
-|kafka|object|  
-|loki|object|  
-|lokiStack|object|  
+|azureMonitor|object|  AzureMonitor configures forwarding log events to the Azure Monitor Logs service
+
+|cloudwatch|object|  Cloudwatch configures forwarding log events to AWS Cloudwatch logs
+
+|elasticsearch|object|  Elasticsearch configures forwarding log events to an Elasticsearch cluster
+
+|googleCloudLogging|object|  GoogleCloudLogging configures forwarding log events to GCP (formally Stackdriver) Operations
+
+|http|object|  HTTP configures forwarding log events to an HTTP server
+
+|kafka|object|  Kafka configures forwarding log events to Apache Kafka topics
+
+|loki|object|  Loki configures forwarding log events to a Loki aggregation system
+
+|lokiStack|object|  LokiStack configures forwarding log events to a Red Hat managed Loki deployment
+using the Red Hat tenancy model
+
 |name|string|  Name used to refer to the output from a `pipeline`.
 
-|otlp|object|  
+|otlp|object|  OTLP configures forwarding log events to a receiver using the OpenTelemetry Protocol
+with Red Openshift logging semantic conventions (ref: https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md)
+
 |rateLimit|object|  Limit imposes a limit in records-per-second on the total aggregate rate of logs forwarded
 to this output from any given collector container. The total log flow from an individual collector
 container to this output cannot exceed the limit.  Generally, one collector is deployed per cluster node
 Logs may be dropped to enforce the limit. Missing or 0 means no rate limit.
 
-|splunk|object|  
-|syslog|object|  
+|splunk|object|  Splunk configures forwarding log events to Splunk&#39;s HTTP event collector
+
+|syslog|object|  Syslog configures forwarding log events to a receiver using the syslog protocol
+
 |tls|object|  TLS contains settings for controlling options on TLS client connections.
 
 |type|string|  Type of output sink.
@@ -1420,7 +1433,9 @@ The &#39;username@password&#39; part of `url` is ignored.
 
 |headers|object|  Headers specify optional headers to be sent with the request
 
-|method|string|  Method specifies the Http method to be used for sending logs. If not set, &#39;POST&#39; is used.
+|method|string|  Method specifies the HTTP method to be used for sending logs. If not set, &#39;POST&#39; is used.
+
+|proxyURL|string|  ProxyURL URL of a HTTP or HTTPS proxy to be used instead of direct connection.
 
 |timeout|int|  Timeout specifies the Http request timeout in seconds. If not set, 10secs is used.
 

--- a/internal/generator/vector/output/http/http.go
+++ b/internal/generator/vector/output/http/http.go
@@ -18,6 +18,7 @@ type Http struct {
 	Inputs      string
 	URI         string
 	Method      string
+	Proxy       string
 	common.RootMixin
 }
 
@@ -32,6 +33,11 @@ type = "http"
 inputs = {{.Inputs}}
 uri = "{{.URI}}"
 method = "{{.Method}}"
+{{with .Proxy -}}
+proxy.enabled = true
+proxy.http = "{{.}}"
+proxy.https = "{{.}}"
+{{end -}}
 {{.Compression}}
 {{end}}
 `
@@ -74,6 +80,7 @@ func Output(id string, o obs.OutputSpec, inputs []string, secrets observability.
 		Inputs:      vectorhelpers.MakeInputs(inputs...),
 		URI:         o.HTTP.URL,
 		Method:      Method(o.HTTP),
+		Proxy:       o.HTTP.ProxyURL,
 		RootMixin:   common.NewRootMixin(nil),
 	}
 }

--- a/internal/generator/vector/output/http/http_test.go
+++ b/internal/generator/vector/output/http/http_test.go
@@ -144,6 +144,11 @@ var _ = Describe("Generate vector config", func() {
 					BaseOutputTuningSpec: *baseTune,
 				}
 			}, secrets, true, framework.NoOptions, "http_with_tuning.toml"),
+			Entry("with proxy", func(spec *obs.OutputSpec) {
+				spec.HTTP.ProxyURL = "http://somewhere.org/proxy"
+				spec.HTTP.Headers = nil
+				spec.HTTP.Authentication = nil
+			}, secrets, true, framework.NoOptions, "http_with_proxy.toml"),
 		)
 	})
 

--- a/internal/generator/vector/output/http/http_with_proxy.toml
+++ b/internal/generator/vector/output/http/http_with_proxy.toml
@@ -1,0 +1,12 @@
+[sinks.http_receiver]
+type = "http"
+inputs = ["application"]
+uri = "https://my-logstore.com"
+method = "post"
+proxy.enabled = true
+proxy.http = "http://somewhere.org/proxy"
+proxy.https = "http://somewhere.org/proxy"
+
+[sinks.http_receiver.encoding]
+codec = "json"
+except_fields = ["_internal"]


### PR DESCRIPTION
-------

### Description

Add a 'proxy' field to HTTP output configuration to enable use of a proxy.e! -->

/cc @jcantrill
/assign @jcantrill

### Links
- JIRA: [LOG-6069](https://issues.redhat.com//browse/LOG-6069)