### PR TITLE
LOG-6130: Use uncached reader for reconciliation SCC to avoid unexpec…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -142,6 +142,7 @@ func main() {
 	// The Log File Metric Exporter Controller
 	if err = (&logfilemetricsexporter.ReconcileLogFileMetricExporter{
 		Client:         mgr.GetClient(),
+		UncachedReader: mgr.GetAPIReader(),
 		Scheme:         mgr.GetScheme(),
 		ClusterVersion: clusterVersion,
 		ClusterID:      clusterID,

--- a/internal/controller/logfilemetricsexporter/logfilemetricsexporter_controller.go
+++ b/internal/controller/logfilemetricsexporter/logfilemetricsexporter_controller.go
@@ -29,8 +29,9 @@ import (
 var _ reconcile.Reconciler = &ReconcileLogFileMetricExporter{}
 
 type ReconcileLogFileMetricExporter struct {
-	Client client.Client
-	Scheme *runtime.Scheme
+	Client         client.Client
+	UncachedReader client.Reader
+	Scheme         *runtime.Scheme
 	// ClusterVersion is the semantic version of the cluster
 	ClusterVersion string
 	// ClusterID is the unique identifier of the cluster in which the operator is deployed
@@ -73,7 +74,7 @@ func (r *ReconcileLogFileMetricExporter) Reconcile(ctx context.Context, request 
 	}
 
 	log.V(3).Info("logfilemetricexporter-controller run reconciler...")
-	reconcileErr := logmetricexporter.Reconcile(lfmeInstance, r.Client, utils.AsOwner(lfmeInstance))
+	reconcileErr := logmetricexporter.Reconcile(lfmeInstance, r.Client, r.UncachedReader, utils.AsOwner(lfmeInstance))
 
 	if reconcileErr != nil {
 		condition := condNotReady(loggingv1alpha1.ReasonInvalid, "%s", reconcileErr.Error())

--- a/internal/controller/observability/collector.go
+++ b/internal/controller/observability/collector.go
@@ -26,7 +26,7 @@ import (
 
 func ReconcileCollector(context internalcontext.ForwarderContext, pollInterval, timeout time.Duration) (err error) {
 
-	if err = reconcile.SecurityContextConstraints(context.Client, auth.NewSCC()); err != nil {
+	if err = reconcile.SecurityContextConstraints(context.Client, context.Reader, auth.NewSCC()); err != nil {
 		log.V(3).Error(err, "reconcile.SecurityContextConstraints")
 		return err
 	}

--- a/internal/metrics/logfilemetricexporter/factory_test.go
+++ b/internal/metrics/logfilemetricexporter/factory_test.go
@@ -3,6 +3,7 @@ package logfilemetricexporter
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -39,6 +40,8 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		reqClient = fake.NewFakeClient( //nolint
 			namespace,
 		)
+
+		reader = reqClient.(client.Reader)
 
 		lfmeInstance = &loggingv1alpha1.LogFileMetricExporter{}
 
@@ -77,7 +80,7 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		}
 
 		// Reconcile the LogFileMetricExporter
-		Expect(Reconcile(lfmeInstance, reqClient, utils.AsOwner(lfmeInstance))).To(Succeed())
+		Expect(Reconcile(lfmeInstance, reqClient, reader, utils.AsOwner(lfmeInstance))).To(Succeed())
 
 		// Daemonset
 		// Get and check the daemonset

--- a/internal/metrics/logfilemetricexporter/metric_exporter.go
+++ b/internal/metrics/logfilemetricexporter/metric_exporter.go
@@ -21,6 +21,7 @@ import (
 
 func Reconcile(lfmeInstance *loggingv1alpha1.LogFileMetricExporter,
 	requestClient client.Client,
+	uncachedReader client.Reader,
 	owner metav1.OwnerReference) error {
 
 	// Adding common labels
@@ -28,7 +29,7 @@ func Reconcile(lfmeInstance *loggingv1alpha1.LogFileMetricExporter,
 		runtime.SetCommonLabels(o, constants.LogfilesmetricexporterName, lfmeInstance.Name, constants.LogfilesmetricexporterName)
 	}
 
-	if err := reconcile.SecurityContextConstraints(requestClient, auth.NewSCC()); err != nil {
+	if err := reconcile.SecurityContextConstraints(requestClient, uncachedReader, auth.NewSCC()); err != nil {
 		log.V(9).Error(err, "logfilemetricexporter.SecurityContextConstraints")
 		return err
 	}

--- a/internal/metrics/logfilemetricexporter/metric_exporter_test.go
+++ b/internal/metrics/logfilemetricexporter/metric_exporter_test.go
@@ -3,6 +3,7 @@ package logfilemetricexporter
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -39,6 +40,8 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		reqClient = fake.NewFakeClient( //nolint
 			namespace,
 		)
+
+		reader = reqClient.(client.Reader)
 
 		lfmeInstance = &loggingv1alpha1.LogFileMetricExporter{}
 
@@ -77,7 +80,7 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		}
 
 		// Reconcile the LogFileMetricExporter
-		Expect(Reconcile(lfmeInstance, reqClient, utils.AsOwner(lfmeInstance))).To(Succeed())
+		Expect(Reconcile(lfmeInstance, reqClient, reader, utils.AsOwner(lfmeInstance))).To(Succeed())
 
 		// Daemonset
 		// Get and check the daemonset

--- a/internal/reconcile/scc.go
+++ b/internal/reconcile/scc.go
@@ -11,11 +11,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func SecurityContextConstraints(k8Client client.Client, desired *security.SecurityContextConstraints) error {
+func SecurityContextConstraints(k8Client client.Client, uncachedReader client.Reader, desired *security.SecurityContextConstraints) error {
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		current := &security.SecurityContextConstraints{}
 		key := client.ObjectKey{Name: desired.Name}
-		if err := k8Client.Get(context.TODO(), key, current); err != nil {
+		if err := uncachedReader.Get(context.TODO(), key, current); err != nil {
 			if errors.IsNotFound(err) {
 				return k8Client.Create(context.TODO(), desired)
 			}

--- a/internal/reconcile/scc_test.go
+++ b/internal/reconcile/scc_test.go
@@ -41,8 +41,9 @@ var _ = Describe("reconciling ", func() {
 			builder.WithRuntimeObjects(initial)
 		}
 		k8sClient := builder.Build()
+		reader := k8sClient.(client.Reader)
 
-		Expect(reconcile.SecurityContextConstraints(k8sClient, &desired)).To(Succeed(), "Expect no error reconciling secrets")
+		Expect(reconcile.SecurityContextConstraints(k8sClient, reader, &desired)).To(Succeed(), "Expect no error reconciling secrets")
 
 		key := client.ObjectKey{Name: desired.Name}
 		act := &security.SecurityContextConstraints{}


### PR DESCRIPTION
…ted behavior

### Description
This PR adds an uncached client to SCC reconciliation since its a cluster resource.  Backport of #2892 

### Links
https://issues.redhat.com/browse/LOG-6130