### PR TITLE
LOG-6236: Align syslog output implementation with spec RFC3164 and RFC5124

### DIFF
--- a/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
@@ -4,14 +4,14 @@ inputs = ["application"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
 if .log_type == "infrastructure" && .log_source == "node" {
-    ._internal.syslog.tag = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "")
-    ._internal.syslog.proc_id = to_string!(.systemd.t.PID || "")
+   ._internal.syslog.tag = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "")
+   ._internal.syslog.proc_id = to_string!(.systemd.t.PID || "")
 }
 if .log_source == "container" {
     ._internal.syslog.tag = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "")
     ._internal.syslog.severity = .level
     ._internal.syslog.facility = "user"
-     #Remove non-alphanumeric characters
+    #Remove non-alphanumeric characters
    	._internal.syslog.tag = replace(._internal.syslog.tag, r'[^a-zA-Z0-9]', "")
 	#Truncate the sanitized tag to 32 characters
 	._internal.syslog.tag = truncate(._internal.syslog.tag, 32)
@@ -21,15 +21,12 @@ if .log_type == "audit" {
     ._internal.syslog.severity = "informational"
     ._internal.syslog.facility = "security"
 }
-.proc_id = "procID"
-.tag = "appName"
+.facility = to_string!(._internal.syslog.facility || "user")
+.severity = to_string!(._internal.syslog.severity || "informational")
+.proc_id = to_string!(._internal.syslog.proc_id || "-")
+.tag = to_string!(._internal.syslog.tag || "")
 if exists(.proc_id) && .proc_id != "-" && .proc_id != "" {
-   .tag = .tag + "[" + .proc_id  + "]"
-}
-if is_null(.plKey) {
-	.payload_key = .
-} else {
-	.payload_key = .plKey
+    .tag = .tag + "[" + .proc_id  + "]"
 }
 '''
 
@@ -43,9 +40,8 @@ mode = "udp"
 codec = "syslog"
 except_fields = ["_internal"]
 rfc = "rfc3164"
-facility = "kern"
-severity = "critical"
 add_log_source = false
-payload_key = "payload_key"
+facility = "$$.message.facility"
+severity = "$$.message.severity"
 proc_id = "$$.message.proc_id"
 tag = "$$.message.tag"

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -60,6 +60,7 @@ type SyslogEncodingRemap struct {
 	Inputs         string
 	EncodingFields EncodingTemplateField
 	PayloadKey     string
+	RFC            string
 }
 
 func (ser SyslogEncodingRemap) Name() string {
@@ -74,10 +75,59 @@ inputs = {{.Inputs}}
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
 
+{{if eq .RFC "RFC3164" -}}
+if .log_type == "infrastructure" && .log_source == "node" {
+    ._internal.syslog.tag = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "")
+	._internal.syslog.proc_id = to_string!(.systemd.t.PID || "")
+}
+if .log_source == "container" {
+   	._internal.syslog.tag = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "")
+   	._internal.syslog.severity = .level
+   	._internal.syslog.facility = "user"
+   	#Remove non-alphanumeric characters
+   	._internal.syslog.tag = replace(._internal.syslog.tag, r'[^a-zA-Z0-9]', "")
+	#Truncate the sanitized tag to 32 characters
+	._internal.syslog.tag = truncate(._internal.syslog.tag, 32)
+
+}
+if .log_type == "audit" {
+   ._internal.syslog.tag = .log_source
+   ._internal.syslog.severity = "informational"
+   ._internal.syslog.facility = "security" 
+}
+{{end}}
+
+{{if eq .RFC "RFC5424" -}}
+._internal.syslog.msg_id = .log_source
+
+if .log_type == "infrastructure" && .log_source == "node" {
+	._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
+	._internal.syslog.proc_id = to_string!(.systemd.t.PID||"-")
+}
+if .log_source == "container" {
+   ._internal.syslog.app_name = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   ._internal.syslog.proc_id = to_string!(.kubernetes.pod_id||"-")
+   ._internal.syslog.severity = .level
+   ._internal.syslog.facility = "user"
+}
+if .log_type == "audit" {
+   ._internal.syslog.app_name = .log_source
+   ._internal.syslog.proc_id = to_string!(.auditID || "-")
+   ._internal.syslog.severity = "informational"
+   ._internal.syslog.facility = "security"
+}
+{{end}}
+
 {{if .EncodingFields.FieldVRLList -}}
 {{range $templatePair := .EncodingFields.FieldVRLList -}}
 	.{{$templatePair.Field}} = {{$templatePair.VRLString}}
 {{end -}}
+{{end}}
+
+{{if eq .RFC "RFC3164" -}}
+if exists(.proc_id) && .proc_id != "-" && .proc_id != "" {
+ .tag = .tag + "[" + .proc_id  + "]"
+}
 {{end}}
 
 {{if .PayloadKey -}}
@@ -111,8 +161,12 @@ func (se SyslogEncoding) Template() string {
 codec = "syslog"
 except_fields = ["_internal"]
 rfc = "{{.RFC}}"
+{{ if .Facility }}
 facility = "{{.Facility}}"
+{{ end }}
+{{ if .Severity }}
 severity = "{{.Severity}}"
+{{ end }}
 {{ .AddLogSource }}
 {{ .PayloadKey }}
 {{end}}`
@@ -170,23 +224,53 @@ func getEncodingTemplatesAndFields(s *obs.Syslog) EncodingTemplateField {
 	templateFields := EncodingTemplateField{
 		FieldVRLList: []FieldVRLStringPair{},
 	}
-	if s.AppName != "" {
+
+	if s.Facility == "" {
+		templateFields.FieldVRLList = append(templateFields.FieldVRLList, FieldVRLStringPair{
+			Field:     "facility",
+			VRLString: commontemplate.TransformUserTemplateToVRL(`{._internal.syslog.facility || "user"}`),
+		})
+	}
+
+	if s.Severity == "" {
+		templateFields.FieldVRLList = append(templateFields.FieldVRLList, FieldVRLStringPair{
+			Field:     "severity",
+			VRLString: commontemplate.TransformUserTemplateToVRL(`{._internal.syslog.severity || "informational"}`),
+		})
+	}
+
+	if s.ProcId == "" {
+		s.ProcId = `{._internal.syslog.proc_id || "-"}`
+	}
+	templateFields.FieldVRLList = append(templateFields.FieldVRLList, FieldVRLStringPair{
+		Field:     "proc_id",
+		VRLString: commontemplate.TransformUserTemplateToVRL(s.ProcId),
+	})
+
+	if s.RFC == obs.SyslogRFC3164 {
+		if s.AppName == "" {
+			s.AppName = `{._internal.syslog.tag || ""}`
+		}
+		templateFields.FieldVRLList = append(templateFields.FieldVRLList, FieldVRLStringPair{
+			Field:     "tag",
+			VRLString: commontemplate.TransformUserTemplateToVRL(s.AppName),
+		})
+
+	} else {
+		if s.AppName == "" {
+			s.AppName = `{._internal.syslog.app_name || "-"}`
+		}
 		templateFields.FieldVRLList = append(templateFields.FieldVRLList, FieldVRLStringPair{
 			Field:     "app_name",
 			VRLString: commontemplate.TransformUserTemplateToVRL(s.AppName),
 		})
-	}
-	if s.MsgId != "" {
+
+		if s.MsgId == "" {
+			s.MsgId = `{._internal.syslog.msg_id || "-"}`
+		}
 		templateFields.FieldVRLList = append(templateFields.FieldVRLList, FieldVRLStringPair{
 			Field:     "msg_id",
 			VRLString: commontemplate.TransformUserTemplateToVRL(s.MsgId),
-		})
-	}
-
-	if s.ProcId != "" {
-		templateFields.FieldVRLList = append(templateFields.FieldVRLList, FieldVRLStringPair{
-			Field:     "proc_id",
-			VRLString: commontemplate.TransformUserTemplateToVRL(s.ProcId),
 		})
 	}
 
@@ -223,12 +307,13 @@ func parseEncoding(id string, inputs []string, templatePairs EncodingTemplateFie
 		Inputs:         vectorhelpers.MakeInputs(inputs...),
 		EncodingFields: templatePairs,
 		PayloadKey:     PayloadKey(o.PayloadKey),
+		RFC:            string(o.RFC),
 	}
 }
 
 func Facility(s *obs.Syslog) string {
 	if s == nil || s.Facility == "" {
-		return "user"
+		return ""
 	}
 	if IsKeyExpr(s.Facility) {
 		return fmt.Sprintf("$%s", s.Facility)
@@ -238,7 +323,7 @@ func Facility(s *obs.Syslog) string {
 
 func Severity(s *obs.Syslog) string {
 	if s == nil || s.Severity == "" {
-		return "informational"
+		return ""
 	}
 	if IsKeyExpr(s.Severity) {
 		return fmt.Sprintf("$%s", s.Severity)

--- a/internal/generator/vector/output/syslog/syslog_test.go
+++ b/internal/generator/vector/output/syslog/syslog_test.go
@@ -2,7 +2,6 @@ package syslog_test
 
 import (
 	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -42,6 +41,7 @@ var _ = Describe("vector syslog clf output", func() {
 				},
 			},
 		}
+
 		initOutput = func() obs.OutputSpec {
 			return obs.OutputSpec{
 				Type: obs.OutputTypeSyslog,
@@ -100,6 +100,13 @@ var _ = Describe("vector syslog clf output", func() {
 			}
 		}, false),
 
+		Entry("should configure with defaults RFC3164", "rfc3164_with_defaults.toml", func(spec *obs.OutputSpec) {
+			spec.Syslog = &obs.Syslog{
+				URL: "udp://logserver:514",
+				RFC: obs.SyslogRFC3164,
+			}
+		}, false),
+
 		Entry("should configure TLS with log record field references", "tls_with_field_references.toml", func(spec *obs.OutputSpec) {
 			spec.TLS = tlsSpec
 			spec.Syslog = &obs.Syslog{
@@ -113,6 +120,7 @@ var _ = Describe("vector syslog clf output", func() {
 				PayloadKey: `{.payload_key}`,
 			}
 		}, false),
+
 		Entry("should set buffer tuning parameters", "tcp_with_tuning.toml", func(spec *obs.OutputSpec) {
 			spec.Syslog.URL = "tcp://logserver:514"
 			spec.Syslog.Tuning = &obs.SyslogTuningSpec{

--- a/internal/generator/vector/output/syslog/tcp_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_defaults.toml
@@ -3,6 +3,29 @@ type = "remap"
 inputs = ["application"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
+._internal.syslog.msg_id = .log_source
+
+if .log_type == "infrastructure" && .log_source == "node" {
+    ._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
+    ._internal.syslog.proc_id = to_string!(.systemd.t.PID||"-")
+}
+if .log_source == "container" {
+   ._internal.syslog.app_name = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   ._internal.syslog.proc_id = to_string!(.kubernetes.pod_id||"-")
+   ._internal.syslog.severity = .level
+   ._internal.syslog.facility = "user"
+}
+if .log_type == "audit" {
+   ._internal.syslog.app_name = .log_source
+   ._internal.syslog.proc_id = to_string!(.auditID || "-")
+   ._internal.syslog.severity = "informational"
+   ._internal.syslog.facility = "security"
+}
+.facility = to_string!(._internal.syslog.facility || "user")
+.severity = to_string!(._internal.syslog.severity || "informational")
+.proc_id = to_string!(._internal.syslog.proc_id || "-")
+.app_name = to_string!(._internal.syslog.app_name || "-")
+.msg_id = to_string!(._internal.syslog.msg_id || "-")
 '''
 
 [sinks.example]
@@ -15,6 +38,9 @@ mode = "tcp"
 codec = "syslog"
 except_fields = ["_internal"]
 rfc = "rfc5424"
-facility = "user"
-severity = "informational"
 add_log_source = false
+facility = "$$.message.facility"
+severity = "$$.message.severity"
+proc_id = "$$.message.proc_id"
+app_name = "$$.message.app_name"
+msg_id = "$$.message.msg_id"

--- a/internal/generator/vector/output/syslog/tcp_with_tuning.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_tuning.toml
@@ -3,6 +3,31 @@ type = "remap"
 inputs = ["application"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
+
+._internal.syslog.msg_id = .log_source
+
+if .log_type == "infrastructure" && .log_source == "node" {
+    ._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
+    ._internal.syslog.proc_id = to_string!(.systemd.t.PID||"-")
+}
+if .log_source == "container" {
+   ._internal.syslog.app_name = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   ._internal.syslog.proc_id = to_string!(.kubernetes.pod_id||"-")
+   ._internal.syslog.severity = .level
+   ._internal.syslog.facility = "user"
+}
+if .log_type == "audit" {
+   ._internal.syslog.app_name = .log_source
+   ._internal.syslog.proc_id = to_string!(.auditID || "-")
+   ._internal.syslog.severity = "informational"
+   ._internal.syslog.facility = "security"
+}
+.facility = to_string!(._internal.syslog.facility || "user")
+.severity = to_string!(._internal.syslog.severity || "informational")
+.proc_id = to_string!(._internal.syslog.proc_id || "-")
+.app_name = to_string!(._internal.syslog.app_name || "-")
+.msg_id = to_string!(._internal.syslog.msg_id || "-")
+
 '''
 
 [sinks.example]
@@ -15,9 +40,12 @@ mode = "tcp"
 codec = "syslog"
 except_fields = ["_internal"]
 rfc = "rfc5424"
-facility = "user"
-severity = "informational"
 add_log_source = false
+facility = "$$.message.facility"
+severity = "$$.message.severity"
+proc_id = "$$.message.proc_id"
+app_name = "$$.message.app_name"
+msg_id = "$$.message.msg_id"
 
 [sinks.example.buffer]
 type = "disk"

--- a/internal/generator/vector/output/syslog/tls_with_field_references.toml
+++ b/internal/generator/vector/output/syslog/tls_with_field_references.toml
@@ -4,9 +4,27 @@ inputs = ["application"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
 
+._internal.syslog.msg_id = .log_source
+
+if .log_type == "infrastructure" && .log_source == "node" {
+    ._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
+    ._internal.syslog.proc_id = to_string!(.systemd.t.PID||"-")
+}
+if .log_source == "container" {
+   ._internal.syslog.app_name = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   ._internal.syslog.proc_id = to_string!(.kubernetes.pod_id||"-")
+   ._internal.syslog.severity = .level
+   ._internal.syslog.facility = "user"
+}
+if .log_type == "audit" {
+   ._internal.syslog.app_name = .log_source
+   ._internal.syslog.proc_id = to_string!(.auditID || "-")
+   ._internal.syslog.severity = "informational"
+   ._internal.syslog.facility = "security"
+}
+.proc_id = to_string!(.proc_id||"none")
 .app_name = to_string!(.app_name||"none")
 .msg_id = to_string!(.msg_id||"none")
-.proc_id = to_string!(.proc_id||"none")
 
 if is_null(.payload_key) {
 	.payload_key = .
@@ -29,9 +47,9 @@ facility = "$$.message.facility"
 severity = "$$.message.severity"
 add_log_source = false
 payload_key = "payload_key"
+proc_id = "$$.message.proc_id"
 app_name = "$$.message.app_name"
 msg_id = "$$.message.msg_id"
-proc_id = "$$.message.proc_id"
 
 [sinks.example.tls]
 enabled = true

--- a/internal/generator/vector/output/syslog/xyz_defaults.toml
+++ b/internal/generator/vector/output/syslog/xyz_defaults.toml
@@ -3,6 +3,29 @@ type = "remap"
 inputs = ["application"]
 source = '''
 . = merge(., parse_json!(string!(.message))) ?? .
+._internal.syslog.msg_id = .log_source
+if .log_type == "infrastructure" && .log_source == "node" {
+    ._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
+    ._internal.syslog.proc_id = to_string!(.systemd.t.PID||"-")
+}
+if .log_source == "container" {
+   ._internal.syslog.app_name = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   ._internal.syslog.proc_id = to_string!(.kubernetes.pod_id||"-")
+   ._internal.syslog.severity = .level
+   ._internal.syslog.facility = "user"
+}
+if .log_type == "audit" {
+   ._internal.syslog.app_name = .log_source
+   ._internal.syslog.proc_id = to_string!(.auditID || "-")
+   ._internal.syslog.severity = "informational"
+   ._internal.syslog.facility = "security"
+}
+
+.facility = to_string!(._internal.syslog.facility || "user")
+.severity = to_string!(._internal.syslog.severity || "informational")
+.proc_id = to_string!(._internal.syslog.proc_id || "-")
+.app_name = to_string!(._internal.syslog.app_name || "-")
+.msg_id = to_string!(._internal.syslog.msg_id || "-")
 '''
 
 [sinks.example]
@@ -15,6 +38,9 @@ mode = "xyz"
 codec = "syslog"
 except_fields = ["_internal"]
 rfc = "rfc5424"
-facility = "user"
-severity = "informational"
 add_log_source = false
+facility = "$$.message.facility"
+severity = "$$.message.severity"
+proc_id = "$$.message.proc_id"
+app_name = "$$.message.app_name"
+msg_id = "$$.message.msg_id"

--- a/test/framework/e2e/syslog_conf.go
+++ b/test/framework/e2e/syslog_conf.go
@@ -59,11 +59,15 @@ ruleset(name="test" parser=["rsyslog.rfc5424"]){
 	`
 
 	RuleSetRfc3164 = `
+# Define the RFC3164 template including <PRI>
+template(name="RFC3164WithPRI" type="string"
+         string="<%PRI%>%TIMESTAMP% %HOSTNAME% %syslogtag%%msg%\n")
+
 #### RULES ####
-ruleset(name="test" parser=["rsyslog.rfc3164"]){
-    action(type="omfile" file="/tmp/infra.log" Template="RSYSLOG_SyslogProtocol23Format")
+ruleset(name="test" parser=["rsyslog.rfc3164"]) {
+    action(type="omfile" file="/tmp/infra.log" Template="RFC3164WithPRI")
 }
-	`
+    `
 	// includes both rfc parsers
 	RuleSetRfc3164Rfc5424 = `
 #### RULES ####

--- a/test/framework/functional/vector/deploy.go
+++ b/test/framework/functional/vector/deploy.go
@@ -2,6 +2,7 @@ package vector
 
 import (
 	"fmt"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"regexp"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
-	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/test/client"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional/common"
 )

--- a/test/functional/outputs/syslog/forward_to_syslog_test.go
+++ b/test/functional/outputs/syslog/forward_to_syslog_test.go
@@ -3,21 +3,25 @@ package syslog
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
-	"time"
-
-	"github.com/openshift/cluster-logging-operator/test/framework/common/secrets"
-
-	obstestruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
-
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/test/framework/common/secrets"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	obstestruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
+	"regexp"
+	"strings"
+	"time"
 )
 
 var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func() {
+
+	const (
+		PRI_14  = "<14>1"
+		PRI_15  = "<15>1"
+		PRI_110 = "<110>1"
+	)
 
 	var (
 		framework *functional.CollectorFunctionalFramework
@@ -28,6 +32,7 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 			outspec.Syslog.AppName = "myapp"
 			outspec.Syslog.ProcId = "myproc"
 			outspec.Syslog.MsgId = "mymsg"
+			outspec.Syslog.RFC = obs.SyslogRFC5424
 		}
 
 		join = func(
@@ -39,6 +44,16 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 			}
 		}
 
+		getTag = func(log string) string {
+			for strings.Contains(log, "  ") {
+				log = strings.ReplaceAll(log, "  ", " ")
+			}
+			fields := strings.Split(log, " ")
+			return strings.TrimSuffix(fields[4], ":")
+		}
+		getPri = func(fields []string) string {
+			return fields[0]
+		}
 		getAppName = func(fields []string) string {
 			return fields[3]
 		}
@@ -70,6 +85,7 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 				if output.TLS == nil {
 					output.TLS = &obs.OutputTLSSpec{}
 				}
+				output.Syslog.RFC = obs.SyslogRFC5424
 				output.TLS.TLSSpec = tlsSpec
 			})
 		Expect(framework.Deploy()).To(BeNil())
@@ -80,10 +96,12 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 		outputlogs, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeSyslog))
 		Expect(err).To(BeNil(), "Expected no errors reading the logs")
 		Expect(outputlogs).To(Not(BeEmpty()), "Expected the receiver to receive the message")
-		Expect(outputlogs[0]).To(MatchRegexp(`^<[0-9]*>[0-9]* ([0-9T:.Z\-]*) ([a-z0-9-.]*) (.*) -(.*)-(.*)- (.*)$`), "Exp a syslog formatted message")
+		Expect(outputlogs[0]).To(MatchRegexp(`^<[0-9]*>[0-9]* ([0-9T:.Z\-]*) ([a-z0-9-.]*) (.*) (.*) (.*) - (.*)$`), "Exp a syslog formatted message")
 	})
+
 	Context("Application Logs", func() {
-		It("should send large message over UDP", func() {
+
+		It("RFC5424: should send large message over UDP", func() {
 			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(obs.InputTypeApplication).
 				ToSyslogOutput(obs.SyslogRFC5424, join(setSyslogSpecValues, func(output *obs.OutputSpec) {
@@ -91,7 +109,7 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 				}))
 			Expect(framework.Deploy()).To(BeNil())
 
-			var MaxLen int = 30000
+			var MaxLen = 30000
 			Expect(framework.WritesNApplicationLogsOfSize(1, MaxLen, 0)).To(BeNil())
 			// Read line from Syslog output
 			outputlogs, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeSyslog))
@@ -108,7 +126,8 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 			ReceivedLen := uint64(len(message))
 			Expect(ReceivedLen).To(BeEquivalentTo(MaxLen), "Expected the message length to be the same")
 		})
-		It("should send NonJson App logs to syslog", func() {
+
+		It("RFC5424: should send NonJson App logs to syslog", func() {
 			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(obs.InputTypeApplication).
 				ToSyslogOutput(obs.SyslogRFC5424, setSyslogSpecValues)
@@ -124,11 +143,13 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 			Expect(err).To(BeNil(), "Expected no errors reading the logs")
 			Expect(outputlogs).ToNot(BeEmpty())
 			fields := strings.Split(outputlogs[0], " ")
+			Expect(getPri(fields)).To(Equal(PRI_15))
 			Expect(getAppName(fields)).To(Equal("myapp"))
 			Expect(getProcID(fields)).To(Equal("myproc"))
 			Expect(getMsgID(fields)).To(Equal("mymsg"))
 		})
-		It("should take values of appname, procid, messageid from record", func() {
+
+		It("RFC5424: should take values of appname, procid, messageid from record", func() {
 			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(obs.InputTypeApplication).
 				ToSyslogOutput(obs.SyslogRFC5424, join(setSyslogSpecValues, func(spec *obs.OutputSpec) {
@@ -148,11 +169,13 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 			Expect(err).To(BeNil(), "Expected no errors reading the logs")
 			Expect(outputlogs).ToNot(BeEmpty())
 			fields := strings.Split(outputlogs[0], " ")
+			Expect(getPri(fields)).To(Equal(PRI_15))
 			Expect(getAppName(fields)).To(Equal("rec_appname"))
 			Expect(getProcID(fields)).To(Equal("rec_procid"))
 			Expect(getMsgID(fields)).To(Equal("rec_msgid"))
 		})
-		It("should allow combination of static + dynamic setting of appname, procid, messageid from record", func() {
+
+		It("RFC5424: should allow combination of static + dynamic setting of appname, procid, messageid from record", func() {
 			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(obs.InputTypeApplication).
 				ToSyslogOutput(obs.SyslogRFC5424, join(setSyslogSpecValues, func(spec *obs.OutputSpec) {
@@ -176,6 +199,32 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 			Expect(getProcID(fields)).To(Equal("bar-rec_appname"))
 			Expect(getMsgID(fields)).To(Equal("bazdefault.application"))
 		})
+
+		It("RFC5424: should take default value for appname", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeApplication).
+				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC5424
+				})
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Log message data
+			for _, log := range JSONApplicationLogs {
+				log = functional.NewFullCRIOLogMessage(timestamp, log)
+				Expect(framework.WriteMessagesToApplicationLog(log, 1)).To(BeNil())
+			}
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			app := strings.Join([]string{framework.Namespace, framework.Pod.Name, constants.CollectorName}, "_")
+			fields := strings.Split(outputlogs[0], " ")
+			Expect(getPri(fields)).To(Equal(PRI_14))
+			Expect(getAppName(fields)).To(Equal(app))
+			Expect(getProcID(fields)).To(Equal(string(framework.Pod.UID)))
+			Expect(getMsgID(fields)).To(Equal("container"))
+		})
+
 		It("should send logs with delivery mode `atLeastOnce` configured", func() {
 			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(obs.InputTypeApplication).
@@ -196,9 +245,55 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 			Expect(err).To(BeNil(), "Expected no errors reading the logs")
 			Expect(outputlogs).ToNot(BeEmpty(), "Expected the receiver to receive the message")
 		})
+
+		It("RFC3164: should take default value for appname", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeApplication).
+				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC3164
+				})
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Log message data
+			for _, log := range JSONApplicationLogs {
+				log = functional.NewFullCRIOLogMessage(timestamp, log)
+				Expect(framework.WriteMessagesToApplicationLog(log, 1)).To(BeNil())
+			}
+			app := strings.Join([]string{framework.Namespace, framework.Pod.Name, constants.CollectorName}, "")
+			re := regexp.MustCompile("[^a-zA-Z0-9]")
+			app = re.ReplaceAllString(app, "")
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			Expect(getTag(outputlogs[0])).To(Equal(app))
+		})
+
+		It("RFC3164: should take values of appname from record", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeApplication).
+				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
+					spec.Syslog.AppName = `{.appname_key||"none"}`
+					spec.Syslog.RFC = obs.SyslogRFC3164
+				})
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Log message data
+			for _, log := range JSONApplicationLogs {
+				log = functional.NewFullCRIOLogMessage(timestamp, log)
+				Expect(framework.WriteMessagesToApplicationLog(log, 1)).To(BeNil())
+			}
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			Expect(getTag(outputlogs[0])).To(Equal("rec_appname"))
+		})
 	})
+
 	Context("Audit logs", func() {
-		It("should send kubernetes audit logs", func() {
+
+		It("RFC5424: should send kubernetes audit logs", func() {
 			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(obs.InputTypeAudit).
 				ToSyslogOutput(obs.SyslogRFC5424, setSyslogSpecValues)
@@ -219,7 +314,8 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 			Expect(getProcID(fields)).To(Equal("myproc"))
 			Expect(getMsgID(fields)).To(Equal("mymsg"))
 		})
-		It("should send openshift audit logs", func() {
+
+		It("RFC5424: should send openshift audit logs", func() {
 			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(obs.InputTypeAudit).
 				ToSyslogOutput(obs.SyslogRFC5424, setSyslogSpecValues)
@@ -236,6 +332,229 @@ var _ = Describe("[Functional][OutputConditions][Syslog] Functional tests", func
 			Expect(getAppName(fields)).To(Equal("myapp"))
 			Expect(getProcID(fields)).To(Equal("myproc"))
 			Expect(getMsgID(fields)).To(Equal("mymsg"))
+		})
+
+		It("RFC5424: should send kubernetes audit logs with default appname", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeAudit).
+				ToSyslogOutput(obs.SyslogRFC5424, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC5424
+				})
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Log message data
+			Expect(framework.WriteK8sAuditLog(1)).To(BeNil())
+
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadAuditLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			for _, o := range outputlogs {
+				fmt.Printf("log received %s\n", o)
+			}
+			fields := strings.Split(outputlogs[0], " ")
+			Expect(getAppName(fields)).To(Equal("kubeAPI"))
+			Expect(getMsgID(fields)).To(Equal("kubeAPI"))
+		})
+
+		It("RFC5424: should send openshift audit logs with default appname", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeAudit).
+				ToSyslogOutput(obs.SyslogRFC5424, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC5424
+				})
+			Expect(framework.Deploy()).To(Succeed())
+
+			// Log message data
+			Expect(framework.WriteOpenshiftAuditLog(1)).To(Succeed())
+
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadAuditLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			fields := strings.Split(outputlogs[0], " ")
+			Expect(getPri(fields)).To(Equal(PRI_110))
+			Expect(getAppName(fields)).To(Equal("openshiftAPI"))
+			Expect(getMsgID(fields)).To(Equal("openshiftAPI"))
+		})
+
+		It("RFC3164: should send kubernetes audit logs", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeAudit).
+				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC3164
+					spec.Syslog.AppName = "myapp"
+				})
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Log message data
+			Expect(framework.WriteK8sAuditLog(1)).To(BeNil())
+
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadAuditLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			for _, o := range outputlogs {
+				fmt.Printf("log received %s\n", o)
+			}
+			Expect(getTag(outputlogs[0])).To(Equal("myapp"))
+		})
+
+		It("RFC3164: should send openshift audit logs", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeAudit).
+				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC3164
+					spec.Syslog.AppName = "myapp"
+				})
+			Expect(framework.Deploy()).To(Succeed())
+
+			// Log message data
+			Expect(framework.WriteOpenshiftAuditLog(1)).To(Succeed())
+
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadAuditLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			Expect(getTag(outputlogs[0])).To(Equal("myapp"))
+		})
+
+		It("RFC3164: should send kubernetes audit logs with default appname", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeAudit).
+				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC3164
+				})
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Log message data
+			Expect(framework.WriteK8sAuditLog(1)).To(BeNil())
+
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadAuditLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			for _, o := range outputlogs {
+				fmt.Printf("log received %s\n", o)
+			}
+			Expect(getTag(outputlogs[0])).To(Equal("kubeAPI"))
+		})
+
+		It("RFC3164: should send openshift audit logs with default appname", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeAudit).
+				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC3164
+				})
+			Expect(framework.Deploy()).To(Succeed())
+
+			// Log message data
+			Expect(framework.WriteOpenshiftAuditLog(1)).To(Succeed())
+
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadAuditLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			Expect(getTag(outputlogs[0])).To(Equal("openshiftAPI"))
+		})
+
+	})
+
+	Context("Infrastructure log logs", func() {
+
+		It("RFC5424: should send infra logs", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeInfrastructure).
+				ToSyslogOutput(obs.SyslogRFC5424, setSyslogSpecValues)
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Log message data
+			logline := functional.NewJournalLog(3, "*", "*")
+			Expect(framework.WriteMessagesToInfraJournalLog(logline, 1)).To(BeNil())
+
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadInfrastructureLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			for _, o := range outputlogs {
+				fmt.Printf("log received %s\n", o)
+			}
+			fields := strings.Split(outputlogs[0], " ")
+			Expect(getAppName(fields)).To(Equal("myapp"))
+			Expect(getProcID(fields)).To(Equal("myproc"))
+			Expect(getMsgID(fields)).To(Equal("mymsg"))
+		})
+
+		It("RFC3164: should calc appname and pid to tag", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeInfrastructure).
+				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC3164
+					spec.Syslog.AppName = "myapp"
+					spec.Syslog.ProcId = "1234"
+				})
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Log message data
+			logline := functional.NewJournalLog(3, "*", "*")
+			Expect(framework.WriteMessagesToInfraJournalLog(logline, 1)).To(BeNil())
+
+			// Read line from Syslog output
+			outputlogs, err := framework.ReadInfrastructureLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			for _, o := range outputlogs {
+				fmt.Printf("log received %s\n", o)
+			}
+			Expect(getTag(outputlogs[0])).To(Equal("myapp[1234]"))
+		})
+
+		It("RFC5424: should take default values of appname, procid, messageid", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeInfrastructure).
+				ToSyslogOutput(obs.SyslogRFC5424, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC5424
+				})
+			Expect(framework.Deploy()).To(BeNil())
+
+			logline := functional.NewJournalLog(3, "*", "*")
+			Expect(framework.WriteMessagesToInfraJournalLog(logline, 1)).To(BeNil())
+
+			// Read line from Syslog output
+
+			outputlogs, err := framework.ReadInfrastructureLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			for _, o := range outputlogs {
+				fmt.Printf("log received %s\n", o)
+			}
+			fields := strings.Split(outputlogs[0], " ")
+			Expect(getAppName(fields)).To(Equal("google-chrome.desktop"))
+			Expect(getProcID(fields)).To(Equal("3194"))
+			Expect(getMsgID(fields)).To(Equal("node"))
+		})
+
+		It("RFC3164: should take default values of tag", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeInfrastructure).
+				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
+					spec.Syslog.RFC = obs.SyslogRFC3164
+				})
+			Expect(framework.Deploy()).To(BeNil())
+
+			logline := functional.NewJournalLog(3, "*", "*")
+			Expect(framework.WriteMessagesToInfraJournalLog(logline, 1)).To(BeNil())
+
+			// Read line from Syslog output
+
+			outputlogs, err := framework.ReadInfrastructureLogsFrom(string(obs.OutputTypeSyslog))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(outputlogs).ToNot(BeEmpty())
+			for _, o := range outputlogs {
+				fmt.Printf("log received %s\n", o)
+			}
+			Expect(getTag(outputlogs[0])).To(Equal("google-chrome.desktop[3194]"))
+
 		})
 	})
 })

--- a/test/functional/outputs/syslog/rfc3164_test.go
+++ b/test/functional/outputs/syslog/rfc3164_test.go
@@ -51,8 +51,7 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 			Expect(outputlogs).To(HaveLen(1), "Expected the receiver to receive the message")
 
 			// 134 = Facility(local0/16)*8 + Severity(Informational/6)
-			// The 1 after <134> is version, which is always set to 1
-			expectedPriority := "<134>1 "
+			expectedPriority := "<134>"
 			Expect(outputlogs[0]).To(MatchRegexp(expectedPriority), "Exp to find tag in received message")
 		})
 	})
@@ -74,7 +73,8 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 		logs, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeSyslog))
 		Expect(err).To(BeNil(), "Expected no errors reading the logs")
 		Expect(logs).To(HaveLen(1), "Expected the receiver to receive the message")
-		expMatch := fmt.Sprintf(".*-  %s", payload)
+
+		expMatch := fmt.Sprintf(".*:\\s*%s", payload)
 		if enrichment == obs.EnrichmentTypeKubernetesMinimal {
 			expMatch = fmt.Sprintf(`namespace_name=.*, container_name=collector, pod_name=functional, message=%s`, payload)
 		}


### PR DESCRIPTION
### Description
This PR addressed to align Syslog Output with syslog specification RFC3164 and RFC5424 

## Default values for fields:
### [RFC3164](https://datatracker.ietf.org/doc/html/rfc3164) 
Format: `<PRI>TIMESTAMP HOSTNAME TAG: MESSAGE`
Example:`<34>Oct 11 22:14:15 mymachine su[1234]: 'su root' failed for lonvick on /dev/pts/`

|   | journal |  application | infrastructure | note |
| ------------- | ------------- |------------- | ------------- |  ------------- |
|AppName  | SYSLOG_IDENTIFIER* | namespacePodContainer  | .log_source  | |
| ProcId | _PID*  | N/A | .auditID (if available) | |
| MsgId | N/A | N/A  | N/A  | will have no effect in settings |
| Payloadkey | .message  | .message  | .message  | |
| Severity | N/A  | .level  | information (6) | |
| Facility | N/A  | user (1)  | security(13) | |

*If `ProcId` available, it will aggregate with `AppName` in the `.tag` field: `appname[procid]`


### [RFC5424](https://datatracker.ietf.org/doc/html/rfc5424) 
Format: `<PRI> VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID [STRUCTURED-DATA] MESSAGE`
Example: `<PRI>1 2024-11-08T14:35:04.123Z ip-10-0-88-196.ec2.internal app-name 1234 ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"] This is a sample message`

|   | journal |  application | infrastructure |
| ------------- | ------------- |------------- | ------------- |
|AppName  | SYSLOG_IDENTIFIER | namespace_pod_container  | .log_source  |
| ProcId | _PID  | pod_id | .auditID (if available) |
| MsgId | .log_source | .log_source  | .log_sourcel  |
| Payloadkey | .message  | .message  | .message  |
| Severity | N/A  | .level  | information (6) |
| Facility | N/A  | user (1)  | security(13) |

## Changes: 
- add calculation for default value if field not configured according to the table above
- fix configuration for deployed syslog server in functional test to follow RFC3164 specification 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-6236
- Enhancement proposal:
