### PR TITLE
LOG-6352: fix pruning condition, avoid infinity loop

### DIFF
--- a/internal/api/observability/conditions.go
+++ b/internal/api/observability/conditions.go
@@ -5,7 +5,6 @@ import (
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclock "k8s.io/utils/clock"
-	"strings"
 )
 
 // clock is used to set status condition timestamps.
@@ -54,11 +53,11 @@ func SetCondition(conditions *[]metav1.Condition, newCond metav1.Condition) bool
 }
 
 // PruneConditions keeps only those conditions that match names from the spec
-func PruneConditions(conditions *[]metav1.Condition, spec NameList) {
+func PruneConditions(conditions *[]metav1.Condition, spec NameList, conditionTypePrefix string) {
 	keepers := []metav1.Condition{}
 	for _, condition := range *conditions {
 		for _, name := range spec.Names() {
-			if strings.HasSuffix(condition.Type, name) {
+			if condition.Type == fmt.Sprintf("%s-%s", conditionTypePrefix, name) {
 				keepers = append(keepers, condition)
 			}
 		}

--- a/internal/api/observability/conditions_test.go
+++ b/internal/api/observability/conditions_test.go
@@ -1,0 +1,30 @@
+package observability_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	. "github.com/openshift/cluster-logging-operator/internal/api/observability"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("[internal][api][observability]", func() {
+
+	Context("Helper Conditions", func() {
+
+		It("should prune conditions", func() {
+			conditions := []metav1.Condition{
+				NewConditionFromPrefix(v1.ConditionTypeValidPipelinePrefix, "bar", true, "", ""),
+				NewConditionFromPrefix(v1.ConditionTypeValidPipelinePrefix, "foo-bar", true, "", ""),
+				NewConditionFromPrefix(v1.ConditionTypeValidPipelinePrefix, "bar-baz", true, "", ""),
+			}
+			pipelines := Pipelines{
+				{Name: "bar"},
+				{Name: "foo-bar"},
+			}
+			Expect(len(conditions)).To(Equal(3))
+			PruneConditions(&conditions, pipelines, v1.ConditionTypeValidPipelinePrefix)
+			Expect(len(conditions)).To(Equal(2))
+		})
+	})
+})

--- a/internal/controller/observability/clusterlogforwarder_controller.go
+++ b/internal/controller/observability/clusterlogforwarder_controller.go
@@ -233,8 +233,8 @@ func removeStaleStatuses(forwarder *obsv1.ClusterLogForwarder) {
 	outputs := internalobs.Outputs(forwarder.Spec.Outputs)
 	filters := internalobs.Filters(forwarder.Spec.Filters)
 	pipelines := internalobs.Pipelines(forwarder.Spec.Pipelines)
-	internalobs.PruneConditions(&forwarder.Status.InputConditions, inputs)
-	internalobs.PruneConditions(&forwarder.Status.OutputConditions, outputs)
-	internalobs.PruneConditions(&forwarder.Status.FilterConditions, filters)
-	internalobs.PruneConditions(&forwarder.Status.PipelineConditions, pipelines)
+	internalobs.PruneConditions(&forwarder.Status.InputConditions, inputs, obsv1.ConditionTypeValidInputPrefix)
+	internalobs.PruneConditions(&forwarder.Status.OutputConditions, outputs, obsv1.ConditionTypeValidOutputPrefix)
+	internalobs.PruneConditions(&forwarder.Status.FilterConditions, filters, obsv1.ConditionTypeValidFilterPrefix)
+	internalobs.PruneConditions(&forwarder.Status.PipelineConditions, pipelines, obsv1.ConditionTypeValidPipelinePrefix)
 }


### PR DESCRIPTION
### Description

This PR fixes an issue where substring collisions were occurring in the suffix matching logic for condition and pipeline names. Previously, the logic used `strings.HasSuffix()` to check if `condition.Type` ends with any of the pipeline names. This approach caused unintended collisions when one name was a substring of another. For example, if both `abc-app-logs` and `app-logs` were included in names, then `condition.Type` ending with `abc-app-logs` would incorrectly match `app-logs` as well. Fix this by adding more strict checking on name equality. 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill  <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-6352
- Enhancement proposal:
