### PR TITLE
[master] Add missing oauth-server volume mount

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -37,6 +37,8 @@ const (
 	sourceAuditdPath                = "/var/log/audit"
 	sourceAuditOVNName              = "varlogovn"
 	sourceOVNPath                   = "/var/log/ovn"
+	sourceOAuthServerName           = "varlogoauthserver"
+	sourceOAuthServerPath           = "/var/log/oauth-server"
 	sourceOAuthAPIServerName        = "varlogoauthapiserver"
 	sourceOAuthAPIServerPath        = "/var/log/oauth-apiserver"
 	sourceOpenshiftAPIServerName    = "varlogopenshiftapiserver"
@@ -141,6 +143,7 @@ func (f *Factory) NewPodSpec(trustedCABundle *v1.ConfigMap, spec obs.ClusterLogF
 			v1.Volume{Name: sourceJournalName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceJournalPath}}},
 			v1.Volume{Name: sourceAuditdName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceAuditdPath}}},
 			v1.Volume{Name: sourceAuditOVNName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOVNPath}}},
+			v1.Volume{Name: sourceOAuthServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOAuthServerPath}}},
 			v1.Volume{Name: sourceOAuthAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOAuthAPIServerPath}}},
 			v1.Volume{Name: sourceOpenshiftAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOpenshiftAPIServerPath}}},
 			v1.Volume{Name: sourceKubeAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceKubeAPIServerPath}}},
@@ -207,6 +210,7 @@ func (f *Factory) NewCollectorContainer(inputs internalobs.Inputs, outputs inter
 		}
 		if inputs.HasAuditSource(obs.AuditSourceOpenShift) {
 			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceOpenshiftAPIServerName, ReadOnly: true, MountPath: sourceOpenshiftAPIServerPath})
+			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceOAuthServerName, ReadOnly: true, MountPath: sourceOAuthServerPath})
 			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceAuditOVNName, ReadOnly: true, MountPath: sourceOAuthAPIServerPath})
 		}
 		if inputs.HasAuditSource(obs.AuditSourceOVN) {

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -282,8 +282,17 @@ var _ = Describe("Factory#Daemonset", func() {
 
 			Context("and mounting volumes", func() {
 				It("should mount host path volumes", func() {
-					Expect(podSpec.Volumes).To(IncludeVolume(v1.Volume{Name: sourcePodsName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourcePodsPath}}}))
-					Expect(podSpec.Volumes).To(HaveLen(15))
+					Expect(podSpec.Volumes).To(IncludeVolume(v1.Volume{
+						Name: sourcePodsName,
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: sourcePodsPath}}}))
+					Expect(podSpec.Volumes).To(IncludeVolume(v1.Volume{
+						Name: sourceOAuthServerName,
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: sourceOAuthServerPath}}}))
+					Expect(podSpec.Volumes).To(HaveLen(16))
 				})
 
 				It("should mount all volumes for output configmaps", func() {


### PR DESCRIPTION
### Description
Manual cherrypick of issue from LOG-6484.  Already fixed in 6.0 and 6.1.   No Jira.

We removed the `oauth-server` log volume from our mounts beginning in v6.      

/cc @Clee2691 @vparfonov
/assign @jcantrill
