### PR TITLE
LOG-6376: skip tls validation if it set in config for HTTP output

### DIFF
--- a/internal/generator/fluentd/output/http/http_test.go
+++ b/internal/generator/fluentd/output/http/http_test.go
@@ -226,8 +226,9 @@ var _ = Describe("Generate fluentd config", func() {
 	tls_private_key_path '/var/run/ocp-collector/secrets/http-receiver/tls.key'
 	tls_client_cert_path '/var/run/ocp-collector/secrets/http-receiver/tls.crt'
 	tls_ca_cert_path '/var/run/ocp-collector/secrets/http-receiver/ca-bundle.crt'
-  tls_private_key_passphrase "#{File.exists?('/var/run/ocp-collector/secrets/http-receiver/passphrase') ? open('/var/run/ocp-collector/secrets/http-receiver/passphrase','r') do |f|f.read end : ''}"
-	<buffer>
+    tls_private_key_passphrase "#{File.exists?('/var/run/ocp-collector/secrets/http-receiver/passphrase') ? open('/var/run/ocp-collector/secrets/http-receiver/passphrase','r') do |f|f.read end : ''}"
+	tls_verify_mode none
+     <buffer>
 	  @type file
 	  path '/var/lib/fluentd/http_receiver'
 	  flush_mode interval

--- a/internal/validations/clusterlogforwarder/validate_url_to_output_tls_config.go
+++ b/internal/validations/clusterlogforwarder/validate_url_to_output_tls_config.go
@@ -16,7 +16,7 @@ func validateUrlAccordingToTls(clf v1.ClusterLogForwarder, k8sClient client.Clie
 		if output.URL != "" {  // some outputs not require to have output URL (e.g. Amazon CloudWatch or Google Cloud Logging) see verifyOutputURL()
 			u, _ := url.Parse(output.URL)
 			scheme := strings.ToLower(u.Scheme)
-			if !url.IsTLSScheme(scheme) && (output.TLS != nil && (output.TLS.InsecureSkipVerify || output.TLS.TLSSecurityProfile != nil)) {
+			if !url.IsTLSScheme(scheme) && output.TLS != nil {
 				log.V(3).Info("validateUrlAccordingToTls failed", "reason", "URL not secure but output has TLS configuration parameters",
 					"output URL", output.URL, "output Name", output.Name)
 				return fmt.Errorf("URL not secure: %v, but output %s has TLS configuration parameters", u, output.Name), nil

--- a/internal/validations/clusterlogforwarder/validate_url_to_output_tls_test.go
+++ b/internal/validations/clusterlogforwarder/validate_url_to_output_tls_test.go
@@ -31,12 +31,12 @@ var _ = Describe("[internal][validations] ClusterLogForwarder: Output URL vs Out
 			clf.Spec.Outputs[0].TLS = nil
 			Expect(validateUrlAccordingToTls(*clf, nil, nil)).To(Succeed())
 		})
-		It("should pass validation when when not secure URL and tls.InsecureSkipVerify=false", func() {
+		It("should fail validation when when not secure URL and tls.InsecureSkipVerify=false", func() {
 			clf.Spec.Outputs[0].URL = "http://local.svc:514"
 			clf.Spec.Outputs[0].TLS = &v1.OutputTLSSpec{
 				InsecureSkipVerify: false,
 			}
-			Expect(validateUrlAccordingToTls(*clf, nil, nil)).To(Succeed())
+			Expect(validateUrlAccordingToTls(*clf, nil, nil)).To(Not(Succeed()))
 		})
 		It("should fail validation when not secure URL and exist TLS config: tls.TLSSecurityProfile", func() {
 			clf.Spec.Outputs[0].URL = "http://local.svc:514"


### PR DESCRIPTION
### Description
This PR:
- fix Fluentd configuration generation in case `InsecureSkipVerify: true` by adding `tls_verify_mode none`
- Improve validation procedure for HTTP output, now will be fired error in case not secure URL and TLS settings 
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-6376
- Enhancement proposal:
