### PR TITLE
[release-6.1] LOG-6579: Manual port of LOG-6508 to release 6.1

### DIFF
--- a/internal/generator/vector/output/factory_test_loki_with_throttle.toml
+++ b/internal/generator/vector/output/factory_test_loki_with_throttle.toml
@@ -38,11 +38,16 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.output_default_loki_apps.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 [sinks.output_default_loki_apps.tls]
 min_tls_version = "VersionTLS12"

--- a/internal/generator/vector/output/loki/with_custom_bearer_token.toml
+++ b/internal/generator/vector/output/loki/with_custom_bearer_token.toml
@@ -32,11 +32,16 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 [sinks.loki_receiver.auth]
 strategy = "bearer"

--- a/internal/generator/vector/output/loki/with_custom_labels.toml
+++ b/internal/generator/vector/output/loki/with_custom_labels.toml
@@ -32,6 +32,8 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_labels_app = "{{kubernetes.labels.\"app\"}}"

--- a/internal/generator/vector/output/loki/with_default_labels.toml
+++ b/internal/generator/vector/output/loki/with_default_labels.toml
@@ -32,8 +32,13 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"

--- a/internal/generator/vector/output/loki/with_default_tls.toml
+++ b/internal/generator/vector/output/loki/with_default_tls.toml
@@ -32,11 +32,16 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 [sinks.loki_receiver.tls]
 min_tls_version = "VersionTLS12"

--- a/internal/generator/vector/output/loki/with_insecure.toml
+++ b/internal/generator/vector/output/loki/with_insecure.toml
@@ -33,11 +33,16 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 
 [sinks.loki_receiver.tls]

--- a/internal/generator/vector/output/loki/with_insecure_nocert.toml
+++ b/internal/generator/vector/output/loki/with_insecure_nocert.toml
@@ -32,11 +32,16 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 
 [sinks.loki_receiver.tls]

--- a/internal/generator/vector/output/loki/with_sa_token.toml
+++ b/internal/generator/vector/output/loki/with_sa_token.toml
@@ -32,11 +32,16 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 [sinks.loki_receiver.auth]
 strategy = "bearer"

--- a/internal/generator/vector/output/loki/with_tenant_id.toml
+++ b/internal/generator/vector/output/loki/with_tenant_id.toml
@@ -41,8 +41,13 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"

--- a/internal/generator/vector/output/loki/with_tls.toml
+++ b/internal/generator/vector/output/loki/with_tls.toml
@@ -33,11 +33,16 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 
 [sinks.loki_receiver.tls]

--- a/internal/generator/vector/output/loki/with_tuning.toml
+++ b/internal/generator/vector/output/loki/with_tuning.toml
@@ -44,9 +44,14 @@ retry_initial_backoff_secs = 20
 retry_max_duration_secs = 35
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 

--- a/internal/generator/vector/output/loki/with_username_password.toml
+++ b/internal/generator/vector/output/loki/with_username_password.toml
@@ -32,11 +32,16 @@ codec = "json"
 except_fields = ["_internal"]
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 [sinks.loki_receiver.auth]
 strategy = "basic"

--- a/test/functional/outputs/loki/application_logs_vector_test.go
+++ b/test/functional/outputs/loki/application_logs_vector_test.go
@@ -67,9 +67,9 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 			Expect(strings.Contains(lines[2], "Present days")).To(BeTrue())
 		})
 	})
-	Context("when label keys are defined that include slashes and dashes. Ref(LOG-4095, LOG-4460)", func() {
+	Context("labelKeys", func() {
 		const myValue = "foobarvalue"
-		BeforeEach(func() {
+		It("should handle the configuration so the collector starts when label keys are defined that include slashes and dashes. Ref(LOG-4095, LOG-4460)", func() {
 			f.Labels["app.kubernetes.io/name"] = myValue
 			f.Labels["prefix-cloud_com_platform-stage"] = "dev"
 			f.Forwarder.Spec.Outputs[0].Loki.LabelKeys = []string{
@@ -79,8 +79,6 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 				"kubernetes.labels.prefix-cloud_com_platform-stage",
 			}
 			Expect(f.Deploy()).To(BeNil())
-		})
-		It("should handle the configuration so the collector starts", func() {
 			now := time.Now()
 			tsNow := functional.CRIOTime(now)
 			msg := functional.NewFullCRIOLogMessage(tsNow, "Present days")
@@ -95,6 +93,9 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 			Expect(len(lines)).To(Equal(1))
 
 			want := map[string]string{
+				"k8s_namespace_name":                                f.Namespace,
+				"k8s_pod_name":                                      f.Pod.Name,
+				"k8s_node_name":                                     f.Pod.Spec.NodeName,
 				"kubernetes_namespace_name":                         f.Namespace,
 				"kubernetes_pod_name":                               f.Pod.Name,
 				"kubernetes_labels_app_kubernetes_io_name":          myValue,
@@ -102,6 +103,39 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 				"kubernetes_host":                                   f.Pod.Spec.NodeName,
 			}
 			labels := result[0].Stream
+			Expect(len(labels)).To(Equal(8))
+			Expect(labels).To(BeEquivalentTo(want))
+		})
+
+		It("should add all otel equivalent default labels when loki.LabelKeys are not defined", func() {
+			Expect(f.Deploy()).To(BeNil())
+			now := time.Now()
+			tsNow := functional.CRIOTime(now)
+			msg := functional.NewFullCRIOLogMessage(tsNow, "Present days")
+			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(Succeed())
+
+			query := fmt.Sprintf(`{openshift_log_type=%q}`, obs.InputTypeApplication)
+			result, err := l.QueryUntil(query, "", 1)
+			Expect(err).To(BeNil())
+			Expect(result).NotTo(BeNil())
+			Expect(len(result)).To(Equal(1))
+			lines := result[0].Lines()
+			Expect(len(lines)).To(Equal(1))
+
+			want := map[string]string{
+				"k8s_container_name":        f.Pod.Spec.Containers[0].Name,
+				"k8s_namespace_name":        f.Namespace,
+				"k8s_pod_name":              f.Pod.Name,
+				"k8s_node_name":             f.Pod.Spec.NodeName,
+				"kubernetes_container_name": f.Pod.Spec.Containers[0].Name,
+				"kubernetes_namespace_name": f.Namespace,
+				"kubernetes_pod_name":       f.Pod.Name,
+				"kubernetes_host":           f.Pod.Spec.NodeName,
+				"log_type":                  string(obs.InputTypeApplication),
+				"openshift_log_type":        string(obs.InputTypeApplication),
+			}
+			labels := result[0].Stream
+			Expect(len(labels)).To(Equal(10))
 			Expect(labels).To(BeEquivalentTo(want))
 		})
 	})

--- a/test/functional/outputs/loki/audit_logs_vector_test.go
+++ b/test/functional/outputs/loki/audit_logs_vector_test.go
@@ -49,8 +49,10 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 		Expect(records).To(HaveCap(1), "Exp. the record to be ingested")
 
 		expLabels := map[string]string{
-			"kubernetes_host": f.Pod.Spec.NodeName,
-			"log_type":        "audit",
+			"kubernetes_host":    f.Pod.Spec.NodeName,
+			"log_type":           string(obs.InputTypeAudit),
+			"openshift_log_type": string(obs.InputTypeAudit),
+			"k8s_node_name":      f.Pod.Spec.NodeName,
 		}
 		actualLabels := r[0].Stream
 		Expect(actualLabels).To(BeEquivalentTo(expLabels), "Exp. labels to be added to the log record")


### PR DESCRIPTION
### Description
This is a manual port of [PR#2926](https://github.com/openshift/cluster-logging-operator/pull/2926) to `release-6.1`.

/cc @cahartma @vparfonov 
/assign @jcantrill 

- JIRA: https://issues.redhat.com/browse/LOG-6579
