### PR TITLE
Add operator to "Observability" category in OperatorHub

### DIFF
--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -79,7 +79,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    categories: OpenShift Optional, Logging & Tracing
+    categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
     createdAt: "2025-04-07T20:20:21Z"

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     capabilities: Seamless Upgrades
-    categories: OpenShift Optional, Logging & Tracing
+    categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for


### PR DESCRIPTION
### Description
Add operator to "Observability" category in OperatorHub.  This should be possible now that "Observability" has been added to https://github.com/operator-framework/api/blob/master/pkg/validation/internal/standardcategories.go#L31

### Links
- JIRA: [OCPSTRAT-954](https://issues.redhat.com/browse/OCPSTRAT-954), [LOG-4691](https://issues.redhat.com/browse/LOG-4691)
