### PR TITLE
LOG-6072: Increase default collector memory limit

### DIFF
--- a/internal/api/initialize/init_resources.go
+++ b/internal/api/initialize/init_resources.go
@@ -13,7 +13,7 @@ var (
 
 	DefaultRequestMemory = resource.MustParse("64Mi")
 	DefaultRequestCpu    = resource.MustParse("500m")
-	DefaultLimitMemory   = resource.MustParse("1024Mi")
+	DefaultLimitMemory   = resource.MustParse("2048Mi")
 	DefaultLimitCpu      = resource.MustParse("6000m")
 )
 

--- a/internal/api/initialize/init_resources_test.go
+++ b/internal/api/initialize/init_resources_test.go
@@ -14,7 +14,7 @@ var _ = Describe("#Resources", func() {
 		forwarder    obs.ClusterLogForwarder
 		expResources = &v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				v1.ResourceMemory: resource.MustParse("1024Mi"),
+				v1.ResourceMemory: resource.MustParse("2048Mi"),
 				v1.ResourceCPU:    resource.MustParse("6000m"),
 			},
 			Requests: v1.ResourceList{
@@ -42,7 +42,7 @@ var _ = Describe("#Resources", func() {
 	It("should apply the spec'd resources when defined", func() {
 		resources := &v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				v1.ResourceMemory: resource.MustParse("1024Mi"),
+				v1.ResourceMemory: resource.MustParse("2048Mi"),
 				v1.ResourceCPU:    resource.MustParse("6000m"),
 			},
 			Requests: v1.ResourceList{


### PR DESCRIPTION
### Description
We've had a few reports of OOM issues during testing of pre-release 6.0, mainly lokistack and the new otlp output (all log_types).    Best solution, we've decided to double the memory limit only, while leaving the other defaults alone.    We need more feedback and possibly add otlp to benchmark functional tests.

One other option we can explore before GA is modifying the group_by MaxEvents in the otlp output. (and possibly allowing it to be configurable)

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- https://issues.redhat.com/browse/LOG-6072
