### PR TITLE
LOG-6347: Update maximum OpenShift version to match supported range

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.17
+    value: 4.16


### PR DESCRIPTION
### Description

Updates the maximum OpenShift version to match the supported versions range.

/cc @cahartma
/assign @jcantrill 

### Links

- JIRA: [LOG-6347](https://issues.redhat.com//browse/LOG-6347)
