### PR TITLE
[release-6.1] LOG-6533: fix audit log oauth-apiserver mount

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -211,7 +211,7 @@ func (f *Factory) NewCollectorContainer(inputs internalobs.Inputs, outputs inter
 		if inputs.HasAuditSource(obs.AuditSourceOpenShift) {
 			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceOpenshiftAPIServerName, ReadOnly: true, MountPath: sourceOpenshiftAPIServerPath})
 			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceOAuthServerName, ReadOnly: true, MountPath: sourceOAuthServerPath})
-			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceAuditOVNName, ReadOnly: true, MountPath: sourceOAuthAPIServerPath})
+			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceOAuthAPIServerName, ReadOnly: true, MountPath: sourceOAuthAPIServerPath})
 		}
 		if inputs.HasAuditSource(obs.AuditSourceOVN) {
 			collector.VolumeMounts = append(collector.VolumeMounts, v1.VolumeMount{Name: sourceAuditOVNName, ReadOnly: true, MountPath: sourceOVNPath})


### PR DESCRIPTION
### Description
Duplicate mount name, resulted in `oauth-apiserver` volumeMount to fail collecting the `audit.log` file for this directory/mount.

/cc @Clee2691 @vparfonov @xperimental
/assign @jcantrill

### Links
- https://issues.redhat.com/browse/LOG-6533
