### PR TITLE
LOG-6354: Infra namespaces spec'd as app inputs have log_type set to 'application'

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -105,7 +105,12 @@ type = "remap"
 inputs = ["input_infrastructure_container"]
 source = '''
   .log_source = "container"
-  .log_type = "infrastructure"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''
 
 [sources.input_infrastructure_journal]
@@ -141,7 +146,12 @@ type = "remap"
 inputs = ["input_mytestapp_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''
 
 [transforms.pipeline_pipeline_viaqjournal_0]

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -105,7 +105,12 @@ type = "remap"
 inputs = ["input_infrastructure_container"]
 source = '''
   .log_source = "container"
-  .log_type = "infrastructure"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''
 
 [sources.input_infrastructure_journal]
@@ -175,7 +180,12 @@ type = "remap"
 inputs = ["input_mytestapp_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''
 
 [transforms.pipeline_pipeline_viaqjournal_0]

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -33,7 +33,12 @@ type = "remap"
 inputs = ["input_myinfra_container"]
 source = '''
   .log_source = "container"
-  .log_type = "infrastructure"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''
 
 # Logs from containers (including openshift containers)
@@ -57,7 +62,12 @@ type = "remap"
 inputs = ["input_mytestapp_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''
 
 [transforms.pipeline_mypipeline_viaq_0]

--- a/internal/generator/vector/input/application.toml
+++ b/internal/generator/vector/input/application.toml
@@ -18,5 +18,10 @@ type = "remap"
 inputs = ["input_application_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''

--- a/internal/generator/vector/input/application_exclude_container_from_infra.toml
+++ b/internal/generator/vector/input/application_exclude_container_from_infra.toml
@@ -19,5 +19,10 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''

--- a/internal/generator/vector/input/application_excludes_container.toml
+++ b/internal/generator/vector/input/application_excludes_container.toml
@@ -18,5 +18,10 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''

--- a/internal/generator/vector/input/application_includes_container.toml
+++ b/internal/generator/vector/input/application_includes_container.toml
@@ -19,5 +19,10 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''

--- a/internal/generator/vector/input/application_with_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_includes_excludes.toml
@@ -19,5 +19,10 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''

--- a/internal/generator/vector/input/application_with_infra_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_excludes.toml
@@ -19,5 +19,10 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''

--- a/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
@@ -19,5 +19,10 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''

--- a/internal/generator/vector/input/application_with_matchLabels.toml
+++ b/internal/generator/vector/input/application_with_matchLabels.toml
@@ -19,5 +19,10 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''

--- a/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
@@ -19,5 +19,10 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''

--- a/internal/generator/vector/input/application_with_throttle.toml
+++ b/internal/generator/vector/input/application_with_throttle.toml
@@ -18,7 +18,12 @@ type = "remap"
 inputs = ["input_application_container"]
 source = '''
   .log_source = "container"
-  .log_type = "application"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''
 
 [transforms.input_application_container_throttle]

--- a/internal/generator/vector/input/audit.go
+++ b/internal/generator/vector/input/audit.go
@@ -23,7 +23,7 @@ func NewAuditAuditdSource(input obs.InputSpec, op generator.Options) ([]generato
 	metaID := helpers.MakeID(hostID, "meta")
 	el := []generator.Element{
 		sources.NewHostAuditLog(hostID),
-		NewLogSourceAndType(metaID, obs.AuditSourceAuditd, obs.InputTypeAudit, hostID),
+		NewLogSourceAndType(metaID, obs.AuditSourceAuditd, obs.InputTypeAudit, hostID, nil),
 	}
 	return el, []string{metaID}
 }
@@ -33,7 +33,7 @@ func NewK8sAuditSource(input obs.InputSpec, op generator.Options) ([]generator.E
 	metaID := helpers.MakeID(id, "meta")
 	el := []generator.Element{
 		sources.NewK8sAuditLog(id),
-		NewLogSourceAndType(metaID, obs.AuditSourceKube, obs.InputTypeAudit, id),
+		NewLogSourceAndType(metaID, obs.AuditSourceKube, obs.InputTypeAudit, id, nil),
 	}
 	return el, []string{metaID}
 }
@@ -43,7 +43,7 @@ func NewOpenshiftAuditSource(input obs.InputSpec, op generator.Options) ([]gener
 	metaID := helpers.MakeID(id, "meta")
 	el := []generator.Element{
 		sources.NewOpenshiftAuditLog(id),
-		NewLogSourceAndType(metaID, obs.AuditSourceOpenShift, obs.InputTypeAudit, id),
+		NewLogSourceAndType(metaID, obs.AuditSourceOpenShift, obs.InputTypeAudit, id, nil),
 	}
 	return el, []string{metaID}
 }
@@ -53,7 +53,7 @@ func NewOVNAuditSource(input obs.InputSpec, op generator.Options) ([]generator.E
 	metaID := helpers.MakeID(id, "meta")
 	el := []generator.Element{
 		sources.NewOVNAuditLog(id),
-		NewLogSourceAndType(metaID, obs.AuditSourceOVN, obs.InputTypeAudit, id),
+		NewLogSourceAndType(metaID, obs.AuditSourceOVN, obs.InputTypeAudit, id, nil),
 	}
 	return el, []string{metaID}
 }

--- a/internal/generator/vector/input/infrastructure.toml
+++ b/internal/generator/vector/input/infrastructure.toml
@@ -19,7 +19,12 @@ type = "remap"
 inputs = ["input_infrastructure_container"]
 source = '''
   .log_source = "container"
-  .log_type = "infrastructure"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''
 
 [sources.input_infrastructure_journal]

--- a/internal/generator/vector/input/infrastructure_container.toml
+++ b/internal/generator/vector/input/infrastructure_container.toml
@@ -19,5 +19,10 @@ type = "remap"
 inputs = ["input_myinfra_container"]
 source = '''
   .log_source = "container"
-  .log_type = "infrastructure"
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      .log_type = "infrastructure"
+  } else {
+      .log_type = "application"
+  }
 '''

--- a/internal/generator/vector/input/journal.go
+++ b/internal/generator/vector/input/journal.go
@@ -12,7 +12,7 @@ func NewJournalSource(input obs.InputSpec) ([]Element, []string) {
 	metaID := helpers.MakeID(id, "meta")
 	el := []Element{
 		source.NewJournalLog(id),
-		NewLogSourceAndType(metaID, string(obs.InfrastructureSourceNode), string(obs.InputTypeInfrastructure), id),
+		NewLogSourceAndType(metaID, string(obs.InfrastructureSourceNode), string(obs.InputTypeInfrastructure), id, nil),
 	}
 	return el, []string{metaID}
 }

--- a/internal/generator/vector/input/meta.go
+++ b/internal/generator/vector/input/meta.go
@@ -2,15 +2,20 @@ package input
 
 import (
 	"fmt"
+
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 )
 
-func NewLogSourceAndType(id string, logSource, logType interface{}, inputs string) framework.Element {
-	return elements.Remap{
+func NewLogSourceAndType(id string, logSource, logType interface{}, inputs string, visit func(remap *elements.Remap)) framework.Element {
+	ele := elements.Remap{
 		ComponentID: id,
 		Inputs:      helpers.MakeInputs(inputs),
 		VRL:         fmt.Sprintf(".log_source = %q\n.log_type = %q", logSource, logType),
 	}
+	if visit != nil {
+		visit(&ele)
+	}
+	return ele
 }

--- a/internal/generator/vector/input/receiver.go
+++ b/internal/generator/vector/input/receiver.go
@@ -22,7 +22,7 @@ func NewViaqReceiverSource(spec obs.InputSpec, resNames factory.ForwarderResourc
 		els = append(els,
 			source.NewSyslogSource(base, resNames.GenerateInputServiceName(spec.Name), spec),
 			tlsConfig,
-			NewLogSourceAndType(metaID, obs.InfrastructureSourceNode, obs.InputTypeInfrastructure, base),
+			NewLogSourceAndType(metaID, obs.InfrastructureSourceNode, obs.InputTypeInfrastructure, base, nil),
 		)
 	case obs.ReceiverTypeHTTP:
 		el, id := source.NewHttpSource(base, resNames.GenerateInputServiceName(spec.Name), spec)
@@ -33,7 +33,7 @@ func NewViaqReceiverSource(spec obs.InputSpec, resNames factory.ForwarderResourc
 			tlsConfig,
 			split,
 			items,
-			NewLogSourceAndType(metaID, obs.AuditSourceKube, obs.InputTypeAudit, itemsID),
+			NewLogSourceAndType(metaID, obs.AuditSourceKube, obs.InputTypeAudit, itemsID, nil),
 		)
 	}
 	return els, []string{metaID}

--- a/internal/generator/vector/input/source.go
+++ b/internal/generator/vector/input/source.go
@@ -2,17 +2,19 @@ package input
 
 import (
 	"fmt"
+	"regexp"
+
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/factory"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/source"
 	"github.com/openshift/cluster-logging-operator/internal/utils/sets"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/set"
-	"regexp"
 )
 
 const (
@@ -165,7 +167,20 @@ func NewContainerSource(spec obs.InputSpec, namespace, includes, excludes string
 			ExcludePaths:       excludes,
 			ExtraLabelSelector: source.LabelSelectorFrom(selector),
 		},
-		NewLogSourceAndType(metaID, logSource, logType, base),
+		NewLogSourceAndType(metaID, logSource, logType, base, func(remap *elements.Remap) {
+			remap.VRL = fmt.Sprintf(
+				`
+.log_source = %q
+# If namespace is infra, label log_type as infra
+if match_any(string!(.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+    .log_type = %q
+} else {
+    .log_type = %q
+}`,
+				logSource,
+				obs.InputTypeInfrastructure,
+				obs.InputTypeApplication)
+		}),
 	}
 	inputID := metaID
 	//TODO: DETERMINE IF key field is correct and actually works


### PR DESCRIPTION
### Description
This PR correctly aligns the `log_type` of `infrastructure` container logs when `infrastructure` namespaces are included in `application` input types.

Infrastructure namespaces are defined as:
1. `default`
2. `kube-*`
3. `openshift-*`

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6354
