### PR TITLE
[release-5.9]LOG-6963:Map cluster-wide proxy env variable for compatibility with Vector expectations

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -209,7 +209,8 @@ func (f *Factory) NewCollectorContainer(inputs logging.InputSpecs, secretNames [
 		{Name: "POD_IP", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"}}},
 		{Name: "POD_IPS", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIPs"}}},
 	}
-	collector.Env = append(collector.Env, utils.GetProxyEnvVars()...)
+
+	collector.Env = append(collector.Env, utils.GetProxyEnvVars(f.CollectorSpec.Type)...)
 
 	collector.VolumeMounts = []v1.VolumeMount{
 		{Name: f.ResourceNames.SecretMetrics, ReadOnly: true, MountPath: metricsVolumePath},

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -341,7 +341,7 @@ func EnvVarResourceFieldSelectorEqual(resource1, resource2 v1.ResourceFieldSelec
 		resource1.Divisor.Cmp(resource2.Divisor) == 0
 }
 
-func GetProxyEnvVars() []v1.EnvVar {
+func GetProxyEnvVars(collectionType logging.LogCollectionType) []v1.EnvVar {
 	envVars := []v1.EnvVar{}
 	for _, envvar := range []string{"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"} {
 		if value := os.Getenv(envvar); value != "" {
@@ -350,8 +350,14 @@ func GetProxyEnvVars() []v1.EnvVar {
 					value = strings.Join(constants.ExtraNoProxyList, ",") + "," + value
 				}
 			}
+			switch collectionType {
+			case logging.LogCollectionTypeVector:
+				envvar = strings.ToUpper(envvar)
+			case logging.LogCollectionTypeFluentd:
+				envvar = strings.ToLower(envvar)
+			}
 			envVars = append(envVars, v1.EnvVar{
-				Name:  strings.ToLower(envvar),
+				Name:  envvar,
 				Value: value,
 			})
 		}


### PR DESCRIPTION
### Description
Adding cluster-wide proxy automatically inject the environment variable, to support `Fluentd` collector  they was lowercased to `http_proxy`, `https_proxy` and `no_proxy`. In the same time, the Vector expects the variable to be named `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` (in uppercase) [1]. This mismatch causes the Vector not picked up proxy settings.

This PR adds a mechanism to support both collectors in the Vector value will be remapped according to current collector expectations.

[1] https://github.com/vectordotdev/vector/blob/f5b9265335c9df7bcbd4a57046738fb5e87a67c1/lib/vector-core/src/config/proxy.rs#L121

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill  <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s): https://github.com/ViaQ/vector/pull/207
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-6963
- Enhancement proposal:
