### PR TITLE
LOG-6723: Update golang to v1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # a go-toolset base image providing go1.22
 #
 # FROM registry.redhat.io/ubi9/go-toolset:latest AS builder
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 as builder
+FROM golang:1.23 as builder
 
 ENV REMOTE_SOURCES=${REMOTE_SOURCES:-.}
 ENV REMOTE_SOURCES_DIR=${REMOTE_SOURCES_DIR:-.}

--- a/olm_deploy/operatorregistry/Dockerfile
+++ b/olm_deploy/operatorregistry/Dockerfile
@@ -1,7 +1,8 @@
 FROM quay.io/operator-framework/upstream-registry-builder AS registry-builder
 
-FROM registry.redhat.io/ubi8:8.5
-
+FROM registry.access.redhat.com/ubi9/ubi-minimal
+USER 0
+RUN microdnf install gettext -y
 WORKDIR /
 COPY bundle/manifests/ /manifests
 COPY bundle/metadata /metadata/


### PR DESCRIPTION
### Description
This PR
* updates the golang builder for development builds.
* unblocks updated CI which keeps reverting changes

### Links
https://issues.redhat.com/browse/LOG-6723

cc @vparfonov @cahartma @Clee2691 
