### PR TITLE
LOG-6333: Fix supported OpenShift versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ coverage: test-unit
 test-cluster:
 	go test  -cover -race ./test/... -- -root=$(CURDIR)
 
-OPENSHIFT_VERSIONS?="v4.14-v4.17"
+OPENSHIFT_VERSIONS?="v4.15-v4.18"
 # Generate bundle manifests and metadata, then validate generated files.
 BUNDLE_VERSION?=$(VERSION)
 CHANNEL=stable-${LOGGING_VERSION}

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -16,7 +16,7 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.14-v4.17"
+LABEL com.redhat.openshift.versions="v4.15-v4.18"
 
 LABEL \
     com.redhat.component="cluster-logging-operator" \

--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.17
+    value: 4.18


### PR DESCRIPTION
### Description

Fixes the supported OpenShift versions for version 6.1

/cc @cahartma 
/assign @jcantrill 

### Links

- JIRA: [LOG-6333](https://issues.redhat.com//browse/LOG-6333)
