### PR TITLE
LOG-6201: avoid empty Reason and Message fields in Ready Condition

### DIFF
--- a/api/logging/v1alpha1/log_file_metrics_exporter_types.go
+++ b/api/logging/v1alpha1/log_file_metrics_exporter_types.go
@@ -6,6 +6,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ReasonValid is used as a reason for the condition indicating that the LogFileMetricExporter is deployed.
+const ReasonValid status.ConditionReason = "Valid"
+
 // LogFileMetricExporterSpec defines the desired state of LogFileMetricExporter
 type LogFileMetricExporterSpec struct {
 	// The resource requirements for the LogFileMetricExporter

--- a/internal/controller/logfilemetricsexporter/logfilemetricsexporter_controller.go
+++ b/internal/controller/logfilemetricsexporter/logfilemetricsexporter_controller.go
@@ -39,7 +39,12 @@ type ReconcileLogFileMetricExporter struct {
 	ClusterID string
 }
 
-var condReady = status.Condition{Type: loggingv1.ConditionReady, Status: corev1.ConditionTrue}
+var condReady = status.Condition{
+	Type:    loggingv1.ConditionReady,
+	Status:  corev1.ConditionTrue,
+	Reason:  loggingv1alpha1.ReasonValid,
+	Message: "Instance is ready to use",
+}
 
 func condNotReady(r status.ConditionReason, format string, args ...interface{}) status.Condition {
 	return loggingv1.NewCondition(loggingv1.ConditionReady, corev1.ConditionFalse, r, format, args...)


### PR DESCRIPTION
### Description
This PR initializes the `Reason` and `Message` fields in the `Ready Condition` of the `LogFileMetricsExporter` instance, ensuring a smooth transition to version 6.x.  
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma @xperimental <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill  <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-6201
- Enhancement proposal:
