### PR TITLE
[release-5.9]LOG-7009: avoid merge data from .message field to the log event root

### DIFF
--- a/internal/generator/vector/output/syslog/syslog_test.go
+++ b/internal/generator/vector/output/syslog/syslog_test.go
@@ -44,7 +44,14 @@ source = '''
 type = "remap"
 inputs = ["example_dedot"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
+obj, err = parse_json(string!(.message))
+if err != null {
+  log(err, level: "error") 
+} else {
+  if is_object(obj) {
+    .message = obj
+  }
+}
 '''
 
 [sinks.example]
@@ -89,7 +96,14 @@ source = '''
 type = "remap"
 inputs = ["example_dedot"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
+obj, err = parse_json(string!(.message))
+if err != null {
+  log(err, level: "error") 
+} else {
+  if is_object(obj) {
+    .message = obj
+  }
+}
 '''
 
 [sinks.example]
@@ -134,7 +148,14 @@ source = '''
 type = "remap"
 inputs = ["example_dedot"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
+obj, err = parse_json(string!(.message))
+if err != null {
+  log(err, level: "error") 
+} else {
+  if is_object(obj) {
+    .message = obj
+  }
+}
 '''
 
 [sinks.example]
@@ -184,7 +205,14 @@ source = '''
 type = "remap"
 inputs = ["example_dedot"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
+obj, err = parse_json(string!(.message))
+if err != null {
+  log(err, level: "error") 
+} else {
+  if is_object(obj) {
+    .message = obj
+  }
+}
 '''
 
 [sinks.example]
@@ -235,7 +263,14 @@ source = '''
 type = "remap"
 inputs = ["example_dedot"]
 source = '''
-. = merge(., parse_json!(string!(.message))) ?? .
+obj, err = parse_json(string!(.message))
+if err != null {
+  log(err, level: "error") 
+} else {
+  if is_object(obj) {
+    .message = obj
+  }
+}
 '''
 
 [sinks.example]

--- a/test/functional/outputs/syslog/rfc3164_test.go
+++ b/test/functional/outputs/syslog/rfc3164_test.go
@@ -53,7 +53,9 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 		Expect(outputlogs).To(HaveLen(1), "Expected the receiver to receive the message")
 		expMatch := fmt.Sprintf(`( %s )`, expTag)
 		Expect(outputlogs[0]).To(MatchRegexp(expMatch), "Exp to find tag in received message")
-		Expect(outputlogs[0]).To(MatchRegexp(`{"index":.*1,.*"timestamp":.*1,.*"tag_key":.*"rec_tag"}`), "Exp to find the original message in received message")
+		Expect(outputlogs[0]).To(MatchRegexp(`"index":.*1`), "Exp to find the original message in received message")
+		Expect(outputlogs[0]).To(MatchRegexp(`"timestamp":.*1`), "Exp to find the original message in received message")
+		Expect(outputlogs[0]).To(MatchRegexp(`"tag_key":.*"rec_tag"`), "Exp to find the original message in received message")
 	},
 
 		Entry("should use the value from the record and include the message", "$.message.tag_key", "rec_tag", false),

--- a/test/functional/outputs/syslog/rfc5424_test.go
+++ b/test/functional/outputs/syslog/rfc5424_test.go
@@ -55,7 +55,10 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC5424 tests", func() {
 		Expect(outputlogs).To(HaveLen(1), "Expected the receiver to receive the message")
 		expMatch := fmt.Sprintf(`( %s )`, expInfo)
 		Expect(outputlogs[0]).To(MatchRegexp(expMatch), "Exp to match the appname/procid/msgid in received message")
-		Expect(outputlogs[0]).To(MatchRegexp(record), "Exp to find the original message in received message")
+		Expect(outputlogs[0]).To(MatchRegexp(`"index":.*1`), "Exp to find the original message in received message")
+		Expect(outputlogs[0]).To(MatchRegexp(`"appname_key":.*"rec_appname"`), "Exp to find the original message in received message")
+		Expect(outputlogs[0]).To(MatchRegexp(`"msgid_key":.*"rec_msgid"`), "Exp to find the original message in received message")
+		Expect(outputlogs[0]).To(MatchRegexp(`"procid_key":.*"rec_procid"`), "Exp to find the original message in received message")
 	},
 
 		Entry("should use the value from the record and include the message", "$.message.appname_key", "$.message.msgid_key", "$.message.procid_key", "rec_appname rec_procid rec_msgid", false),


### PR DESCRIPTION
### Description
This PR addresses several issues introduced during the migration from `Fluentd` to `Vector`, particularly related to how the`.message` field was merged into the log event. 

These issues include:

- Overwriting important system fields
- Duplication of data
- Corruption of log events due to improper structure

With this change, the `.message` field is replaced if it will valid JSON string, with structured data instead of being blindly merged. This enables correct handling of **nested fields** during the Syslog encoding process in Vector.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s): https://github.com/ViaQ/vector/pull/203
- GitHub issue:
- JIRA:https://issues.redhat.com/browse/LOG-7009, https://issues.redhat.com/browse/LOG-7010, https://issues.redhat.com/browse/LOG-7008 
- Enhancement proposal