### PR TITLE
LOG-7014: fix parsing complex auditd logs for otlp mode

### DIFF
--- a/internal/generator/vector/output/lokistack/lokistack_otel.toml
+++ b/internal/generator/vector/output/lokistack/lokistack_otel.toml
@@ -189,7 +189,13 @@ if exists(kv.type) {
     r.attributes = push(r.attributes, {"key": "auditd.type", "value": {"stringValue": kv.type }})
 }
 if exists(kv.msg) {
-    trimmed = slice!(kv.msg, find!(kv.msg, "(") + 1, -2)
+    msg_str = ""
+    if is_array(kv.msg) {
+        msg_str = kv.msg[0]
+    } else {
+        msg_str = kv.msg
+    }
+    trimmed = slice!(msg_str, find!(msg_str, "(") + 1, -2)
     parts = split!(trimmed, ":")
     r.attributes = push(r.attributes, {"key": "auditd.sequence", "value": {"stringValue": parts[1] }})
 }

--- a/internal/generator/vector/output/otlp/otlp_all.toml
+++ b/internal/generator/vector/output/otlp/otlp_all.toml
@@ -215,7 +215,13 @@ if exists(kv.type) {
     r.attributes = push(r.attributes, {"key": "auditd.type", "value": {"stringValue": kv.type }})
 }
 if exists(kv.msg) {
-    trimmed = slice!(kv.msg, find!(kv.msg, "(") + 1, -2)
+    msg_str = ""
+    if is_array(kv.msg) {
+        msg_str = kv.msg[0]
+    } else {
+        msg_str = kv.msg
+    }
+    trimmed = slice!(msg_str, find!(msg_str, "(") + 1, -2)
     parts = split!(trimmed, ":")
     r.attributes = push(r.attributes, {"key": "auditd.sequence", "value": {"stringValue": parts[1] }})
 }

--- a/internal/generator/vector/output/otlp/otlp_tuning.toml
+++ b/internal/generator/vector/output/otlp/otlp_tuning.toml
@@ -215,7 +215,13 @@ if exists(kv.type) {
     r.attributes = push(r.attributes, {"key": "auditd.type", "value": {"stringValue": kv.type }})
 }
 if exists(kv.msg) {
-    trimmed = slice!(kv.msg, find!(kv.msg, "(") + 1, -2)
+    msg_str = ""
+    if is_array(kv.msg) {
+        msg_str = kv.msg[0]
+    } else {
+        msg_str = kv.msg
+    }
+    trimmed = slice!(msg_str, find!(msg_str, "(") + 1, -2)
     parts = split!(trimmed, ":")
     r.attributes = push(r.attributes, {"key": "auditd.sequence", "value": {"stringValue": parts[1] }})
 }

--- a/internal/generator/vector/output/otlp/otlp_with_auth_basic.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_basic.toml
@@ -215,7 +215,13 @@ if exists(kv.type) {
     r.attributes = push(r.attributes, {"key": "auditd.type", "value": {"stringValue": kv.type }})
 }
 if exists(kv.msg) {
-    trimmed = slice!(kv.msg, find!(kv.msg, "(") + 1, -2)
+    msg_str = ""
+    if is_array(kv.msg) {
+        msg_str = kv.msg[0]
+    } else {
+        msg_str = kv.msg
+    }
+    trimmed = slice!(msg_str, find!(msg_str, "(") + 1, -2)
     parts = split!(trimmed, ":")
     r.attributes = push(r.attributes, {"key": "auditd.sequence", "value": {"stringValue": parts[1] }})
 }

--- a/internal/generator/vector/output/otlp/otlp_with_auth_sa_token.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_sa_token.toml
@@ -215,7 +215,13 @@ if exists(kv.type) {
     r.attributes = push(r.attributes, {"key": "auditd.type", "value": {"stringValue": kv.type }})
 }
 if exists(kv.msg) {
-    trimmed = slice!(kv.msg, find!(kv.msg, "(") + 1, -2)
+    msg_str = ""
+    if is_array(kv.msg) {
+        msg_str = kv.msg[0]
+    } else {
+        msg_str = kv.msg
+    }
+    trimmed = slice!(msg_str, find!(msg_str, "(") + 1, -2)
     parts = split!(trimmed, ":")
     r.attributes = push(r.attributes, {"key": "auditd.sequence", "value": {"stringValue": parts[1] }})
 }

--- a/internal/generator/vector/output/otlp/otlp_with_auth_token.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_token.toml
@@ -215,7 +215,13 @@ if exists(kv.type) {
     r.attributes = push(r.attributes, {"key": "auditd.type", "value": {"stringValue": kv.type }})
 }
 if exists(kv.msg) {
-    trimmed = slice!(kv.msg, find!(kv.msg, "(") + 1, -2)
+    msg_str = ""
+    if is_array(kv.msg) {
+        msg_str = kv.msg[0]
+    } else {
+        msg_str = kv.msg
+    }
+    trimmed = slice!(msg_str, find!(msg_str, "(") + 1, -2)
     parts = split!(trimmed, ":")
     r.attributes = push(r.attributes, {"key": "auditd.sequence", "value": {"stringValue": parts[1] }})
 }

--- a/internal/generator/vector/output/otlp/transform.go
+++ b/internal/generator/vector/output/otlp/transform.go
@@ -110,7 +110,13 @@ if exists(kv.type) {
   r.attributes = push(r.attributes, {"key": "auditd.type", "value": {"stringValue": kv.type }})
 }
 if exists(kv.msg) {
-  trimmed = slice!(kv.msg, find!(kv.msg, "(") + 1, -2)
+  msg_str = ""
+  if is_array(kv.msg) {
+    msg_str = kv.msg[0] 
+  } else {
+    msg_str = kv.msg 
+  }
+  trimmed = slice!(msg_str, find!(msg_str, "(") + 1, -2)
   parts = split!(trimmed, ":")
   r.attributes = push(r.attributes, {"key": "auditd.sequence", "value": {"stringValue": parts[1] }})
 }

--- a/test/framework/functional/factory.go
+++ b/test/framework/functional/factory.go
@@ -23,7 +23,7 @@ func NewKubeAuditLog(eventTime time.Time) string {
 
 func NewAuditHostLog(eventTime time.Time) string {
 	now := fmt.Sprintf("%.3f", float64(eventTime.UnixNano())/float64(time.Second))
-	return fmt.Sprintf(`type=DAEMON_START msg=audit(%s:2914): op=start ver=3.0 format=enriched kernel=4.18.0-240.15.1.el8_3.x86_64 auid=4294967295 pid=1396 uid=0 ses=4294967295 subj=system_u:system_r:auditd_t:s0 res=successAUID="unset" UID="root"`, now)
+	return fmt.Sprintf(`type=DAEMON_START msg=audit(%s:2914): op=start ver=3.0 format=enriched kernel=4.18.0-240.15.1.el8_3.x86_64 auid=4294967295 pid=1396 uid=0 ses=4294967295 subj=system_u:system_r:auditd_t:s0 res=successAUID="unset" UID="root" msg="PAM:authentication"`, now)
 }
 func NewOVNAuditLog(eventTime time.Time) string {
 	now := CRIOTime(eventTime)


### PR DESCRIPTION
### Description
This PR fixes the parsing of `auditd` log messages that contain multiple `msg` keys in a single line, such as:: 
`type=USER_AUTH msg=audit(1617908892.234:123): pid=1023 uid=0 auid=1000 ses=1 msg='PAM:authentication grantors=pam_unix acct="user1" exe="/usr/bin/sudo" hostname=? addr=? terminal=/dev/pts/0 res=success'`

When using the `parse_key_value()` VRL function on such messages, the `msg` key is returned as an array. However, for our parsing logic, only the first msg entry is relevant — in this case:
`msg=audit(1617908892.234:123)`

This PR ensures that only the first `msg` value is used during parsing.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @cahartma @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-7014
- Enhancement proposal:
