### PR TITLE
LOG-6869: Improve description for rfc and enrichment in syslog

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -1074,6 +1074,12 @@ type Syslog struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Destination URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	URL string `json:"url"`
 
+	// The RFC to which the generated messages conform to.
+	//
+	// Supported values are:
+	// 1. RFC3164
+	// 2. RFC5424
+	//
 	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Syslog RFC"
 	RFC SyslogRFCType `json:"rfc"`
@@ -1200,7 +1206,14 @@ type Syslog struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="MSGID",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	MsgId string `json:"msgId,omitempty"`
 
-	// Enrichment is an additional modification the log message before forwarding it to the receiver
+	// Enrichment is an additional modification to the log message before forwarding it to the receiver.
+	//
+	// Supported values are:
+	// 1. None
+	//    - Adds no additional enrichment to the record
+	// 2. KubernetesMinimal
+	//    - Adds namespace_name, pod_name, and container_name to the beginning of the message body (e.g. namespace_name=myproject, container_name=server, pod_name=pod-123, message={"foo":"bar"}).
+	// This may result in the message body being an invalid JSON structure.
 	//
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Enrichment Type",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2025-03-12T20:13:39Z"
+    createdAt: "2025-03-14T18:44:23Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -1611,8 +1611,16 @@ spec:
         path: outputs[0].syslog.appName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Enrichment is an additional modification the log message before
-          forwarding it to the receiver
+      - description: |-
+          Enrichment is an additional modification to the log message before forwarding it to the receiver.
+
+
+          Supported values are:
+          1. None
+             - Adds no additional enrichment to the record
+          2. KubernetesMinimal
+             - Adds namespace_name, pod_name, and container_name to the beginning of the message body (e.g. namespace_name=myproject, container_name=server, pod_name=pod-123, message={"foo":"bar"}).
+          This may result in the message body being an invalid JSON structure.
         displayName: Enrichment Type
         path: outputs[0].syslog.enrichment
         x-descriptors:
@@ -1723,7 +1731,14 @@ spec:
         path: outputs[0].syslog.procId
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Syslog RFC
+      - description: |-
+          The RFC to which the generated messages conform to.
+
+
+          Supported values are:
+          1. RFC3164
+          2. RFC5424
+        displayName: Syslog RFC
         path: outputs[0].syslog.rfc
       - description: |-
           Severity to set on outgoing syslog records.

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -2354,8 +2354,15 @@ spec:
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         enrichment:
-                          description: Enrichment is an additional modification the
-                            log message before forwarding it to the receiver
+                          description: |-
+                            Enrichment is an additional modification to the log message before forwarding it to the receiver.
+
+                            Supported values are:
+                            1. None
+                               - Adds no additional enrichment to the record
+                            2. KubernetesMinimal
+                               - Adds namespace_name, pod_name, and container_name to the beginning of the message body (e.g. namespace_name=myproject, container_name=server, pod_name=pod-123, message={"foo":"bar"}).
+                            This may result in the message body being an invalid JSON structure.
                           enum:
                           - None
                           - KubernetesMinimal
@@ -2437,8 +2444,12 @@ spec:
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         rfc:
-                          description: SyslogRFCType sets which RFC the generated
-                            messages conform to.
+                          description: |-
+                            The RFC to which the generated messages conform to.
+
+                            Supported values are:
+                            1. RFC3164
+                            2. RFC5424
                           enum:
                           - RFC3164
                           - RFC5424

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -2354,8 +2354,15 @@ spec:
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         enrichment:
-                          description: Enrichment is an additional modification the
-                            log message before forwarding it to the receiver
+                          description: |-
+                            Enrichment is an additional modification to the log message before forwarding it to the receiver.
+
+                            Supported values are:
+                            1. None
+                               - Adds no additional enrichment to the record
+                            2. KubernetesMinimal
+                               - Adds namespace_name, pod_name, and container_name to the beginning of the message body (e.g. namespace_name=myproject, container_name=server, pod_name=pod-123, message={"foo":"bar"}).
+                            This may result in the message body being an invalid JSON structure.
                           enum:
                           - None
                           - KubernetesMinimal
@@ -2437,8 +2444,12 @@ spec:
                           pattern: ^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$
                           type: string
                         rfc:
-                          description: SyslogRFCType sets which RFC the generated
-                            messages conform to.
+                          description: |-
+                            The RFC to which the generated messages conform to.
+
+                            Supported values are:
+                            1. RFC3164
+                            2. RFC5424
                           enum:
                           - RFC3164
                           - RFC5424

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -1534,8 +1534,16 @@ spec:
         path: outputs[0].syslog.appName
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Enrichment is an additional modification the log message before
-          forwarding it to the receiver
+      - description: |-
+          Enrichment is an additional modification to the log message before forwarding it to the receiver.
+
+
+          Supported values are:
+          1. None
+             - Adds no additional enrichment to the record
+          2. KubernetesMinimal
+             - Adds namespace_name, pod_name, and container_name to the beginning of the message body (e.g. namespace_name=myproject, container_name=server, pod_name=pod-123, message={"foo":"bar"}).
+          This may result in the message body being an invalid JSON structure.
         displayName: Enrichment Type
         path: outputs[0].syslog.enrichment
         x-descriptors:
@@ -1646,7 +1654,14 @@ spec:
         path: outputs[0].syslog.procId
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-      - displayName: Syslog RFC
+      - description: |-
+          The RFC to which the generated messages conform to.
+
+
+          Supported values are:
+          1. RFC3164
+          2. RFC5424
+        displayName: Syslog RFC
         path: outputs[0].syslog.rfc
       - description: |-
           Severity to set on outgoing syslog records.


### PR DESCRIPTION
### Description
This PR adds descriptions for the `RFC` and `enrichment` types for the `syslog` output when using `oc explain`.

When using `oc explain obsclf.spec.outputs.syslog`
```
...
FIELDS:
  ...
  enrichment	<string>
      Enrichment is an additional modification to the log message before
      forwarding it to the receiver.
    
      Supported values are:
      1. None
         - Adds no additional enrichment to the record
      2. KubernetesMinimal
         - Adds namespace_name, pod_name, and container_name to the beginning of
      the message body (e.g. namespace_name=myproject, container_name=server,
      pod_name=pod-123, message={"foo":"bar"}).
      This may result in the message body being an invalid JSON structure.
  ...
  rfc	  <string> -required-
      The RFC to which the generated messages conform to.
    
      Supported values are:
      1. RFC3164
      2. RFC5424
  ...
```

/cc @cahartma @vparfonov 
/assign @jcantrill

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6869

