### PR TITLE
LOG-6812: Set dns cache to expire

### DIFF
--- a/internal/generator/fluentd/fluent_conf_test/exclude.conf
+++ b/internal/generator/fluentd/fluent_conf_test/exclude.conf
@@ -342,6 +342,7 @@
     heartbeat_type none
     keepalive true
     keepalive_timeout 30s
+    expire_dns_cache 30s
 
     <buffer>
       @type file

--- a/internal/generator/fluentd/output/fluentdforward/fluentdforward.go
+++ b/internal/generator/fluentd/output/fluentdforward/fluentdforward.go
@@ -47,6 +47,7 @@ func (ff FluentdForward) Template() string {
 heartbeat_type none
 keepalive true
 keepalive_timeout 30s
+expire_dns_cache 30s
 {{compose .SecurityConfig}}
 {{compose .BufferConfig}}
 {{- end}}

--- a/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/fluentdforward_test.go
@@ -72,6 +72,7 @@ var _ = Describe("fluentd conf generation", func() {
     heartbeat_type none
     keepalive true
     keepalive_timeout 30s
+    expire_dns_cache 30s
     transport tls
     tls_verify_hostname false
     tls_version 'TLSv1_2'
@@ -141,6 +142,7 @@ var _ = Describe("fluentd conf generation", func() {
     heartbeat_type none
     keepalive true
     keepalive_timeout 30s
+    expire_dns_cache 30s
     transport tls
     tls_verify_hostname false
     tls_version 'TLSv1_2'
@@ -205,6 +207,7 @@ var _ = Describe("fluentd conf generation", func() {
     heartbeat_type none
     keepalive true
     keepalive_timeout 30s
+    expire_dns_cache 30s
     
     <buffer>
       @type file

--- a/internal/generator/fluentd/output/fluentdforward/output_conf_forward_test.go
+++ b/internal/generator/fluentd/output/fluentdforward/output_conf_forward_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
     heartbeat_type none
     keepalive true
     keepalive_timeout 30s
+    expire_dns_cache 30s
     transport tls
     tls_verify_hostname false
     tls_version 'TLSv1_2'
@@ -134,6 +135,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
     heartbeat_type none
     keepalive true
     keepalive_timeout 30s
+    expire_dns_cache 30s
     transport tls
     tls_verify_hostname false
     tls_version 'TLSv1_2'
@@ -186,6 +188,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
     heartbeat_type none
     keepalive true
     keepalive_timeout 30s
+    expire_dns_cache 30s
     transport tls
     tls_verify_hostname false
     tls_version 'TLSv1_2'
@@ -255,6 +258,7 @@ var _ = Describe("Generating fluentd secure forward output store config blocks",
     heartbeat_type none
     keepalive true
     keepalive_timeout 30s
+    expire_dns_cache 30s
     <buffer>
       @type file
       path '/var/lib/fluentd/secureforward_receiver'

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -584,6 +584,7 @@ var _ = Describe("Generating fluentd config", func() {
             heartbeat_type none
             keepalive true
             keepalive_timeout 30s
+	    expire_dns_cache 30s
             <buffer>
             @type file
             path '/var/lib/fluentd/secureforward_receiver'
@@ -634,6 +635,7 @@ var _ = Describe("Generating fluentd config", func() {
           heartbeat_type none
           keepalive true
           keepalive_timeout 30s
+	  expire_dns_cache 30s
 
           <buffer>
           @type file

--- a/internal/generator/fluentd/output/output_fluentd_buffer_test.go
+++ b/internal/generator/fluentd/output/output_fluentd_buffer_test.go
@@ -584,7 +584,7 @@ var _ = Describe("Generating fluentd config", func() {
             heartbeat_type none
             keepalive true
             keepalive_timeout 30s
-	    expire_dns_cache 30s
+            expire_dns_cache 30s
             <buffer>
             @type file
             path '/var/lib/fluentd/secureforward_receiver'
@@ -635,7 +635,7 @@ var _ = Describe("Generating fluentd config", func() {
           heartbeat_type none
           keepalive true
           keepalive_timeout 30s
-	  expire_dns_cache 30s
+          expire_dns_cache 30s
 
           <buffer>
           @type file


### PR DESCRIPTION
When the target server DNS record changes during runtime, the change is not picked by the forwarder. With this change the cached DNS record expires and renews each 30 seconds.
https://docs.fluentd.org/output/forward#expire_dns_cache

### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
https://issues.redhat.com/browse/LOG-6812
