### PR TITLE
LOG-6623: better description for 'obsclf.spec.outputs.elasticsearch.index' when log forwarding to the Red Hat Managed Elasticsearch

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -477,6 +477,10 @@ type Elasticsearch struct {
 	//
 	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
 	//
+	// When forwarding logs to the Red Hat Managed Elasticsearch, the index must match the pattern ^(app|infra|audit)-write$
+	// where the prefix depends upon the log_type. This requires defining a distinct output for each log type or distinct pipelines
+	// with the openshiftLabels filter. See the product documentation for examples.
+	//
 	// Example:
 	//
 	//  1. foo-{.bar||"none"}

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2025-01-13T19:29:18Z"
+    createdAt: "2025-02-06T14:39:16Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -694,6 +694,11 @@ spec:
 
 
           Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+
+
+          When forwarding logs to the Red Hat Managed Elasticsearch, the index must match the pattern ^(app|infra|audit)-write$
+          where the prefix depends upon the log_type. This requires defining a distinct output for each log type or distinct pipelines
+          with the openshiftLabels filter. See the product documentation for examples.
 
 
           Example:

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1209,6 +1209,10 @@ spec:
 
                             Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
 
+                            When forwarding logs to the Red Hat Managed Elasticsearch, the index must match the pattern ^(app|infra|audit)-write$
+                            where the prefix depends upon the log_type. This requires defining a distinct output for each log type or distinct pipelines
+                            with the openshiftLabels filter. See the product documentation for examples.
+
                             Example:
 
                              1. foo-{.bar||"none"}

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1209,6 +1209,10 @@ spec:
 
                             Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
 
+                            When forwarding logs to the Red Hat Managed Elasticsearch, the index must match the pattern ^(app|infra|audit)-write$
+                            where the prefix depends upon the log_type. This requires defining a distinct output for each log type or distinct pipelines
+                            with the openshiftLabels filter. See the product documentation for examples.
+
                             Example:
 
                              1. foo-{.bar||"none"}

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -619,6 +619,11 @@ spec:
           Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
 
 
+          When forwarding logs to the Red Hat Managed Elasticsearch, the index must match the pattern ^(app|infra|audit)-write$
+          where the prefix depends upon the log_type. This requires defining a distinct output for each log type or distinct pipelines
+          with the openshiftLabels filter. See the product documentation for examples.
+
+
           Example:
 
 

--- a/docs/features/logforwarding/outputs/elasticsearch-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/elasticsearch-forwarding.adoc
@@ -24,24 +24,24 @@ spec:
       elasticsearch:
         url: 'https://example-elasticsearch-secure.com:9200'
         version: 8  # <1>
-        index: '{.log_type||"undefined"}'  # <2>
+        index: '{.log_type||"undefined"}'  # <2> <3>
         authentication:
           username:
             key: username
-            secretName: es-secret  # <3>
+            secretName: es-secret  # <4>
           password:
             key: password
-            secretName: es-secret  # <3>
+            secretName: es-secret  # <4>
       tls:
         ca:
-          key: ca-bundle.crt       # <4>
+          key: ca-bundle.crt       # <5>
           secretName: es-secret
         certificate:
           key: tls.crt
-          secretName: es-secret    # <4>
+          secretName: es-secret    # <5>
         key:
           key: tls.key
-          secretName: es-secret    # <4>
+          secretName: es-secret    # <5>
   pipelines:
     - name: my-logs
       inputRefs:
@@ -53,8 +53,11 @@ spec:
 +
 <1> Forwarding to an external Elasticsearch of version 8.x or greater requires the `version` field to be specified otherwise this can be omitted.
 <2> `index` is set to read the field value `.log_type` and falls back to "unknown" if not found
-<3> Use username and password to authenticate to the server
-<4> Enable Mutual Transport Layer Security (mTLS) between collector and elasticsearch, the spec identifies the keys and secret to the respective certificates that they represent.
+<3> When forwarding logs to the Red Hat Managed Elasticsearch, the index must match the pattern `^(app|infra|audit)-write$`
+    where the prefix depends upon the `log_type`. This requires defining a distinct output for each log type or distinct
+    pipelines with the `openshiftLabels` filter. See the product documentation for examples.
+<4> Use username and password to authenticate to the server
+<5> Enable Mutual Transport Layer Security (mTLS) between collector and elasticsearch, the spec identifies the keys and secret to the respective certificates that they represent.
 
 == Custom Index Configuration
 


### PR DESCRIPTION
### Description
This PR:
- adds better description when reviewing the fields using `$ oc explain obsclf.spec.outputs.elasticsearch.index` for when log forwarding to the Red Hat Managed Elasticsearch for knowing about the limitation with the name of the indices
- add same information to the internal documentation 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-6623
- Enhancement proposal:
