### PR TITLE
LOG-6126: Alerting rules for log-collection contains message instead of description

### DIFF
--- a/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -8,7 +8,7 @@ spec:
     rules:
     - alert: CollectorNodeDown
       annotations:
-        message: Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod
+        description: Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod
           }} collector component for more than 10m.
         summary: Collector cannot be scraped
       expr: |
@@ -19,12 +19,12 @@ spec:
         severity: critical
     - alert: ElasticsearchDeprecation
       annotations:
-        message: In Red Hat OpenShift Logging Operator 6.0, support for the Red Hat
-          Elasticsearch Operator has been removed. Bug fixes and support are provided
+        description: In Red Hat OpenShift Logging Operator 6.0, support for the Red
+          Hat Elasticsearch Operator has been removed. Bug fixes and support are provided
           only through the end of the 5.9 lifecycle. As an alternative to the Elasticsearch
           Operator, you can use the Loki Operator instead.
         summary: Detected Elasticsearch as the in-cluster storage, which has been
-          removed in 6.0 release
+          removed in the 6.0 release
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging",label_component='elasticsearch'}) > 0
       for: 5m
@@ -34,12 +34,12 @@ spec:
         severity: Warning
     - alert: FluentdDeprecation
       annotations:
-        message: In Red Hat OpenShift Logging Operator 6.0, support for Fluentd as
-          a collector has been removed. Bug fixes and support are provided only through
-          the end of the 5.9 lifecycle. As an alternative to Fluentd, you can use
-          the Vector collector instead.
-        summary: Detected Fluentd as the collector, which has been removed in a 6.0
-          release
+        description: In Red Hat OpenShift Logging Operator 6.0, support for Fluentd
+          as a collector has been removed. Bug fixes and support are provided only
+          through the end of the 5.9 lifecycle. As an alternative to Fluentd, you
+          can use the Vector collector instead.
+        summary: Detected Fluentd as the collector, which has been removed in the
+          6.0 release
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging", label_implementation='fluentd', label_app_kubernetes_io_managed_by="cluster-logging-operator"}) > 0
       for: 5m
@@ -49,10 +49,10 @@ spec:
         severity: Warning
     - alert: KibanaDeprecation
       annotations:
-        message: In Red Hat OpenShift Logging Operator 6.0, support for Kibana as
-          a data visualization dashboard has been removed. Bug fixes and support are
-          provided only through the end of the 5.9 lifecycle. As an alternative to
-          Kibana, you can use the Grafana Dashboard instead.
+        description: In Red Hat OpenShift Logging Operator 6.0, support for Kibana
+          as a data visualization dashboard has been removed. Bug fixes and support
+          are provided only through the end of the 5.9 lifecycle. As an alternative
+          to Kibana, you can use the Grafana Dashboard instead.
         summary: Detected Kibana as the log data visualization, which has been removed
           in the 6.0 release
       expr: |
@@ -64,7 +64,8 @@ spec:
         severity: Warning
     - alert: DiskBufferUsage
       annotations:
-        message: 'Collectors potentially consuming too much node disk, {{ $value }}% '
+        description: 'Collectors potentially consuming too much node disk, {{ $value
+          }}% '
         summary: Detected consuming too much node disk on $labels.hostname host
       expr: "(label_replace(sum by(hostname) (vector_buffer_byte_size{component_kind='sink',
         buffer_type='disk'}), 'instance', '$1', 'hostname', '(.*)') \n/ on(instance)

--- a/config/prometheus/collector_alerts.yaml
+++ b/config/prometheus/collector_alerts.yaml
@@ -9,7 +9,7 @@ spec:
     rules:
     - alert: CollectorNodeDown
       annotations:
-        message: "Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod }} collector component for more than 10m."
+        description: "Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod }} collector component for more than 10m."
         summary: "Collector cannot be scraped"
       expr: |
         up{app_kubernetes_io_component = "collector", app_kubernetes_io_part_of = "cluster-logging"} == 0
@@ -19,8 +19,8 @@ spec:
         severity: critical
     - alert: ElasticsearchDeprecation
       annotations:
-        message: "In Red Hat OpenShift Logging Operator 6.0, support for the Red Hat Elasticsearch Operator has been removed. Bug fixes and support are provided only through the end of the 5.9 lifecycle. As an alternative to the Elasticsearch Operator, you can use the Loki Operator instead."
-        summary: "Detected Elasticsearch as the in-cluster storage, which has been removed in 6.0 release"
+        description: "In Red Hat OpenShift Logging Operator 6.0, support for the Red Hat Elasticsearch Operator has been removed. Bug fixes and support are provided only through the end of the 5.9 lifecycle. As an alternative to the Elasticsearch Operator, you can use the Loki Operator instead."
+        summary: "Detected Elasticsearch as the in-cluster storage, which has been removed in the 6.0 release"
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging",label_component='elasticsearch'}) > 0
       for: 5m
@@ -30,8 +30,8 @@ spec:
         namespace: openshift-logging
     - alert: FluentdDeprecation
       annotations:
-        message: "In Red Hat OpenShift Logging Operator 6.0, support for Fluentd as a collector has been removed. Bug fixes and support are provided only through the end of the 5.9 lifecycle. As an alternative to Fluentd, you can use the Vector collector instead."
-        summary: "Detected Fluentd as the collector, which has been removed in a 6.0 release"
+        description: "In Red Hat OpenShift Logging Operator 6.0, support for Fluentd as a collector has been removed. Bug fixes and support are provided only through the end of the 5.9 lifecycle. As an alternative to Fluentd, you can use the Vector collector instead."
+        summary: "Detected Fluentd as the collector, which has been removed in the 6.0 release"
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging", label_implementation='fluentd', label_app_kubernetes_io_managed_by="cluster-logging-operator"}) > 0
       for: 5m
@@ -41,7 +41,7 @@ spec:
         namespace: openshift-logging
     - alert: KibanaDeprecation
       annotations:
-        message: "In Red Hat OpenShift Logging Operator 6.0, support for Kibana as a data visualization dashboard has been removed. Bug fixes and support are provided only through the end of the 5.9 lifecycle. As an alternative to Kibana, you can use the Grafana Dashboard instead."
+        description: "In Red Hat OpenShift Logging Operator 6.0, support for Kibana as a data visualization dashboard has been removed. Bug fixes and support are provided only through the end of the 5.9 lifecycle. As an alternative to Kibana, you can use the Grafana Dashboard instead."
         summary: "Detected Kibana as the log data visualization, which has been removed in the 6.0 release"
       expr: |
         sum(kube_pod_labels{namespace="openshift-logging",label_component='kibana'}) > 0
@@ -52,7 +52,7 @@ spec:
         namespace: openshift-logging
     - alert: DiskBufferUsage
       annotations:
-        message: "Collectors potentially consuming too much node disk, {{ $value }}% "
+        description: "Collectors potentially consuming too much node disk, {{ $value }}% "
         summary: "Detected consuming too much node disk on $labels.hostname host"
       expr: |
         (label_replace(sum by(hostname) (vector_buffer_byte_size{component_kind='sink', buffer_type='disk'}), 'instance', '$1', 'hostname', '(.*)') 

--- a/docs/administration/collector-metrics-and-alerts.adoc
+++ b/docs/administration/collector-metrics-and-alerts.adoc
@@ -129,12 +129,16 @@ You can view this alerts in the OpenShift Container Platform web console.
 image::buffer-alert.png[Fired allert]
 
 === CollectorNodeDown
-
 Will be fired if collector component was offline for more than 10m
 
-=== CollectorVeryHighErrorRate
+=== ElasticsearchDeprecation
+Will fire when Elasticsearch is detected as the in-cluster storage.
 
-Will be fired if collector component errors are very high, will contain namespace and pod name
+=== FluentdDeprecation
+Will fire when Fluentd is detected as the collector type.
+
+=== KibanaDeprecation
+Will fire when Kibana is detected as the log data visualization.
 
 == Enabling ability to collect metrics from non infrastructure namespaces
 


### PR DESCRIPTION
### Description
This PR changes the collector's alerting rules `message` field to `description` according to the [style guide](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#style-guide).

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6126

