### PR TITLE
LOG-6539: use Patch() instead of Update() in updateStatus func

### DIFF
--- a/internal/controller/observability/clusterlogforwarder_controller.go
+++ b/internal/controller/observability/clusterlogforwarder_controller.go
@@ -212,7 +212,8 @@ func validateForwarder(forwarderContext internalcontext.ForwarderContext) (valid
 
 func updateStatus(k8Client client.Client, instance *obsv1.ClusterLogForwarder, ready metav1.Condition) {
 	internalobs.SetCondition(&instance.Status.Conditions, ready)
-	if err := k8Client.Status().Update(context.TODO(), instance); err != nil {
+	patch := client.MergeFrom(instance.DeepCopy())
+	if err := k8Client.Status().Patch(context.TODO(), instance, patch); err != nil {
 		log.Error(err, "clusterlogforwarder-controller error updating status", "status", instance.Status)
 	}
 }


### PR DESCRIPTION
### Description
Use `Patch()` instead of `Update()` should prevent conflicts during updating.
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-6539
- Enhancement proposal:
