### PR TITLE
LOG-6422: adding missing resources in Logging 6 must-gather

### DIFF
--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -22,171 +22,147 @@ Note that this command will only get data related to the cluster-logging part of
 
 You will get a dump of:
 - The openshift-logging namespace and its children objects
-- The openshift-operators-redhat namespace and its children objects
+- The openshift-operators and openshift-operators-redhat namespaces and its children objects
+- Other namespaces with ClusterLogForwarder object
+- The UIplugin and console namespace
 - The cluster-logging install objects
 - All cluster-logging CRD's definitions
 - All nodes objects
 - All persistent volumes objects
-- Custom logs, configurations and health status per component, i.e. collection, logStore, curation, visualization
+- Custom logs, configurations and health status per component, i.e. collection, logStore
 
 In order to get data about other parts of the cluster (not specific to cluster-logging) you should
 run `oc adm must-gather` (without passing a custom image). Run `oc adm must-gather -h` to see more options.
 
-Example must-gather for cluster-logging output:
+### Resources in the generated must-gather directory
+CLO information is located in `cluster-logging/clo/`, and some resources information (like collectors) are in individual namespaces under `cluster-logging/[namespace_name]`.
+
+The `clusterlogging` and `clusterlogforwarder` resources, and also `installplans`, `subscriptions`, `clusterserviceversions`, `logfilemetricexporter`, `uiplugion`, etc. are now collected by `oc adm inspect` command in the different `namespaces/[namespace_name]/` directories and no longer in `cluster-logging/clo`. This directory structure allows tools like [`omc`](https://github.com/gmeghnag/omc/) to work with those resources in a similar way to `oc` commands on a cluster.
+
+The `deployments`, `daemonsets` and `secrets` are also found under `namespaces/[namespace_name]/` and can also be seen using the [`omc`](https://github.com/gmeghnag/omc/) tool.
+
+Example must-gather for cluster-logging output (use `tree` for up-to-date structure):
 ```
 ├── cluster-logging
-│  ├── clo
-│  │  └── [nampespace_name]       ## including openshift-logging
-│  │     ├── cluster-logging-operator-74dd5994f-6ttgt
-│  │     ├── cr
-│  │     ├── collector-config_vector.toml
-│  │     ├── version
-│  │     └── [keys]
-│  ├── collectors
-│  │  └── [nampespace_name]       ## including openshift-logging
-│  │     └── collector-2tr64.describe
-│  ├── eo
-│  │  ├── elasticsearch-operator-7dc7d97b9d-jb4r4
-│  │  ├── indicex.txt
-│  │  └── eo-deployment.describe
-│  ├── es
-│  │  ├── cluster-elasticsearch
-│  │  │  ├── aliases.cat
-│  │  │  ├── health.cat
-│  │  │  ├── hot_threads.txt
-│  │  │  ├── indices.cat
-│  │  │  ├── indices_size.cat
-│  │  │  ├── latest_documents.json
-│  │  │  ├── nodes.cat
-│  │  │  ├── nodes_state.json
-│  │  │  ├── nodes_stats.json
-│  │  │  ├── pending_tasks.cat      (iff cluster health not green)
-│  │  │  ├── recovery.cat           (iff cluster health not green)
-│  │  │  ├── shards.cat             (iff cluster health not green)
-│  │  │  ├── thread_pool.cat
-│  │  │  └── unassigned_shards.cat  (iff cluster health not green)
-│  │  ├── cr
-│  │  ├── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
-│  │  └── logs
-│  │     └── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
-│  └── kibana
-│     ├── cr
-│     └── kibana-9d69668d4-2rkvz
+│  ├── clo
+│  │  ├── cluster-logging-operator-xxxxxxxxxx-xxxxx
+│  │  └── version
+│  └── namespaces
+│  │  └── [nampespace_name]               ## including openshift-logging
+│  │     ├── collector-xxxxx.describe
+│  │     ├── collector-yyyyy.describe
+│  │     └── configmap_collector-config_vector.toml
 ├── cluster-scoped-resources
+│  ├── apiextensions.k8s.io
+│  │  └── customresourcedefinitions
+│  │     ├── [all_CRDs]
+│  ├── config.openshift.io
+│  │  ├── [...]
+│  ├── console.openshift.io
+│  │  └── consoleplugins
+│  │     ├── logging-view-plugin.yaml
+│  │     └── [...]
 │  └── core
 │     ├── nodes
 │     │  └── ip-10-0-146-180.eu-west-1.compute.internal.yaml
 │     └── persistentvolumes
 │        └── pvc-0a8d65d9-54aa-4c44-9ecc-33d9381e41c1.yaml
+│  ├── machineconfiguration.openshift.io
+│  │  └── machineconfigpools
+│  │     └── [...]
+│  ├── [...]
+│  ├── observability.openshift.io
+│  │  └── uiplugins
+│  │     └── logging.yaml
+│  └── [...]
+├── [...]
 ├── event-filter.html
 ├── gather-debug.log
 └── namespaces
-   ├── [namespace_name]       ## including openshift-logging
-   │  ├── apps
-   │  │  ├── daemonsets.yaml
-   │  │  ├── deployments.yaml
-   │  │  ├── replicasets.yaml
-   │  │  └── statefulsets.yaml
-   │  ├── batch
-   │  │  ├── cronjobs.yaml
-   │  │  └── jobs.yaml
-   │  ├── logging.openshift.io/
-   │  │  ├── clusterloggings
-   │  │  │  └── [instance_name.yaml]
-   │  │  └── clusterlogforwarders
-   │  │     └── [clf_name.yaml]   
-   │  ├── core
-   │  │  ├── configmaps.yaml
-   │  │  ├── endpoints.yaml
-   │  │  ├── events
-   │  │  │  ├── elasticsearch-delete-app-1596020400-gm6nl.1626341a296c16a1.yaml
-   │  │  │  ├── elasticsearch-delete-audit-1596020400-9l9n4.1626341a2af81bbd.yaml
-   │  │  │  ├── elasticsearch-delete-infra-1596020400-v98tk.1626341a2d821069.yaml
-   │  │  │  ├── elasticsearch-rollover-app-1596020400-cc5vc.1626341a3019b238.yaml
-   │  │  │  ├── elasticsearch-rollover-audit-1596020400-s8d5s.1626341a31f7b315.yaml
-   │  │  │  └── elasticsearch-rollover-infra-1596020400-7mgv8.1626341a35ea59ed.yaml
-   │  │  ├── events.yaml
-   │  │  ├── persistentvolumeclaims.yaml
-   │  │  ├── pods.yaml
-   │  │  ├── replicationcontrollers.yaml
-   │  │  ├── secrets.yaml
-   │  │  └── services.yaml
-   │  ├── operators.coreos.com
-   │  │  ├── clusterserviceversions
-   │  │  │  └── elasticsearch-operator.v5.8.8.yaml
-   │  │  ├── installplans
-   │  │  │  └── install-xyzwq.yaml
-   │  │  └── subscriptions
-   │  │     └── cluster-logging.yaml
-   │  ├── openshift-logging.yaml
-   │  ├── pods
-   │  │  ├── cluster-logging-operator-74dd5994f-6ttgt
-   │  │  │  ├── cluster-logging-operator
-   │  │  │  │  └── cluster-logging-operator
-   │  │  │  │     └── logs
-   │  │  │  │        ├── current.log
-   │  │  │  │        ├── previous.insecure.log
-   │  │  │  │        └── previous.log
-   │  │  │  └── cluster-logging-operator-74dd5994f-6ttgt.yaml
-   │  │  ├── cluster-logging-operator-registry-6df49d7d4-mxxff
-   │  │  │  ├── cluster-logging-operator-registry
-   │  │  │  │  └── cluster-logging-operator-registry
-   │  │  │  │     └── logs
-   │  │  │  │        ├── current.log
-   │  │  │  │        ├── previous.insecure.log
-   │  │  │  │        └── previous.log
-   │  │  │  ├── cluster-logging-operator-registry-6df49d7d4-mxxff.yaml
-   │  │  │  └── mutate-csv-and-generate-sqlite-db
-   │  │  │     └── mutate-csv-and-generate-sqlite-db
-   │  │  │        └── logs
-   │  │  │           ├── current.log
-   │  │  │           ├── previous.insecure.log
-   │  │  │           └── previous.log
-   │  │  ├── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
-   │  │  │  └── elasticsearch
-   │  │  │     └── elasticsearch
-   │  │  │        └── logs
-   │  │  │           ├── current.log
-   │  │  │           ├── previous.insecure.log
-   │  │  │           └── previous.log   
-   │  │  ├── elasticsearch-im-app-1596030300-bpgcx
-   │  │  │  └── indexmanagement
-   │  │  │     └── indexmanagement
-   │  │  │        └── logs
-   │  │  │           ├── current.log
-   │  │  │           ├── previous.insecure.log
-   │  │  │           └── previous.log
-   │  │  ├── colletor-2tr64
-   │  │  │  ├── collector
-   │  │  │  │  └── collector
-   │  │  │  │     └── logs
-   │  │  │  │        ├── current.log
-   │  │  │  │        ├── previous.insecure.log
-   │  │  │  │        └── previous.log
-   │  │  │  └── collector-2tr64.yaml
-   │  │  ├── kibana-9d69668d4-2rkvz
-   │  │  │  ├── kibana
-   │  │  │  │  └── kibana
-   │  │  │  │     └── logs
-   │  │  │  │        ├── current.log
-   │  │  │  │        ├── previous.insecure.log
-   │  │  │  │        └── previous.log
-   │  │  │  ├── kibana-9d69668d4-2rkvz.yaml
-   │  │  │  └── kibana-proxy
-   │  │  │     └── kibana-proxy
-   │  │  │        └── logs
-   │  │  │           ├── current.log
-   │  │  │           ├── previous.insecure.log
-   │  │  │           └── previous.log
-   │  └── route.openshift.io
-   │     └── routes.yaml
-   └── openshift-operators-redhat
-      ├── ...
-```
-
-### Moved resources
-With the support of [multi log-forwarder feature](https://docs.openshift.com/container-platform/4.14/logging/log_collection_forwarding/log-forwarding.html#log-forwarding-implementations-multi-clf_log-forwarding) in Cluster Logging v5.8, CLO resources have moved from `cluster-logging/clo/` to individual namespaces under `cluster-logging/clo/[namespace_name]`.
-
-The `clusterlogging` and `clusterlogforwarder` resources, and also `installplans`, `subscriptions`, `clusterserviceversions`, `logfilemetricexporter`, etc. are now collected by `oc adm inspect` command in the different `namespaces/[namespace_name]/` directories and no longer in `cluster-logging/clo`. This directory structure allows tools like [`omc`](https://github.com/gmeghnag/omc/) to work with those resources in a similar way to `oc` commands on a cluster.
-
-The `deployments`, `daemonsets` and `secrets` are also found under `namespaces/[namespace_name]/` and can also be seen using the [`omc`](https://github.com/gmeghnag/omc/) tool.
+│  ├── [namespace_name]       ## including openshift-logging
+│  │  ├── apps
+│  │  │  ├── daemonsets.yaml
+│  │  │  ├── deployments.yaml
+│  │  │  ├── replicasets.yaml
+│  │  │  └── statefulsets.yaml
+│  │  ├── batch
+│  │  │  ├── cronjobs.yaml
+│  │  │  └── jobs.yaml
+│  │  ├── core
+│  │  │  ├── configmaps
+│  │  │  │  ├── collector-config.yaml
+│  │  │  │  ├── collector-trustbundle.yaml
+│  │  │  │  ├── kube-root-ca.crt.yaml
+│  │  │  │  ├── logging-loki-ca-bundle.yaml
+│  │  │  │  ├── logging-loki-config.yaml
+│  │  │  │  ├── logging-loki-gateway-ca-bundle.yaml
+│  │  │  │  ├── logging-loki-gateway.yaml
+│  │  │  │  └── openshift-service-ca.crt.yaml
+│  │  │  ├── configmaps.yaml
+│  │  ├── [...]
+│  │  │  ├── persistentvolumeclaims.yaml
+│  │  │  ├── pods
+│  │  │  │  ├── cluster-logging-operator-xxxxxxxxxx-xxxxx.yaml
+│  │  │  │  ├── collector-xxxxx.yaml
+│  │  │  │  ├── collector-xxxxx.yaml
+│  │  │  │  ├── collector-xxxxx.yaml
+│  │  │  │  ├── collector-xxxxx.yaml
+│  │  │  │  ├── collector-xxxxx.yaml
+│  │  │  │  ├── logfilesmetricexporter-xxxxx.yaml
+│  │  │  │  ├── logfilesmetricexporter-xxxxx.yaml
+│  │  │  │  ├── logfilesmetricexporter-xxxxx.yaml
+│  │  │  │  ├── logfilesmetricexporter-xxxxx.yaml
+│  │  │  │  ├── logfilesmetricexporter-xxxxx.yaml
+│  │  │  │  ├── logging-loki-compactor-0.yaml
+│  │  │  │  ├── logging-loki-distributor-xxxxxxxxxx-xxxxx.yaml
+│  │  │  │  ├── logging-loki-gateway-xxxxxxxxxx-xxxxx.yaml
+│  │  │  │  ├── logging-loki-gateway-xxxxxxxxxx-xxxxx.yaml
+│  │  │  │  ├── logging-loki-index-gateway-0.yaml
+│  │  │  │  ├── logging-loki-ingester-0.yaml
+│  │  │  │  ├── logging-loki-querier-xxxxxxxxxx-xxxxx.yaml
+│  │  │  │  └── logging-loki-query-frontend-xxxxxxxxxx-xxxxx.yaml
+│  │  │  ├── pods.yaml
+│  │  ├── [...]
+│  │  ├── logging.openshift.io
+│  │  │  └── logfilemetricexporters
+│  │  │     └── instance.yaml
+│  │  ├── loki.grafana.com
+│  │  │  └── lokistacks
+│  │  │     └── logging-loki.yaml
+│  │  ├── [...]
+│  │  ├── observability.openshift.io
+│  │  │   └── clusterlogforwarders
+│  │  │       └── collector.yaml
+│  │  ├── openshift-logging.yaml
+│  │  ├── operators.coreos.com
+│  │  │  ├── clusterserviceversions
+│  │  │  │  ├── cluster-logging.v6.1.1.yaml
+│  │  │  │  ├── cluster-observability-operator.0.4.1.yaml
+│  │  │  │  ├── elasticsearch-operator.v5.8.16.yaml
+│  │  │  │  ├── jaeger-operator.v1.62.0-1.yaml
+│  │  │  │  ├── kiali-operator.v1.89.8.yaml
+│  │  │  │  ├── loki-operator.v6.1.1.yaml
+│  │  │  │  └── servicemeshoperator.v2.6.4.yaml
+│  │  │  ├── installplans
+│  │  │  │  └── install-bb9t6.yaml
+│  │  │  └── subscriptions
+│  │  │     └── cluster-logging.yaml
+│  │  ├── pods
+│  │  │  ├── cluster-logging-operator-xxxxxxxxxx-xxxxx
+│  │  │  │  ├── cluster-logging-operator
+│  │  │  │  │  └── cluster-logging-operator
+│  │  │  │  │     └── logs
+│  │  │  │  │        ├── current.log
+│  │  │  │  │        ├── previous.insecure.log
+│  │  │  │  │        └── previous.log
+│  │  │  │  └── cluster-logging-operator-xxxxxxxxxx-xxxxx.yaml
+│  │  │  ├── collector-xxxxx
+│  │  │  │  ├── [...]
+│  │  │  └── [...]
+│  │  └── [...]
+│  └── [...]
+│  ├── openshift-operators
+│     ├── [...]
+│  └── openshift-operators-redhat
+│     ├── [...]
+└── timestamp

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -32,6 +32,9 @@ namespace_resources+=($LOGGING_NS)
 # elasticsearch operator namespace
 namespace_resources+=(openshift-operators-redhat)
 
+# uiplugin namespace
+namespace_resources+=(openshift-operators)
+
 # multi-forwarder namespaces
 for kind in $(oc get crd -A -o custom-columns=:.metadata.name | grep clusterlogforwarder); do
   namespaces=$(oc get $kind -A -o custom-columns=:.metadata.namespace | sort -u)
@@ -55,7 +58,6 @@ cluster_resources+=(clusterrolebindings)
 cluster_resources+=(persistentvolumes)
 cluster_resources+=(clusterversion)
 cluster_resources+=(machineconfigpool)
-cluster_resources+=(uiplugin)
 cluster_resources+=(customresourcedefinitions)
 
 log "- BEGIN inspecting cluster resources and namespaces..." | tee -a "${LOGFILE_PATH}"
@@ -88,13 +90,22 @@ for ns in ${namespace_resources[@]}    ; do
 done
 log "END inspecting namespaced resources ..." | tee -a "${LOGFILE_PATH}"
 
-# if the uiplugin is installed, collect the console CO
-uiplugin_found="$(oc get uiplugin --ignore-not-found --no-headers)"
-if [ "$uiplugin_found" != "" ] ; then
-  log "BEGIN gathering console resources ..." | tee -a "${LOGFILE_PATH}"
-  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" co/console 2>&1 | tee -a "${LOGFILE_PATH}"  &
-  pids+=($!)
-  log "END gathering console resources ..." | tee -a "${LOGFILE_PATH}"
+# if the uiplugin is installed, collect it and the console CO
+uiplugin_crd=$(oc get crd -A -o custom-columns=:.metadata.name | grep uiplugin) || true
+if [ "$uiplugin_crd" != "" ] ; then
+  uiplugin_found="$(oc get uiplugin --ignore-not-found --no-headers)" || true
+  if [ "$uiplugin_found" != "" ] ; then
+    log "BEGIN gathering uiplugin and console resources ..." | tee -a "${LOGFILE_PATH}"
+    oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" uiplugin  >> "${LOGFILE_PATH}" 2>&1 &
+    pids+=($!)
+    oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" co/console 2>&1 | tee -a "${LOGFILE_PATH}"  &
+    pids+=($!)
+    log "END gathering uiplugin and console resources ..." | tee -a "${LOGFILE_PATH}"
+  else
+    log "UIPlugin not configured" 2>&1 | tee -a "${LOGFILE_PATH}"
+  fi
+else
+  log "UIPlugin not installed" 2>&1 | tee -a "${LOGFILE_PATH}"
 fi
 
 default_clo_found="$(oc -n "$LOGGING_NS" get deployment cluster-logging-operator --ignore-not-found --no-headers)"
@@ -107,7 +118,7 @@ else
   log "Skipping collection inspection.  No default CLO found" 2>&1 | tee -a "${LOGFILE_PATH}"
 fi
 
-loki_crd=$(oc get crd -A -o custom-columns=:.metadata.name | grep lokistack)
+loki_crd=$(oc get crd -A -o custom-columns=:.metadata.name | grep lokistack) || true
 
 if [ "$loki_crd" != "" ] ; then
   found_lokistack="$(oc -n $LOGGING_NS get lokistack.loki.grafana.com --ignore-not-found --no-headers)"

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -11,6 +11,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/common
 BASE_COLLECTION_PATH="${1:-/must-gather}"
 BASE_COLLECTION_PATH=$(cd "$(dirname -- $BASE_COLLECTION_PATH)" >/dev/null; pwd -P)/$(basename -- "$BASE_COLLECTION_PATH")
+
 LOGGING_NS="${2:-openshift-logging}"
 LOGFILE_NAME="${3:-gather-debug.log}"
 LOGFILE_PATH="${BASE_COLLECTION_PATH}/${LOGFILE_NAME}" # must-gather/gather-debug.log
@@ -22,25 +23,27 @@ log "must-gather logs are located at: '${LOGFILE_PATH}'"
 mkdir ${BASE_COLLECTION_PATH}/cache-dir||:
 export KUBECACHEDIR=${BASE_COLLECTION_PATH}/cache-dir
 
-# cluster-scoped resources
-cluster_resources=(ns/openshift-operator-lifecycle-manager)
+# namespaces
+namespace_resources=(openshift-operator-lifecycle-manager)
 
 # cluster logging operator namespace
-cluster_resources+=(ns/$LOGGING_NS)
+namespace_resources+=($LOGGING_NS)
 
 # elasticsearch operator namespace
-cluster_resources+=(ns/openshift-operators-redhat)
+namespace_resources+=(openshift-operators-redhat)
 
 # multi-forwarder namespaces
 for kind in $(oc get crd -A -o custom-columns=:.metadata.name | grep clusterlogforwarder); do
   namespaces=$(oc get $kind -A -o custom-columns=:.metadata.namespace | sort -u)
   for multi in ${namespaces} ; do
       # add to the list of namespaces
-      cluster_resources+=(ns/$multi)
-      log "Adding namespace '$multi' to cluster resources list" >> "${LOGFILE_PATH}"
+      if [ "$multi" != "$LOGGING_NS" ] ; then
+        namespace_resources+=($multi)
+        log "Adding namespace '$multi' to cluster resources list" | tee -a "${LOGFILE_PATH}"
+      fi
 
       # get collector resources from the namespace
-      log "Inspecting collector resources in namespace '$multi'" | tee "${LOGFILE_PATH}"
+      log "Inspecting collector resources in namespace '$multi'" | tee -a "${LOGFILE_PATH}"
       ${SCRIPT_DIR}/gather_collection_resources "$BASE_COLLECTION_PATH" "$multi" 2>&1 >> "${LOGFILE_PATH}"
   done
 done
@@ -52,43 +55,56 @@ cluster_resources+=(clusterrolebindings)
 cluster_resources+=(persistentvolumes)
 cluster_resources+=(clusterversion)
 cluster_resources+=(machineconfigpool)
+cluster_resources+=(uiplugin)
 cluster_resources+=(customresourcedefinitions)
 
-log "- BEGIN inspecting cluster resources..." | tee "${LOGFILE_PATH}"
+log "- BEGIN inspecting cluster resources and namespaces..." | tee -a "${LOGFILE_PATH}"
+
 for cr in "${cluster_resources[@]}" ; do
-  log "-- BEGIN inspecting cluster resource ${cr} ..." >> "${LOGFILE_PATH}"
+  log "-- BEGIN inspecting cluster resource ${cr} ..." | tee -a "${LOGFILE_PATH}"
   oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" "${cr}"  >> "${LOGFILE_PATH}" 2>&1 &
   pids+=($!)
 done
-log "- END inspecting cluster resources..." >> "${LOGFILE_PATH}"
+
+for ns in "${namespace_resources[@]}" ; do
+  log "-- BEGIN inspecting namespace ${ns} ..." | tee -a "${LOGFILE_PATH}"
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" "ns/${ns}"  >> "${LOGFILE_PATH}" 2>&1 &
+  pids+=($!)
+done
+log "- END inspecting cluster resources..." | tee -a "${LOGFILE_PATH}"
 
 # namespace-scoped resources
 resources="pods,roles,rolebindings,configmaps,serviceaccounts,events,installplans,subscriptions,clusterserviceversions,logfilemetricexporter"
 
-log "BEGIN inspecting namespaced resources ..." | tee "${LOGFILE_PATH}"
+log "BEGIN inspecting namespaced resources ..." | tee -a "${LOGFILE_PATH}"
 
-for namespace in ${cluster_resources}    ; do
+for ns in ${namespace_resources[@]}    ; do
   # grab all our namespaces -- openshift-logging, openshift-operator-lifecycle-manager, openshift-operators-redhat
   # should also include any multi-forwarder namespaces found above
-  if [[ $namespace == ns/* ]]; then
-    ns=${namespace#ns/}  # remove "ns/" prefix
-      log "-- BEGIN inspecting ${ns}/${resources} ..." >> "${LOGFILE_PATH}"
-      oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" -n "$ns" "$resources" 2>&1 | tee "${LOGFILE_PATH}"  &
-      pids+=($!)
-  fi
+  log "-- BEGIN inspecting ${ns}/${resources} ..." | tee -a "${LOGFILE_PATH}"
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" -n "$ns" "$resources" 2>&1 | tee -a "${LOGFILE_PATH}"  &
+  pids+=($!)
 
 done
-log "END inspecting namespaced resources ..." >> "${LOGFILE_PATH}"
+log "END inspecting namespaced resources ..." | tee -a "${LOGFILE_PATH}"
 
+# if the uiplugin is installed, collect the console CO
+uiplugin_found="$(oc get uiplugin --ignore-not-found --no-headers)"
+if [ "$uiplugin_found" != "" ] ; then
+  log "BEGIN gathering console resources ..." | tee -a "${LOGFILE_PATH}"
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" co/console 2>&1 | tee -a "${LOGFILE_PATH}"  &
+  pids+=($!)
+  log "END gathering console resources ..." | tee -a "${LOGFILE_PATH}"
+fi
 
 default_clo_found="$(oc -n "$LOGGING_NS" get deployment cluster-logging-operator --ignore-not-found --no-headers)"
 
 if [ "$default_clo_found" != "" ] ; then
-  log "BEGIN gathering default CLO resources ..." | tee "${LOGFILE_PATH}"
+  log "BEGIN gathering default CLO resources ..." | tee -a "${LOGFILE_PATH}"
   ${SCRIPT_DIR}/gather_cluster_logging_operator_resources "$BASE_COLLECTION_PATH" "$LOGGING_NS" 2>&1 >> "${LOGFILE_PATH}"
-  log "END gathering default CLO resources ..." >> "${LOGFILE_PATH}"
+  log "END gathering default CLO resources ..." | tee -a "${LOGFILE_PATH}"
 else
-  log "Skipping collection inspection.  No default CLO found" 2>&1 | tee "${LOGFILE_PATH}"
+  log "Skipping collection inspection.  No default CLO found" 2>&1 | tee -a "${LOGFILE_PATH}"
 fi
 
 loki_crd=$(oc get crd -A -o custom-columns=:.metadata.name | grep lokistack)
@@ -97,11 +113,11 @@ if [ "$loki_crd" != "" ] ; then
   found_lokistack="$(oc -n $LOGGING_NS get lokistack.loki.grafana.com --ignore-not-found --no-headers)"
   if [ "$found_lokistack" != "" ] ; then
 
-    log "BEGIN gathering lokistack resources ..." | tee "${LOGFILE_PATH}"
-    ${SCRIPT_DIR}/gather_logstore_resources "$BASE_COLLECTION_PATH" "lokistack" 2>&1 | tee "${LOGFILE_PATH}"
-    log "END gathering logstorage resources ..."  >> "${LOGFILE_PATH}"
+    log "BEGIN gathering lokistack resources ..." | tee -a "${LOGFILE_PATH}"
+    ${SCRIPT_DIR}/gather_logstore_resources "$BASE_COLLECTION_PATH" "lokistack" 2>&1 >>  "${LOGFILE_PATH}"
+    log "END gathering logstorage resources ..."  | tee -a "${LOGFILE_PATH}"
   else
-    log "Skipping logstorage inspection.  No deployment found" 2>&1 | tee "${LOGFILE_PATH}"
+    log "Skipping logstorage inspection.  No deployment found" 2>&1 | tee -a "${LOGFILE_PATH}"
   fi
 fi
 

--- a/must-gather/collection-scripts/gather_collection_resources
+++ b/must-gather/collection-scripts/gather_collection_resources
@@ -22,13 +22,13 @@ collector_folder="$CLO_COLLECTION_PATH/namespaces/$NAMESPACE"
 log "- BEGIN <gather_collection_resources> for namespace: $NAMESPACE ..."
 
 log "-- Exporting ClusterLogForwarder.observability.openshift.io resources"
-crs="$(oc get clusterLogForwarder.observability.openshift.io -n $NAMESPACE -o custom-columns=:.metadata.name)"
+crs="$(oc get clusterLogForwarder.observability.openshift.io -n $NAMESPACE -o custom-columns=:.metadata.name --ignore-not-found)"
 
 # get name of collector from CR name
 for collector in ${crs}; do
   log "-- Gathering data for ClusterLogForwarder: $collector"
   mkdir -p $collector_folder
-  oc adm inspect -n $NAMESPACE clusterLogForwarders.observability.openshift.io --cache-dir=${KUBECACHEDIR} 2>&1
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" -n $NAMESPACE clusterLogForwarders.observability.openshift.io 2>&1
 
   # find daemonset
   log "--- Describe Daemonset ds/$collector"
@@ -38,7 +38,7 @@ for collector in ${crs}; do
   fi
 
   # gathering collector pods
-  pods="$(oc -n $NAMESPACE get pods -lapp.kubernetes.io/instance=$collector -lapp.kubernetes.io/component=collector -o custom-columns=:.metadata.name)"
+  pods="$(oc -n $NAMESPACE get pods -lapp.kubernetes.io/instance=$collector -lapp.kubernetes.io/component=collector -o custom-columns=:.metadata.name --ignore-not-found)"
   for pod in $pods
   do
       log "--- Describe collector pod: $pod"

--- a/must-gather/collection-scripts/gather_collection_resources
+++ b/must-gather/collection-scripts/gather_collection_resources
@@ -28,7 +28,7 @@ crs="$(oc get clusterLogForwarder.observability.openshift.io -n $NAMESPACE -o cu
 for collector in ${crs}; do
   log "-- Gathering data for ClusterLogForwarder: $collector"
   mkdir -p $collector_folder
-  oc -n $NAMESPACE get clusterLogForwarder.observability.openshift.io/$collector -o yaml > $collector_folder/$collector.yaml --cache-dir=${KUBECACHEDIR} 2>&1
+  oc adm inspect -n $NAMESPACE clusterLogForwarders.observability.openshift.io --cache-dir=${KUBECACHEDIR} 2>&1
 
   # find daemonset
   log "--- Describe Daemonset ds/$collector"

--- a/must-gather/collection-scripts/gather_logstore_resources
+++ b/must-gather/collection-scripts/gather_logstore_resources
@@ -18,15 +18,13 @@ NAMESPACE=${3:-openshift-logging}
 CLO_COLLECTION_PATH="$BASE_COLLECTION_PATH/cluster-logging"
 es_folder="$CLO_COLLECTION_PATH/es"
 
-lokistack_folder="$CLO_COLLECTION_PATH/lokistack"
-
 list_es_storage() {
   local pod=$1
   local mountPath=$(oc -n $NAMESPACE get pod $pod -o jsonpath='{.spec.containers[0].volumeMounts[?(@.name=="elasticsearch-storage")].mountPath}')
   echo "-- Persistence files" >> $es_folder/$pod
 
   oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR}  exec -c elasticsearch $pod -- ls -lR $mountPath >> $es_folder/$pod
-  
+
   echo "-- Persistence  storage size " >> $es_folder/$pod-storage
 
   oc -n $NAMESPACE --cache-dir=${KUBECACHEDIR}  exec -c elasticsearch $pod -- df -h $mountPath >> $es_folder/$pod-storage
@@ -77,11 +75,11 @@ get_elasticsearch_status() {
 }
 
 get_elasticsearch_cr() {
-  oc get -n $NAMESPACE --cache-dir=${KUBECACHEDIR} elasticsearch.logging.openshift.io elasticsearch -o yaml > $es_folder/elasticsearch_cr.yaml
+  oc adm inspect -n $NAMESPACE --cache-dir=${KUBECACHEDIR} elasticsearch.logging.openshift.io elasticsearch
 }
 
 get_lokistack_cr() {
-  oc get -n $NAMESPACE --cache-dir=${KUBECACHEDIR} lokistacks.loki.grafana.com -o yaml > $lokistack_folder/lokistack_cr.yaml
+  oc adm inspect -n $NAMESPACE --cache-dir=${KUBECACHEDIR} lokistacks.loki.grafana.com
 }
 
 log "Gathering data for logstore component"
@@ -111,7 +109,6 @@ fi
 
 if [ "$LOG_STORE_TYPE" = "lokistack" ] ; then
   log "Gathering Lokistack resources"
-  mkdir -p "$lokistack_folder"
 
   log "-- Gather Lokistack CR"
   get_lokistack_cr

--- a/must-gather/collection-scripts/gather_logstore_resources
+++ b/must-gather/collection-scripts/gather_logstore_resources
@@ -75,11 +75,11 @@ get_elasticsearch_status() {
 }
 
 get_elasticsearch_cr() {
-  oc adm inspect -n $NAMESPACE --cache-dir=${KUBECACHEDIR} elasticsearch.logging.openshift.io elasticsearch
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" -n $NAMESPACE elasticsearch.logging.openshift.io elasticsearch
 }
 
 get_lokistack_cr() {
-  oc adm inspect -n $NAMESPACE --cache-dir=${KUBECACHEDIR} lokistacks.loki.grafana.com
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir="${BASE_COLLECTION_PATH}" -n $NAMESPACE lokistacks.loki.grafana.com
 }
 
 log "Gathering data for logstore component"


### PR DESCRIPTION
### Description
Collect some resources missing in Logging 6 must-gather, and collect them with `oc adm inspect` for being compatible with `omc` tool.
Separated `namespaces` and `cluster_resources` for clarity and because different data is collected from them. Not adding `$multi` to `namespace_resources` when it's already `$LOGGING_NS`.
Collect `console` Cluster Operator if the UIPlugin is present.

/cc @jcantrill 
/assign @xperimental 

/cherry-pick release-6.1 release-6.0

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6422

