### PR TITLE
LOG-6860: Support Splunk Metadata keys in ClusterLogForwarder

### DIFF
--- a/api/observability/v1/clusterlogforwarder_types.go
+++ b/api/observability/v1/clusterlogforwarder_types.go
@@ -344,6 +344,15 @@ type ClusterLogForwarderList struct {
 	Items           []ClusterLogForwarder `json:"items"`
 }
 
+// FieldPath represents a path to find a value for a given field.  The format must be a value that can be converted to a
+// valid collector configuration. It is a dot delimited path to a field in the log record. It must start with a `.`.
+// The path can contain alphanumeric characters and underscores (a-zA-Z0-9_).
+// If segments contain characters outside of this range, the segment must be quoted.
+// Examples: `.kubernetes.namespace_name`, `.log_type`, '.kubernetes.labels.foobar', `.kubernetes.labels."foo-bar/baz"`
+//
+// +kubebuilder:validation:Pattern:=`^(\.[a-zA-Z0-9_]+|\."[^"]+")(\.[a-zA-Z0-9_]+|\."[^"]+")*$`
+type FieldPath string
+
 func init() {
 	SchemeBuilder.Register(&ClusterLogForwarder{}, &ClusterLogForwarderList{})
 }

--- a/api/observability/v1/filter_types.go
+++ b/api/observability/v1/filter_types.go
@@ -40,15 +40,6 @@ var (
 	}
 )
 
-// FieldPath represents a path to find a value for a given field.  The format must a value that can be converted to a
-// valid collector configuration. It is a dot delimited path to a field in the log record. It must start with a `.`.
-// The path can contain alphanumeric characters and underscores (a-zA-Z0-9_).
-// If segments contain characters outside of this range, the segment must be quoted.
-// Examples: `.kubernetes.namespace_name`, `.log_type`, '.kubernetes.labels.foobar', `.kubernetes.labels."foo-bar/baz"`
-//
-// +kubebuilder:validation:Pattern:=`^(\.[a-zA-Z0-9_]+|\."[^"]+")(\.[a-zA-Z0-9_]+|\."[^"]+")*$`
-type FieldPath string
-
 // FilterSpec defines a filter for log messages.
 //
 // +kubebuilder:validation:XValidation:rule="self.type != 'kubeAPIAudit' || has(self.kubeAPIAudit)", message="Additional type specific spec is required for the filter type"

--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -1045,6 +1045,53 @@ type Splunk struct {
 	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Index",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Index string `json:"index,omitempty"`
+
+	// IndexedFields are the list of fields to be indexed by Splunk, increase storage usage, they should be used sparingly and only for high-value fields that provide significant search benefits.
+	// Nested fields are flattened into top-level fields.
+	// Field paths are joined using dot notation, and unsupported characters are replaced with underscores (_).
+	// Non-string values are automatically converted to strings (e.g., 3 → "3", true → "true").
+	// Object values serialized as JSON strings (e.g., { status: 200 } → "{\"status\":200}").
+	//
+	// Examples: [`.kubernetes`, `.log_type`, '.kubernetes.labels.foobar', `.kubernetes.labels."foo-bar/baz"`]
+	// +nullable
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Indexed Fields"
+	IndexedFields []FieldPath `json:"indexedFields,omitempty"`
+
+	// Source identifies the origin of a log event.
+	// The Source can be a combination of static and dynamic values consisting of field paths followed by `||` followed by another field path or a static value.
+	// A dynamic value is encased in single curly brackets `{}` and MUST end with a static fallback value separated with `||`.
+	// Static values can only contain alphanumeric characters along with dashes, underscores, dots and forward slashes.
+	// If not specified will be detected according to .log_source and .log_type value.
+	// Details see in: docs/features/logforwarding/outputs/splunk-forwarding.adoc
+	//
+	// Example:
+	//
+	//  1. foo-{.bar||"none"}
+	//
+	//  2. {.foo||.bar||"missing"}
+	//
+	//  3. foo.{.bar.baz||.qux.quux.corge||.grault||"nil"}-waldo.fred{.plugh||"none"}
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Pattern:=`^(([a-zA-Z0-9-_.\/])*(\{(\.[a-zA-Z0-9_]+|\."[^"]+")+((\|\|)(\.[a-zA-Z0-9_]+|\.?"[^"]+")+)*\|\|"[^"]*"\})*)*$`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Source",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	Source string `json:"source,omitempty"`
+
+	// PayloadKey specifies record field to use as payload.
+	// The PayloadKey must be a single field path.
+	//
+	// Field paths must only contain alphanumeric and underscores. Any field with other characters must be quoted.
+	//
+	// By default, payloadKey is not set, which means the complete log record is forwarded as the payload.
+	// Use payloadKey carefully. Selecting a single field as the payload may cause other important information in the
+	// log to be dropped, potentially leading to inconsistent or incomplete log events.
+	//
+	// Examples: `.kubernetes`, `.log_type`, '.kubernetes.labels.foobar', `.kubernetes.labels."foo-bar/baz"`
+	//
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Payload Key",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
+	PayloadKey FieldPath `json:"payloadKey,omitempty"`
 }
 
 // SyslogRFCType sets which RFC the generated messages conform to.

--- a/internal/generator/vector/helpers/helpers_test.go
+++ b/internal/generator/vector/helpers/helpers_test.go
@@ -1,0 +1,61 @@
+package helpers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+)
+
+var _ = Describe("helpers functions", func() {
+	Context("#GenerateQuotedPathSegmentArrayStr", func() {
+		It("should generate array of path segments and flat path for single value", func() {
+			pathExpression := []obs.FieldPath{`.kubernetes.labels.foo`}
+			expectedArrayPath := `[["kubernetes","labels","foo"]]`
+			expectedFlatPath := `["kubernetes_labels_foo"]`
+			arrayPath, flatPath := GenerateQuotedPathSegmentArrayStr(pathExpression)
+			Expect(arrayPath).To(Equal(expectedArrayPath))
+			Expect(flatPath).To(Equal(expectedFlatPath))
+		})
+		It("should generate array of path segments and flat path for multiple value", func() {
+			pathExpression := []obs.FieldPath{`.kubernetes.labels.foo`, `.kubernetes.labels.bar`}
+			expectedArrayPath := `[["kubernetes","labels","foo"],["kubernetes","labels","bar"]]`
+			expectedFlatPath := `["kubernetes_labels_foo","kubernetes_labels_bar"]`
+			arrayPath, flatPath := GenerateQuotedPathSegmentArrayStr(pathExpression)
+			Expect(arrayPath).To(Equal(expectedArrayPath))
+			Expect(flatPath).To(Equal(expectedFlatPath))
+		})
+		It("should generate array of path segments and escaped flat path", func() {
+			pathExpression := []obs.FieldPath{`.kubernetes.labels."bar/baz0-9.test"`}
+			expectedArrayPath := `[["kubernetes","labels","bar/baz0-9.test"]]`
+			expectedFlatPath := `["kubernetes_labels_bar_baz0-9_test"]`
+			arrayPath, flatPath := GenerateQuotedPathSegmentArrayStr(pathExpression)
+			Expect(arrayPath).To(Equal(expectedArrayPath))
+			Expect(flatPath).To(Equal(expectedFlatPath))
+		})
+		It("should generate array of path segments and escaped flat path", func() {
+			pathExpression := []obs.FieldPath{`.foo.bar."foo.bar.baz-ok".foo123."bar/baz0-9.test"`, `.foo.bar`}
+			expectedArrayPath := `[["foo","bar","foo.bar.baz-ok","foo123","bar/baz0-9.test"],["foo","bar"]]`
+			expectedFlatPath := `["foo_bar_foo_bar_baz-ok_foo123_bar_baz0-9_test","foo_bar"]`
+			arrayPath, flatPath := GenerateQuotedPathSegmentArrayStr(pathExpression)
+			Expect(arrayPath).To(Equal(expectedArrayPath))
+			Expect(flatPath).To(Equal(expectedFlatPath))
+		})
+	})
+
+	DescribeTable("#SplitPath generates correct array of path segments", func(path string, expectedArray []string) {
+		Expect(SplitPath(path)).To(Equal(expectedArray))
+	},
+		Entry("with single segment", `.foo`, []string{"foo"}),
+		Entry("with 2 segments", `.foo.bar`, []string{"foo", "bar"}),
+		Entry("with first segment in quotes", `."@foobar"`, []string{`"@foobar"`}),
+		Entry("with 1 quoted segment and one with quotes", `.foo."bar111-22/333"`, []string{"foo", `"bar111-22/333"`}),
+		Entry("with 2 non quoted segments and one quoted segment ", `.foo.bar."baz111-22/333"`, []string{"foo", "bar", `"baz111-22/333"`}),
+		Entry("with multiple quoted and unquoted segments", `.foo."@some"."d.f.g.o111-22/333".foo_bar`, []string{"foo", `"@some"`, `"d.f.g.o111-22/333"`, "foo_bar"}))
+
+	DescribeTable("#QuotePathSegments generates array with path segments quoted", func(pathSegments []string, expectedArray []string) {
+		Expect(QuotePathSegments(pathSegments)).To(Equal(expectedArray))
+	},
+		Entry("single value", []string{"foo"}, []string{`"foo"`}),
+		Entry("multiple value", []string{"foo", "bar.zip", `"foo-bar"`}, []string{`"foo"`, `"bar.zip"`, `"foo-bar"`}),
+	)
+})

--- a/internal/generator/vector/output/splunk/splunk.go
+++ b/internal/generator/vector/output/splunk/splunk.go
@@ -3,6 +3,8 @@ package splunk
 import (
 	"fmt"
 	"github.com/openshift/cluster-logging-operator/internal/api/observability"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"strings"
 
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	. "github.com/openshift/cluster-logging-operator/internal/generator/framework"
@@ -15,12 +17,78 @@ import (
 	commontemplate "github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common/template"
 )
 
+// VRL template for detecting default Splunk 'source' field by .log_type and .log_source
+var sourceTmpl = `
+# Splunk 'source' field detection
+if ._internal.log_type == "infrastructure" && ._internal.log_source == "node" {
+    ._internal.splunk.source = to_string!(._internal.systemd.u.SYSLOG_IDENTIFIER || "")
+}
+if ._internal.log_source == "container" {
+   	._internal.splunk.source = join!([._internal.kubernetes.namespace_name, ._internal.kubernetes.pod_name, ._internal.kubernetes.container_name], "_")
+}
+if ._internal.log_type == "audit" {
+   ._internal.splunk.source = ._internal.log_source
+}
+`
+
+// VRL template to set payload for log event and detecting 'sourcetype'.
+// If payload is object will be set 'sourcetype':"_json",
+// 'sourcetype': "generic_single_line" otherwise
+var payloadKeyTmpl = `
+payloadKey = %s
+if !is_null(payloadKey) {
+	value = get!(., payloadKey) 
+	if !is_null(value) {
+        internal = ._internal
+        . = {}
+        . = set!(., payloadKey, value)
+        ._internal = internal
+		if is_object(value) {
+			._internal.splunk.sourcetype = "_json"
+		} else {
+			._internal.splunk.sourcetype = "generic_single_line"
+		}
+	} else {
+		._internal.splunk.sourcetype = "_json"
+	}
+}
+`
+
+// VRL template to proceed indexed fields:
+// - the nested field convert to root-level, original path remove from object
+// - "." and "/" replaced with "_"
+var indexedFieldsRemap = `
+# Splunk indexed fields
+indexed_fields = %s
+for_each(indexed_fields) -> |_, field| {
+	value = get!(., field) 
+	if !is_null(value) {
+		new_key = replace(join!(field,"_"), r'[\./]', "_")  
+		if !is_string(value) {
+		  if is_object(value) {
+			value = encode_json(value)
+		  } else {
+			value = to_string!(value)
+		  }
+		}
+        . = remove!(., field, true)
+		. = set!(., [new_key], value)	
+	} else {
+        log("Path " + join!(field, ".") + " not found in log event", level: "warn")
+    }
+}
+`
+
 type Splunk struct {
-	ComponentID  string
-	Inputs       string
-	Endpoint     string
-	DefaultToken string
-	Index        Element
+	ComponentID   string
+	Inputs        string
+	Endpoint      string
+	DefaultToken  string
+	Index         Element
+	IndexedFields Element
+	Source        Element
+	SourceType    Element
+	HostKey       Element
 	common.RootMixin
 }
 
@@ -38,36 +106,70 @@ endpoint = "{{.Endpoint}}"
 default_token = "{{.DefaultToken}}"
 {{kv .Index -}}
 timestamp_key = "@timestamp"
-{{end}}`
+{{kv .IndexedFields}}
+{{kv .Source -}}
+{{kv .SourceType -}}
+{{kv .HostKey -}}
+{{end}}
+`
 }
 
 func (s *Splunk) SetCompression(algo string) {
 	s.Compression.Value = algo
 }
 
-func New(id string, o obs.OutputSpec, inputs []string, secrets observability.Secrets, strategy common.ConfigStrategy, op Options) []Element {
+func New(id string, o obs.OutputSpec, inputs []string, secrets observability.Secrets, strategy common.ConfigStrategy, op utils.Options) []Element {
 	if genhelper.IsDebugOutput(op) {
 		return []Element{
 			Debug(id, vectorhelpers.MakeInputs(inputs...)),
 		}
 	}
-
-	timestampID := vectorhelpers.MakeID(id, "timestamp")
+	inputID := vectorhelpers.MakeID(id, "timestamp")
 
 	var indexTemplate Element
-	splunkSink := sink(id, o, []string{timestampID}, "", secrets, op)
+	splunkIndexID := ""
 	if hasIndexKey(o.Splunk) {
-		splunkIndexID := vectorhelpers.MakeID(id, "splunk_index")
-		indexTemplate = commontemplate.TemplateRemap(splunkIndexID, []string{timestampID}, o.Splunk.Index, splunkIndexID, "Splunk Index")
-		splunkSink = sink(id, o, []string{splunkIndexID}, splunkIndexID, secrets, op)
+		splunkIndexID = vectorhelpers.MakeID(id, "splunk_index")
+		indexTemplate = commontemplate.TemplateRemap(splunkIndexID, []string{inputID}, o.Splunk.Index, splunkIndexID, "Splunk Index")
+		inputID = splunkIndexID
 	}
+
+	var builder strings.Builder
+	if o.Splunk.Source != "" {
+		builder.WriteString(fmt.Sprintf("._internal.splunk.source = %s", commontemplate.TransformUserTemplateToVRL(o.Splunk.Source)))
+	} else {
+		builder.WriteString(sourceTmpl)
+	}
+
+	builder.WriteString("\n._internal.splunk.sourcetype = \"_json\"\n")
+
+	if o.Splunk.PayloadKey != "" {
+		path := vectorhelpers.SplitPath(string(o.Splunk.PayloadKey))
+		quotedSegments := vectorhelpers.QuotePathSegments(path)
+		quotedPathArray := fmt.Sprintf("[%s]", strings.Join(quotedSegments, ","))
+		builder.WriteString(fmt.Sprintf(payloadKeyTmpl, quotedPathArray))
+	}
+
+	if o.Splunk.IndexedFields != nil {
+		pathSegmentArrayStr, remapped := vectorhelpers.GenerateQuotedPathSegmentArrayStr(o.Splunk.IndexedFields)
+		builder.WriteString(fmt.Sprintf(indexedFieldsRemap, pathSegmentArrayStr))
+		op["indexed_fields"] = remapped
+	}
+	splunkMetadataID := vectorhelpers.MakeID(id, "metadata")
+	metadata := Remap{ComponentID: splunkMetadataID,
+		Inputs: vectorhelpers.MakeInputs(inputID),
+		VRL:    builder.String()}
+
+	inputID = splunkMetadataID
+	splunkSink := sink(id, o, []string{inputID}, splunkIndexID, secrets, op)
 
 	if strategy != nil {
 		strategy.VisitSink(splunkSink)
 	}
 	return []Element{
-		FixTimestampFormat(timestampID, inputs),
+		FixTimestampFormat(vectorhelpers.MakeID(id, "timestamp"), inputs),
 		indexTemplate,
+		metadata,
 		splunkSink,
 		common.NewEncoding(id, common.CodecJSON),
 		common.NewAcknowledgments(id, strategy),
@@ -78,13 +180,17 @@ func New(id string, o obs.OutputSpec, inputs []string, secrets observability.Sec
 	}
 }
 
-func sink(id string, o obs.OutputSpec, inputs []string, index string, secrets observability.Secrets, op Options) *Splunk {
+func sink(id string, o obs.OutputSpec, inputs []string, index string, secrets observability.Secrets, op utils.Options) *Splunk {
 	s := &Splunk{
-		ComponentID: id,
-		Inputs:      vectorhelpers.MakeInputs(inputs...),
-		Endpoint:    o.Splunk.URL,
-		Index:       Tenant(o.Splunk, index),
-		RootMixin:   common.NewRootMixin("none"),
+		ComponentID:   id,
+		Inputs:        vectorhelpers.MakeInputs(inputs...),
+		Endpoint:      o.Splunk.URL,
+		Index:         Tenant(o.Splunk, index),
+		RootMixin:     common.NewRootMixin("none"),
+		Source:        KV("source", `"{{ ._internal.splunk.source }}"`),
+		SourceType:    KV("sourcetype", `"{{ ._internal.splunk.sourcetype }}"`),
+		HostKey:       KV("host_key", `"hostname"`),
+		IndexedFields: IndexedFields(o.Splunk, op),
 	}
 	authentication := o.Splunk.Authentication
 	if authentication != nil && authentication.Token != nil {
@@ -119,4 +225,12 @@ func Tenant(s *obs.Splunk, index string) Element {
 		return Nil
 	}
 	return KV("index", fmt.Sprintf(`"{{ ._internal.%s }}"`, index))
+}
+
+func IndexedFields(s *obs.Splunk, op utils.Options) Element {
+	if s.IndexedFields != nil && op.Has("indexed_fields") {
+		in, _ := utils.GetOption[string](op, "indexed_fields", "")
+		return KV("indexed_fields", in)
+	}
+	return Nil
 }

--- a/internal/generator/vector/output/splunk/splunk_sink_payloadkey.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_payloadkey.toml
@@ -26,6 +26,23 @@ if ._internal.log_type == "audit" {
    ._internal.splunk.source = ._internal.log_source
 }
 ._internal.splunk.sourcetype = "_json"
+payloadKey = ["openshift"]
+if !is_null(payloadKey) {
+	value = get!(., payloadKey)
+	if !is_null(value) {
+        internal = ._internal
+        . = {}
+        . = set!(., payloadKey, value)
+        ._internal = internal
+		if is_object(value) {
+			._internal.splunk.sourcetype = "_json"
+		} else {
+			._internal.splunk.sourcetype = "generic_single_line"
+		}
+	} else {
+		._internal.splunk.sourcetype = "_json"
+	}
+}
 '''
 [sinks.splunk_hec]
 type = "splunk_hec_logs"

--- a/internal/generator/vector/output/splunk/splunk_sink_with_custom_index.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_custom_index.toml
@@ -20,14 +20,34 @@ source = '''
 ._internal.splunk_hec_splunk_index = "foo-" + to_string!(._internal.kubernetes.namespace_name||"missing")
 '''
 
+[transforms.splunk_hec_metadata]
+type = "remap"
+inputs = ["splunk_hec_splunk_index"]
+source = '''
+# Splunk 'source' field detection
+if ._internal.log_type == "infrastructure" && ._internal.log_source == "node" {
+    ._internal.splunk.source = to_string!(._internal.systemd.u.SYSLOG_IDENTIFIER || "")
+}
+if ._internal.log_source == "container" {
+   	._internal.splunk.source = join!([._internal.kubernetes.namespace_name, ._internal.kubernetes.pod_name, ._internal.kubernetes.container_name], "_")
+}
+if ._internal.log_type == "audit" {
+   ._internal.splunk.source = ._internal.log_source
+}
+._internal.splunk.sourcetype = "_json"
+'''
+
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_splunk_index"]
+inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
 index = "{{ ._internal.splunk_hec_splunk_index }}"
 timestamp_key = "@timestamp"
+source = "{{ ._internal.splunk.source }}"
+sourcetype = "{{ ._internal.splunk.sourcetype }}"
+host_key = "hostname"
 [sinks.splunk_hec.encoding]
 codec = "json"
 except_fields = ["_internal"]

--- a/internal/generator/vector/output/splunk/splunk_sink_with_custom_index_dedot.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_custom_index_dedot.toml
@@ -20,14 +20,34 @@ source = '''
 ._internal.splunk_hec_splunk_index = "foo-" + to_string!(._internal.kubernetes.namespace_labels."test/logging.io"||"missing")
 '''
 
+[transforms.splunk_hec_metadata]
+type = "remap"
+inputs = ["splunk_hec_splunk_index"]
+source = '''
+# Splunk 'source' field detection
+if ._internal.log_type == "infrastructure" && ._internal.log_source == "node" {
+    ._internal.splunk.source = to_string!(._internal.systemd.u.SYSLOG_IDENTIFIER || "")
+}
+if ._internal.log_source == "container" {
+   	._internal.splunk.source = join!([._internal.kubernetes.namespace_name, ._internal.kubernetes.pod_name, ._internal.kubernetes.container_name], "_")
+}
+if ._internal.log_type == "audit" {
+   ._internal.splunk.source = ._internal.log_source
+}
+._internal.splunk.sourcetype = "_json"
+'''
+
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_splunk_index"]
+inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
 index = "{{ ._internal.splunk_hec_splunk_index }}"
 timestamp_key = "@timestamp"
+source = "{{ ._internal.splunk.source }}"
+sourcetype = "{{ ._internal.splunk.sourcetype }}"
+host_key = "hostname"
 [sinks.splunk_hec.encoding]
 codec = "json"
 except_fields = ["_internal"]

--- a/internal/generator/vector/output/splunk/splunk_sink_with_indexed_fields.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_indexed_fields.toml
@@ -11,6 +11,7 @@ if err != null {
 }
 
 '''
+
 [transforms.splunk_hec_metadata]
 type = "remap"
 inputs = ["splunk_hec_timestamp"]
@@ -26,7 +27,27 @@ if ._internal.log_type == "audit" {
    ._internal.splunk.source = ._internal.log_source
 }
 ._internal.splunk.sourcetype = "_json"
+# Splunk indexed fields
+indexed_fields = [["log_source"],["kubernetes","namespace_labels","bar/baz0-9.test"],["annotations","authorization.k8s.io/decision"]]
+for_each(indexed_fields) -> |_, field| {
+    value = get!(., field)
+    if !is_null(value) {
+        new_key = replace(join!(field,"_"), r'[\./]', "_")
+        if !is_string(value) {
+          if is_object(value) {
+            value = encode_json(value)
+          } else {
+            value = to_string!(value)
+          }
+        }
+        . = remove!(., field, true)
+        . = set!(., [new_key], value)
+    } else {
+        log("Path " + join!(field, ".") + " not found in log event", level: "warn")
+    }
+}
 '''
+
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
 inputs = ["splunk_hec_metadata"]
@@ -34,6 +55,7 @@ endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
 timestamp_key = "@timestamp"
+indexed_fields = ["log_source","kubernetes_namespace_labels_bar_baz0-9_test","annotations_authorization_k8s_io_decision"]
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"
 host_key = "hostname"

--- a/internal/generator/vector/output/splunk/splunk_sink_with_indexed_fields_and_source.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_indexed_fields_and_source.toml
@@ -11,22 +11,35 @@ if err != null {
 }
 
 '''
+
 [transforms.splunk_hec_metadata]
 type = "remap"
 inputs = ["splunk_hec_timestamp"]
 source = '''
-# Splunk 'source' field detection
-if ._internal.log_type == "infrastructure" && ._internal.log_source == "node" {
-    ._internal.splunk.source = to_string!(._internal.systemd.u.SYSLOG_IDENTIFIER || "")
-}
-if ._internal.log_source == "container" {
-   	._internal.splunk.source = join!([._internal.kubernetes.namespace_name, ._internal.kubernetes.pod_name, ._internal.kubernetes.container_name], "_")
-}
-if ._internal.log_type == "audit" {
-   ._internal.splunk.source = ._internal.log_source
-}
+._internal.splunk.source = to_string!(._internal.foo||"missing")
 ._internal.splunk.sourcetype = "_json"
+
+# Splunk indexed fields
+indexed_fields = [["log_source"],["kubernetes","namespace_labels","bar/baz0-9.test"],["annotations","authorization.k8s.io/decision"]]
+for_each(indexed_fields) -> |_, field| {
+    value = get!(., field)
+    if !is_null(value) {
+        new_key = replace(join!(field,"_"), r'[\./]', "_")
+        if !is_string(value) {
+          if is_object(value) {
+            value = encode_json(value)
+          } else {
+            value = to_string!(value)
+          }
+        }
+        . = remove!(., field, true)
+        . = set!(., [new_key], value)
+    } else {
+        log("Path " + join!(field, ".") + " not found in log event", level: "warn")
+    }
+}
 '''
+
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
 inputs = ["splunk_hec_metadata"]
@@ -34,6 +47,7 @@ endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
 timestamp_key = "@timestamp"
+indexed_fields = ["log_source","kubernetes_namespace_labels_bar_baz0-9_test","annotations_authorization_k8s_io_decision"]
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"
 host_key = "hostname"

--- a/internal/generator/vector/output/splunk/splunk_sink_with_tls.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_tls.toml
@@ -11,13 +11,34 @@ if err != null {
 }
 
 '''
+
+[transforms.splunk_hec_metadata]
+type = "remap"
+inputs = ["splunk_hec_timestamp"]
+source = '''
+# Splunk 'source' field detection
+if ._internal.log_type == "infrastructure" && ._internal.log_source == "node" {
+    ._internal.splunk.source = to_string!(._internal.systemd.u.SYSLOG_IDENTIFIER || "")
+}
+if ._internal.log_source == "container" {
+   	._internal.splunk.source = join!([._internal.kubernetes.namespace_name, ._internal.kubernetes.pod_name, ._internal.kubernetes.container_name], "_")
+}
+if ._internal.log_type == "audit" {
+   ._internal.splunk.source = ._internal.log_source
+}
+._internal.splunk.sourcetype = "_json"
+'''
+
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_timestamp"]
+inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
 timestamp_key = "@timestamp"
+source = "{{ ._internal.splunk.source }}"
+sourcetype = "{{ ._internal.splunk.sourcetype }}"
+host_key = "hostname"
 [sinks.splunk_hec.encoding]
 codec = "json"
 except_fields = ["_internal"]

--- a/internal/generator/vector/output/splunk/splunk_sink_with_tls_and_static_index.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_tls_and_static_index.toml
@@ -20,14 +20,34 @@ source = '''
 ._internal.splunk_hec_splunk_index = "foo"
 '''
 
+[transforms.splunk_hec_metadata]
+type = "remap"
+inputs = ["splunk_hec_splunk_index"]
+source = '''
+# Splunk 'source' field detection
+if ._internal.log_type == "infrastructure" && ._internal.log_source == "node" {
+    ._internal.splunk.source = to_string!(._internal.systemd.u.SYSLOG_IDENTIFIER || "")
+}
+if ._internal.log_source == "container" {
+   	._internal.splunk.source = join!([._internal.kubernetes.namespace_name, ._internal.kubernetes.pod_name, ._internal.kubernetes.container_name], "_")
+}
+if ._internal.log_type == "audit" {
+   ._internal.splunk.source = ._internal.log_source
+}
+._internal.splunk.sourcetype = "_json"
+'''
+
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_splunk_index"]
+inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
 index = "{{ ._internal.splunk_hec_splunk_index }}"
 timestamp_key = "@timestamp"
+source = "{{ ._internal.splunk.source }}"
+sourcetype = "{{ ._internal.splunk.sourcetype }}"
+host_key = "hostname"
 [sinks.splunk_hec.encoding]
 codec = "json"
 except_fields = ["_internal"]

--- a/internal/generator/vector/output/splunk/splunk_test.go
+++ b/internal/generator/vector/output/splunk/splunk_test.go
@@ -111,5 +111,14 @@ var _ = Describe("Generating vector config for Splunk output", func() {
 				BaseOutputTuningSpec: *baseTune,
 			}
 		}),
-	)
+		Entry("with indexed fields", "splunk_sink_with_indexed_fields.toml", framework.NoOptions, true, func(spec *obs.OutputSpec) {
+			spec.Splunk.IndexedFields = []obs.FieldPath{`.log_source`, `.kubernetes.namespace_labels."bar/baz0-9.test"`, `.annotations."authorization.k8s.io/decision"`}
+		}),
+		Entry("with indexed fields & source", "splunk_sink_with_indexed_fields_and_source.toml", framework.NoOptions, true, func(spec *obs.OutputSpec) {
+			spec.Splunk.Source = `{.foo||"missing"}`
+			spec.Splunk.IndexedFields = []obs.FieldPath{`.log_source`, `.kubernetes.namespace_labels."bar/baz0-9.test"`, `.annotations."authorization.k8s.io/decision"`}
+		}),
+		Entry("with payloadKey", "splunk_sink_payloadkey.toml", framework.NoOptions, true, func(spec *obs.OutputSpec) {
+			spec.Splunk.PayloadKey = ".openshift"
+		}))
 })

--- a/internal/generator/vector/output/splunk/splunk_tune.toml
+++ b/internal/generator/vector/output/splunk/splunk_tune.toml
@@ -11,13 +11,34 @@ if err != null {
 }
 
 '''
+
+[transforms.splunk_hec_metadata]
+type = "remap"
+inputs = ["splunk_hec_timestamp"]
+source = '''
+# Splunk 'source' field detection
+if ._internal.log_type == "infrastructure" && ._internal.log_source == "node" {
+    ._internal.splunk.source = to_string!(._internal.systemd.u.SYSLOG_IDENTIFIER || "")
+}
+if ._internal.log_source == "container" {
+   	._internal.splunk.source = join!([._internal.kubernetes.namespace_name, ._internal.kubernetes.pod_name, ._internal.kubernetes.container_name], "_")
+}
+if ._internal.log_type == "audit" {
+   ._internal.splunk.source = ._internal.log_source
+}
+._internal.splunk.sourcetype = "_json"
+'''
+
 [sinks.splunk_hec]
 type = "splunk_hec_logs"
-inputs = ["splunk_hec_timestamp"]
+inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
 timestamp_key = "@timestamp"
+source = "{{ ._internal.splunk.source }}"
+sourcetype = "{{ ._internal.splunk.sourcetype }}"
+host_key = "hostname"
 
 [sinks.splunk_hec.encoding]
 codec = "json"

--- a/test/functional/filters/prune/prune_filter_test.go
+++ b/test/functional/filters/prune/prune_filter_test.go
@@ -128,7 +128,7 @@ var _ = Describe("[Functional][Filters][Prune] Prune filter", func() {
 			Expect(f.WriteMessagesToApplicationLog(msg, 1)).To(BeNil())
 
 			// Get logs
-			logs, err := f.ReadAppLogsByIndexFromSplunk(f.Namespace, f.Name, "*")
+			logs, err := f.ReadAppLogsByIndexFromSplunk("*")
 			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
 			Expect(logs).ToNot(BeEmpty())
 		})

--- a/test/functional/outputs/splunk/forward_to_splunk_metadata_test.go
+++ b/test/functional/outputs/splunk/forward_to_splunk_metadata_test.go
@@ -1,0 +1,329 @@
+package splunk
+
+import (
+	"fmt"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
+	obstestruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
+	"regexp"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	v1 "k8s.io/api/core/v1"
+	"strings"
+)
+
+var _ = Describe("Forwarding to Splunk with Metadata", func() {
+	var (
+		framework      *functional.CollectorFunctionalFramework
+		secret         *v1.Secret
+		hecSecretKey   = *internalobs.NewSecretReference(constants.SplunkHECTokenKey, SplunkSecretName)
+		regexpSource   = regexp.MustCompile(`"source"\s*:\s*"([^"]+)"`)
+		regexpHost     = regexp.MustCompile(`"host"\s*:\s*"([^"]+)"`)
+		regexOpenshift = regexp.MustCompile(`{"openshift":{"cluster_id":".*","sequence":[0-9]+}}`)
+		regexMessage   = regexp.MustCompile(`{"message":".*"}`)
+	)
+
+	BeforeEach(func() {
+		framework = functional.NewCollectorFunctionalFramework()
+		secret = runtime.NewSecret(framework.Namespace, SplunkSecretName,
+			map[string][]byte{
+				"hecToken": functional.HecToken,
+			},
+		)
+	})
+
+	AfterEach(func() {
+		framework.Cleanup()
+	})
+
+	Context("splunk metadata", func() {
+		It("should accept indexed fields for Application log type", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeApplication).
+				ToSplunkOutput(hecSecretKey, func(output *obs.OutputSpec) {
+					output.Splunk.IndexedFields = []obs.FieldPath{`.log_type`, `.openshift.sequence`, `.kubernetes.annotations."openshift.io/scc"`}
+				})
+			framework.Secrets = append(framework.Secrets, secret)
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Wait for splunk to be ready
+			WaitOnSplunk(framework)
+
+			// Write app logs
+			timestamp := "2020-11-04T18:13:59.061892+00:00"
+			applicationLogLine := functional.NewCRIOLogMessage(timestamp, "This is my test message", false)
+			Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 2)).To(BeNil())
+
+			// Read app logs
+			logs, err := framework.ReadLogsByTypeFromSplunk(string(obs.InputTypeApplication))
+			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+			Expect(logs).ToNot(BeEmpty())
+
+			// Parse the logs
+			var appLogs []types.ApplicationLog
+			jsonString := fmt.Sprintf("[%s]", strings.Join(logs, ","))
+			Expect(strings.Count(jsonString, "openshift_sequence")).To(Equal(2))
+			scc := "kubernetes_annotations_openshift_io_scc"
+			Expect(strings.Count(jsonString, scc)).To(Equal(2))
+
+			err = types.ParseLogsFrom(jsonString, &appLogs, false)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+			outputTestLog := appLogs[0]
+			Expect(outputTestLog.LogType).To(Equal(string(obs.InputTypeApplication)))
+			Expect(outputTestLog.Openshift.Sequence).To(BeEmpty()) //.openshift.sequence must be removed because it was set as root-level field openshift_sequence
+			Expect(outputTestLog.Openshift.ClusterID).To(Equal("functional"))
+			_, exist := outputTestLog.Kubernetes.Annotations["openshift.io/scc"]
+			Expect(exist).To(BeFalse()) // .kubernetes.annotations."openshift.io/scc" must be removed because was set as root-level field kubernetes_annotations_openshift_io_scc
+
+			//checking Splunk index fields with 'index=${index} | stats count by ${field_name}'
+			//not direct checking to be sure fields sent as indexed
+			//if field is indexed will return counts 2*logs_count or logs_count otherwise
+			output, err := framework.ReadStatsForFieldByIndexFromSplunk(functional.SplunkDefaultIndex, scc, "json")
+			Expect(err).To(BeNil(), "Expected no errors getting field stats")
+			Expect(checkFieldCount(output, scc, 4)).To(BeTrue())
+
+			output, err = framework.ReadStatsForFieldByIndexFromSplunk(functional.SplunkDefaultIndex, "log_type", "json")
+			Expect(err).To(BeNil(), "Expected no errors getting field stats")
+			Expect(checkFieldCount(output, "log_type", 4)).To(BeTrue())
+
+			output, err = framework.ReadStatsForFieldByIndexFromSplunk(functional.SplunkDefaultIndex, "log_source", "json")
+			Expect(err).To(BeNil(), "Expected no errors getting field stats")
+			Expect(checkFieldCount(output, "log_source", 2)).To(BeTrue())
+		})
+
+		It("should accept indexed fields for Audit log type", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeAudit).
+				ToSplunkOutput(hecSecretKey, func(output *obs.OutputSpec) {
+					output.Splunk.IndexedFields = []obs.FieldPath{`.log_type`, `.auditID`, `.annotations."authorization.k8s.io/decision"`, `.annotations."authorization.k8s.io/reason"`}
+				})
+			framework.Secrets = append(framework.Secrets, secret)
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Wait for splunk to be ready
+			WaitOnSplunk(framework)
+
+			// Write audit logs
+			writeAuditLogs := framework.WriteK8sAuditLog(2)
+			Expect(writeAuditLogs).To(BeNil(), "Expect no errors writing audit logs")
+
+			// Read app logs
+			logs, err := framework.ReadLogsByTypeFromSplunk(string(obs.InputTypeAudit))
+			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+			Expect(logs).ToNot(BeEmpty())
+
+			decision := "annotations_authorization_k8s_io_decision"
+			reason := "annotations_authorization_k8s_io_reason"
+
+			// Parse the logs
+			var appLogs []types.AuditLog
+			jsonString := fmt.Sprintf("[%s]", strings.Join(logs, ","))
+			Expect(strings.Count(jsonString, decision)).To(Equal(2))
+			Expect(strings.Count(jsonString, reason)).To(Equal(2))
+
+			err = types.ParseLogsFrom(jsonString, &appLogs, false)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+			outputTestLog := appLogs[0]
+			Expect(outputTestLog.LogType).To(Equal(string(obs.InputTypeAudit)))
+			Expect(outputTestLog.AuditID).ToNot(BeEmpty())
+			Expect(outputTestLog.Annotations.AuthorizationK8SIoDecision).To(BeEmpty()) // must be removed because was set as root-level field annotations_authorization_k8s_io_decision
+			Expect(outputTestLog.Annotations.AuthorizationK8SIoReason).To(BeEmpty())
+
+			//checking Splunk index fields with 'index=${index} | stats count by ${field_name}'
+			//not direct checking to be sure fields sent as indexed
+			//if field is indexed will return counts 2*logs_count or logs_count otherwise
+
+			output, err := framework.ReadStatsForFieldByIndexFromSplunk(functional.SplunkDefaultIndex, decision, "json")
+			Expect(err).To(BeNil(), "Expected no errors getting field stats")
+			Expect(checkFieldCount(output, decision, 4)).To(BeTrue())
+
+			output, err = framework.ReadStatsForFieldByIndexFromSplunk(functional.SplunkDefaultIndex, reason, "json")
+			Expect(err).To(BeNil(), "Expected no errors getting field stats")
+			Expect(checkFieldCount(output, reason, 4)).To(BeTrue())
+
+			output, err = framework.ReadStatsForFieldByIndexFromSplunk(functional.SplunkDefaultIndex, "auditID", "json")
+			Expect(err).To(BeNil(), "Expected no errors getting field stats")
+			Expect(checkFieldCount(output, "auditID", 4)).To(BeTrue())
+
+			output, err = framework.ReadStatsForFieldByIndexFromSplunk(functional.SplunkDefaultIndex, "log_type", "json")
+			Expect(err).To(BeNil(), "Expected no errors getting field stats")
+			Expect(checkFieldCount(output, "log_type", 4)).To(BeTrue())
+
+			output, err = framework.ReadStatsForFieldByIndexFromSplunk(functional.SplunkDefaultIndex, "log_source", "json")
+			Expect(err).To(BeNil(), "Expected no errors getting field stats")
+			Expect(checkFieldCount(output, "log_source", 2)).To(BeTrue())
+
+		})
+
+		It("should send correct hostname", func() {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeApplication).
+				ToSplunkOutput(hecSecretKey, func(output *obs.OutputSpec) {})
+			framework.Secrets = append(framework.Secrets, secret)
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Wait for splunk to be ready
+			WaitOnSplunk(framework)
+
+			// Write app logs
+			timestamp := "2020-11-04T18:13:59.061892+00:00"
+			applicationLogLine := functional.NewCRIOLogMessage(timestamp, "This is my test message", false)
+			Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 2)).To(BeNil())
+
+			// Read app logs
+			logs, err := framework.ReadLogsByTypeFromSplunk(string(obs.InputTypeApplication))
+			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+			Expect(logs).ToNot(BeEmpty())
+
+			// Parse the logs
+			var appLogs []types.ApplicationLog
+			jsonString := fmt.Sprintf("[%s]", strings.Join(logs, ","))
+
+			err = types.ParseLogsFrom(jsonString, &appLogs, false)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+
+			outputTestLog := appLogs[0]
+			Expect(outputTestLog.LogType).To(Equal(string(obs.InputTypeApplication)))
+
+			result, err := framework.ReadFieldByIndexFromSplunk(functional.SplunkDefaultIndex, "host", "json")
+			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+
+			for _, v := range result {
+				matches := regexpHost.FindStringSubmatch(v)
+				Expect(matches[1]).To(Equal(outputTestLog.Hostname), "Expected to find match for host")
+			}
+
+		})
+
+		DescribeTable("with user defined source", func(source, expSource string, inputType obs.InputType) {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(inputType).
+				ToSplunkOutput(hecSecretKey, func(output *obs.OutputSpec) {
+					if source != "" {
+						output.Splunk.Source = source
+					}
+				})
+			framework.Secrets = append(framework.Secrets, secret)
+			if inputType == obs.InputTypeApplication {
+				framework.Labels["slash/test.dot"] = "application"
+			}
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Wait for splunk to be ready
+			WaitOnSplunk(framework)
+
+			if inputType == obs.InputTypeApplication {
+				if expSource == "" {
+					expSource = strings.Join([]string{framework.Namespace, framework.Pod.Name, "collector"}, "_")
+				}
+				// Write app logs
+				timestamp := "2020-11-04T18:13:59.061892+00:00"
+				applicationLogLine := functional.NewCRIOLogMessage(timestamp, "This is my test message", false)
+				Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 2)).To(BeNil())
+			}
+
+			if inputType == obs.InputTypeAudit {
+				if expSource == "" {
+					expSource = "auditd"
+				}
+				// Write audit logs
+				timestamp, _ := time.Parse(time.RFC3339Nano, "2024-04-16T09:46:19.116+00:00")
+				auditLogLine := functional.NewAuditHostLog(timestamp)
+				writeAuditLogs := framework.WriteMessagesToAuditLog(auditLogLine, 1)
+				Expect(writeAuditLogs).To(BeNil(), "Expect no errors writing audit logs")
+			}
+
+			if inputType == obs.InputTypeInfrastructure {
+				if expSource == "" {
+					expSource = "google-chrome.desktop"
+				}
+				// Write journal logs
+				logline := functional.NewJournalLog(0, "journal message", "functional")
+				Expect(framework.WriteMessagesToInfraJournalLog(logline, 1)).To(BeNil())
+			}
+
+			// Read logs
+			logs, err := framework.ReadLogsByTypeFromSplunk(string(inputType))
+			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+			Expect(logs).ToNot(BeEmpty())
+
+			result, err := framework.ReadFieldByIndexFromSplunk(functional.SplunkDefaultIndex, "source", "json")
+			Expect(err).To(BeNil(), "Expected no errors getting field from splunk")
+			for _, v := range result {
+				matches := regexpSource.FindStringSubmatch(v)
+				Expect(matches[1]).To(Equal(expSource), "Expected to find match for source")
+			}
+
+		},
+			Entry("should send application logs with dynamic source field", `{.log_type||"missing"}`, "application", obs.InputTypeApplication),
+			Entry("should send application logs with static + dynamic source field", `foo-{.log_type||"missing"}`, "foo-application", obs.InputTypeApplication),
+			Entry("should send application logs with static + label with dot/slash source field", `foo-{.kubernetes.labels."slash/test.dot"||"missing"}`, "foo-application", obs.InputTypeApplication),
+			Entry("should send application logs with static + fallback value's source field", `foo-{.missing||"application"}`, "foo-application", obs.InputTypeApplication),
+			Entry("should send application logs with default source ", "", "", obs.InputTypeApplication),
+			Entry("should send audit logs with default source ", "", "", obs.InputTypeAudit),
+			Entry("should send journal logs with default source ", "", "", obs.InputTypeInfrastructure))
+
+		DescribeTable("with user defined payloadKey", func(payloadKey, expSourceType string, expression *regexp.Regexp) {
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeApplication).
+				ToSplunkOutput(hecSecretKey, func(output *obs.OutputSpec) {
+					if payloadKey != "" {
+						output.Splunk.PayloadKey = obs.FieldPath(payloadKey)
+					}
+				})
+			framework.Secrets = append(framework.Secrets, secret)
+
+			Expect(framework.Deploy()).To(BeNil())
+
+			// Wait for splunk to be ready
+			WaitOnSplunk(framework)
+
+			// Write app logs
+			timestamp := "2020-11-04T18:13:59.061892+00:00"
+			applicationLogLine := functional.NewCRIOLogMessage(timestamp, "This is my test message", false)
+			Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 2)).To(BeNil())
+
+			// Read logs
+			logs, err := framework.ReadAppLogsByIndexFromSplunk(functional.SplunkDefaultIndex)
+			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
+			Expect(logs).ToNot(BeEmpty())
+			Expect(len(logs)).To(Equal(2))
+
+			if expression != nil {
+				for _, v := range logs {
+					Expect(expression.MatchString(v)).To(BeTrue())
+				}
+			} else {
+				//Parse the logs
+				var appLogs []types.ApplicationLog
+				jsonString := fmt.Sprintf("[%s]", strings.Join(logs, ","))
+				err = types.ParseLogsFrom(jsonString, &appLogs, false)
+				Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+			}
+
+			result, err := framework.ReadFieldByIndexFromSplunk(functional.SplunkDefaultIndex, "sourcetype", "json")
+			Expect(err).To(BeNil(), "Expected no errors getting field from splunk")
+			for _, v := range result {
+				Expect(strings.HasSuffix(v, fmt.Sprintf(`"result":{"sourcetype":"%s"}}`, expSourceType))).To(BeTrue())
+			}
+		},
+			Entry("should send only 'openshift' payload of application logs", ".openshift", "_json", regexOpenshift),
+			Entry("should send only 'message' payload of application logs", ".message", "generic_single_line", regexMessage),
+			Entry("should send full application log if payload not found", ".not_found", "_json", nil))
+	})
+})
+
+func checkFieldCount(output, field string, count int) bool {
+	pattern := `"result":\{"%s":"(.*?)","count":"%d"\}\}$`
+	expr := fmt.Sprintf(pattern, field, count)
+	re := regexp.MustCompile(expr)
+	return re.MatchString(output)
+}


### PR DESCRIPTION
### Description
This PR addressed to extend the `ClusterLogForwarder` to support `Splunk` `metadata fields` when forwarding logs
so that we enable better integration with `Splunk`.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma <!-- MANDATORY: Assign one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign ne approver from top-level OWNERS file -->

/cherry-pick <!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot -->

### Links
<!-- Provide links to depending PRs, Bugzilla or JIRA issue addressed or enhancement proposal that gets implemented by this PR -->
- Depending on PR(s):
- Bugzilla:
- Github issue:
- JIRA: https://issues.redhat.com/browse/LOG-6860
- Enhancement proposal: https://github.com/openshift/cluster-logging-operator/pull/2979
