### PR TITLE
LOG-6103: Adapt support statements for 4.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ coverage: test-unit
 test-cluster:
 	go test  -cover -race ./test/... -- -root=$(CURDIR)
 
-OPENSHIFT_VERSIONS?="v4.12-v4.16"
+OPENSHIFT_VERSIONS?="v4.12-v4.17"
 # Generate bundle manifests and metadata, then validate generated files.
 BUNDLE_VERSION?=$(VERSION)
 CHANNEL=$(or $(filename $(OVERLAY)),stable)

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -16,7 +16,7 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.12-v4.16"
+LABEL com.redhat.openshift.versions="v4.12-v4.17"
 
 LABEL \
     com.redhat.component="cluster-logging-operator" \

--- a/bundle/manifests/cluster-logging-operator_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/cluster-logging-operator_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cluster-logging-operator
+spec:
+  groups:
+  - name: cluster_logging_operator.alerts
+    rules:
+    - alert: RedHatOpenShiftLoggingRemovalWarning
+      annotations:
+        message: Red Hat OpenShift Logging 5.8 will be removed from the catalog on
+          November 2025.
+        summary: Red Hat OpenShift Logging 5.8 is supported on OCP 4.16 and 4.17 to
+          help customers upgrade and migrate to Red Hat OpenShift Logging 6.0.  Logging
+          5.8 will be End of Life in November 2025. At that time, it will no longer
+          be available or supported.
+      expr: |
+        last_over_time((max by(version) (csv_succeeded{exported_namespace="openshift-logging", name=~"clusterlogging.*", version=~"5.8.*"}) * on() group_left() group(cluster_version{version=~"4.1[6-9].*", type="current"}))[5m:]) > 0
+      for: 1m
+      labels:
+        namespace: openshift-logging
+        severity: warning

--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -118,7 +118,7 @@ metadata:
     certified: "false"
     console.openshift.io/plugins: '["logging-view-plugin"]'
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-05-03T19:44:05Z"
+    createdAt: "2024-09-19T19:40:21Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing your aggregated logging stack.
     features.operators.openshift.io/cnf: "false"
@@ -410,6 +410,10 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:logFileMetricsExporterConditions
       version: v1alpha1
   description: |-
+    ### Notice for OCP 4.16 and 4.17 Only
+
+    Logging 5.8 is supported on OCP 4.16 and 4.17 to help customers upgrade and migrate to Logging 6.0. **Logging 5.8 will be End of Life in November 2025.**  At that time, it will no longer be available or supported.
+
     # Red Hat OpenShift Logging
     The Red Hat OpenShift Logging Operator orchestrates and manages the aggregated logging stack as a cluster-wide service.
 

--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.16
+    value: 4.17

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -298,6 +298,10 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:logFileMetricsExporterConditions
       version: v1alpha1
   description: |-
+    ### Notice for OCP 4.16 and 4.17 Only
+
+    Logging 5.8 is supported on OCP 4.16 and 4.17 to help customers upgrade and migrate to Logging 6.0. **Logging 5.8 will be End of Life in November 2025.**  At that time, it will no longer be available or supported.
+
     # Red Hat OpenShift Logging
     The Red Hat OpenShift Logging Operator orchestrates and manages the aggregated logging stack as a cluster-wide service.
 

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
 - servicemonitor.yaml
 - service.yaml
 - collector_alerts.yaml
+- operator_alerts.yaml

--- a/config/prometheus/operator_alerts.yaml
+++ b/config/prometheus/operator_alerts.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cluster-logging-operator
+  namespace: openshift-logging
+spec:
+  groups:
+  - name: cluster_logging_operator.alerts
+    rules:
+    - alert: RedHatOpenShiftLoggingRemovalWarning
+      annotations:
+        message: "Red Hat OpenShift Logging 5.8 will be removed from the catalog on November 2025."
+        summary: "Red Hat OpenShift Logging 5.8 is supported on OCP 4.16 and 4.17 to help customers upgrade and migrate to Red Hat OpenShift Logging 6.0.  Logging 5.8 will be End of Life in November 2025. At that time, it will no longer be available or supported."
+      expr: |
+        last_over_time((max by(version) (csv_succeeded{exported_namespace="openshift-logging", name=~"clusterlogging.*", version=~"5.8.*"}) * on() group_left() group(cluster_version{version=~"4.1[6-9].*", type="current"}))[5m:]) > 0
+      for: 1m
+      labels:
+        namespace: openshift-logging
+        severity: warning


### PR DESCRIPTION
### Description

- Add notice on the operator install view to inform users on OCP 4.17 that the 5.8 operator version will be removed from the catalog on November 2025.
- Add alert informing users about the removal.

**Operator Install Page**

![image](https://github.com/user-attachments/assets/97e391eb-1533-4b19-ae5a-dbf290e18c7b)

**Alerts**

![image](https://github.com/user-attachments/assets/19d03394-44c3-4fff-b6a1-ffd7e4c8b095)

![image](https://github.com/user-attachments/assets/a1f9ea1d-b6a0-49db-b83c-212761843e59)

/cc @jcantrill 
