### PR TITLE
[master] LOG-6468: Fix input spec nil exception violation

### DIFF
--- a/internal/api/initialize/process_pipelines.go
+++ b/internal/api/initialize/process_pipelines.go
@@ -88,21 +88,36 @@ func getInputTypeFromName(spec obs.ClusterLogForwarderSpec, inputName string) st
 		// use name as type
 		return inputName
 	}
-
 	for _, input := range spec.Inputs {
 		if input.Name == inputName {
-			if input.Application != nil {
+			switch {
+			case isApplicationInput(input):
 				return string(obs.InputTypeApplication)
-			}
-			if input.Infrastructure != nil || input.Receiver.Type == obs.ReceiverTypeSyslog {
+			case isInfrastructureInput(input):
 				return string(obs.InputTypeInfrastructure)
-			}
-			if input.Audit != nil || (input.Receiver.Type == obs.ReceiverTypeHTTP && input.Receiver.HTTP != nil && input.Receiver.HTTP.Format == obs.HTTPReceiverFormatKubeAPIAudit) {
+			case isAuditInput(input):
 				return string(obs.InputTypeAudit)
 			}
 		}
 	}
 	return ""
+}
+
+func isApplicationInput(input obs.InputSpec) bool {
+	return input.Application != nil
+}
+
+func isInfrastructureInput(input obs.InputSpec) bool {
+	return input.Infrastructure != nil ||
+		(input.Receiver != nil && input.Receiver.Type == obs.ReceiverTypeSyslog)
+}
+
+func isAuditInput(input obs.InputSpec) bool {
+	return input.Audit != nil ||
+		(input.Receiver != nil &&
+			input.Receiver.Type == obs.ReceiverTypeHTTP &&
+			input.Receiver.HTTP != nil &&
+			input.Receiver.HTTP.Format == obs.HTTPReceiverFormatKubeAPIAudit)
 }
 
 // findLokistackOutputs identifies and returns a set of lokistack output names that need to be migrated

--- a/internal/api/initialize/process_pipelines_test.go
+++ b/internal/api/initialize/process_pipelines_test.go
@@ -1,0 +1,118 @@
+package initialize
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+)
+
+var _ = Describe("[internal][api][initialize]", func() {
+	Context("getInputTypeFromName", func() {
+		var (
+			forwarder = obs.ClusterLogForwarder{
+				Spec: obs.ClusterLogForwarderSpec{
+					Inputs: []obs.InputSpec{{}},
+				},
+			}
+		)
+		Context("reserved named inputs", func() {
+			forwarder.Spec.Inputs = []obs.InputSpec{
+				{
+					Name: string(obs.InputTypeApplication),
+				},
+				{
+					Name: string(obs.InputTypeInfrastructure),
+				},
+				{
+					Name: string(obs.InputTypeAudit),
+				},
+			}
+			It("should return type application when name is application", func() {
+				inputType := getInputTypeFromName(forwarder.Spec, "application")
+				Expect(inputType).To(Equal(string(obs.InputTypeApplication)))
+			})
+			It("should return type infrastructure when name is infrastructure", func() {
+				inputType := getInputTypeFromName(forwarder.Spec, "infrastructure")
+				Expect(inputType).To(Equal(string(obs.InputTypeInfrastructure)))
+			})
+			It("should return type audit when name is audit", func() {
+				inputType := getInputTypeFromName(forwarder.Spec, "audit")
+				Expect(inputType).To(Equal(string(obs.InputTypeAudit)))
+			})
+		})
+
+		Context("named inputs", func() {
+			forwarder.Spec.Inputs = []obs.InputSpec{
+				{
+					Name: "my-app",
+					Type: obs.InputTypeApplication,
+					Application: &obs.Application{
+						Includes: []obs.NamespaceContainerSpec{
+							{
+								Container: "foo",
+							},
+						},
+					},
+				},
+				{
+					Name: "my-infra",
+					Type: obs.InputTypeInfrastructure,
+					Infrastructure: &obs.Infrastructure{
+						Sources: []obs.InfrastructureSource{obs.InfrastructureSourceContainer},
+					},
+				},
+				{
+					Name: "my-audit",
+					Type: obs.InputTypeAudit,
+					Audit: &obs.Audit{
+						Sources: []obs.AuditSource{obs.AuditSourceAuditd},
+					},
+				},
+				{
+					Name: "my-syslog-receiver",
+					Type: obs.InputTypeReceiver,
+					Receiver: &obs.ReceiverSpec{
+						Type: obs.ReceiverTypeSyslog,
+						Port: 10514,
+					},
+				},
+				{
+					Name: "my-http-receiver",
+					Type: obs.InputTypeReceiver,
+					Receiver: &obs.ReceiverSpec{
+						Type: obs.ReceiverTypeHTTP,
+						Port: 8080,
+						HTTP: &obs.HTTPReceiver{
+							Format: obs.HTTPReceiverFormatKubeAPIAudit,
+						},
+					},
+				},
+			}
+			It("should return type application when type is application", func() {
+				inputType := getInputTypeFromName(forwarder.Spec, "my-app")
+				Expect(inputType).To(Equal(string(obs.InputTypeApplication)))
+			})
+			It("should return type infrastructure when type is infrastructure", func() {
+				inputType := getInputTypeFromName(forwarder.Spec, "my-infra")
+				Expect(inputType).To(Equal(string(obs.InputTypeInfrastructure)))
+			})
+			It("should return type infrastructure when type is syslog receiver", func() {
+				inputType := getInputTypeFromName(forwarder.Spec, "my-syslog-receiver")
+				Expect(inputType).To(Equal(string(obs.InputTypeInfrastructure)))
+			})
+			It("should return type audit when type is audit", func() {
+				inputType := getInputTypeFromName(forwarder.Spec, "my-audit")
+				Expect(inputType).To(Equal(string(obs.InputTypeAudit)))
+			})
+			It("should return type audit when type is http receiver with kubeAPIAudit format", func() {
+				inputType := getInputTypeFromName(forwarder.Spec, "my-http-receiver")
+				Expect(inputType).To(Equal(string(obs.InputTypeAudit)))
+			})
+			// TODO: update method to return type, and handle this scenario in validation
+			It("should return empty when input name not found?", func() {
+				inputType := getInputTypeFromName(forwarder.Spec, "notfound")
+				Expect(inputType).To(BeEmpty())
+			})
+		})
+	})
+})


### PR DESCRIPTION
### Description
Manual cherry pick from 6.1 the quick fix to handle nil exception when a named input is of type audit.  Occurs while migrating internal lokistack output

/cc @Clee2691 @vparfonov
/assign @jcantrill

### Links
- https://issues.redhat.com/browse/LOG-6468
- release-6.2 clone:   https://issues.redhat.com/browse/LOG-6449
   - PR:  https://github.com/openshift/cluster-logging-operator/pull/2888 

