### PR TITLE
[release-6.2]LOG-6878: fix validation rule for Loki Tuning to allow it to be empty without failing validation 

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -782,7 +782,7 @@ type LokiStackAuthentication struct {
 
 // LokiStack provides optional extra properties for `type: lokistack`
 // +kubebuilder:validation:XValidation:rule="!has(self.labelKeys) || !has(self.dataModel) || self.dataModel == 'Viaq'", message="'labelKeys' cannot be set when data model is 'Otel'"
-// +kubebuilder:validation:XValidation:rule="!has(self.tuning) || self.tuning.compression != 'snappy' || !has(self.dataModel) || self.dataModel == 'Viaq'", message="'snappy' compression cannot be used when data model is 'Otel'"
+// +kubebuilder:validation:XValidation:rule="!has(self.tuning) || !has(self.tuning.compression) || self.tuning.compression != 'snappy' || !has(self.dataModel) || self.dataModel == 'Viaq'", message="'snappy' compression cannot be used when data model is 'Otel'"
 type LokiStack struct {
 	// Authentication sets credentials for authenticating the requests.
 	//

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -2077,8 +2077,9 @@ spec:
                           == ''Viaq'''
                       - message: '''snappy'' compression cannot be used when data
                           model is ''Otel'''
-                        rule: '!has(self.tuning) || self.tuning.compression != ''snappy''
-                          || !has(self.dataModel) || self.dataModel == ''Viaq'''
+                        rule: '!has(self.tuning) || !has(self.tuning.compression)
+                          || self.tuning.compression != ''snappy'' || !has(self.dataModel)
+                          || self.dataModel == ''Viaq'''
                     name:
                       description: Name used to refer to the output from a `pipeline`.
                       pattern: ^[a-z][a-z0-9-]*[a-z0-9]$

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -2077,8 +2077,9 @@ spec:
                           == ''Viaq'''
                       - message: '''snappy'' compression cannot be used when data
                           model is ''Otel'''
-                        rule: '!has(self.tuning) || self.tuning.compression != ''snappy''
-                          || !has(self.dataModel) || self.dataModel == ''Viaq'''
+                        rule: '!has(self.tuning) || !has(self.tuning.compression)
+                          || self.tuning.compression != ''snappy'' || !has(self.dataModel)
+                          || self.dataModel == ''Viaq'''
                     name:
                       description: Name used to refer to the output from a `pipeline`.
                       pattern: ^[a-z][a-z0-9-]*[a-z0-9]$

--- a/test/e2e/collection/apivalidations/api_validations_test.go
+++ b/test/e2e/collection/apivalidations/api_validations_test.go
@@ -47,6 +47,12 @@ var _ = Describe("", func() {
 		_, err = buffer.ReadFrom(reader)
 		assert(buffer.String(), err)
 	},
+		Entry("should pass for LokiStack with empty tuning", "lokistack-empty-tuning.yaml", func(out string, err error) {
+			Expect(err).ToNot(HaveOccurred())
+		}),
+		Entry("should fail for LokiStack with snappy compression", "lokistack-snappy-compression-otel.yaml", func(out string, err error) {
+			Expect(err.Error()).To(MatchRegexp(".'snappy' compression cannot be used when data model is 'Otel'"))
+		}),
 		Entry("should pass for syslog with valid udp URL", "syslog_valid_url_udp.yaml", func(out string, err error) {
 			Expect(err).ToNot(HaveOccurred())
 		}),

--- a/test/e2e/collection/apivalidations/lokistack-empty-tuning.yaml
+++ b/test/e2e/collection/apivalidations/lokistack-empty-tuning.yaml
@@ -1,0 +1,51 @@
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: clf-validation-test
+spec:
+  outputs:
+    - lokiStack:
+        authentication:
+          token:
+            from: serviceAccount
+        target:
+          name: lokistack-dev
+          namespace: openshift-logging
+        tuning: { }
+        dataModel: Otel
+      name: logging-loki-otel
+      tls:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+      type: lokiStack
+    - lokiStack:
+        authentication:
+          token:
+            from: serviceAccount
+        target:
+          name: lokistack-dev
+          namespace: openshift-logging
+        tuning: { }
+        dataModel: Viaq
+      name: logging-loki-viaq
+      tls:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+      type: lokiStack
+  pipelines:
+      - inputRefs:
+          - application
+          - infrastructure
+          - audit
+        name: logs-to-loki-otel
+        outputRefs:
+          - logging-loki-otel
+      - inputRefs:
+          - application
+        name: logs-to-loki-viaq
+        outputRefs:
+          - logging-loki-viaq
+  serviceAccount:
+    name: clf-validation-test

--- a/test/e2e/collection/apivalidations/lokistack-snappy-compression-otel.yaml
+++ b/test/e2e/collection/apivalidations/lokistack-snappy-compression-otel.yaml
@@ -1,0 +1,32 @@
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: clf-validation-test
+spec:
+  outputs:
+    - lokiStack:
+        authentication:
+          token:
+            from: serviceAccount
+        target:
+          name: lokistack-dev
+          namespace: openshift-logging
+        tuning:
+          compression: snappy
+        dataModel: Otel
+      name: logging-loki
+      tls:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+      type: lokiStack
+  pipelines:
+      - inputRefs:
+          - application
+          - infrastructure
+          - audit
+        name: logs-to-loki
+        outputRefs:
+          - logging-loki
+  serviceAccount:
+    name: clf-validation-test


### PR DESCRIPTION
### Description
back-port https://github.com/openshift/cluster-logging-operator/pull/2956

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-6878
- Enhancement proposal:
