### PR TITLE
Revert "LOG-6204: Manual port of LOG-6044 to release-6.0"

### DIFF
--- a/internal/validations/observability/validate_permissions.go
+++ b/internal/validations/observability/validate_permissions.go
@@ -27,7 +27,7 @@ const (
 	allNamespaces = ""
 )
 
-var infraNamespaces = regexp.MustCompile(`^default$|^kube$|^openshift$|^openshift-.*$|^kube-.*$`)
+var infraNamespaces = regexp.MustCompile(`^default$|^openshift.*$|^kube.*$`)
 
 // ValidatePermissions validates the serviceAccount for the CLF has the needed permissions to collect the desired inputs
 func ValidatePermissions(context internalcontext.ForwarderContext) {

--- a/internal/validations/observability/validate_permissions_test.go
+++ b/internal/validations/observability/validate_permissions_test.go
@@ -279,13 +279,7 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder permissio
 
 			Context("when service account only has collect-application-logs permission", func() {
 				It("should pass validation for non-infra namespaces that include infra keywords kube, default, openshift", func() {
-					namespaces := []string{
-						"sample-kube-namespace",
-						"my-default-ns",
-						"custom-openshift-namespace",
-						"default-custom",
-						"kube1",
-						"openshift1"}
+					namespaces := []string{"sample-kube-namespace", "my-default-ns", "custom-openshift-namespace", "default-custom"}
 					var includes []obs.NamespaceContainerSpec
 					for _, ns := range namespaces {
 						includes = append(includes, obs.NamespaceContainerSpec{Namespace: ns})
@@ -350,12 +344,12 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder permissio
 				},
 					Entry("with default namespace", []string{"default"}),
 					Entry("with openshift namespace", []string{"openshift"}),
-					Entry("with openshift- and wildcard namespace", []string{"openshift-*"}),
+					Entry("with openshift and wildcard namespace", []string{"openshift*"}),
 					Entry("with openshift-operators-redhat namespace", []string{"openshift-operators-redhat"}),
 					Entry("with kube namespace", []string{"kube"}),
-					Entry("with kube- and wildcard namespace", []string{"kube-*"}),
+					Entry("with kube and wildcard namespace", []string{"kube*"}),
 					Entry("with kube-system namespace", []string{"kube-system"}),
-					Entry("with multiple namespaces including an infra namespace", []string{"kube-*", "custom-ns"}),
+					Entry("with multiple namespaces including an infra namespace", []string{"kube*", "custom-ns"}),
 				)
 
 				It("when including infra namespaces and excluding other namespaces", func() {


### PR DESCRIPTION
### Description
This PR reverts: https://github.com/openshift/cluster-logging-operator/pull/2837. We have determined that users should not create namespaces starting with `openshift` or `kube`.

/cc @cahartma @vparfonov 
/assign @jcantrill 

/cherry-pick release-6.0

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6342

