### PR TITLE
LOG-6204: Manual port of LOG-6044 to release-6.0

### DIFF
--- a/internal/validations/observability/validate_permissions.go
+++ b/internal/validations/observability/validate_permissions.go
@@ -27,7 +27,7 @@ const (
 	allNamespaces = ""
 )
 
-var infraNamespaces = regexp.MustCompile(`^default$|^openshift.*$|^kube.*$`)
+var infraNamespaces = regexp.MustCompile(`^default$|^kube$|^openshift$|^openshift-.*$|^kube-.*$`)
 
 // ValidatePermissions validates the serviceAccount for the CLF has the needed permissions to collect the desired inputs
 func ValidatePermissions(context internalcontext.ForwarderContext) {

--- a/internal/validations/observability/validate_permissions_test.go
+++ b/internal/validations/observability/validate_permissions_test.go
@@ -279,7 +279,13 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder permissio
 
 			Context("when service account only has collect-application-logs permission", func() {
 				It("should pass validation for non-infra namespaces that include infra keywords kube, default, openshift", func() {
-					namespaces := []string{"sample-kube-namespace", "my-default-ns", "custom-openshift-namespace", "default-custom"}
+					namespaces := []string{
+						"sample-kube-namespace",
+						"my-default-ns",
+						"custom-openshift-namespace",
+						"default-custom",
+						"kube1",
+						"openshift1"}
 					var includes []obs.NamespaceContainerSpec
 					for _, ns := range namespaces {
 						includes = append(includes, obs.NamespaceContainerSpec{Namespace: ns})
@@ -344,12 +350,12 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder permissio
 				},
 					Entry("with default namespace", []string{"default"}),
 					Entry("with openshift namespace", []string{"openshift"}),
-					Entry("with openshift and wildcard namespace", []string{"openshift*"}),
+					Entry("with openshift- and wildcard namespace", []string{"openshift-*"}),
 					Entry("with openshift-operators-redhat namespace", []string{"openshift-operators-redhat"}),
 					Entry("with kube namespace", []string{"kube"}),
-					Entry("with kube and wildcard namespace", []string{"kube*"}),
+					Entry("with kube- and wildcard namespace", []string{"kube-*"}),
 					Entry("with kube-system namespace", []string{"kube-system"}),
-					Entry("with multiple namespaces including an infra namespace", []string{"kube*", "custom-ns"}),
+					Entry("with multiple namespaces including an infra namespace", []string{"kube-*", "custom-ns"}),
 				)
 
 				It("when including infra namespaces and excluding other namespaces", func() {


### PR DESCRIPTION
### Description
This is a manual port of #2835

#### Original Description
This PR specifies these namespaces as infrastructure and validates them as such:
1. `default`
2. `kube`
3. `openshift`
4. `kube-* - any namespace starting with kube-`
5. `openshift-* - any namespace starting with openshift-`

A namespace like `kube1` or `openshift1` will not be validated as infrastructure namespaces nor any namespace containing the above keywords like `sample-kube-namespace`.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links

- JIRA: https://issues.redhat.com/browse/LOG-6204
