### PR TITLE
LOG-6375: Update maximum OpenShift version to match supported versions (5.6)

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.14
+    value: 4.13


### PR DESCRIPTION
### Description

This PR updates the maximum OpenShift version the operator is installable on to match the last version of OpenShift we officially [support](https://access.redhat.com/support/policy/updates/openshift_operators) for it.

/cc @cahartma 
/assign @jcantrill 

### Links

- JIRA: [LOG-6375](https://issues.redhat.com//browse/LOG-6375)
