### PR TITLE
LOG-6085: Enable CLF spec'd to write to LokiStack using OTEL semantics

### DIFF
--- a/api/observability/v1/conditions.go
+++ b/api/observability/v1/conditions.go
@@ -56,6 +56,9 @@ const (
 	// ConditionTypeValidFilterPrefix prefixes a named filter to identify its validation state
 	ConditionTypeValidFilterPrefix = GroupName + "/ValidFilter"
 
+	// ConditionTypeValidLokistackOTLPOutputs identifies the validity of the lokistack OTLP outputs
+	ConditionTypeValidLokistackOTLPOutputs = GroupName + "/ValidLokistackOTLPOutputs"
+
 	// ReasonClusterRolesExist means the collector serviceAccount is bound to all the cluster roles needed to collect a log_type
 	ReasonClusterRolesExist = "ClusterRolesExist"
 

--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -748,6 +748,8 @@ type LokiStackAuthentication struct {
 }
 
 // LokiStack provides optional extra properties for `type: lokistack`
+// +kubebuilder:validation:XValidation:rule="!has(self.labelKeys) || !has(self.dataModel) || self.dataModel == 'Viaq'", message="'labelKeys' cannot be set when data model is 'Otel'"
+// +kubebuilder:validation:XValidation:rule="!has(self.tuning) || self.tuning.compression != 'snappy' || !has(self.dataModel) || self.dataModel == 'Viaq'", message="'snappy' compression cannot be used when data model is 'Otel'"
 type LokiStack struct {
 	// Authentication sets credentials for authenticating the requests.
 	//
@@ -790,6 +792,19 @@ type LokiStack struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Stream Label Configuration"
 	LabelKeys *LokiStackLabelKeys `json:"labelKeys,omitempty"`
+
+	// DataModel can be used to customize how log data is stored in LokiStack.
+	//
+	// There are two different models to choose from:
+	//
+	//  - Viaq
+	//  - Otel
+	//
+	// When the data model is not set, it currently defaults to the "Viaq" data model.
+	//
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Data Model"
+	DataModel LokiStackDataModel `json:"dataModel,omitempty"`
 }
 
 // LokiStackLabelKeys contains the configuration that maps log record's keys to Loki labels used to identify streams.
@@ -850,6 +865,19 @@ type LokiStackTenantLabelKeys struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Label Keys"
 	LabelKeys []string `json:"labelKeys,omitempty"`
 }
+
+// LokiStackDataModel selects which data model is used to send and store the log data.
+//
+// +kubebuilder:validation:Enum:=Viaq;Otel
+type LokiStackDataModel string
+
+const (
+	// LokiStackDataModelViaq selects the ViaQ data model for the LokiStack output.
+	LokiStackDataModelViaq LokiStackDataModel = "Viaq"
+	// LokiStackDataModelOpenTelemetry selects a data model based on the OpenTelemetry semantic conventions
+	// and uses OTLP as transport.
+	LokiStackDataModelOpenTelemetry LokiStackDataModel = "Otel"
+)
 
 // Loki provides optional extra properties for `type: loki`
 type Loki struct {

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-09-30T19:29:31Z"
+    createdAt: "2024-10-08T19:52:45Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -999,6 +999,12 @@ spec:
         path: outputs[0].lokiStack.authentication.token.secret.name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "DataModel can be used to customize how log data is stored in
+          LokiStack. \n There are two different models to choose from: \n - Viaq -
+          Otel \n When the data model is not set, it currently defaults to the \"Viaq\"
+          data model."
+        displayName: Data Model
+        path: outputs[0].lokiStack.dataModel
       - description: "LabelKeys can be used to customize which log record keys are
           mapped to Loki stream labels. \n Note: Loki label names must match the regular
           expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\" Log record keys may contain characters

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1786,6 +1786,16 @@ spec:
                           required:
                           - token
                           type: object
+                        dataModel:
+                          description: "DataModel can be used to customize how log
+                            data is stored in LokiStack. \n There are two different
+                            models to choose from: \n - Viaq - Otel \n When the data
+                            model is not set, it currently defaults to the \"Viaq\"
+                            data model."
+                          enum:
+                          - Viaq
+                          - Otel
+                          type: string
                         labelKeys:
                           description: "LabelKeys can be used to customize which log
                             record keys are mapped to Loki stream labels. \n Note:
@@ -1928,6 +1938,14 @@ spec:
                       - authentication
                       - target
                       type: object
+                      x-kubernetes-validations:
+                      - message: '''labelKeys'' cannot be set when data model is ''Otel'''
+                        rule: '!has(self.labelKeys) || !has(self.dataModel) || self.dataModel
+                          == ''Viaq'''
+                      - message: '''snappy'' compression cannot be used when data
+                          model is ''Otel'''
+                        rule: '!has(self.tuning) || self.tuning.compression != ''snappy''
+                          || !has(self.dataModel) || self.dataModel == ''Viaq'''
                     name:
                       description: Name used to refer to the output from a `pipeline`.
                       pattern: ^[a-z][a-z0-9-]*[a-z0-9]$

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1787,6 +1787,16 @@ spec:
                           required:
                           - token
                           type: object
+                        dataModel:
+                          description: "DataModel can be used to customize how log
+                            data is stored in LokiStack. \n There are two different
+                            models to choose from: \n - Viaq - Otel \n When the data
+                            model is not set, it currently defaults to the \"Viaq\"
+                            data model."
+                          enum:
+                          - Viaq
+                          - Otel
+                          type: string
                         labelKeys:
                           description: "LabelKeys can be used to customize which log
                             record keys are mapped to Loki stream labels. \n Note:
@@ -1929,6 +1939,14 @@ spec:
                       - authentication
                       - target
                       type: object
+                      x-kubernetes-validations:
+                      - message: '''labelKeys'' cannot be set when data model is ''Otel'''
+                        rule: '!has(self.labelKeys) || !has(self.dataModel) || self.dataModel
+                          == ''Viaq'''
+                      - message: '''snappy'' compression cannot be used when data
+                          model is ''Otel'''
+                        rule: '!has(self.tuning) || self.tuning.compression != ''snappy''
+                          || !has(self.dataModel) || self.dataModel == ''Viaq'''
                     name:
                       description: Name used to refer to the output from a `pipeline`.
                       pattern: ^[a-z][a-z0-9-]*[a-z0-9]$

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -922,6 +922,12 @@ spec:
         path: outputs[0].lokiStack.authentication.token.secret.name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
+      - description: "DataModel can be used to customize how log data is stored in
+          LokiStack. \n There are two different models to choose from: \n - Viaq -
+          Otel \n When the data model is not set, it currently defaults to the \"Viaq\"
+          data model."
+        displayName: Data Model
+        path: outputs[0].lokiStack.dataModel
       - description: "LabelKeys can be used to customize which log record keys are
           mapped to Loki stream labels. \n Note: Loki label names must match the regular
           expression \"[a-zA-Z_:][a-zA-Z0-9_:]*\" Log record keys may contain characters

--- a/docs/features/logforwarding/outputs/redhat-managed-lokistack.adoc
+++ b/docs/features/logforwarding/outputs/redhat-managed-lokistack.adoc
@@ -1,0 +1,64 @@
+= Red Hat Managed Lokistack
+
+This guide provides configuration instructions for setting up the `ClusterLogForwarder` spec to send logs to a Red Hat managed Lokistack in either the `Viaq` or `Otel (through OTLP)` data model.
+
+See `otlp-forwarding.adoc` for more information about the `Viaq` -> `Otel` data mapping as well as resources for the `OpenTelemetry OTLP Specifications`.
+
+.Technical Preview
+This feature is currently in tech-preview and an annotation is required
+
+`observability.openshift.io/tech-preview-otlp-output: "enabled"`
+
+---
+== Configuring the Forwarder
+
+.ClusterLogForwarder
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: my-logforwarder
+  namespace: my-app-namespace
+  annotations:
+    observability.openshift.io/tech-preview-otlp-output: "enabled" <1>
+spec:
+  outputs:
+    - type: lokistack  <2>
+      name: loki-otlp
+      lokiStack:
+        target:
+          name: my-lokistack <3>
+          namespace: openshift-logging <3>
+        dataModel: Otel <4>
+        tuning:
+          compression: none  <5>
+        authentication:
+          token:
+            from: serviceAccount  <6>
+      tls: 
+        ca:
+          key: service-ca.crt <7>
+          configMapName: openshift-service-ca.crt <7>
+  pipelines:
+   - name: my-pipeline
+     inputRefs:
+     - application
+     - infrastructure
+     outputRefs:
+     - loki-otlp
+  serviceAccount:
+    name: logger-admin
+----
+. The tech preview annotation required to enable `Otel` output.
+. Output `type` is '*lokistack*'.
+. `lokiStack` `target`, specify a valid `lokistack` instance in the appropriate namespace.
+. `lokiStack` `dataModel` is optional but `Viaq` or `Otel` can also be specified. If omitted, will default to `Viaq`.
+. `lokiStack` `tuning` `compression` is optional but can specify one of `none` or `gzip`.
+. `lokiStack` `authentication` specifies a `token` `from` and a value of "*serviceAccount*"
+.. The token can also be read from a secret
+.. Also available with `username` and `password` authentication spec (refer to HTTP Auth Specification for full scope)
+. `tls` spec identifies the keys and secret to the respective certificates that they represent.
+
+[NOTE]
+`lokistack` `labeKeys` cannot be used when `dataModel` is `Otel`. 

--- a/internal/api/observability/forwarder.go
+++ b/internal/api/observability/forwarder.go
@@ -1,10 +1,11 @@
 package observability
 
 import (
+	"strings"
+
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 // NameList provides a list of names for any resource implementing Names
@@ -31,6 +32,18 @@ func IsValid(forwarder obs.ClusterLogForwarder) bool {
 		isValid(obs.ConditionTypeValidOutputPrefix, status.OutputConditions, len(forwarder.Spec.Outputs)) &&
 		isValid(obs.ConditionTypeValidPipelinePrefix, status.PipelineConditions, len(forwarder.Spec.Pipelines)) &&
 		isValid(obs.ConditionTypeValidFilterPrefix, status.FilterConditions, len(forwarder.Spec.Filters))
+}
+
+func IsValidLokistackOTLPAnnotation(forwarder obs.ClusterLogForwarder) bool {
+	// Check if lokistacks designated to receive OTEL data has the OTEL tp annotation
+	validOutputs := true
+	for _, cond := range forwarder.Status.Conditions {
+		if cond.Type == obs.ConditionTypeValidLokistackOTLPOutputs && cond.Status == obs.ConditionFalse {
+			validOutputs = false
+		}
+	}
+
+	return validOutputs
 }
 
 func isValid(prefix string, conditions []metav1.Condition, expConditions int) bool {

--- a/internal/api/observability/forwarder_test.go
+++ b/internal/api/observability/forwarder_test.go
@@ -113,4 +113,33 @@ var _ = Describe("[internal][api][observability]", func() {
 			})
 		})
 	})
+
+	Context("#IsValidLokistackOTLPAnnotation", func() {
+		var (
+			forwarder obs.ClusterLogForwarder
+		)
+		BeforeEach(func() {
+			forwarder = obs.ClusterLogForwarder{
+				Spec: obs.ClusterLogForwarderSpec{
+					Outputs: []obs.OutputSpec{{}},
+				},
+				Status: obs.ClusterLogForwarderStatus{
+					Conditions: []metav1.Condition{
+						NewCondition(obs.ConditionTypeValidLokistackOTLPOutputs, obs.ConditionTrue, "", ""),
+					},
+				},
+			}
+		})
+
+		It("should be true when lokistack OTLP outputs are valid", func() {
+			Expect(IsValidLokistackOTLPAnnotation(forwarder)).To(BeTrue())
+		})
+
+		It("should be false when output is invalid", func() {
+			forwarder.Status.Conditions = []metav1.Condition{
+				NewCondition(obs.ConditionTypeValidLokistackOTLPOutputs, obs.ConditionFalse, "", ""),
+			}
+			Expect(IsValidLokistackOTLPAnnotation(forwarder)).To(BeFalse())
+		})
+	})
 })

--- a/internal/controller/observability/collector.go
+++ b/internal/controller/observability/collector.go
@@ -1,6 +1,9 @@
 package observability
 
 import (
+	"strings"
+	"time"
+
 	log "github.com/ViaQ/logerr/v2/log/static"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
@@ -20,8 +23,6 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"time"
 )
 
 func ReconcileCollector(context internalcontext.ForwarderContext, pollInterval, timeout time.Duration) (err error) {
@@ -35,6 +36,12 @@ func ReconcileCollector(context internalcontext.ForwarderContext, pollInterval, 
 	resourceNames := factory.ResourceNames(*context.Forwarder)
 
 	options := framework.Options{}
+
+	// Set options to any options added during initialization of CLF
+	if context.AdditionalContext != nil {
+		options = context.AdditionalContext
+	}
+
 	if internalobs.Outputs(context.Forwarder.Spec.Outputs).NeedServiceAccountToken() {
 		// temporarily create SA token until collector is capable of dynamically reloading a projected serviceaccount token
 		var sa *corev1.ServiceAccount

--- a/internal/generator/vector/output/factory_test.go
+++ b/internal/generator/vector/output/factory_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"fmt"
+
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 
 	. "github.com/onsi/ginkgo"

--- a/internal/generator/vector/output/otlp/otlp.go
+++ b/internal/generator/vector/output/otlp/otlp.go
@@ -62,6 +62,7 @@ func New(id string, o obs.OutputSpec, inputs []string, secrets observability.Sec
 			elements.Debug(helpers.MakeID(id, "debug"), vectorhelpers.MakeInputs(inputs...)),
 		}
 	}
+
 	// TODO: create a pattern to filter by input so all this is not necessary
 	var els []Element
 	// Creates reroutes for 'container','node','auditd','kubeAPI','openshiftAPI','ovn'

--- a/internal/generator/vector/output/otlp/otlp_all.toml
+++ b/internal/generator/vector/output/otlp/otlp_all.toml
@@ -26,6 +26,16 @@ source = '''
       {"key": "k8s.container.name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
       {"key": "k8s.namespace.name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
+  # Append backward compatibility attributes for container logs
+  resource.attributes = append( resource.attributes,
+      [{"key": "kubernetes_pod_name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+      {"key": "kubernetes_container_name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+      {"key": "kubernetes_namespace_name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -97,6 +107,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -155,6 +169,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Append auditd host attributes
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
@@ -201,6 +219,10 @@ source = '''
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
   )
   # Create logRecord object
   r = {}
@@ -256,6 +278,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -309,6 +335,10 @@ source = '''
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
   )
   # Create logRecord object
   r = {}

--- a/internal/generator/vector/output/otlp/otlp_test.go
+++ b/internal/generator/vector/output/otlp/otlp_test.go
@@ -2,9 +2,10 @@ package otlp
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	corev1 "k8s.io/api/core/v1"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/internal/generator/vector/output/otlp/otlp_tuning.toml
+++ b/internal/generator/vector/output/otlp/otlp_tuning.toml
@@ -26,6 +26,16 @@ source = '''
       {"key": "k8s.container.name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
       {"key": "k8s.namespace.name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
+  # Append backward compatibility attributes for container logs
+  resource.attributes = append( resource.attributes,
+      [{"key": "kubernetes_pod_name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+      {"key": "kubernetes_container_name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+      {"key": "kubernetes_namespace_name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -97,6 +107,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -155,6 +169,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Append auditd host attributes
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
@@ -201,6 +219,10 @@ source = '''
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
   )
   # Create logRecord object
   r = {}
@@ -256,6 +278,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -309,6 +335,10 @@ source = '''
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
   )
   # Create logRecord object
   r = {}

--- a/internal/generator/vector/output/otlp/otlp_with_auth_basic.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_basic.toml
@@ -26,6 +26,16 @@ source = '''
       {"key": "k8s.container.name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
       {"key": "k8s.namespace.name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
+  # Append backward compatibility attributes for container logs
+  resource.attributes = append( resource.attributes,
+      [{"key": "kubernetes_pod_name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+      {"key": "kubernetes_container_name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+      {"key": "kubernetes_namespace_name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -97,6 +107,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -155,6 +169,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Append auditd host attributes
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
@@ -201,6 +219,10 @@ source = '''
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
   )
   # Create logRecord object
   r = {}
@@ -256,6 +278,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -309,6 +335,10 @@ source = '''
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
   )
   # Create logRecord object
   r = {}

--- a/internal/generator/vector/output/otlp/otlp_with_auth_sa_token.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_sa_token.toml
@@ -26,6 +26,16 @@ source = '''
       {"key": "k8s.container.name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
       {"key": "k8s.namespace.name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
+  # Append backward compatibility attributes for container logs
+  resource.attributes = append( resource.attributes,
+      [{"key": "kubernetes_pod_name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+      {"key": "kubernetes_container_name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+      {"key": "kubernetes_namespace_name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -97,6 +107,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -155,6 +169,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Append auditd host attributes
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
@@ -201,6 +219,10 @@ source = '''
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
   )
   # Create logRecord object
   r = {}
@@ -256,6 +278,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -309,6 +335,10 @@ source = '''
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
   )
   # Create logRecord object
   r = {}

--- a/internal/generator/vector/output/otlp/otlp_with_auth_token.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_token.toml
@@ -26,6 +26,16 @@ source = '''
       {"key": "k8s.container.name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
       {"key": "k8s.namespace.name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
+  # Append backward compatibility attributes for container logs
+  resource.attributes = append( resource.attributes,
+      [{"key": "kubernetes_pod_name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+      {"key": "kubernetes_container_name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+      {"key": "kubernetes_namespace_name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -97,6 +107,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -155,6 +169,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Append auditd host attributes
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.node.name", "value": {"stringValue": .hostname}}]
@@ -201,6 +219,10 @@ source = '''
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
   )
   # Create logRecord object
   r = {}
@@ -256,6 +278,10 @@ source = '''
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
   )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
+  )
   # Create logRecord object
   r = {}
   r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
@@ -309,6 +335,10 @@ source = '''
   resource.attributes = append( resource.attributes,
       [{"key": "k8s.cluster.uid", "value": {"stringValue": get!(.,["openshift","cluster_id"])}},
       {"key": "openshift.log.source", "value": {"stringValue": .log_source}}]
+  )
+  # Append backward compatibility attributes
+  resource.attributes = append( resource.attributes,
+      [{"key": "log_type", "value": {"stringValue": .log_type}}]
   )
   # Create logRecord object
   r = {}

--- a/internal/generator/vector/output/otlp/transform.go
+++ b/internal/generator/vector/output/otlp/transform.go
@@ -1,10 +1,11 @@
 package otlp
 
 import (
+	"strings"
+
 	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
-	"strings"
 )
 
 // VRL for OTLP transforms by route
@@ -135,12 +136,29 @@ o = {
   "logRecords": r
 }
 `
+	// The (M)inimum (V)iable (P)roduct Labels (MVP)
+	BackwardCompatBaseResourceAttributes = `
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[{"key": "log_type", "value": {"stringValue": .log_type}}]
+)
+`
+	BackwardCompatContainerResourceAttributes = `
+# Append backward compatibility attributes for container logs
+resource.attributes = append( resource.attributes,
+	[{"key": "kubernetes_pod_name", "value": {"stringValue": get!(.,["kubernetes","pod_name"])}},
+	{"key": "kubernetes_container_name", "value": {"stringValue": get!(.,["kubernetes","container_name"])}},
+	{"key": "kubernetes_namespace_name", "value": {"stringValue": get!(.,["kubernetes","namespace_name"])}}]
+)
+`
 )
 
 func containerLogsVRL() string {
 	return strings.Join(helpers.TrimSpaces([]string{
 		BaseResourceAttributes,
 		ContainerResourceAttributes,
+		BackwardCompatBaseResourceAttributes,
+		BackwardCompatContainerResourceAttributes,
 		LogRecord,
 		BodyFromMessage,
 		LogAttributes,
@@ -152,6 +170,7 @@ func containerLogsVRL() string {
 func nodeLogsVRL() string {
 	return strings.Join(helpers.TrimSpaces([]string{
 		BaseResourceAttributes,
+		BackwardCompatBaseResourceAttributes,
 		LogRecord,
 		BodyFromMessage,
 		LogAttributes,
@@ -163,6 +182,7 @@ func nodeLogsVRL() string {
 func auditHostLogsVRL() string {
 	return strings.Join(helpers.TrimSpaces([]string{
 		BaseResourceAttributes,
+		BackwardCompatBaseResourceAttributes,
 		HostResourceAttributes,
 		LogRecord,
 		BodyFromInternal,
@@ -174,6 +194,7 @@ func auditHostLogsVRL() string {
 func auditAPILogsVRL() string {
 	return strings.Join(helpers.TrimSpaces([]string{
 		BaseResourceAttributes,
+		BackwardCompatBaseResourceAttributes,
 		LogRecord,
 		BodyFromInternal,
 		LogAttributes,
@@ -185,6 +206,7 @@ func auditAPILogsVRL() string {
 func auditOvnLogsVRL() string {
 	return strings.Join(helpers.TrimSpaces([]string{
 		BaseResourceAttributes,
+		BackwardCompatBaseResourceAttributes,
 		LogRecord,
 		BodyFromMessage,
 		LogAttributes,

--- a/internal/validations/observability/outputs/lokistack.go
+++ b/internal/validations/observability/outputs/lokistack.go
@@ -1,0 +1,29 @@
+package outputs
+
+import (
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
+	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+)
+
+// ValidateLokistackOTLPForAnnotation validates lokistacks designated to ingest OTLP data has the OTLP tech preview annotation
+func ValidateLokistackOTLPForAnnotation(context internalcontext.ForwarderContext) {
+	clf := context.Forwarder
+
+	cond := internalobs.NewCondition(obs.ConditionTypeValidLokistackOTLPOutputs, obs.ConditionTrue, obs.ReasonValidationSuccess, "")
+	for _, outSpec := range clf.Spec.Outputs {
+		if outSpec.Type == obs.OutputTypeLokiStack &&
+			(outSpec.LokiStack != nil && outSpec.LokiStack.DataModel == obs.LokiStackDataModelOpenTelemetry) {
+			// Check if OTLP tech preview annotation is defined
+			if _, ok := clf.Annotations[constants.AnnotationOtlpOutputTechPreview]; !ok {
+				cond.Status = obs.ConditionFalse
+				cond.Reason = obs.ReasonValidationFailure
+				cond.Message = "missing tech-preview annotation for OTLP output"
+				internalobs.SetCondition(&context.Forwarder.Status.Conditions, cond)
+				return
+			}
+		}
+	}
+	internalobs.SetCondition(&context.Forwarder.Status.Conditions, cond)
+}

--- a/internal/validations/observability/outputs/lokistack_test.go
+++ b/internal/validations/observability/outputs/lokistack_test.go
@@ -1,0 +1,60 @@
+package outputs
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Validate lokistacks designated to ingest OTLP data", func() {
+	var (
+		forwarder *obs.ClusterLogForwarder
+		context   *internalcontext.ForwarderContext
+		out       *obs.OutputSpec
+	)
+
+	BeforeEach(func() {
+		out = &obs.OutputSpec{
+			Name:      "my-lokistack-otlp",
+			Type:      obs.OutputTypeLokiStack,
+			LokiStack: &obs.LokiStack{},
+		}
+		forwarder = &obs.ClusterLogForwarder{
+			ObjectMeta: v1.ObjectMeta{
+				Annotations: map[string]string{constants.AnnotationOtlpOutputTechPreview: "enabled"},
+			},
+			Spec: obs.ClusterLogForwarderSpec{},
+		}
+
+	})
+	It("should pass validation if lokistacks are designated for OTLP output and has the OTLP tech preview annotation", func() {
+		out.LokiStack = &obs.LokiStack{
+			DataModel: obs.LokiStackDataModelOpenTelemetry,
+		}
+		forwarder.Spec.Outputs = append(forwarder.Spec.Outputs, *out)
+
+		context = &internalcontext.ForwarderContext{
+			Forwarder: forwarder,
+		}
+		ValidateLokistackOTLPForAnnotation(*context)
+		Expect(forwarder.Status.Conditions).To(HaveCondition(obs.ConditionTypeValidLokistackOTLPOutputs, true, obs.ReasonValidationSuccess, ""))
+	})
+
+	It("should fail validation if lokistacks are designated for OTLP output but OTLP tech preview annotation is missing", func() {
+		out.LokiStack = &obs.LokiStack{
+			DataModel: obs.LokiStackDataModelOpenTelemetry,
+		}
+		forwarder.Spec.Outputs = append(forwarder.Spec.Outputs, *out)
+		forwarder.Annotations = map[string]string{}
+
+		context = &internalcontext.ForwarderContext{
+			Forwarder: forwarder,
+		}
+		ValidateLokistackOTLPForAnnotation(*context)
+		Expect(forwarder.Status.Conditions).To(HaveCondition(obs.ConditionTypeValidLokistackOTLPOutputs, false, obs.ReasonValidationFailure, "missing tech-preview annotation for OTLP output"))
+	})
+})

--- a/internal/validations/observability/validate.go
+++ b/internal/validations/observability/validate.go
@@ -19,12 +19,24 @@ var (
 		filters.Validate,
 		pipelines.Validate,
 	}
+
+	clfPreValidators = []func(internalcontext.ForwarderContext){
+		outputs.ValidateLokistackOTLPForAnnotation,
+	}
 )
 
 // ValidateClusterLogForwarder validates the forwarder spec that can not be accomplished using api attributes and returns a set of conditions that apply to the spec
 func ValidateClusterLogForwarder(context internalcontext.ForwarderContext) {
 	for _, validate := range clfValidators {
 		validate(context)
+	}
+}
+
+// PreValidateClusterLogForwarder validates the forwarder spec before initialization
+// Currently supporting one use-case, forwarding OTEL data format to Lokistack
+func PreValidateClusterLogForwarder(context internalcontext.ForwarderContext) {
+	for _, preValidate := range clfPreValidators {
+		preValidate(context)
 	}
 }
 

--- a/test/functional/outputs/otlp/forward_to_otlp_test.go
+++ b/test/functional/outputs/otlp/forward_to_otlp_test.go
@@ -2,14 +2,16 @@ package otlp
 
 import (
 	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/otlp"
 	obstestruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
-	"time"
 )
 
 const (
@@ -45,7 +47,7 @@ var _ = Describe("[Functional][Outputs][OTLP] Functional tests", func() {
 			appNamespace = framework.Pod.Namespace
 
 			// Write message to namespace
-			crioLine := functional.NewCRIOLogMessage(timestamp, "Format me to a container message!", false)
+			crioLine := functional.NewCRIOLogMessage(timestamp, "Format me to a c`ontainer message!", false)
 			Expect(framework.WriteMessagesToNamespace(crioLine, appNamespace, 1)).To(Succeed())
 			crioLine = functional.NewCRIOLogMessage(timestamp, "My second message.", false)
 			Expect(framework.WriteMessagesToNamespace(crioLine, appNamespace, 1)).To(Succeed())
@@ -188,6 +190,75 @@ var _ = Describe("[Functional][Outputs][OTLP] Functional tests", func() {
 			Expect(logRecord.Attributes).ToNot(BeEmpty(), "Expect logRecord attributes to be populated")
 			logType := logRecord.FindStringValue(logRecord.LogTypeAttribute())
 			Expect(logType).To(Equal(string(obs.InputTypeInfrastructure)))
+		})
+
+		Context("with tuning parameters", func() {
+			DescribeTable("with compression", func(compression string) {
+				obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+					FromInput(obs.InputTypeApplication).
+					ToOtlpOutput(func(output *obs.OutputSpec) {
+						output.OTLP.Tuning = &obs.OTLPTuningSpec{
+							Compression: compression,
+						}
+					})
+
+				Expect(framework.DeployWithVisitor(func(b *runtime.PodBuilder) error {
+					return framework.AddOTELCollector(b, string(obs.OutputTypeOTLP))
+				})).To(BeNil())
+
+				appNamespace = framework.Pod.Namespace
+
+				// Write message to namespace
+				crioLine := functional.NewCRIOLogMessage(timestamp, "Format me to a c`ontainer message!", false)
+				Expect(framework.WriteMessagesToNamespace(crioLine, appNamespace, 1)).To(Succeed())
+				crioLine = functional.NewCRIOLogMessage(timestamp, "My second message.", false)
+				Expect(framework.WriteMessagesToNamespace(crioLine, appNamespace, 1)).To(Succeed())
+				crioLine = functional.NewCRIOLogMessage(timestamp, "My third and final message.", false)
+				Expect(framework.WriteMessagesToNamespace(crioLine, appNamespace, 1)).To(Succeed())
+
+				// Read logs
+				raw, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeOTLP))
+				Expect(err).To(BeNil(), "Expected no errors reading the logs for type")
+				Expect(raw).ToNot(BeEmpty())
+
+				logs, err := otlp.ParseLogs(raw[0])
+				Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+				// Access the first (and only) ResourceLog
+				// Inspect resource attributes
+				resourceLog := logs.ResourceLogs[0]
+				resource := resourceLog.Resource
+				namespaceName := resource.FindStringValue(resource.NamespaceNameAttribute())
+				Expect(namespaceName).To(Equal(appNamespace), "Expect namespace name to exist in resource attributes")
+
+				logSource := resource.FindStringValue(resource.LogSourceAttribute())
+				Expect(logSource).To(Equal("container"))
+
+				clusterId := resource.FindStringValue(resource.ClusterIDAttribute())
+				Expect(clusterId).ToNot(BeEmpty(), "Expected cluster.id resource attribute")
+
+				scopeLogs := resourceLog.ScopeLogs
+				Expect(scopeLogs).ToNot(BeEmpty(), "Expected scopeLogs")
+				Expect(scopeLogs).To(HaveLen(1), "Expected a single scopeLog")
+
+				logRecords := scopeLogs[0].LogRecords
+				Expect(logRecords).ToNot(BeEmpty(), "Expected log records for the scope")
+				Expect(logRecords).To(HaveLen(3), "Expected same count as sent for log records")
+
+				// Inspect the first log record for correct fields
+				logRecord := logRecords[0]
+				Expect(logRecord.TimeUnixNano).To(Equal(timestampNano), "Expect timestamp to be converted into unix nano")
+				Expect(logRecord.SeverityNumber).To(Equal(9), "Expect severityNumber to not be parsed to 9")
+				Expect(logRecord.Body.StringValue).ToNot(BeEmpty(), "Expect message to be populated")
+
+				// Ensure we have log.type populated
+				Expect(logRecord.Attributes).ToNot(BeEmpty(), "Expect logRecord attributes to be populated")
+				logType := logRecord.FindStringValue(logRecord.LogTypeAttribute())
+				Expect(logType).To(Equal(string(obs.InputTypeApplication)))
+			},
+				Entry("should pass with gzip", "gzip"),
+				Entry("should pass with zlib", "zlib"),
+				Entry("should pass with no compression", "none"))
 		})
 	})
 })


### PR DESCRIPTION
### Description
This PR enables the `ClusterLogForwarder` to write `OTEL` data to Red Hat managed `Lokistack`.

A new field, `dataModel`, is added to the `Lokistack` output in order to designate the type of data sent to `Lokistack`. It supports 2 values: `viaq` or `otel`. The field can be omitted and data sent will default to `viaq`.

The `OTLP` output generation now includes additional attributes in order to preserve UI plugin functionality and will be included in **ALL** `OTLP` outputs.

These attributes are:
1. `log_type`
2. `log_source`
3. `kubernetes_pod_name`
4. `kubernetes_container_name`
5. `kubernetest_namespace_name`

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6085
- Enhancement proposal: https://github.com/openshift/enhancements/pull/1684
