### PR TITLE
LOG-7009: remove  parse and merge data from message to the log event

### DIFF
--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -38,16 +38,9 @@ func (s Syslog) Name() string {
 
 func (s Syslog) Template() string {
 	return `{{define "` + s.Name() + `" -}}
-[transforms.{{.ComponentID}}_json]
-type = "remap"
-inputs = {{.Inputs}}
-source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
-'''
-
 [sinks.{{.ComponentID}}]
 type = "socket"
-inputs = ["{{.ComponentID}}_json"]
+inputs = {{.Inputs}}
 address = "{{.Address}}"
 mode = "{{.Mode}}"
 {{end}}`

--- a/internal/generator/vector/output/syslog/syslog_test.go
+++ b/internal/generator/vector/output/syslog/syslog_test.go
@@ -38,18 +38,11 @@ source = '''
 		}
 	  }
   }
-
-'''
-[transforms.example_json]
-type = "remap"
-inputs = ["example_dedot"]
-source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
 '''
 
 [sinks.example]
 type = "socket"
-inputs = ["example_json"]
+inputs = ["example_dedot"]
 address = "logserver:514"
 mode = "xyz"
 
@@ -85,16 +78,9 @@ source = '''
   }
 '''
 
-[transforms.example_json]
-type = "remap"
-inputs = ["example_dedot"]
-source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
-'''
-
 [sinks.example]
 type = "socket"
-inputs = ["example_json"]
+inputs = ["example_dedot"]
 address = "logserver:514"
 mode = "tcp"
 
@@ -130,16 +116,9 @@ source = '''
   }
 '''
 
-[transforms.example_json]
-type = "remap"
-inputs = ["example_dedot"]
-source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
-'''
-
 [sinks.example]
 type = "socket"
-inputs = ["example_json"]
+inputs = ["example_dedot"]
 address = "logserver:514"
 mode = "tcp"
 
@@ -180,16 +159,9 @@ source = '''
   }
 '''
 
-[transforms.example_json]
-type = "remap"
-inputs = ["example_dedot"]
-source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
-'''
-
 [sinks.example]
 type = "socket"
-inputs = ["example_json"]
+inputs = ["example_dedot"]
 address = "logserver:514"
 mode = "udp"
 
@@ -231,16 +203,9 @@ source = '''
   }
 '''
 
-[transforms.example_json]
-type = "remap"
-inputs = ["example_dedot"]
-source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
-'''
-
 [sinks.example]
 type = "socket"
-inputs = ["example_json"]
+inputs = ["example_dedot"]
 address = "logserver:6514"
 mode = "tcp"
 

--- a/test/functional/outputs/syslog/forward_to_syslog_test.go
+++ b/test/functional/outputs/syslog/forward_to_syslog_test.go
@@ -131,30 +131,6 @@ var _ = Describe("[Functional][Outputs][Syslog] Functional tests", func() {
 			Expect(getProcID(fields)).To(Equal("myproc"))
 			Expect(getMsgID(fields)).To(Equal("mymsg"))
 		})
-		It("should take values of appname, procid, messageid from record", func() {
-			functional.NewClusterLogForwarderBuilder(framework.Forwarder).
-				FromInput(logging.InputNameApplication).
-				ToOutputWithVisitor(join(setSyslogSpecValues, func(spec *logging.OutputSpec) {
-					spec.Syslog.AppName = "$.message.appname_key"
-					spec.Syslog.ProcID = "$.message.procid_key"
-					spec.Syslog.MsgID = "$.message.msgid_key"
-				}), logging.OutputTypeSyslog)
-			Expect(framework.Deploy()).To(BeNil())
-
-			// Log message data
-			for _, log := range JSONApplicationLogs {
-				log = functional.NewFullCRIOLogMessage(timestamp, log)
-				Expect(framework.WriteMessagesToApplicationLog(log, 1)).To(BeNil())
-			}
-			// Read line from Syslog output
-			outputlogs, err := framework.ReadRawApplicationLogsFrom(logging.OutputTypeSyslog)
-			Expect(err).To(BeNil(), "Expected no errors reading the logs")
-			Expect(outputlogs).ToNot(BeEmpty())
-			fields := strings.Split(outputlogs[0], " ")
-			Expect(getAppName(fields)).To(Equal("rec_appname"))
-			Expect(getProcID(fields)).To(Equal("rec_procid"))
-			Expect(getMsgID(fields)).To(Equal("rec_msgid"))
-		})
 		It("should take values from fluent tag", func() {
 			if testfw.LogCollectionType != logging.LogCollectionTypeFluentd {
 				Skip("Test requires fluentd")


### PR DESCRIPTION
### Description
This PR addresses several issues caused by problematic behavior introduced during the migration from `Fluentd` to `Vector`. These issues are related to parsing and merging data from the message into the log event, which can result in system information being overwritten, data being duplicated, or log events becoming corrupted. This fix also helps align the Syslog output with other output types because it was introduced only for Syslog output. 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:https://issues.redhat.com/browse/LOG-7009, https://issues.redhat.com/browse/LOG-7010, https://issues.redhat.com/browse/LOG-7008 
- Enhancement proposal
