### PR TITLE
[release-5.9] LOG-6581: Manual port of LOG-6508 to release-5.9

### DIFF
--- a/internal/generator/vector/output/factory_test_loki_no_throttle.toml
+++ b/internal/generator/vector/output/factory_test_loki_no_throttle.toml
@@ -56,11 +56,16 @@ healthcheck.enabled = false
 codec = "json"
 
 [sinks.output_default_loki_apps.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 [sinks.output_default_loki_apps.tls]
 min_tls_version = "VersionTLS12"

--- a/internal/generator/vector/output/factory_test_loki_with_throttle.toml
+++ b/internal/generator/vector/output/factory_test_loki_with_throttle.toml
@@ -62,11 +62,16 @@ healthcheck.enabled = false
 codec = "json"
 
 [sinks.output_default_loki_apps.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 [sinks.output_default_loki_apps.tls]
 min_tls_version = "VersionTLS12"

--- a/internal/generator/vector/output/loki/loki.go
+++ b/internal/generator/vector/output/loki/loki.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
 
-	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/normalize"
 
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
@@ -26,6 +25,13 @@ const (
 	lokiLabelKubernetesHost          = "kubernetes.host"
 	lokiLabelKubernetesContainerName = "kubernetes.container_name"
 	podNamespace                     = "kubernetes.namespace_name"
+
+	// OTel
+	otellogType                          = "openshift.log_type"
+	otellokiLabelKubernetesNamespaceName = "k8s.namespace_name"
+	otellokiLabelKubernetesPodName       = "k8s.pod_name"
+	otellokiLabelKubernetesContainerName = "k8s.container_name"
+	otellokiLabelKubernetesNodeName      = "k8s.node_name"
 )
 
 var (
@@ -36,6 +42,12 @@ var (
 		lokiLabelKubernetesNamespaceName,
 		lokiLabelKubernetesPodName,
 		lokiLabelKubernetesContainerName,
+
+		// OTel labels
+		otellogType,
+		otellokiLabelKubernetesNamespaceName,
+		otellokiLabelKubernetesPodName,
+		otellokiLabelKubernetesContainerName,
 	}
 
 	containerLabels = []string{
@@ -45,7 +57,15 @@ var (
 	}
 
 	requiredLabelKeys = []string{
+		otellokiLabelKubernetesNodeName,
 		lokiLabelKubernetesHost,
+	}
+
+	viaqOtelLabelMap = map[string]string{
+		logType:                          otellogType,
+		lokiLabelKubernetesNamespaceName: otellokiLabelKubernetesNamespaceName,
+		lokiLabelKubernetesPodName:       otellokiLabelKubernetesPodName,
+		lokiLabelKubernetesContainerName: otellokiLabelKubernetesContainerName,
 	}
 	lokiEncodingJson = fmt.Sprintf("%q", "json")
 )
@@ -173,6 +193,8 @@ func lokiLabelKeys(l *logging.Loki) []string {
 	var keys sets.String
 	if l != nil && len(l.LabelKeys) != 0 {
 		keys = *sets.NewString(l.LabelKeys...)
+		// Determine which of the OTel labels need to also be added based on spec'd custom labels
+		keys.Insert(addOtelEquivalentLabels(l.LabelKeys)...)
 	} else {
 		keys = *sets.NewString(defaultLabelKeys...)
 	}
@@ -190,15 +212,47 @@ func lokiLabels(lo *logging.Loki) []Label {
 			Name:  name,
 			Value: formatLokiLabelValue(k),
 		}
-		if k == lokiLabelKubernetesHost {
-			l.Value = "${VECTOR_SELF_NODE_NAME}"
-		}
-		if k == lokiLabelKubernetesNamespaceName {
-			l.Value = fmt.Sprintf("{{%s}}", podNamespace)
+		if val := generateCustomLabelValues(k); val != "" {
+			l.Value = val
 		}
 		ls = append(ls, l)
 	}
 	return ls
+}
+
+// addOtelEquivalentLabels checks spec'd custom label keys to add matching otel labels
+// e.g kubernetes.namespace_name = k8s.namespace_name
+func addOtelEquivalentLabels(customLabelKeys []string) []string {
+	matchingLabels := []string{}
+
+	for _, label := range customLabelKeys {
+		if val, ok := viaqOtelLabelMap[label]; ok {
+			matchingLabels = append(matchingLabels, val)
+		}
+	}
+	return matchingLabels
+}
+
+// generateCustomLabelValues generates custom values for specific labels like kubernetes.host, k8s_* labels
+func generateCustomLabelValues(value string) string {
+	var labelVal string
+
+	switch value {
+	case otellogType:
+		labelVal = logType
+	case otellokiLabelKubernetesContainerName:
+		labelVal = lokiLabelKubernetesContainerName
+	case lokiLabelKubernetesNamespaceName, otellokiLabelKubernetesNamespaceName:
+		labelVal = podNamespace
+	case otellokiLabelKubernetesPodName:
+		labelVal = lokiLabelKubernetesPodName
+	// Special case for the kubernetes node name (same as kubernetes.host)
+	case lokiLabelKubernetesHost, otellokiLabelKubernetesNodeName:
+		return "${VECTOR_SELF_NODE_NAME}"
+	default:
+		return ""
+	}
+	return fmt.Sprintf("{{%s}}", labelVal)
 }
 
 func remapLabelsVrl(labels []string) string {
@@ -227,7 +281,7 @@ func formatLokiLabelValue(value string) string {
 func RemapLabels(id string, o logging.OutputSpec, inputs []string) Element {
 	return Remap{
 		ComponentID: id,
-		Inputs:      helpers.MakeInputs(inputs...),
+		Inputs:      vectorhelpers.MakeInputs(inputs...),
 		VRL:         remapLabelsVrl(containerLabels),
 	}
 }
@@ -326,7 +380,7 @@ func BearerTokenAuth(id string, o logging.OutputSpec, secret *corev1.Secret) []E
 func CleanupFields(id string, inputs []string) Element {
 	return Remap{
 		ComponentID: id,
-		Inputs:      helpers.MakeInputs(inputs...),
+		Inputs:      vectorhelpers.MakeInputs(inputs...),
 		VRL:         "del(.tag)",
 	}
 }

--- a/internal/generator/vector/output/loki/with_custom_bearer_token.toml
+++ b/internal/generator/vector/output/loki/with_custom_bearer_token.toml
@@ -57,11 +57,16 @@ healthcheck.enabled = false
 codec = "json"
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 # Bearer Auth Config
 [sinks.loki_receiver.auth]

--- a/internal/generator/vector/output/loki/with_custom_labels.toml
+++ b/internal/generator/vector/output/loki/with_custom_labels.toml
@@ -58,6 +58,8 @@ healthcheck.enabled = false
 codec = "json"
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_labels_app = "{{kubernetes.labels.\"app\"}}"

--- a/internal/generator/vector/output/loki/with_default_labels.toml
+++ b/internal/generator/vector/output/loki/with_default_labels.toml
@@ -56,11 +56,16 @@ healthcheck.enabled = false
 codec = "json"
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 # Basic Auth Config
 [sinks.loki_receiver.auth]

--- a/internal/generator/vector/output/loki/with_default_logcollector_bearer_token.toml
+++ b/internal/generator/vector/output/loki/with_default_logcollector_bearer_token.toml
@@ -56,11 +56,16 @@ healthcheck.enabled = false
 codec = "json"
 
 [sinks.default_loki_apps.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 
 [sinks.default_loki_apps.tls]

--- a/internal/generator/vector/output/loki/with_default_tls.toml
+++ b/internal/generator/vector/output/loki/with_default_tls.toml
@@ -57,11 +57,16 @@ healthcheck.enabled = false
 codec = "json"
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 
 [sinks.loki_receiver.tls]

--- a/internal/generator/vector/output/loki/with_insecure.toml
+++ b/internal/generator/vector/output/loki/with_insecure.toml
@@ -57,11 +57,16 @@ healthcheck.enabled = false
 codec = "json"
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 
 [sinks.loki_receiver.tls]

--- a/internal/generator/vector/output/loki/with_insecure_nocert.toml
+++ b/internal/generator/vector/output/loki/with_insecure_nocert.toml
@@ -57,11 +57,16 @@ healthcheck.enabled = false
 codec = "json"
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 
 [sinks.loki_receiver.tls]

--- a/internal/generator/vector/output/loki/with_tenant_id.toml
+++ b/internal/generator/vector/output/loki/with_tenant_id.toml
@@ -57,11 +57,16 @@ tenant_id = "{{foo.bar.baz}}"
 codec = "json"
 
 [sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
 kubernetes_container_name = "{{kubernetes.container_name}}"
 kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
 kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
 kubernetes_pod_name = "{{kubernetes.pod_name}}"
 log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"
 
 
 # Basic Auth Config

--- a/test/functional/outputs/loki/application_logs_vector_test.go
+++ b/test/functional/outputs/loki/application_logs_vector_test.go
@@ -81,9 +81,10 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 			Expect(strings.Contains(lines[2], "Present days")).To(BeTrue())
 		})
 	})
-	Context("when label keys are defined that include slashes and dashes. Ref(LOG-4095, LOG-4460)", func() {
+
+	Context("labelKeys", func() {
 		const myValue = "foobarvalue"
-		BeforeEach(func() {
+		It("should handle the configuration so the collector starts when label keys are defined that include slashes and dashes. Ref(LOG-4095, LOG-4460)", func() {
 			f.Labels["app.kubernetes.io/name"] = myValue
 			f.Labels["prefix-cloud_com_platform-stage"] = "dev"
 			f.Forwarder.Spec.Outputs[0].Loki.LabelKeys = []string{
@@ -93,8 +94,6 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 				"kubernetes.labels.prefix-cloud_com_platform-stage",
 			}
 			Expect(f.Deploy()).To(BeNil())
-		})
-		It("should handle the configuration so the collector starts", func() {
 			now := time.Now()
 			tsNow := functional.CRIOTime(now)
 			msg := functional.NewFullCRIOLogMessage(tsNow, "Present days")
@@ -107,6 +106,52 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 			Expect(len(result)).To(Equal(1))
 			lines := result[0].Lines()
 			Expect(len(lines)).To(Equal(1))
+
+			want := map[string]string{
+				"k8s_namespace_name":                                f.Namespace,
+				"k8s_pod_name":                                      f.Pod.Name,
+				"k8s_node_name":                                     f.Pod.Spec.NodeName,
+				"kubernetes_namespace_name":                         f.Namespace,
+				"kubernetes_pod_name":                               f.Pod.Name,
+				"kubernetes_labels_app_kubernetes_io_name":          myValue,
+				"kubernetes_labels_prefix_cloud_com_platform_stage": "dev",
+				"kubernetes_host":                                   f.Pod.Spec.NodeName,
+			}
+			labels := result[0].Stream
+			Expect(len(labels)).To(Equal(8))
+			Expect(labels).To(BeEquivalentTo(want))
+		})
+
+		It("should add all otel equivalent default labels when loki.LabelKeys are not defined", func() {
+			Expect(f.Deploy()).To(BeNil())
+			now := time.Now()
+			tsNow := functional.CRIOTime(now)
+			msg := functional.NewFullCRIOLogMessage(tsNow, "Present days")
+			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(Succeed())
+
+			query := fmt.Sprintf(`{openshift_log_type=%q}`, logging.InputNameApplication)
+			result, err := l.QueryUntil(query, "", 1)
+			Expect(err).To(BeNil())
+			Expect(result).NotTo(BeNil())
+			Expect(len(result)).To(Equal(1))
+			lines := result[0].Lines()
+			Expect(len(lines)).To(Equal(1))
+
+			want := map[string]string{
+				"k8s_container_name":        f.Pod.Spec.Containers[0].Name,
+				"k8s_namespace_name":        f.Namespace,
+				"k8s_pod_name":              f.Pod.Name,
+				"k8s_node_name":             f.Pod.Spec.NodeName,
+				"kubernetes_container_name": f.Pod.Spec.Containers[0].Name,
+				"kubernetes_namespace_name": f.Namespace,
+				"kubernetes_pod_name":       f.Pod.Name,
+				"kubernetes_host":           f.Pod.Spec.NodeName,
+				"log_type":                  logging.InputNameApplication,
+				"openshift_log_type":        logging.InputNameApplication,
+			}
+			labels := result[0].Stream
+			Expect(len(labels)).To(Equal(10))
+			Expect(labels).To(BeEquivalentTo(want))
 		})
 	})
 

--- a/test/functional/outputs/loki/audit_logs_vector_test.go
+++ b/test/functional/outputs/loki/audit_logs_vector_test.go
@@ -4,12 +4,13 @@ package loki
 
 import (
 	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	logging "github.com/openshift/cluster-logging-operator/api/logging/v1"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/loki"
-	"time"
 )
 
 var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
@@ -61,8 +62,10 @@ var _ = Describe("[Functional][Outputs][Loki] Forwarding to Loki", func() {
 		Expect(records).To(HaveCap(1), "Exp. the record to be ingested")
 
 		expLabels := map[string]string{
-			"kubernetes_host": f.Pod.Spec.NodeName,
-			"log_type":        "audit",
+			"kubernetes_host":    f.Pod.Spec.NodeName,
+			"log_type":           logging.InputNameAudit,
+			"openshift_log_type": logging.InputNameAudit,
+			"k8s_node_name":      f.Pod.Spec.NodeName,
 		}
 		actualLabels := r[0].Stream
 		Expect(actualLabels).To(BeEquivalentTo(expLabels), "Exp. labels to be added to the log record")


### PR DESCRIPTION
### Description
This is a manual port of https://github.com/openshift/cluster-logging-operator/pull/2926 to `release-5.9`.

This only adds functionality to `vector` and **NOT** `fluentd` because `fluentd` is deprecated.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6581

