### PR TITLE
LOG-6280: Only cleanup dashboard when owned by 'this' operator version

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -125,7 +125,7 @@ func main() {
 
 	// Clean up
 	defer func() {
-		if err := cleanUpResources(mgr.GetClient()); err != nil {
+		if err := cleanUpResources(mgr.GetClient(), mgr.GetAPIReader()); err != nil {
 			log.V(3).Error(err, "error with resource cleanup")
 		}
 	}()
@@ -219,9 +219,9 @@ func migrateManifestResources(k8sClient client.Client) {
 	}
 }
 
-func cleanUpResources(k8sClient client.Client) error {
+func cleanUpResources(k8sClient client.Client, apiReader client.Reader) error {
 	// Remove the dashboard config map
-	if err := dashboard.RemoveDashboardConfigMap(k8sClient); err != nil {
+	if err := dashboard.RemoveDashboardConfigMap(k8sClient, apiReader); err != nil {
 		return err
 	}
 	return nil

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -80,8 +80,25 @@ func GroupVersionKind(o runtime.Object) schema.GroupVersionKind {
 	return gvk
 }
 
-// Labels returns the labels map for object, guaratneed to be non-nil.
-func Labels(o runtime.Object) map[string]string {
+type ObjectLabels map[string]string
+
+// Includes compares an object labels to those given and returns true if
+// the object set includes the keys and also matches the values
+func (objLabels ObjectLabels) Includes(other ObjectLabels) bool {
+	for includeKey, includeValue := range other {
+		if value, found := objLabels[includeKey]; found {
+			if value != includeValue {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+// Labels returns the labels map for object, guaranteed to be non-nil.
+func Labels(o runtime.Object) ObjectLabels {
 	m := Meta(o)
 	l := m.GetLabels()
 	if l == nil {


### PR DESCRIPTION
### Description
This PR:
* Adds labels version, managedby to the collector dashboard configmap
* Modifies logic to only delete the dashboard on operator exit if the label set matches those expected by the operator
* Resolves the issue where the old version of the operator deleted the dashboard on_exit after the new version of the operator updated it

### Links
https://issues.redhat.com/browse/LOG-6280
