### PR TITLE
LOG-6759: Collectors in crashloopbackoff when defined an output that not used in the pipeline

### DIFF
--- a/internal/api/observability/pipelines.go
+++ b/internal/api/observability/pipelines.go
@@ -1,6 +1,9 @@
 package observability
 
-import obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+import (
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"k8s.io/utils/set"
+)
 
 type Pipelines []obs.PipelineSpec
 
@@ -19,4 +22,14 @@ func (pipeline Pipelines) Map() map[string]obs.PipelineSpec {
 		m[p.Name] = p
 	}
 	return m
+}
+
+// ReferenceOutput iterates through the list of pipelines to see if any reference the given output
+func (pipeline Pipelines) ReferenceOutput(output obs.OutputSpec) bool {
+	for _, i := range pipeline {
+		if set.New(i.OutputRefs...).Has(output.Name) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
### Description
This PR is a backport of https://github.com/openshift/cluster-logging-operator/pull/2940, in which the validation will fail if outputs are not referenced by any pipeline.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6759
- Related JIRA: https://issues.redhat.com/browse/LOG-6585

