### PR TITLE
Expose `OPENSHIFT_CLUSTER_NAME` as an env variable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -135,6 +135,11 @@ func main() {
 		log.Error(err, "unable to retrieve the cluster version")
 		os.Exit(1)
 	}
+	clusterName, err := version.ClusterName(mgr.GetAPIReader())
+	if err != nil {
+		log.Error(err, "unable to retrieve the cluster name")
+		os.Exit(1)
+	}
 	migrateManifestResources(mgr.GetClient())
 
 	log.Info("Registering Components.")
@@ -170,6 +175,7 @@ func main() {
 			Reader:         mgr.GetAPIReader(),
 			ClusterVersion: clusterVersion,
 			ClusterID:      clusterID,
+			ClusterName:    clusterName,
 		},
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/api/context/context.go
+++ b/internal/api/context/context.go
@@ -32,6 +32,9 @@ type ForwarderContext struct {
 	// ClusterVersion is the version of the cluster on which the operator is deployed
 	ClusterVersion string
 
+	// ClusterName is the name of the cluster on which the operator is deployed
+	ClusterName string
+
 	// AdditionalContext are additional context options to take pass along during reconciliation
 	AdditionalContext utils.Options
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Factory#Daemonset", func() {
 					},
 				},
 			},
-		}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+		}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 		collector = podSpec.Containers[0]
 	})
 
@@ -102,7 +102,7 @@ var _ = Describe("Factory#Daemonset", func() {
 				logLevelDebug := "debug"
 				factory.LogLevel = logLevelDebug
 
-				podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+				podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 				collector = podSpec.Containers[0]
 				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{Name: "VECTOR_LOG", Value: logLevelDebug}))
 			})
@@ -150,7 +150,7 @@ var _ = Describe("Factory#Daemonset", func() {
 							providedToleration,
 						},
 					}
-					podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+					podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 					expTolerations := append(constants.DefaultTolerations(), providedToleration)
 					Expect(podSpec.Tolerations).To(Equal(expTolerations))
 				})
@@ -171,7 +171,7 @@ var _ = Describe("Factory#Daemonset", func() {
 							"foo": "bar",
 						},
 					}
-					podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+					podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 					Expect(podSpec.NodeSelector).To(Equal(expSelector))
 				})
 
@@ -204,7 +204,7 @@ var _ = Describe("Factory#Daemonset", func() {
 						Data: map[string]string{
 							constants.TrustedCABundleKey: caBundle,
 						},
-					}, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+					}, obs.ClusterLogForwarderSpec{}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 					collector = podSpec.Containers[0]
 
 					Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{Name: "http_proxy", Value: httpproxy}))
@@ -253,7 +253,7 @@ var _ = Describe("Factory#Daemonset", func() {
 					Data: map[string]string{
 						constants.TrustedCABundleKey: caBundle,
 					},
-				}, obs.ClusterLogForwarderSpec{}, "foobar", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+				}, obs.ClusterLogForwarderSpec{}, "foobar", "cluster-foo", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 
 				collector = podSpec.Containers[0]
 				Expect(podSpec.Volumes).To(ContainElement(expectedPodSpecMetricsVol))
@@ -363,7 +363,7 @@ var _ = Describe("Factory#Deployment", func() {
 			},
 			PodLabelVisitor: vector.PodLogExcludeLabel,
 		}
-		podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+		podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 		collector = podSpec.Containers[0]
 		saToken = v1.VolumeProjection{
 			ServiceAccountToken: &v1.ServiceAccountTokenProjection{
@@ -426,7 +426,7 @@ var _ = Describe("Factory#Deployment", func() {
 							providedToleration,
 						},
 					}
-					podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+					podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 					expTolerations := append(constants.DefaultTolerations(), providedToleration)
 					Expect(podSpec.Tolerations).To(Equal(expTolerations))
 				})
@@ -447,7 +447,7 @@ var _ = Describe("Factory#Deployment", func() {
 							"foo": "bar",
 						},
 					}
-					podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+					podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 					Expect(podSpec.NodeSelector).To(Equal(expSelector))
 				})
 
@@ -480,7 +480,7 @@ var _ = Describe("Factory#Deployment", func() {
 						Data: map[string]string{
 							constants.TrustedCABundleKey: caBundle,
 						},
-					}, obs.ClusterLogForwarderSpec{}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+					}, obs.ClusterLogForwarderSpec{}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 					collector = podSpec.Containers[0]
 
 					Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{Name: "http_proxy", Value: httpproxy}))
@@ -552,7 +552,7 @@ var _ = Describe("Factory#Deployment", func() {
 						Data: map[string]string{
 							constants.TrustedCABundleKey: caBundle,
 						},
-					}, clf.Spec, "foobar", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+					}, clf.Spec, "foobar", "cluster-foo", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 
 					collector = podSpec.Containers[0]
 					Expect(podSpec.Volumes).To(ContainElement(expectedPodSpecMetricsVol))
@@ -715,7 +715,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch STS Resources", func() {
 			podSpec := *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{
 				Outputs:   outputs,
 				Pipelines: pipelines,
-			}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+			}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 			collector := podSpec.Containers[0]
 
 			Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{
@@ -741,7 +741,7 @@ var _ = Describe("Factory#NewPodSpec Add Cloudwatch STS Resources", func() {
 			podSpec := *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{
 				Outputs:   outputs,
 				Pipelines: pipelines,
-			}, "1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
+			}, "1234", "cluster-1234", tls.GetClusterTLSProfileSpec(nil), constants.OpenshiftNS)
 			collector := podSpec.Containers[0]
 			Expect(podSpec.Volumes).To(IncludeVolume(
 				v1.Volume{

--- a/internal/controller/observability/collector.go
+++ b/internal/controller/observability/collector.go
@@ -88,7 +88,7 @@ func ReconcileCollector(context internalcontext.ForwarderContext, pollInterval, 
 
 	isDaemonSet := !internalobs.DeployAsDeployment(*context.Forwarder)
 	log.V(3).Info("Deploying as DaemonSet", "isDaemonSet", isDaemonSet)
-	factory := collector.New(collectorConfHash, context.ClusterID, context.Forwarder.Spec.Collector, context.Secrets, context.ConfigMaps, context.Forwarder.Spec, resourceNames, isDaemonSet, LogLevel(context.Forwarder.Annotations))
+	factory := collector.New(collectorConfHash, context.ClusterID, context.ClusterName, context.Forwarder.Spec.Collector, context.Secrets, context.ConfigMaps, context.Forwarder.Spec, resourceNames, isDaemonSet, LogLevel(context.Forwarder.Annotations))
 	if err = factory.ReconcileCollectorConfig(context.Client, context.Reader, context.Forwarder.Namespace, collectorConfig, ownerRef); err != nil {
 		log.Error(err, "collector.ReconcileCollectorConfig")
 		return

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -3,12 +3,13 @@ package functional
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/api/initialize"
 	"net"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/cluster-logging-operator/internal/api/initialize"
 
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 
@@ -270,6 +271,7 @@ func (f *CollectorFunctionalFramework) DeployWithVisitors(visitors []runtime.Pod
 	b = f.collector.BuildCollectorContainer(
 		b.AddContainer(constants.CollectorName, f.image).
 			AddEnvVar("OPENSHIFT_CLUSTER_ID", f.Name).
+			AddEnvVar("OPENSHIFT_CLUSTER_NAME", "cluster-"+f.Name).
 			AddEnvVarFromFieldRef("POD_IPS", "status.podIPs").
 			WithImagePullPolicy(corev1.PullAlways).ResourceRequirements(resources), FunctionalNodeName).
 		End()

--- a/version/cluster.go
+++ b/version/cluster.go
@@ -12,6 +12,7 @@ import (
 var (
 	clusterVersion string
 	clusterID      string
+	clusterName    string
 )
 
 // ClusterVersion retrieves the ClusterVersion spec
@@ -26,6 +27,19 @@ func ClusterVersion(k8client client.Reader) (string, string, error) {
 		clusterID = string(proto.Spec.ClusterID)
 	}
 	return clusterVersion, clusterID, nil
+}
+
+// ClusterVersion retrieves the ClusterVersion spec
+func ClusterName(k8client client.Reader) (string, error) {
+	if clusterName == "" {
+		proto := &configv1.Infrastructure{}
+		key := client.ObjectKey{Name: "cluster"}
+		if err := k8client.Get(context.TODO(), key, proto); err != nil {
+			return "", err
+		}
+		clusterName = proto.Status.InfrastructureName
+	}
+	return clusterName, nil
 }
 
 // HostedClusterVersion retrieves the version info of the hosted cluster or the clustser ID where the operator is deployed


### PR DESCRIPTION
### Description
Expose the name of the cluster the operator is running on:
```sh
$ oc get infrastructure/cluster -o json | jq .status.infrastructureName
```
as an environment variable `OPENSHIFT_CLUSTER_NAME` on the collector container.
The previous major release `v5.x` of the operator used to set the cluster name as the default value of the `groupPrefix` field on the `ClusterLogForwarder`:
```yaml
apiVersion: logging.openshift.io
kind: ClusterLogForwarder
spec:
  outputs:
  - type: cloudwatch
    cloudwatch:
      groupPrefix: ...
```
check the validation function [here](https://github.com/openshift/cluster-logging-operator/blob/1c607cd51f0cf835d12b15faa251d68c95308b58/internal/validations/clusterlogforwarder/validate_clusterlogforwarderspec.go#L226-L235).
As far as I'm able to understand, that's not the case anymore in `v6.x`.
The old behavior was pretty convenient for a cluster admin because, with no configuration at all, it was possible to give meaningful names to log groups in AWS CloudWatch.
By exposing `OPENSHIFT_CLUSTER_NAME` it would allowed to mimic it once again:
```yaml
apiVersion: observability.openshift.io
kind: ClusterLogForwarder
spec:
  outputs:
  - type: cloudwatch
    cloudwatch:
      groupName: '{ get_env_var("OPENSHIFT_CLUSTER_NAME") + .log_type || "noname" }'
```

/cc @jcantrill 
/assign @jcantrill 