### PR TITLE
NO-JIRA: enhance 'sysctl' test to handle multiple expected outputs

### DIFF
--- a/test/e2e/collection/security/container_security_test.go
+++ b/test/e2e/collection/security/container_security_test.go
@@ -121,7 +121,10 @@ var _ = Describe("Tests of collector container security stance", func() {
 
 		By("having all sysctls disabled")
 		result, _ = runInCollectorContainer("/usr/sbin/sysctl", "net.ipv4.ip_local_port_range=0")
-		Expect(result).To(ContainSubstring("sysctl: no such file"))
+		Expect(result).To(Or(
+			ContainSubstring("sysctl: no such file"),
+			ContainSubstring("executable file `/usr/sbin/sysctl` not found in $PATH"),
+		))
 
 		By("disabling privilege escalation")
 		result, err = runInCollectorContainer("cat", "/proc/1/status")


### PR DESCRIPTION
### Description
This PR updates the collector container security: sysctl test to account for multiple possible outputs when the `sysctl` command is unavailable or the executable file is not found.
By adding the `Or` matcher with `ContainSubstring` to handle variations in error messages:
`sysctl: no such file`
`executable file '/usr/sbin/sysctl' not found in $PATH`

This is need because this test fail if run in on latest (4.18.x) OpenShift version. 


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill  <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA:
- Enhancement proposal:
