### PR TITLE
Revert "LOG-6539: use Patch() instead of Update() in updateStatus func"

### DIFF
--- a/internal/controller/observability/clusterlogforwarder_controller.go
+++ b/internal/controller/observability/clusterlogforwarder_controller.go
@@ -212,8 +212,7 @@ func validateForwarder(forwarderContext internalcontext.ForwarderContext) (valid
 
 func updateStatus(k8Client client.Client, instance *obsv1.ClusterLogForwarder, ready metav1.Condition) {
 	internalobs.SetCondition(&instance.Status.Conditions, ready)
-	patch := client.MergeFrom(instance.DeepCopy())
-	if err := k8Client.Status().Patch(context.TODO(), instance, patch); err != nil {
+	if err := k8Client.Status().Update(context.TODO(), instance); err != nil {
 		log.Error(err, "clusterlogforwarder-controller error updating status", "status", instance.Status)
 	}
 }


### PR DESCRIPTION
### Description
This PR reverts https://github.com/openshift/cluster-logging-operator/pull/2955

/cc @vparfonov @cahartma 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6761
- Related JIRA: https://issues.redhat.com/browse/LOG-6539

