### PR TITLE
LOG-6816: fix operator permissions to update SCC

### DIFF
--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2025-02-06T14:39:16Z"
+    createdAt: "2025-03-12T19:43:07Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -2131,9 +2131,8 @@ spec:
           verbs:
           - create
           - get
-          - list
           - use
-          - watch
+          - update
         serviceAccountName: cluster-logging-operator
       deployments:
       - name: cluster-logging-operator

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -164,6 +164,5 @@ rules:
   verbs:
   - create
   - get
-  - list
   - use
-  - watch
+  - update


### PR DESCRIPTION
### Description
This PR:
* fixes the operator permissions to allow it to update securitycontextconstraints

### Links
https://issues.redhat.com/browse/LOG-6816
