### PR TITLE
LOG-6585: Fail validition if output is unreferenced

### DIFF
--- a/internal/api/observability/pipelines.go
+++ b/internal/api/observability/pipelines.go
@@ -1,6 +1,9 @@
 package observability
 
-import obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+import (
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"k8s.io/utils/set"
+)
 
 type Pipelines []obs.PipelineSpec
 
@@ -19,4 +22,14 @@ func (pipeline Pipelines) Map() map[string]obs.PipelineSpec {
 		m[p.Name] = p
 	}
 	return m
+}
+
+// ReferenceOutput iterates through the list of pipelines to see if any reference the given output
+func (pipeline Pipelines) ReferenceOutput(output obs.OutputSpec) bool {
+	for _, i := range pipeline {
+		if set.New(i.OutputRefs...).Has(output.Name) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
### Description
This PR:
* validates each output is referenced by a pipeline or fails
* this will keep the operator from deploying a collector with configuration not accepted by vector

### Links
https://issues.redhat.com/browse/LOG-6585

cc @vparfonov @cahartma 