### PR TITLE
LOG-6044: validation failure when adding a namespace which contains `kube` or `openshift`

### DIFF
--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account.go
@@ -24,7 +24,7 @@ const (
 	allNamespaces = ""
 )
 
-var infraNamespaces = regexp.MustCompile(`^default$|^openshift.*$|^kube.*$`)
+var infraNamespaces = regexp.MustCompile(`^default$|^kube$|^openshift$|^openshift-.*$|^kube-.*$`)
 
 // ValidateServiceAcccount validates the serviceaccount for the CLF has the needed permissions to collect the desired inputs
 func ValidateServiceAccount(clf loggingv1.ClusterLogForwarder, k8sClient client.Client, extras map[string]bool) (error, *loggingv1.ClusterLogForwarderStatus) {

--- a/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account_test.go
+++ b/internal/validations/clusterlogforwarder/validate_clusterlogforwarder_service_account_test.go
@@ -263,7 +263,13 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder permissio
 							{
 								Name: appInput,
 								Application: &loggingv1.Application{
-									Namespaces: []string{"sample-kube-namespace", "my-default-ns", "custom-openshift-namespace", "default-custom"},
+									Namespaces: []string{
+										"sample-kube-namespace",
+										"my-default-ns",
+										"custom-openshift-namespace",
+										"default-custom",
+										"kube1",
+										"openshift1"},
 								},
 							},
 						},
@@ -302,12 +308,12 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder permissio
 				},
 					Entry("with default namespace", []string{"default"}),
 					Entry("with openshift namespace", []string{"openshift"}),
-					Entry("with openshift and wildcard namespace", []string{"openshift*"}),
+					Entry("with openshift- and wildcard namespace", []string{"openshift-*"}),
 					Entry("with openshift-operators-redhat namespace", []string{"openshift-operators-redhat"}),
 					Entry("with kube namespace", []string{"kube"}),
-					Entry("with kube and wildcard namespace", []string{"kube*"}),
+					Entry("with kube- and wildcard namespace", []string{"kube-*"}),
 					Entry("with kube-system namespace", []string{"kube-system"}),
-					Entry("with multiple namespaces including an infra namespace", []string{"kube*", "custom-ns"}),
+					Entry("with multiple namespaces including an infra namespace", []string{"kube-*", "custom-ns", "openshift-*"}),
 				)
 
 				It("when including infra namespaces and excluding other namespaces", func() {


### PR DESCRIPTION
### Description
This PR specifies these namespaces as infrastructure and validates them as such:
1. `default`
2. `kube`
3. `openshift`
4. `kube-*` - any namespace **starting** with `kube-`
5. `openshift-*` - any namespace **starting** with `openshift-`

A namespace like `kube1` or `openshift1` will not be validated as infrastructure namespaces nor any namespace containing the above keywords like `sample-kube-namespace`.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6044

