### PR TITLE
Observability output types - doc update

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -356,19 +356,19 @@ type Cloudwatch struct {
 
 	// GroupName defines the strategy for grouping logstreams
 	//
-	// The GroupName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+	// The GroupName can be a combination of static and dynamic values consisting of field paths followed by "\|\|" followed by another field path or a static value.
 	//
-	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	// A dynamic value is encased in single curly brackets "{}" and MUST end with a static fallback value separated with "\|\|".
 	//
 	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
 	//
 	// Example:
 	//
-	//  1. foo-{.bar||"none"}
+	//  1. foo-{.bar\|\|"none"}
 	//
-	//  2. {.foo||.bar||"missing"}
+	//  2. {.foo\|\|.bar\|\|"missing"}
 	//
-	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//  3. foo.{.bar.baz\|\|.qux.quux.corge\|\|.grault\|\|"nil"}-waldo.fred{.plugh\|\|"none"}
 	//
 	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Group Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -568,10 +568,10 @@ spec:
           GroupName defines the strategy for grouping logstreams
 
 
-          The GroupName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+          The GroupName can be a combination of static and dynamic values consisting of field paths followed by "\|\|" followed by another field path or a static value.
 
 
-          A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+          A dynamic value is encased in single curly brackets "{}" and MUST end with a static fallback value separated with "\|\|".
 
 
           Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
@@ -580,13 +580,13 @@ spec:
           Example:
 
 
-           1. foo-{.bar||"none"}
+           1. foo-{.bar\|\|"none"}
 
 
-           2. {.foo||.bar||"missing"}
+           2. {.foo\|\|.bar\|\|"missing"}
 
 
-           3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+           3. foo.{.bar.baz\|\|.qux.quux.corge\|\|.grault\|\|"nil"}-waldo.fred{.plugh\|\|"none"}
         displayName: Group Name
         path: outputs[0].cloudwatch.groupName
         x-descriptors:

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1052,19 +1052,19 @@ spec:
                           description: |-
                             GroupName defines the strategy for grouping logstreams
 
-                            The GroupName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+                            The GroupName can be a combination of static and dynamic values consisting of field paths followed by "\|\|" followed by another field path or a static value.
 
-                            A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+                            A dynamic value is encased in single curly brackets "{}" and MUST end with a static fallback value separated with "\|\|".
 
                             Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
 
                             Example:
 
-                             1. foo-{.bar||"none"}
+                             1. foo-{.bar\|\|"none"}
 
-                             2. {.foo||.bar||"missing"}
+                             2. {.foo\|\|.bar\|\|"missing"}
 
-                             3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+                             3. foo.{.bar.baz\|\|.qux.quux.corge\|\|.grault\|\|"nil"}-waldo.fred{.plugh\|\|"none"}
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         region:

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1052,19 +1052,19 @@ spec:
                           description: |-
                             GroupName defines the strategy for grouping logstreams
 
-                            The GroupName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+                            The GroupName can be a combination of static and dynamic values consisting of field paths followed by "\|\|" followed by another field path or a static value.
 
-                            A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+                            A dynamic value is encased in single curly brackets "{}" and MUST end with a static fallback value separated with "\|\|".
 
                             Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
 
                             Example:
 
-                             1. foo-{.bar||"none"}
+                             1. foo-{.bar\|\|"none"}
 
-                             2. {.foo||.bar||"missing"}
+                             2. {.foo\|\|.bar\|\|"missing"}
 
-                             3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+                             3. foo.{.bar.baz\|\|.qux.quux.corge\|\|.grault\|\|"nil"}-waldo.fred{.plugh\|\|"none"}
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         region:

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -492,10 +492,10 @@ spec:
           GroupName defines the strategy for grouping logstreams
 
 
-          The GroupName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+          The GroupName can be a combination of static and dynamic values consisting of field paths followed by "\|\|" followed by another field path or a static value.
 
 
-          A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+          A dynamic value is encased in single curly brackets "{}" and MUST end with a static fallback value separated with "\|\|".
 
 
           Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
@@ -504,13 +504,13 @@ spec:
           Example:
 
 
-           1. foo-{.bar||"none"}
+           1. foo-{.bar\|\|"none"}
 
 
-           2. {.foo||.bar||"missing"}
+           2. {.foo\|\|.bar\|\|"missing"}
 
 
-           3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+           3. foo.{.bar.baz\|\|.qux.quux.corge\|\|.grault\|\|"nil"}-waldo.fred{.plugh\|\|"none"}
         displayName: Group Name
         path: outputs[0].cloudwatch.groupName
         x-descriptors:

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -1012,19 +1012,19 @@ Type:: object
 
 |groupName|string|  GroupName defines the strategy for grouping logstreams
 
-The GroupName can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+The GroupName can be a combination of static and dynamic values consisting of field paths followed by &#34;\|\|&#34; followed by another field path or a static value.
 
-A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+A dynamic value is encased in single curly brackets &#34;{}&#34; and MUST end with a static fallback value separated with &#34;\|\|&#34;.
 
 Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
 
 Example:
 
-1. foo-{.bar||&#34;none&#34;}
+1. foo-{.bar\|\|&#34;none&#34;}
 
-2. {.foo||.bar||&#34;missing&#34;}
+2. {.foo\|\|.bar\|\|&#34;missing&#34;}
 
-3. foo.{.bar.baz||.qux.quux.corge||.grault||&#34;nil&#34;}-waldo.fred{.plugh||&#34;none&#34;}
+3. foo.{.bar.baz\|\|.qux.quux.corge\|\|.grault\|\|&#34;nil&#34;}-waldo.fred{.plugh\|\|&#34;none&#34;}
 
 |region|string|  
 |tuning|object|  Tuning specs tuning for the output


### PR DESCRIPTION
Fixed some of the tables content which was broken due to special characters.

### Description
The content was broken due to the "pipes" which were creating new table lines.
Have fixed the content presentation in the document sections. The table was broken due to the "||" characters. Inserted the backslash to prevent it.
The goal here was to change the documentation only, not the service definition which now has the backslashes in the description.

/cc @jcantrill 
/assign @jcantrill 
