### PR TITLE
LOG-6130: Use uncached client when fetching cluster SCC resource

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -142,6 +142,7 @@ func main() {
 	// The Log File Metric Exporter Controller
 	if err = (&logfilemetricsexporter.ReconcileLogFileMetricExporter{
 		Client:         mgr.GetClient(),
+		Reader:         mgr.GetAPIReader(),
 		Scheme:         mgr.GetScheme(),
 		ClusterVersion: clusterVersion,
 		ClusterID:      clusterID,

--- a/internal/controller/logfilemetricsexporter/logfilemetricsexporter_controller.go
+++ b/internal/controller/logfilemetricsexporter/logfilemetricsexporter_controller.go
@@ -30,6 +30,11 @@ var _ reconcile.Reconciler = &ReconcileLogFileMetricExporter{}
 
 type ReconcileLogFileMetricExporter struct {
 	Client client.Client
+
+	// Reader is a read only client for retrieving kubernetes resources. This
+	// client hits the API server directly, by-passing the controller cache
+	Reader client.Reader
+
 	Scheme *runtime.Scheme
 	// ClusterVersion is the semantic version of the cluster
 	ClusterVersion string
@@ -73,7 +78,7 @@ func (r *ReconcileLogFileMetricExporter) Reconcile(ctx context.Context, request 
 	}
 
 	log.V(3).Info("logfilemetricexporter-controller run reconciler...")
-	reconcileErr := logmetricexporter.Reconcile(lfmeInstance, r.Client, utils.AsOwner(lfmeInstance))
+	reconcileErr := logmetricexporter.Reconcile(lfmeInstance, r.Reader, r.Client, utils.AsOwner(lfmeInstance))
 
 	if reconcileErr != nil {
 		condition := condNotReady(loggingv1alpha1.ReasonInvalid, "%s", reconcileErr.Error())

--- a/internal/controller/observability/collector.go
+++ b/internal/controller/observability/collector.go
@@ -27,7 +27,7 @@ import (
 
 func ReconcileCollector(context internalcontext.ForwarderContext, pollInterval, timeout time.Duration) (err error) {
 
-	if err = reconcile.SecurityContextConstraints(context.Client, auth.NewSCC()); err != nil {
+	if err = reconcile.SecurityContextConstraints(context.Reader, context.Client, auth.NewSCC()); err != nil {
 		log.V(3).Error(err, "reconcile.SecurityContextConstraints")
 		return err
 	}

--- a/internal/metrics/logfilemetricexporter/factory_test.go
+++ b/internal/metrics/logfilemetricexporter/factory_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		}
 
 		// Reconcile the LogFileMetricExporter
-		Expect(Reconcile(lfmeInstance, reqClient, utils.AsOwner(lfmeInstance))).To(Succeed())
+		Expect(Reconcile(lfmeInstance, reqClient, reqClient, utils.AsOwner(lfmeInstance))).To(Succeed())
 
 		// Daemonset
 		// Get and check the daemonset

--- a/internal/metrics/logfilemetricexporter/metric_exporter.go
+++ b/internal/metrics/logfilemetricexporter/metric_exporter.go
@@ -20,6 +20,7 @@ import (
 )
 
 func Reconcile(lfmeInstance *loggingv1alpha1.LogFileMetricExporter,
+	reader client.Reader,
 	requestClient client.Client,
 	owner metav1.OwnerReference) error {
 
@@ -28,7 +29,7 @@ func Reconcile(lfmeInstance *loggingv1alpha1.LogFileMetricExporter,
 		runtime.SetCommonLabels(o, constants.LogfilesmetricexporterName, lfmeInstance.Name, constants.LogfilesmetricexporterName)
 	}
 
-	if err := reconcile.SecurityContextConstraints(requestClient, auth.NewSCC()); err != nil {
+	if err := reconcile.SecurityContextConstraints(reader, requestClient, auth.NewSCC()); err != nil {
 		log.V(9).Error(err, "logfilemetricexporter.SecurityContextConstraints")
 		return err
 	}

--- a/internal/metrics/logfilemetricexporter/metric_exporter_test.go
+++ b/internal/metrics/logfilemetricexporter/metric_exporter_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		}
 
 		// Reconcile the LogFileMetricExporter
-		Expect(Reconcile(lfmeInstance, reqClient, utils.AsOwner(lfmeInstance))).To(Succeed())
+		Expect(Reconcile(lfmeInstance, reqClient, reqClient, utils.AsOwner(lfmeInstance))).To(Succeed())
 
 		// Daemonset
 		// Get and check the daemonset

--- a/internal/reconcile/scc.go
+++ b/internal/reconcile/scc.go
@@ -11,11 +11,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func SecurityContextConstraints(k8Client client.Client, desired *security.SecurityContextConstraints) error {
+func SecurityContextConstraints(reader client.Reader, k8Client client.Client, desired *security.SecurityContextConstraints) error {
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		current := &security.SecurityContextConstraints{}
 		key := client.ObjectKey{Name: desired.Name}
-		if err := k8Client.Get(context.TODO(), key, current); err != nil {
+		if err := reader.Get(context.TODO(), key, current); err != nil {
 			if errors.IsNotFound(err) {
 				return k8Client.Create(context.TODO(), desired)
 			}

--- a/internal/reconcile/scc_test.go
+++ b/internal/reconcile/scc_test.go
@@ -43,7 +43,7 @@ var _ = Describe("reconciling ", func() {
 			k8sClient = fake.NewFakeClient(initial)
 		}
 
-		Expect(reconcile.SecurityContextConstraints(k8sClient, &desired)).To(Succeed(), "Expect no error reconciling secrets")
+		Expect(reconcile.SecurityContextConstraints(k8sClient, k8sClient, &desired)).To(Succeed(), "Expect no error reconciling secrets")
 
 		key := client.ObjectKey{Name: desired.Name}
 		act := &security.SecurityContextConstraints{}


### PR DESCRIPTION
### Description
This PR:
* uses the uncached, readonly client to fetch SCC which is a cluster resource

### Links
https://issues.redhat.com/browse/LOG-6130
