### PR TITLE
LOG-6661: fix inconsistency for syslog facillity and severity templating

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -1083,6 +1083,7 @@ type Syslog struct {
 	//     Emergency Alert Critical Error Warning Notice Informational Debug
 	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Severity",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Severity string `json:"severity,omitempty"`
 
@@ -1099,6 +1100,7 @@ type Syslog struct {
 	//     local0 local1 local2 local3 local4 local5 local6 local7
 	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Facility",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Facility string `json:"facility,omitempty"`
 

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -2359,6 +2359,7 @@ spec:
                                 kernel user mail daemon auth syslog lpr news
                                 uucp cron authpriv ftp ntp security console solaris-cron
                                 local0 local1 local2 local3 local4 local5 local6 local7
+                          pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         msgId:
                           description: |-
@@ -2437,6 +2438,7 @@ spec:
                             The value can be a decimal integer or one of these case-insensitive keywords:
 
                                 Emergency Alert Critical Error Warning Notice Informational Debug
+                          pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
                           description: Tuning specs tuning for the output

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -2359,6 +2359,7 @@ spec:
                                 kernel user mail daemon auth syslog lpr news
                                 uucp cron authpriv ftp ntp security console solaris-cron
                                 local0 local1 local2 local3 local4 local5 local6 local7
+                          pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         msgId:
                           description: |-
@@ -2437,6 +2438,7 @@ spec:
                             The value can be a decimal integer or one of these case-insensitive keywords:
 
                                 Emergency Alert Critical Error Warning Notice Informational Debug
+                          pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         tuning:
                           description: Tuning specs tuning for the output

--- a/internal/generator/vector/output/syslog/syslog_test.go
+++ b/internal/generator/vector/output/syslog/syslog_test.go
@@ -112,8 +112,8 @@ var _ = Describe("vector syslog clf output", func() {
 			spec.Syslog = &obs.Syslog{
 				URL:        "tls://logserver:6514",
 				RFC:        obs.SyslogRFC5424,
-				Facility:   "$$.message.facility",
-				Severity:   "$$.message.severity",
+				Facility:   `{.facility||"none"}`,
+				Severity:   `{.severity||"none"}`,
 				AppName:    `{.app_name||"none"}`,
 				MsgId:      `{.msg_id||"none"}`,
 				ProcId:     `{.proc_id||"none"}`,

--- a/internal/generator/vector/output/syslog/tls_with_field_references.toml
+++ b/internal/generator/vector/output/syslog/tls_with_field_references.toml
@@ -22,6 +22,8 @@ if .log_type == "audit" {
    ._internal.syslog.severity = "informational"
    ._internal.syslog.facility = "security"
 }
+.facility = to_string!(.facility||"none")
+.severity = to_string!(.severity||"none")
 .proc_id = to_string!(.proc_id||"none")
 .app_name = to_string!(.app_name||"none")
 .msg_id = to_string!(.msg_id||"none")
@@ -43,10 +45,10 @@ mode = "tcp"
 codec = "syslog"
 except_fields = ["_internal"]
 rfc = "rfc5424"
-facility = "$$.message.facility"
-severity = "$$.message.severity"
 add_log_source = false
 payload_key = "payload_key"
+facility = "$$.message.facility"
+severity = "$$.message.severity"
 proc_id = "$$.message.proc_id"
 app_name = "$$.message.app_name"
 msg_id = "$$.message.msg_id"

--- a/internal/generator/vector/output/syslog/udp_with_every_setting.toml
+++ b/internal/generator/vector/output/syslog/udp_with_every_setting.toml
@@ -21,6 +21,8 @@ if .log_type == "audit" {
     ._internal.syslog.severity = "informational"
     ._internal.syslog.facility = "security"
 }
+.facility = "kern"
+.severity = "critical"
 .proc_id = "procID"
 .tag = "appName"
 if exists(.proc_id) && .proc_id != "-" && .proc_id != "" {
@@ -43,9 +45,9 @@ mode = "udp"
 codec = "syslog"
 except_fields = ["_internal"]
 rfc = "rfc3164"
-facility = "kern"
-severity = "critical"
 add_log_source = false
 payload_key = "payload_key"
+facility = "$$.message.facility"
+severity = "$$.message.severity"
 proc_id = "$$.message.proc_id"
 tag = "$$.message.tag"

--- a/test/functional/outputs/syslog/rfc3164_test.go
+++ b/test/functional/outputs/syslog/rfc3164_test.go
@@ -36,8 +36,8 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(obs.InputTypeApplication).
 				ToSyslogOutput(obs.SyslogRFC3164, func(spec *obs.OutputSpec) {
-					spec.Syslog.Facility = "$.message.facility_key"
-					spec.Syslog.Severity = "$.message.severity_key"
+					spec.Syslog.Facility = `{.facility_key||"notfound"}`
+					spec.Syslog.Severity = `{.severity_key||"notfound"}`
 					spec.Syslog.RFC = obs.SyslogRFC3164
 				})
 			Expect(framework.Deploy()).To(BeNil())

--- a/test/functional/outputs/syslog/rfc5424_test.go
+++ b/test/functional/outputs/syslog/rfc5424_test.go
@@ -95,8 +95,8 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC5424 tests", func() {
 			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 				FromInput(obs.InputTypeApplication).
 				ToSyslogOutput(obs.SyslogRFC5424, func(spec *obs.OutputSpec) {
-					spec.Syslog.Facility = "$.message.facility_key"
-					spec.Syslog.Severity = "$.message.severity_key"
+					spec.Syslog.Facility = `{.facility_key||"notfound"}`
+					spec.Syslog.Severity = `{.severity_key||"notfound"}`
 				})
 			Expect(framework.Deploy()).To(BeNil())
 


### PR DESCRIPTION
### Description
This change:
* Restricts syslog.(severity|facility) to the template pattern supported elsewhere in the API
* Removes the capability to use the 5.x syslog template notation (e.g. `$$.message.foo`)
* Updates tests to validate changes

### Links
* https://issues.redhat.com/browse/LOG-6661
