### PR TITLE
LOG-6128: Fix console plugin api version

### DIFF
--- a/internal/k8shandler/visualization_test.go
+++ b/internal/k8shandler/visualization_test.go
@@ -78,7 +78,7 @@ func TestConsolePluginIsCreatedAndDeleted(t *testing.T) {
 			Kibana: &logging.KibanaSpec{},
 		},
 	}
-	r := console.NewReconciler(c, console.NewConfig(cl, "some-loki-stack-gateway-http", constants.Korrel8rNamespace, constants.Korrel8rName, []string{}), nil)
+	r := console.NewReconciler(c, console.NewConfig(cl, "some-loki-stack-gateway-http", constants.Korrel8rNamespace, constants.Korrel8rName, []string{}, cr.ClusterVersion), nil)
 	cp := &consolev1alpha1.ConsolePlugin{}
 
 	deploymentNSName := types.NamespacedName{Name: r.Name, Namespace: r.Namespace()}
@@ -124,7 +124,7 @@ func TestConsolePluginIsCreatedAndDeleted_WithoutLokiStack(t *testing.T) {
 			Type: logging.VisualizationTypeOCPConsole,
 		},
 	}
-	r := console.NewReconciler(c, console.NewConfig(cl, "some-loki-stack-gateway-http", constants.Korrel8rNamespace, constants.Korrel8rName, []string{}), nil)
+	r := console.NewReconciler(c, console.NewConfig(cl, "some-loki-stack-gateway-http", constants.Korrel8rNamespace, constants.Korrel8rName, []string{}, cr.ClusterVersion), nil)
 	cp := &consolev1alpha1.ConsolePlugin{}
 
 	t.Run("create", func(t *testing.T) {
@@ -166,7 +166,7 @@ func TestConsolePluginIsCreatedAndDeleted_WithoutKorrel8rPreview(t *testing.T) {
 			Kibana: &logging.KibanaSpec{},
 		},
 	}
-	r := console.NewReconciler(c, console.NewConfig(cl, "some-loki-stack-gateway-http", constants.Korrel8rNamespace, constants.Korrel8rName, []string{}), nil)
+	r := console.NewReconciler(c, console.NewConfig(cl, "some-loki-stack-gateway-http", constants.Korrel8rNamespace, constants.Korrel8rName, []string{}, cr.ClusterVersion), nil)
 	cp := &consolev1alpha1.ConsolePlugin{}
 
 	t.Run("create", func(t *testing.T) {
@@ -215,7 +215,7 @@ func TestConsolePluginIsCreatedAndDeleted_WithCustomNodeSelectorAndToleration(t 
 			},
 		},
 	}
-	r := console.NewReconciler(c, console.NewConfig(cl, "some-loki-stack-gateway-http", constants.Korrel8rNamespace, constants.Korrel8rName, []string{}), cl.Spec.Visualization)
+	r := console.NewReconciler(c, console.NewConfig(cl, "some-loki-stack-gateway-http", constants.Korrel8rNamespace, constants.Korrel8rName, []string{}, cr.ClusterVersion), cl.Spec.Visualization)
 	cp := &consolev1alpha1.ConsolePlugin{}
 
 	deploymentNSName := types.NamespacedName{Name: r.Name, Namespace: r.Namespace()}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -15,6 +15,7 @@ import (
 	log "github.com/ViaQ/logerr/v2/log/static"
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"golang.org/x/mod/semver"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -392,4 +393,17 @@ func GetCollectorName(collectorType logging.LogCollectionType) string {
 		return constants.VectorName
 	}
 	return "unknown"
+}
+
+func IsVersionAheadOrEqual(currentVersion, version string) bool {
+	if !strings.HasPrefix(currentVersion, "v") {
+		currentVersion = "v" + currentVersion
+	}
+	if version == "" {
+		return false
+	}
+
+	canonicalMinVersion := fmt.Sprintf("%s-0", semver.Canonical(version))
+
+	return semver.Compare(currentVersion, canonicalMinVersion) >= 0
 }

--- a/internal/visualization/console/config.go
+++ b/internal/visualization/console/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Korrel8rNamespace string        // Namespace of korrel8r service.
 	Korrel8rPort      int32         // Port of the Korrel8r service.
 	Features          []string      // The features enabled for the plugin
+	ClusterVersion    string        // The cluster version
 }
 
 func (cf *Config) Namespace() string        { return cf.Owner.GetNamespace() }
@@ -30,7 +31,7 @@ func (cf *Config) defaultMode() *int32      { return utils.GetPtr[int32](420) }
 func (cf *Config) pluginBackendPort() int32 { return 9443 }
 
 // NewConfig returns a config with default settings.
-func NewConfig(owner client.Object, lokiService, korrel8rName, korrel8rNS string, features []string) Config {
+func NewConfig(owner client.Object, lokiService, korrel8rName, korrel8rNS string, features []string, clusterVersion string) Config {
 	return Config{
 		Owner:             owner,
 		Name:              Name,
@@ -41,5 +42,6 @@ func NewConfig(owner client.Object, lokiService, korrel8rName, korrel8rNS string
 		Korrel8rNamespace: korrel8rNS,
 		Korrel8rPort:      8443,
 		Features:          features,
+		ClusterVersion:    clusterVersion,
 	}
 }

--- a/internal/visualization/console/plugin.go
+++ b/internal/visualization/console/plugin.go
@@ -19,7 +19,7 @@ func ReconcilePlugin(k8sClient client.Client, cl *logging.ClusterLogging, owner 
 	if cl != nil && cl.Spec.Visualization != nil {
 		visSpec = cl.Spec.Visualization
 	}
-	r := NewReconciler(k8sClient, NewConfig(owner, lokiService, korrel8rNN.Name, korrel8rNN.Namespace, FeaturesForOCP(clusterVersion)), visSpec)
+	r := NewReconciler(k8sClient, NewConfig(owner, lokiService, korrel8rNN.Name, korrel8rNN.Namespace, FeaturesForOCP(clusterVersion), clusterVersion), visSpec)
 	if lokiService != "" {
 		log.V(3).Info("Enabling logging console plugin", "created-by", r.CreatedBy(), "loki-service", lokiService)
 		return r.Reconcile(context.TODO())

--- a/internal/visualization/console/reconciler_test.go
+++ b/internal/visualization/console/reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	consolev1 "github.com/openshift/api/console/v1"
 	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
@@ -23,9 +24,9 @@ func fakeClient() client.Client { return fake.NewClientBuilder().WithScheme(sche
 var ctx = context.Background()
 
 // assertConfig asserts that the Reconciler config matches the cluster state.
-func assertConfig(t *testing.T, r *Reconciler) {
+func assertLegacyConfig(t *testing.T, r *Reconciler) {
 	c := r.c
-	cp := &r.consolePlugin
+	cp := &r.legacyConsolePlugin
 	if assert.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(cp), cp)) {
 		assert.Equal(t, r.Name, cp.Name)
 		assert.Equal(t, r.Name, cp.Spec.Service.Name)
@@ -35,6 +36,45 @@ func assertConfig(t *testing.T, r *Reconciler) {
 		assert.Equal(t, r.LokiPort, cp.Spec.Proxy[0].Service.Port)
 		assert.Equal(t, r.Korrel8rName, cp.Spec.Proxy[1].Service.Name)
 		assert.Equal(t, r.Korrel8rPort, cp.Spec.Proxy[1].Service.Port)
+		assert.Equal(t, r.CreatedBy(), cp.Labels[constants.LabelK8sCreatedBy])
+	}
+
+	d := &r.deployment
+	if assert.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(d), d)) {
+		assert.Equal(t, r.Image, d.Spec.Template.Spec.Containers[0].Image)
+	}
+
+	for _, o := range []client.Object{&r.deployment, &r.service, &r.configMap} {
+		o := o
+		kind := o.GetObjectKind().GroupVersionKind().Kind
+		require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(o), o), kind)
+		if assert.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(o), o), kind) {
+			assert.Equal(t, r.Namespace(), o.GetNamespace(), kind)
+			assert.Equal(t, r.CreatedBy(), o.GetLabels()[constants.LabelK8sCreatedBy])
+			if assert.Len(t, o.GetOwnerReferences(), 1, kind) {
+				oref := o.GetOwnerReferences()[0]
+				assert.Equal(t, oref.Name, r.Owner.GetName(), kind)
+				assert.Equal(t, oref.Kind, "ClusterLogging", kind)
+				require.NotNil(t, oref.Controller, kind)
+				assert.True(t, *oref.Controller, kind)
+			}
+		}
+
+	}
+}
+
+func assertConfig(t *testing.T, r *Reconciler) {
+	c := r.c
+	cp := &r.consolePlugin
+	if assert.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(cp), cp)) {
+		assert.Equal(t, r.Name, cp.Name)
+		assert.Equal(t, r.Name, cp.Spec.Backend.Service.Name)
+
+		assert.Equal(t, r.Namespace(), cp.Spec.Backend.Service.Namespace)
+		assert.Equal(t, r.LokiService, cp.Spec.Proxy[0].Endpoint.Service.Name)
+		assert.Equal(t, r.LokiPort, cp.Spec.Proxy[0].Endpoint.Service.Port)
+		assert.Equal(t, r.Korrel8rName, cp.Spec.Proxy[1].Endpoint.Service.Name)
+		assert.Equal(t, r.Korrel8rPort, cp.Spec.Proxy[1].Endpoint.Service.Port)
 		assert.Equal(t, r.CreatedBy(), cp.Labels[constants.LabelK8sCreatedBy])
 	}
 
@@ -73,9 +113,9 @@ func assertNotFound(t *testing.T, r *Reconciler) {
 	}))
 }
 
-func TestVerifyResources(t *testing.T) {
+func TestVerifyLegacyResources(t *testing.T) {
 	c := fakeClient()
-	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "someservice", "korrel8rSvc", "korrel8rNS", []string{}), nil)
+	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "someservice", "korrel8rSvc", "korrel8rNS", []string{}, "v4.16"), nil)
 	assert.NoError(t, r.Reconcile(ctx))
 	assert.NoError(t, r.each(func(m mutable) error {
 		kind := m.o.GetObjectKind().GroupVersionKind().String()
@@ -87,7 +127,90 @@ func TestVerifyResources(t *testing.T) {
 			assert.Equal(t, r.CreatedBy(), m.o.GetLabels()[constants.LabelK8sCreatedBy])
 			if m.o.GetObjectKind().GroupVersionKind().Kind == "ConsolePlugin" {
 				assert.Empty(t, m.o.GetNamespace())
-				cp := &r.consolePlugin
+				cp := &r.legacyConsolePlugin
+				assert.Equal(t, consolev1alpha1.ConsolePluginService{
+					Name:      name,
+					Namespace: r.Namespace(),
+					BasePath:  "/",
+					Port:      r.pluginBackendPort(),
+				}, cp.Spec.Service)
+				assert.Equal(t, []consolev1alpha1.ConsolePluginProxy{
+					{
+						Type:      "Service",
+						Alias:     "backend",
+						Authorize: true,
+						Service: consolev1alpha1.ConsolePluginProxyServiceConfig{
+							Name:      "someservice",
+							Namespace: "openshift-logging",
+							Port:      8080,
+						},
+					},
+					{
+						Type:      "Service",
+						Alias:     "korrel8rSvc",
+						Authorize: false,
+						Service: consolev1alpha1.ConsolePluginProxyServiceConfig{
+							Name:      "korrel8rSvc",
+							Namespace: "korrel8rNS",
+							Port:      8443,
+						},
+					},
+				}, cp.Spec.Proxy)
+
+			} else {
+				assert.Equal(t, "openshift-logging", m.o.GetNamespace())
+			}
+		})
+		return nil
+	}))
+}
+
+func TestReconcileCreatesLegacyObjects(t *testing.T) {
+	c := fakeClient()
+	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "myLoki", "myKorrel8r", "myKorrel8rNS", []string{}, "v4.16"), nil)
+	require.NoError(t, r.Reconcile(ctx))
+	assertLegacyConfig(t, r)
+}
+
+func TestReconcileUpdatesLegacyObjects(t *testing.T) {
+	c := fakeClient()
+	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "myLoki", "myKorrel8r", "myKorrel8rNS", []string{}, "v4.16"), nil)
+	require.NoError(t, r.Reconcile(ctx)) // Create objects
+	assertLegacyConfig(t, r)
+
+	// Modify configuration
+	r.Image = "newimage"
+	r.LokiService = "newloki"
+	r.LokiPort = 42
+	require.NoError(t, r.Reconcile(ctx)) // Create objects
+	assertLegacyConfig(t, r)
+}
+
+func TestReconcilerDeletesLegacyObjects(t *testing.T) {
+	c := fakeClient()
+	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "myLoki", "myKorrel8r", "myKorrel8rNS", []string{}, "v4.16"), nil)
+	require.NoError(t, r.Reconcile(ctx)) // Create objects
+	assertLegacyConfig(t, r)
+
+	require.NoError(t, r.Delete(ctx))
+	assertNotFound(t, r)
+}
+
+func TestPreviewKorrel8rFeatureGate(t *testing.T) {
+	c := fakeClient()
+	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "someservice", "korrel8rSvc", "korrel8rNS", []string{}, "v4.16"), nil)
+	assert.NoError(t, r.Reconcile(ctx))
+	assert.NoError(t, r.each(func(m mutable) error {
+		kind := m.o.GetObjectKind().GroupVersionKind().String()
+		t.Run("verify resource values "+kind, func(t *testing.T) {
+			name := m.o.GetName()
+			assert.Equal(t, "logging-view-plugin", name)
+			assert.Equal(t, name, m.o.GetLabels()[constants.LabelApp])
+			assert.Equal(t, name, m.o.GetLabels()[constants.LabelK8sName])
+			assert.Equal(t, r.CreatedBy(), m.o.GetLabels()[constants.LabelK8sCreatedBy])
+			if m.o.GetObjectKind().GroupVersionKind().Kind == "ConsolePlugin" {
+				assert.Empty(t, m.o.GetNamespace())
+				cp := &r.legacyConsolePlugin
 				assert.Equal(t, consolev1alpha1.ConsolePluginService{
 					Name:      name,
 					Namespace: r.Namespace(),
@@ -127,14 +250,14 @@ func TestVerifyResources(t *testing.T) {
 
 func TestReconcileCreatesObjects(t *testing.T) {
 	c := fakeClient()
-	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "myLoki", "myKorrel8r", "myKorrel8rNS", []string{}), nil)
+	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "myLoki", "myKorrel8r", "myKorrel8rNS", []string{}, "v4.17"), nil)
 	require.NoError(t, r.Reconcile(ctx))
 	assertConfig(t, r)
 }
 
 func TestReconcileUpdatesObjects(t *testing.T) {
 	c := fakeClient()
-	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "myLoki", "myKorrel8r", "myKorrel8rNS", []string{}), nil)
+	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "myLoki", "myKorrel8r", "myKorrel8rNS", []string{}, "v4.17"), nil)
 	require.NoError(t, r.Reconcile(ctx)) // Create objects
 	assertConfig(t, r)
 
@@ -148,7 +271,7 @@ func TestReconcileUpdatesObjects(t *testing.T) {
 
 func TestReconcilerDeletesObjects(t *testing.T) {
 	c := fakeClient()
-	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "myLoki", "myKorrel8r", "myKorrel8rNS", []string{}), nil)
+	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "myLoki", "myKorrel8r", "myKorrel8rNS", []string{}, "v4.17"), nil)
 	require.NoError(t, r.Reconcile(ctx)) // Create objects
 	assertConfig(t, r)
 
@@ -156,9 +279,9 @@ func TestReconcilerDeletesObjects(t *testing.T) {
 	assertNotFound(t, r)
 }
 
-func TestPreviewKorrel8rFeatureGate(t *testing.T) {
+func TestVerifyResources(t *testing.T) {
 	c := fakeClient()
-	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "someservice", "korrel8rSvc", "korrel8rNS", []string{}), nil)
+	r := NewReconciler(c, NewConfig(runtime.NewClusterLogging(), "someservice", "korrel8rSvc", "korrel8rNS", []string{}, "v4.17"), nil)
 	assert.NoError(t, r.Reconcile(ctx))
 	assert.NoError(t, r.each(func(m mutable) error {
 		kind := m.o.GetObjectKind().GroupVersionKind().String()
@@ -171,31 +294,35 @@ func TestPreviewKorrel8rFeatureGate(t *testing.T) {
 			if m.o.GetObjectKind().GroupVersionKind().Kind == "ConsolePlugin" {
 				assert.Empty(t, m.o.GetNamespace())
 				cp := &r.consolePlugin
-				assert.Equal(t, consolev1alpha1.ConsolePluginService{
+				assert.Equal(t, consolev1.ConsolePluginService{
 					Name:      name,
 					Namespace: r.Namespace(),
 					BasePath:  "/",
 					Port:      r.pluginBackendPort(),
-				}, cp.Spec.Service)
-				assert.Equal(t, []consolev1alpha1.ConsolePluginProxy{
+				}, cp.Spec.Backend.Service)
+				assert.Equal(t, []consolev1.ConsolePluginProxy{
 					{
-						Type:      "Service",
-						Alias:     "backend",
-						Authorize: true,
-						Service: consolev1alpha1.ConsolePluginProxyServiceConfig{
-							Name:      "someservice",
-							Namespace: "openshift-logging",
-							Port:      8080,
+						Alias:         "backend",
+						Authorization: "UserToken",
+						Endpoint: consolev1.ConsolePluginProxyEndpoint{
+							Type: consolev1.ProxyTypeService,
+							Service: &consolev1.ConsolePluginProxyServiceConfig{
+								Name:      "someservice",
+								Namespace: "openshift-logging",
+								Port:      8080,
+							},
 						},
 					},
 					{
-						Type:      "Service",
-						Alias:     "korrel8rSvc",
-						Authorize: false,
-						Service: consolev1alpha1.ConsolePluginProxyServiceConfig{
-							Name:      "korrel8rSvc",
-							Namespace: "korrel8rNS",
-							Port:      8443,
+						Alias:         "korrel8rSvc",
+						Authorization: "UserToken",
+						Endpoint: consolev1.ConsolePluginProxyEndpoint{
+							Type: consolev1.ProxyTypeService,
+							Service: &consolev1.ConsolePluginProxyServiceConfig{
+								Name:      "korrel8rSvc",
+								Namespace: "korrel8rNS",
+								Port:      8443,
+							},
 						},
 					},
 				}, cp.Spec.Proxy)

--- a/test/e2e/consoleplugin/smoke_test/consoleplugin_test.go
+++ b/test/e2e/consoleplugin/smoke_test/consoleplugin_test.go
@@ -53,7 +53,7 @@ var _ = Describe("[ConsolePlugin]", func() {
 		c = client.NewTest()
 		r = console.NewReconciler(
 			c.ControllerRuntimeClient(),
-			console.NewConfig(testruntime.NewClusterLogging(), "lokiService", "korrel8r", "korrel8r", []string{}), nil)
+			console.NewConfig(testruntime.NewClusterLogging(), "lokiService", "korrel8r", "korrel8r", []string{}, "v4.16"), nil)
 		cleanup() // Clear out objects left behind by previous tests.
 	})
 


### PR DESCRIPTION
### Description
From OCP v4.17+, the ConsolePlugin v1alpha1 was deprecated in favor of ConsolePlugin v1. This causes the logging plugin to fail during reconciliation as the new version of the spec needs for 4.17+. This PR adds support for ConsolePlugin v1 when the operator is running on clusters with v4.17+

This is targeted directly to the 5.9 branch as 6.0 (master) has removed the console plugin

/cc @jcantrill  
/assign @alanconway 

### Links
- JIRA: [LOG-6128](https://issues.redhat.com/browse/LOG-6128)
