### PR TITLE
LOG-6573: Require namespace for LokiStack target

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -747,9 +747,8 @@ type LokiTuningSpec struct {
 type LokiStackTarget struct {
 	// Namespace of the in-cluster LokiStack resource.
 	//
-	// If unset, this defaults to "openshift-logging".
-	//
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength:=3
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="LokiStack Namespace",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Namespace string `json:"namespace,omitempty"`
 

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-10-25T13:58:52Z"
+    createdAt: "2025-01-13T19:29:18Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -1341,11 +1341,7 @@ spec:
         path: outputs[0].lokiStack.target.name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: |-
-          Namespace of the in-cluster LokiStack resource.
-
-
-          If unset, this defaults to "openshift-logging".
+      - description: Namespace of the in-cluster LokiStack resource.
         displayName: LokiStack Namespace
         path: outputs[0].lokiStack.target.namespace
         x-descriptors:

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1998,13 +1998,12 @@ spec:
                               pattern: ^[a-z][a-z0-9-]{2,62}[a-z0-9]$
                               type: string
                             namespace:
-                              description: |-
-                                Namespace of the in-cluster LokiStack resource.
-
-                                If unset, this defaults to "openshift-logging".
+                              description: Namespace of the in-cluster LokiStack resource.
+                              minLength: 3
                               type: string
                           required:
                           - name
+                          - namespace
                           type: object
                         tuning:
                           description: Tuning specs tuning for the output

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1998,13 +1998,12 @@ spec:
                               pattern: ^[a-z][a-z0-9-]{2,62}[a-z0-9]$
                               type: string
                             namespace:
-                              description: |-
-                                Namespace of the in-cluster LokiStack resource.
-
-                                If unset, this defaults to "openshift-logging".
+                              description: Namespace of the in-cluster LokiStack resource.
+                              minLength: 3
                               type: string
                           required:
                           - name
+                          - namespace
                           type: object
                         tuning:
                           description: Tuning specs tuning for the output

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -1264,11 +1264,7 @@ spec:
         path: outputs[0].lokiStack.target.name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: |-
-          Namespace of the in-cluster LokiStack resource.
-
-
-          If unset, this defaults to "openshift-logging".
+      - description: Namespace of the in-cluster LokiStack resource.
         displayName: LokiStack Namespace
         path: outputs[0].lokiStack.target.namespace
         x-descriptors:

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -2103,8 +2103,6 @@ Type:: object
 
 |namespace|string|  Namespace of the in-cluster LokiStack resource.
 
-If unset, this defaults to &#34;openshift-logging&#34;.
-
 |======================
 
 === .spec.outputs[].lokiStack.tuning


### PR DESCRIPTION
### Description
This PR:
* updates the LokiStack output type api to require setting the target namespace of the loki deployment
* Modifies the comments to no longer imply the operator defaults anything

### Links
https://issues.redhat.com/browse/LOG-6573
backport of #2922 