### PR TITLE
LOG-6764: Update maximum OpenShift version to match supported range

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.18
+    value: 4.19


### PR DESCRIPTION
### Description

This PR updates the maximum OpenShift version the operator is compatible with to match the supported range for this version.

/cc @cahartma 
/assign @jcantrill 

### Links

- JIRA: LOG-6467
