### PR TITLE
LOG-5998: fix max_line_bytes for audit logs

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -19,7 +19,8 @@ include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_host_meta]
@@ -37,7 +38,8 @@ include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_kube_meta]
@@ -55,7 +57,8 @@ include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/au
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_openshift_meta]
@@ -73,7 +76,8 @@ include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_ovn_meta]

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -19,7 +19,8 @@ include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_host_meta]
@@ -37,7 +38,8 @@ include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_kube_meta]
@@ -55,7 +57,8 @@ include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/au
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_openshift_meta]
@@ -73,7 +76,8 @@ include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_ovn_meta]

--- a/internal/generator/vector/input/audit.toml
+++ b/internal/generator/vector/input/audit.toml
@@ -5,7 +5,8 @@ include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_host_meta]
@@ -23,7 +24,8 @@ include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_kube_meta]
@@ -41,7 +43,8 @@ include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/au
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_openshift_meta]
@@ -59,7 +62,8 @@ include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_audit_ovn_meta]

--- a/internal/generator/vector/input/audit_host.toml
+++ b/internal/generator/vector/input/audit_host.toml
@@ -5,7 +5,8 @@ include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_myaudit_host_meta]

--- a/internal/generator/vector/input/audit_kube.toml
+++ b/internal/generator/vector/input/audit_kube.toml
@@ -5,7 +5,8 @@ include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_myaudit_kube_meta]

--- a/internal/generator/vector/input/audit_openshift.toml
+++ b/internal/generator/vector/input/audit_openshift.toml
@@ -5,7 +5,8 @@ include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/au
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_myaudit_openshift_meta]

--- a/internal/generator/vector/input/audit_ovn.toml
+++ b/internal/generator/vector/input/audit_ovn.toml
@@ -5,7 +5,8 @@ include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 
 [transforms.input_myaudit_ovn_meta]

--- a/internal/generator/vector/source/audit_logs.go
+++ b/internal/generator/vector/source/audit_logs.go
@@ -13,7 +13,8 @@ include = ["/var/log/audit/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 {{end}}`
 
@@ -28,7 +29,8 @@ include = ["/var/log/oauth-apiserver/audit.log","/var/log/openshift-apiserver/au
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 {{end}}
 `
@@ -44,7 +46,8 @@ include = ["/var/log/kube-apiserver/audit.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 {{end}}
 `
@@ -60,7 +63,8 @@ include = ["/var/log/ovn/acl-audit-log.log"]
 host_key = "hostname"
 glob_minimum_cooldown_ms = 15000
 ignore_older_secs = 3600
-max_read_bytes = 3145728
+max_line_bytes = 3145728
+max_read_bytes =  262144
 rotate_wait_secs = 5
 {{end}}
 `


### PR DESCRIPTION
### Description
This PR:
* bumps the max_line_bytes for audit logs
* bumps the max_read_line_bytes for audit logs

### Links
https://issues.redhat.com/browse/LOG-5998
