### PR TITLE
LOG-5587: fix provider so operator is evaluated as official

### DIFF
--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-10-14T13:29:40Z"
+    createdAt: "2024-10-15T13:40:40Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -2175,7 +2175,7 @@ spec:
     url: https://vector.dev/
   minKubeVersion: 1.18.3
   provider:
-    name: Red Hat, Inc
+    name: Red Hat
   relatedImages:
   - image: quay.io/openshift-logging/vector:6.0
     name: vector

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -1883,5 +1883,5 @@ spec:
     url: https://vector.dev/
   minKubeVersion: 1.18.3
   provider:
-    name: Red Hat, Inc
+    name: Red Hat
   version: 6.0.0


### PR DESCRIPTION
### Description
This PR:
* updates the provider in the manifest so the console will evaluate it as an official Red Hat operator

### Links
https://issues.redhat.com/browse/LOG-5587
