### PR TITLE
LOG-7012: Parsing errors under Loki distributor for audit tenant when using Otel DataModel

### DIFF
--- a/internal/generator/vector/output/lokistack/lokistack_otel.toml
+++ b/internal/generator/vector/output/lokistack/lokistack_otel.toml
@@ -248,11 +248,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group
@@ -329,11 +331,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group

--- a/internal/generator/vector/output/otlp/otlp_all.toml
+++ b/internal/generator/vector/output/otlp/otlp_all.toml
@@ -274,11 +274,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group
@@ -355,11 +357,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group

--- a/internal/generator/vector/output/otlp/otlp_tuning.toml
+++ b/internal/generator/vector/output/otlp/otlp_tuning.toml
@@ -274,11 +274,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group
@@ -355,11 +357,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group

--- a/internal/generator/vector/output/otlp/otlp_with_auth_basic.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_basic.toml
@@ -274,11 +274,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group
@@ -355,11 +357,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group

--- a/internal/generator/vector/output/otlp/otlp_with_auth_sa_token.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_sa_token.toml
@@ -274,11 +274,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group
@@ -355,11 +357,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group

--- a/internal/generator/vector/output/otlp/otlp_with_auth_token.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_token.toml
@@ -274,11 +274,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group
@@ -355,11 +357,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group

--- a/internal/generator/vector/output/otlp/transform.go
+++ b/internal/generator/vector/output/otlp/transform.go
@@ -68,11 +68,13 @@ r.attributes = append(r.attributes,
     {"key": "k8s.audit.event.stage", "value": {"stringValue": .stage}},
     {"key": "k8s.audit.event.request.uri", "value": {"stringValue": .requestURI}},
     {"key": "k8s.audit.event.request.verb", "value": {"stringValue": .verb}},
-    {"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}},
     {"key": "k8s.audit.event.user_agent", "value": {"stringValue": .userAgent}},
     {"key": "k8s.user.username", "value": {"stringValue": .user.username}}
   ]
 )
+if exists(.responseStatus.code) {
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+}
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
     .group = group

--- a/test/e2e/logforwarding/lokistack/forward_to_lokistack_test.go
+++ b/test/e2e/logforwarding/lokistack/forward_to_lokistack_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var _ = Describe("[ClusterLogForwarder] Forward to Lokistack", func() {
@@ -61,6 +62,13 @@ var _ = Describe("[ClusterLogForwarder] Forward to Lokistack", func() {
 				OutputRefs: []string{outputName},
 				InputRefs:  []string{string(obs.InputTypeApplication), string(obs.InputTypeAudit), string(obs.InputTypeInfrastructure)},
 			})
+			clf.Spec.Collector = &obs.CollectorSpec{
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("500m"),
+					},
+				},
+			}
 		})
 
 		lokiStackOut = &obs.OutputSpec{

--- a/test/framework/e2e/lokistack.go
+++ b/test/framework/e2e/lokistack.go
@@ -274,7 +274,7 @@ metadata:
   name: %s
   namespace: %s
 spec:
-  size: 1x.pico
+  size: 1x.demo
   storage:
     schemas:
     - version: v13
@@ -293,6 +293,11 @@ spec:
     namespaceSelector:
       matchLabels:
         openshift.io/cluster-monitoring: "true"
+  limits:
+    global:
+      ingestion:
+        ingestionBurstSize: 10
+        ingestionRate: 10
 `, LokistackName, namespace, minioName+"-secret")
 
 	uri := fmt.Sprintf(lokistackURI, namespace, LokistackName)


### PR DESCRIPTION
### Description
This PR fixes `int` parsing errors in the loki distributor for audit logs that do not contain a `responseStatus.code`.

Additionally, this PR attempts to fix the `lokistack` e2e test flake by decreasing the lokistack size to `1x.demo` and increasing `ingestionRate` and `burst` size. 

It also sets a resource request for the collector so that it does not get `OOM` killed on master nodes.

/cc @cahartma @vparfonov 
/assign @jcantrill 

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
- JIRA: https://issues.redhat.com/browse/LOG-7012
