### PR TITLE
LOG-6863: safety parsing/read fields to avoid messing data in log event

### DIFF
--- a/internal/generator/vector/output/common/template/template.go
+++ b/internal/generator/vector/output/common/template/template.go
@@ -47,9 +47,12 @@ func TemplateRemap(componentID string, inputs []string, userTemplate, field, des
 
 // TransformUserTemplateToVRL converts the user entered template to VRL compatible syntax
 // Example: foo-{.log_type||"none"} -> "foo-" + to_string!(.log_type||"none")
-func TransformUserTemplateToVRL(userTemplate string) string {
+func TransformUserTemplateToVRL(userTemplate string, suffix ...string) string {
 	// Finds and replaces expressions defined in `{}` with to_string!()
 	replacedUserTemplate := ReplaceBracketWithToString(userTemplate, "to_string!(%s)")
+	if len(suffix) > 0 && suffix[0] != "" {
+		replacedUserTemplate = ReplaceBracketWithToString(userTemplate, "to_string!("+suffix[0]+"%s)")
+	}
 
 	// Finding all matches of to_string!() returning their start + end indices
 	matchedIndices := splitRegex.FindAllStringSubmatchIndex(replacedUserTemplate, -1)

--- a/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
@@ -2,33 +2,25 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-#calculate defaults
 if .log_type == "infrastructure" && .log_source == "node" {
    ._internal.syslog.tag = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "")
    ._internal.syslog.proc_id = to_string!(.systemd.t.PID || "")
 }
 if .log_source == "container" {
     ._internal.syslog.tag = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "")
-    ._internal.syslog.severity = .level
-    ._internal.syslog.facility = "user"
-    #Remove non-alphanumeric characters
+     #Remove non-alphanumeric characters
    	._internal.syslog.tag = replace(._internal.syslog.tag, r'[^a-zA-Z0-9]', "")
 	#Truncate the sanitized tag to 32 characters
 	._internal.syslog.tag = truncate(._internal.syslog.tag, 32)
+    ._internal.syslog.severity = .level
+    ._internal.syslog.facility = "user"
 }
 if .log_type == "audit" {
     ._internal.syslog.tag = .log_source
     ._internal.syslog.severity = "informational"
     ._internal.syslog.facility = "security"
 }
-_tmp, err = parse_json(string!(.message))
-if err != null {
-  _tmp = .
-  log(err, level: "error")
-} else {
-  _tmp = merge!(.,_tmp)
-}
-parsed_msg = _tmp
+
 .facility = to_string!(._internal.syslog.facility || "user")
 .severity = to_string!(._internal.syslog.severity || "informational")
 .proc_id = to_string!(._internal.syslog.proc_id || "-")

--- a/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
@@ -2,7 +2,7 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
+#calculate defaults
 if .log_type == "infrastructure" && .log_source == "node" {
    ._internal.syslog.tag = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "")
    ._internal.syslog.proc_id = to_string!(.systemd.t.PID || "")
@@ -21,6 +21,14 @@ if .log_type == "audit" {
     ._internal.syslog.severity = "informational"
     ._internal.syslog.facility = "security"
 }
+_tmp, err = parse_json(string!(.message))
+if err != null {
+  _tmp = .
+  log(err, level: "error")
+} else {
+  _tmp = merge!(.,_tmp)
+}
+parsed_msg = _tmp
 .facility = to_string!(._internal.syslog.facility || "user")
 .severity = to_string!(._internal.syslog.severity || "informational")
 .proc_id = to_string!(._internal.syslog.proc_id || "-")

--- a/internal/generator/vector/output/syslog/tcp_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_defaults.toml
@@ -2,7 +2,6 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-#calculate defaults
 ._internal.syslog.msg_id = .log_source
 
 if .log_type == "infrastructure" && .log_source == "node" {
@@ -21,14 +20,6 @@ if .log_type == "audit" {
    ._internal.syslog.severity = "informational"
    ._internal.syslog.facility = "security"
 }
-_tmp, err = parse_json(string!(.message))
-if err != null {
-  _tmp = .
-  log(err, level: "error")
-} else {
-  _tmp = merge!(.,_tmp)
-}
-parsed_msg = _tmp
 
 .facility = to_string!(._internal.syslog.facility || "user")
 .severity = to_string!(._internal.syslog.severity || "informational")

--- a/internal/generator/vector/output/syslog/tcp_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_defaults.toml
@@ -2,7 +2,7 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
+#calculate defaults
 ._internal.syslog.msg_id = .log_source
 
 if .log_type == "infrastructure" && .log_source == "node" {
@@ -21,6 +21,15 @@ if .log_type == "audit" {
    ._internal.syslog.severity = "informational"
    ._internal.syslog.facility = "security"
 }
+_tmp, err = parse_json(string!(.message))
+if err != null {
+  _tmp = .
+  log(err, level: "error")
+} else {
+  _tmp = merge!(.,_tmp)
+}
+parsed_msg = _tmp
+
 .facility = to_string!(._internal.syslog.facility || "user")
 .severity = to_string!(._internal.syslog.severity || "informational")
 .proc_id = to_string!(._internal.syslog.proc_id || "-")

--- a/internal/generator/vector/output/syslog/tcp_with_tuning.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_tuning.toml
@@ -2,7 +2,6 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-#calculate defaults
 ._internal.syslog.msg_id = .log_source
 if .log_type == "infrastructure" && .log_source == "node" {
     ._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
@@ -20,14 +19,6 @@ if .log_type == "audit" {
    ._internal.syslog.severity = "informational"
    ._internal.syslog.facility = "security"
 }
-_tmp, err = parse_json(string!(.message))
-if err != null {
-  _tmp = .
-  log(err, level: "error")
-} else {
-  _tmp = merge!(.,_tmp)
-}
-parsed_msg = _tmp
 
 .facility = to_string!(._internal.syslog.facility || "user")
 .severity = to_string!(._internal.syslog.severity || "informational")

--- a/internal/generator/vector/output/syslog/tcp_with_tuning.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_tuning.toml
@@ -2,10 +2,8 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
-
+#calculate defaults
 ._internal.syslog.msg_id = .log_source
-
 if .log_type == "infrastructure" && .log_source == "node" {
     ._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
     ._internal.syslog.proc_id = to_string!(.systemd.t.PID||"-")
@@ -22,6 +20,15 @@ if .log_type == "audit" {
    ._internal.syslog.severity = "informational"
    ._internal.syslog.facility = "security"
 }
+_tmp, err = parse_json(string!(.message))
+if err != null {
+  _tmp = .
+  log(err, level: "error")
+} else {
+  _tmp = merge!(.,_tmp)
+}
+parsed_msg = _tmp
+
 .facility = to_string!(._internal.syslog.facility || "user")
 .severity = to_string!(._internal.syslog.severity || "informational")
 .proc_id = to_string!(._internal.syslog.proc_id || "-")

--- a/internal/generator/vector/output/syslog/tls_with_field_references.toml
+++ b/internal/generator/vector/output/syslog/tls_with_field_references.toml
@@ -2,10 +2,8 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
-
+#calculate defaults
 ._internal.syslog.msg_id = .log_source
-
 if .log_type == "infrastructure" && .log_source == "node" {
     ._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
     ._internal.syslog.proc_id = to_string!(.systemd.t.PID||"-")
@@ -22,11 +20,21 @@ if .log_type == "audit" {
    ._internal.syslog.severity = "informational"
    ._internal.syslog.facility = "security"
 }
-.facility = to_string!(.facility||"none")
-.severity = to_string!(.severity||"none")
-.proc_id = to_string!(.proc_id||"none")
-.app_name = to_string!(.app_name||"none")
-.msg_id = to_string!(.msg_id||"none")
+
+_tmp, err = parse_json(string!(.message))
+if err != null {
+  _tmp = .
+  log(err, level: "error")
+} else {
+  _tmp = merge!(.,_tmp)
+}
+parsed_msg = _tmp
+
+.facility = to_string!(parsed_msg.facility||"none")
+.severity = to_string!(parsed_msg.severity||"none")
+.proc_id = to_string!(parsed_msg.proc_id||"none")
+.app_name = to_string!(parsed_msg.app_name||"none")
+.msg_id = to_string!(parsed_msg.msg_id||"none")
 
 if is_null(.payload_key) {
 	.payload_key = .

--- a/internal/generator/vector/output/syslog/tls_with_field_references.toml
+++ b/internal/generator/vector/output/syslog/tls_with_field_references.toml
@@ -2,25 +2,7 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-#calculate defaults
 ._internal.syslog.msg_id = .log_source
-if .log_type == "infrastructure" && .log_source == "node" {
-    ._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
-    ._internal.syslog.proc_id = to_string!(.systemd.t.PID||"-")
-}
-if .log_source == "container" {
-   ._internal.syslog.app_name = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
-   ._internal.syslog.proc_id = to_string!(.kubernetes.pod_id||"-")
-   ._internal.syslog.severity = .level
-   ._internal.syslog.facility = "user"
-}
-if .log_type == "audit" {
-   ._internal.syslog.app_name = .log_source
-   ._internal.syslog.proc_id = to_string!(.auditID || "-")
-   ._internal.syslog.severity = "informational"
-   ._internal.syslog.facility = "security"
-}
-
 _tmp, err = parse_json(string!(.message))
 if err != null {
   _tmp = .

--- a/internal/generator/vector/output/syslog/udp_with_every_setting.toml
+++ b/internal/generator/vector/output/syslog/udp_with_every_setting.toml
@@ -2,7 +2,7 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
+#calculate defaults
 if .log_type == "infrastructure" && .log_source == "node" {
     ._internal.syslog.tag = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "")
     ._internal.syslog.proc_id = to_string!(.systemd.t.PID || "")
@@ -21,6 +21,16 @@ if .log_type == "audit" {
     ._internal.syslog.severity = "informational"
     ._internal.syslog.facility = "security"
 }
+
+_tmp, err = parse_json(string!(.message))
+if err != null {
+  _tmp = .
+  log(err, level: "error")
+} else {
+  _tmp = merge!(.,_tmp)
+}
+parsed_msg = _tmp
+
 .facility = "kern"
 .severity = "critical"
 .proc_id = "procID"

--- a/internal/generator/vector/output/syslog/udp_with_every_setting.toml
+++ b/internal/generator/vector/output/syslog/udp_with_every_setting.toml
@@ -2,35 +2,6 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-#calculate defaults
-if .log_type == "infrastructure" && .log_source == "node" {
-    ._internal.syslog.tag = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "")
-    ._internal.syslog.proc_id = to_string!(.systemd.t.PID || "")
-}
-if .log_source == "container" {
-    ._internal.syslog.tag = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "")
-    ._internal.syslog.severity = .level
-    ._internal.syslog.facility = "user"
-     #Remove non-alphanumeric characters
-   	._internal.syslog.tag = replace(._internal.syslog.tag, r'[^a-zA-Z0-9]', "")
-	#Truncate the sanitized tag to 32 characters
-	._internal.syslog.tag = truncate(._internal.syslog.tag, 32)
-}
-if .log_type == "audit" {
-    ._internal.syslog.tag = .log_source
-    ._internal.syslog.severity = "informational"
-    ._internal.syslog.facility = "security"
-}
-
-_tmp, err = parse_json(string!(.message))
-if err != null {
-  _tmp = .
-  log(err, level: "error")
-} else {
-  _tmp = merge!(.,_tmp)
-}
-parsed_msg = _tmp
-
 .facility = "kern"
 .severity = "critical"
 .proc_id = "procID"

--- a/internal/generator/vector/output/syslog/xyz_defaults.toml
+++ b/internal/generator/vector/output/syslog/xyz_defaults.toml
@@ -2,7 +2,6 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-#calculate defaults
 ._internal.syslog.msg_id = .log_source
 if .log_type == "infrastructure" && .log_source == "node" {
     ._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
@@ -20,15 +19,6 @@ if .log_type == "audit" {
    ._internal.syslog.severity = "informational"
    ._internal.syslog.facility = "security"
 }
-
-_tmp, err = parse_json(string!(.message))
-if err != null {
-  _tmp = .
-  log(err, level: "error")
-} else {
-  _tmp = merge!(.,_tmp)
-}
-parsed_msg = _tmp
 
 .facility = to_string!(._internal.syslog.facility || "user")
 .severity = to_string!(._internal.syslog.severity || "informational")

--- a/internal/generator/vector/output/syslog/xyz_defaults.toml
+++ b/internal/generator/vector/output/syslog/xyz_defaults.toml
@@ -2,7 +2,7 @@
 type = "remap"
 inputs = ["application"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
+#calculate defaults
 ._internal.syslog.msg_id = .log_source
 if .log_type == "infrastructure" && .log_source == "node" {
     ._internal.syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER||"-")
@@ -20,6 +20,15 @@ if .log_type == "audit" {
    ._internal.syslog.severity = "informational"
    ._internal.syslog.facility = "security"
 }
+
+_tmp, err = parse_json(string!(.message))
+if err != null {
+  _tmp = .
+  log(err, level: "error")
+} else {
+  _tmp = merge!(.,_tmp)
+}
+parsed_msg = _tmp
 
 .facility = to_string!(._internal.syslog.facility || "user")
 .severity = to_string!(._internal.syslog.severity || "informational")


### PR DESCRIPTION
### Description
This PR addresses an issue where data in a Syslog log event could become corrupted after a `merge` operation. Such behavior can lead to unpredictable and hard-to-diagnose issues.

The fix involves `parsing` and `merging` data into a temporary value, from which the necessary information is extracted. This ensures that the original log event remains structured and valid.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:
