### PR TITLE
LOG-5131: Add recording rules for telemetry collection

### DIFF
--- a/bundle/manifests/cluster-logging-operator-telemetry_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/cluster-logging-operator-telemetry_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cluster-logging-operator-telemetry
+spec:
+  groups:
+  - name: telemetry.rules
+    rules:
+    - expr: sum by (resource_namespace, version) (log_forwarder_pipelines)
+      record: openshift_logging:log_forwarder_pipelines:sum
+    - expr: count by (resource_namespace, version) (log_forwarder_pipelines)
+      record: openshift_logging:log_forwarders:sum
+    - expr: sum by (resource_namespace, version, input) (log_forwarder_input_type)
+      record: openshift_logging:log_forwarder_input_type:sum
+    - expr: sum by (resource_namespace, version, output) (log_forwarder_output_type)
+      record: openshift_logging:log_forwarder_output_type:sum
+    - expr: sum by(namespace) (rate(vector_component_received_bytes_total{component_kind="source",
+        component_type!="internal_metrics"}[5m]))
+      record: openshift_logging:vector_component_received_bytes_total:rate5m

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
 - servicemonitor.yaml
 - service.yaml
 - collector_alerts.yaml
+- telemetry_rules.yaml

--- a/config/prometheus/telemetry_rules.yaml
+++ b/config/prometheus/telemetry_rules.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cluster-logging-operator-telemetry
+spec:
+  groups:
+  - name: telemetry.rules
+    rules:
+    # Number of logging pipelines in each namespace (mostly just "openshift-logging")
+    - expr: |-
+        sum by (resource_namespace, version) (log_forwarder_pipelines)
+      record: openshift_logging:log_forwarder_pipelines:sum
+    # Number of ClusterLogForwarder instances in each namespace (mostly just "openshift-logging")
+    - expr: |-
+        count by (resource_namespace, version) (log_forwarder_pipelines)
+      record: openshift_logging:log_forwarders:sum
+    # Number of inputs per namespace (mostly just "openshift-logging") and type (four types in total)
+    # Only used types will be present
+    - expr: |-
+        sum by (resource_namespace, version, input) (log_forwarder_input_type)
+      record: openshift_logging:log_forwarder_input_type:sum
+    # Number of outputs per namespace (mostly just "openshift-logging") and type (~11 types in total)
+    # Only used types will be present
+    - expr: |-
+        sum by (resource_namespace, version, output) (log_forwarder_output_type)
+      record: openshift_logging:log_forwarder_output_type:sum
+    # Total number of collected log bytes per namespace (mostly just "openshift-logging")
+    - expr: |-
+        sum by(namespace) (rate(vector_component_received_bytes_total{component_kind="source", component_type!="internal_metrics"}[5m]))
+      record: openshift_logging:vector_component_received_bytes_total:rate5m


### PR DESCRIPTION
### Description

This PR introduces recording rules to reduce the possible number of metrics being sent to telemetry for a single installation of Cluster Logging Operator.

This also needs review from the monitoring team, I'll ping them separately.

/cc @jcantrill
/assign @cahartma

### Links

- JIRA: [LOG-5131](https://issues.redhat.com//browse/LOG-5131), [MON-4051](https://issues.redhat.com/browse/MON-4051)
