### PR TITLE
NO-JIRA: replace deprecated Ginkgo command line flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ test-functional: test-functional-benchmarker-vector
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	go test -race \
 		./test/functional/... \
-		-ginkgo.noColor -timeout=40m -ginkgo.slowSpecThreshold=45.0
+		-ginkgo.no-color -timeout=40m -ginkgo.slow-spec-threshold='45.0s'
 
 .PHONY: test-forwarder-generator
 test-forwarder-generator: bin/forwarder-generator


### PR DESCRIPTION
### Description
All camel case flags (e.g. -noColor) are replaced with kebab case flags (e.g. -no-color) in Ginkgo 2.0. The camel case versions continue to work but emit a deprecation warning.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @cahartma <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:
