### PR TITLE
LOG-6855: Not listed the types for different fields in the clusterLogging

### DIFF
--- a/api/logging/v1/clusterlogging_types.go
+++ b/api/logging/v1/clusterlogging_types.go
@@ -102,6 +102,9 @@ type ClusterLoggingStatus struct {
 type VisualizationSpec struct {
 
 	// The type of Visualization to configure
+	// Supported values are:
+	// 1. ocp-console
+	// 2. kibana
 	//
 	// +kubebuilder:validation:Enum=ocp-console;kibana
 	Type VisualizationType `json:"type"`
@@ -291,6 +294,10 @@ type CollectionSpec struct {
 	// TODO make type required in v2 once Logs is removed. For now assume default which is vector
 
 	// The type of Log Collection to configure
+	// Supported values are:
+	// 1. vector
+	// 2. fluentd
+	//
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Collector Implementation",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:fluentd","urn:alm:descriptor:com.tectonic.ui:select:vector"}
 	// +kubebuilder:validation:Optional
 	Type LogCollectionType `json:"type"`

--- a/bundle/manifests/clusterlogging.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterlogging.clusterserviceversion.yaml
@@ -118,7 +118,7 @@ metadata:
     certified: "false"
     console.openshift.io/plugins: '["logging-view-plugin"]'
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2024-10-24T09:59:21Z"
+    createdAt: "2025-03-14T20:19:21Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing your aggregated logging stack.
     features.operators.openshift.io/cnf: "false"
@@ -309,7 +309,11 @@ spec:
         path: collection.tolerations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Toleration
-      - description: The type of Log Collection to configure
+      - description: |-
+          The type of Log Collection to configure
+          Supported values are:
+          1. vector
+          2. fluentd
         displayName: Collector Implementation
         path: collection.type
         x-descriptors:

--- a/bundle/manifests/logging.openshift.io_clusterloggings.yaml
+++ b/bundle/manifests/logging.openshift.io_clusterloggings.yaml
@@ -385,7 +385,11 @@ spec:
                     nullable: true
                     type: array
                   type:
-                    description: The type of Log Collection to configure
+                    description: |-
+                      The type of Log Collection to configure
+                      Supported values are:
+                      1. vector
+                      2. fluentd
                     type: string
                 type: object
               curation:
@@ -1225,7 +1229,11 @@ spec:
                     nullable: true
                     type: array
                   type:
-                    description: The type of Visualization to configure
+                    description: |-
+                      The type of Visualization to configure
+                      Supported values are:
+                      1. ocp-console
+                      2. kibana
                     enum:
                     - ocp-console
                     - kibana

--- a/config/crd/bases/logging.openshift.io_clusterloggings.yaml
+++ b/config/crd/bases/logging.openshift.io_clusterloggings.yaml
@@ -385,7 +385,11 @@ spec:
                     nullable: true
                     type: array
                   type:
-                    description: The type of Log Collection to configure
+                    description: |-
+                      The type of Log Collection to configure
+                      Supported values are:
+                      1. vector
+                      2. fluentd
                     type: string
                 type: object
               curation:
@@ -1225,7 +1229,11 @@ spec:
                     nullable: true
                     type: array
                   type:
-                    description: The type of Visualization to configure
+                    description: |-
+                      The type of Visualization to configure
+                      Supported values are:
+                      1. ocp-console
+                      2. kibana
                     enum:
                     - ocp-console
                     - kibana

--- a/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
+++ b/config/manifests/bases/clusterlogging.clusterserviceversion.yaml
@@ -197,7 +197,11 @@ spec:
         path: collection.tolerations
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Toleration
-      - description: The type of Log Collection to configure
+      - description: |-
+          The type of Log Collection to configure
+          Supported values are:
+          1. vector
+          2. fluentd
         displayName: Collector Implementation
         path: collection.type
         x-descriptors:


### PR DESCRIPTION
### Description
This PR adds the supported values for the `ClusterLogging`'s `collection` and `visualization` specs.

#### When using `oc explain clusterlogging.spec.visualization`:
Output:
```
FIELDS:
  ...
  type	<string> -required-
    The type of Visualization to configure
    Supported values are:
    1. ocp-console
    2. kibana
```
#### When using `oc explain clusterlogging.spec.collection`:
Output:
```
FIELDS:
  ...
  type	<string>
    The type of Log Collection to configure
    Supported values are:
    1. vector
    2. fluentd
```
/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-6855

