### PR TITLE
LOG-6277: Fix LokiStack is not gathered even if it exists.

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -91,7 +91,8 @@ else
   log "Skipping collection inspection.  No default CLO found" 2>&1 | tee "${LOGFILE_PATH}"
 fi
 
-loki_crd=$(oc get crd -A -o custom-columns=:.metadata.name | grep lokistack)||
+loki_crd=$(oc get crd -A -o custom-columns=:.metadata.name | grep lokistack)
+
 if [ "$loki_crd" != "" ] ; then
   found_lokistack="$(oc -n $LOGGING_NS get lokistack.loki.grafana.com --ignore-not-found --no-headers)"
   if [ "$found_lokistack" != "" ] ; then


### PR DESCRIPTION
### Description
The must-gather code[1] gathers LokiStack only when "lokistack" wasn't found in the result of "oc get crd".
It means that LokiStack isn't gathered even if it exists.

[1] https://github.com/openshift/cluster-logging-operator/blob/b8e2d71d573fca3717c232d3778aa021f63fc15d/must-gather/collection-scripts/gather#L94

The current line should use && instead of ||. This change is important because, in bash, if the left expression of || is true, the right expression is not evaluated. By using &&, the right expression will be evaluated if LokiStack exists, ensuring that the information is gathered correctly.

Here is an example to demonstrate this point:
```
$ bash -c 'echo first expression || echo second expression'
first expression  # <--- second expression is not evaluated
$ bash -c 'echo first expression && echo second expression'
first expression
second expression
```

/cc @Clee2691
/assign @jcantrill


### Links
JIRA: https://issues.redhat.com/browse/LOG-6277