### PR TITLE
LOG-6296: GCP expects certain severity value strings

### DIFF
--- a/internal/generator/vector/output/gcl/gcl_with_custom_logid.toml
+++ b/internal/generator/vector/output/gcl/gcl_with_custom_logid.toml
@@ -6,9 +6,28 @@ source = '''
 ._internal.gcl_1_log_id = "my-id" + to_string!(.log_type||"none")
 '''
 
+# Normalize GCL severity levels
+[transforms.gcl_1_normalize_severity]
+type = "remap"
+inputs = ["gcl_1_log_id"]
+source = '''
+# Set audit log level to 'INFO'
+if .log_type == "audit" {
+	.level = "INFO"
+} else if !exists(.level) {
+  	.level = "DEFAULT"
+} else if .level == "warn" {
+	.level = "WARNING"
+} else if .level == "trace" {
+	.level = "DEBUG"
+} else {
+	.level = upcase!(.level) 
+}
+'''
+
 [sinks.gcl_1]
 type = "gcp_stackdriver_logs"
-inputs = ["gcl_1_log_id"]
+inputs = ["gcl_1_normalize_severity"]
 billing_account_id = "billing-1"
 credentials_path = "/var/run/ocp-collector/secrets/gcl-1/google-application-credentials.json"
 log_id = "{{ _internal.gcl_1_log_id }}"

--- a/internal/generator/vector/output/gcl/gcl_with_tls.toml
+++ b/internal/generator/vector/output/gcl/gcl_with_tls.toml
@@ -6,9 +6,28 @@ source = '''
 ._internal.gcl_1_log_id = "vector-1"
 '''
 
+# Normalize GCL severity levels
+[transforms.gcl_1_normalize_severity]
+type = "remap"
+inputs = ["gcl_1_log_id"]
+source = '''
+# Set audit log level to 'INFO'
+if .log_type == "audit" {
+	.level = "INFO"
+} else if !exists(.level) {
+  	.level = "DEFAULT"
+} else if .level == "warn" {
+	.level = "WARNING"
+} else if .level == "trace" {
+	.level = "DEBUG"
+} else {
+	.level = upcase!(.level) 
+}
+'''
+
 [sinks.gcl_1]
 type = "gcp_stackdriver_logs"
-inputs = ["gcl_1_log_id"]
+inputs = ["gcl_1_normalize_severity"]
 billing_account_id = "billing-1"
 credentials_path = "/var/run/ocp-collector/secrets/gcl-1/google-application-credentials.json"
 log_id = "{{ _internal.gcl_1_log_id }}"

--- a/internal/generator/vector/output/gcl/gcl_with_token.toml
+++ b/internal/generator/vector/output/gcl/gcl_with_token.toml
@@ -6,9 +6,28 @@ source = '''
 ._internal.gcl_1_log_id = "vector-1"
 '''
 
+# Normalize GCL severity levels
+[transforms.gcl_1_normalize_severity]
+type = "remap"
+inputs = ["gcl_1_log_id"]
+source = '''
+# Set audit log level to 'INFO'
+if .log_type == "audit" {
+	.level = "INFO"
+} else if !exists(.level) {
+  	.level = "DEFAULT"
+} else if .level == "warn" {
+	.level = "WARNING"
+} else if .level == "trace" {
+	.level = "DEBUG"
+} else {
+	.level = upcase!(.level) 
+}
+'''
+
 [sinks.gcl_1]
 type = "gcp_stackdriver_logs"
-inputs = ["gcl_1_log_id"]
+inputs = ["gcl_1_normalize_severity"]
 billing_account_id = "billing-1"
 credentials_path = "/var/run/ocp-collector/secrets/gcl-1/google-application-credentials.json"
 log_id = "{{ _internal.gcl_1_log_id }}"

--- a/internal/generator/vector/output/gcl/gcl_with_tuning.toml
+++ b/internal/generator/vector/output/gcl/gcl_with_tuning.toml
@@ -6,9 +6,28 @@ source = '''
 ._internal.gcl_1_log_id = "vector-1"
 '''
 
+# Normalize GCL severity levels
+[transforms.gcl_1_normalize_severity]
+type = "remap"
+inputs = ["gcl_1_log_id"]
+source = '''
+# Set audit log level to 'INFO'
+if .log_type == "audit" {
+	.level = "INFO"
+} else if !exists(.level) {
+  	.level = "DEFAULT"
+} else if .level == "warn" {
+	.level = "WARNING"
+} else if .level == "trace" {
+	.level = "DEBUG"
+} else {
+	.level = upcase!(.level) 
+}
+'''
+
 [sinks.gcl_1]
 type = "gcp_stackdriver_logs"
-inputs = ["gcl_1_log_id"]
+inputs = ["gcl_1_normalize_severity"]
 billing_account_id = "billing-1"
 credentials_path = "/var/run/ocp-collector/secrets/gcl-1/google-application-credentials.json"
 log_id = "{{ _internal.gcl_1_log_id }}"


### PR DESCRIPTION
### Description
This PR normalizes log severity levels for the `GCL` sink based on GCL's standard referenced below.
The severity level of `audit` logs is `INFO`.

Ref: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6296

