### PR TITLE
LOG-6850: syslog input missing from 'obsclf.spec.inputs.receiver'

### DIFF
--- a/api/observability/v1/input_types.go
+++ b/api/observability/v1/input_types.go
@@ -258,6 +258,13 @@ type InputTLSSpec TLSSpec
 type ReceiverSpec struct {
 	// Type of Receiver plugin.
 	//
+	// Supported Receiver types are:
+	//
+	// 1. http
+	//    - Currently only supports kubernetes audit logs (log_type = "audit")
+	// 2. syslog
+	//    - Currently only supports node infrastucture logs (log_type = "infrastructure")
+	//
 	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Receiver Type"
 	Type ReceiverType `json:"type"`
@@ -296,6 +303,8 @@ const (
 // HTTPReceiver receives encoded logs as a HTTP endpoint.
 type HTTPReceiver struct {
 	// Format is the format of incoming log data.
+	//
+	// The only currently supported format is `kubeAPIAudit`.
 	//
 	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Data Format"

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2025-02-06T14:39:16Z"
+    createdAt: "2025-03-12T17:45:14Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -380,7 +380,11 @@ spec:
         path: inputs[0].receiver
       - displayName: HTTP Receiver Configuration
         path: inputs[0].receiver.http
-      - description: Format is the format of incoming log data.
+      - description: |-
+          Format is the format of incoming log data.
+
+
+          The current supported format is `kubeAPIAudit`.
         displayName: Data Format
         path: inputs[0].receiver.http.format
       - description: Port the Receiver listens on. It must be a value between 1024
@@ -398,7 +402,17 @@ spec:
           the collector. The collector is configured to use the public and private key provided by the service
         displayName: TLS Options
         path: inputs[0].receiver.tls
-      - description: Type of Receiver plugin.
+      - description: |-
+          Type of Receiver plugin.
+
+
+          Supported Receiver types are:
+
+
+          1. http
+             - Currently only supports kubernetes audit logs (log_type = "audit")
+          2. syslog
+             - Currently only supports node infrastucture logs (log_type = "infrastructure")
         displayName: Receiver Type
         path: inputs[0].receiver.type
       - description: Type of output sink.

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -683,7 +683,10 @@ spec:
                             endpoint.
                           properties:
                             format:
-                              description: Format is the format of incoming log data.
+                              description: |-
+                                Format is the format of incoming log data.
+
+                                The current supported format is `kubeAPIAudit`.
                               enum:
                               - kubeAPIAudit
                               type: string
@@ -791,7 +794,15 @@ spec:
                               type: object
                           type: object
                         type:
-                          description: Type of Receiver plugin.
+                          description: |-
+                            Type of Receiver plugin.
+
+                            Supported Receiver types are:
+
+                            1. http
+                               - Currently only supports kubernetes audit logs (log_type = "audit")
+                            2. syslog
+                               - Currently only supports node infrastucture logs (log_type = "infrastructure")
                           enum:
                           - http
                           - syslog

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -683,7 +683,10 @@ spec:
                             endpoint.
                           properties:
                             format:
-                              description: Format is the format of incoming log data.
+                              description: |-
+                                Format is the format of incoming log data.
+
+                                The current supported format is `kubeAPIAudit`.
                               enum:
                               - kubeAPIAudit
                               type: string
@@ -791,7 +794,15 @@ spec:
                               type: object
                           type: object
                         type:
-                          description: Type of Receiver plugin.
+                          description: |-
+                            Type of Receiver plugin.
+
+                            Supported Receiver types are:
+
+                            1. http
+                               - Currently only supports kubernetes audit logs (log_type = "audit")
+                            2. syslog
+                               - Currently only supports node infrastucture logs (log_type = "infrastructure")
                           enum:
                           - http
                           - syslog

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -303,7 +303,11 @@ spec:
         path: inputs[0].receiver
       - displayName: HTTP Receiver Configuration
         path: inputs[0].receiver.http
-      - description: Format is the format of incoming log data.
+      - description: |-
+          Format is the format of incoming log data.
+
+
+          The current supported format is `kubeAPIAudit`.
         displayName: Data Format
         path: inputs[0].receiver.http.format
       - description: Port the Receiver listens on. It must be a value between 1024
@@ -321,7 +325,17 @@ spec:
           the collector. The collector is configured to use the public and private key provided by the service
         displayName: TLS Options
         path: inputs[0].receiver.tls
-      - description: Type of Receiver plugin.
+      - description: |-
+          Type of Receiver plugin.
+
+
+          Supported Receiver types are:
+
+
+          1. http
+             - Currently only supports kubernetes audit logs (log_type = "audit")
+          2. syslog
+             - Currently only supports node infrastucture logs (log_type = "infrastructure")
         displayName: Receiver Type
         path: inputs[0].receiver.type
       - description: Type of output sink.


### PR DESCRIPTION
### Description
This PR adds information about the supported `input receiver` types when using `oc explain`.

1. When using `oc explain obsclf.spec.inputs.receiver`:
Output:
```
...
FIELDS:
...
  type	<string> -required-
    Type of Receiver plugin.
    
    Supported Receiver types are:
    
    1. http
       - Currently only supports kubernetes audit logs (log_type = "audit")
    2. syslog
       - Currently only supports node infrastucture logs (log_type =
    "infrastructure")

```
2. When using `oc explain obsclf.spec.inputs.receiver.http`:
Output:
```
...
FIELDS:
  format	<string> -required-
    Format is the format of incoming log data.
    
    The current supported format is `kubeAPIAudit`.
```

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6850

