### PR TITLE
NO-JIRA: make sysctl missing binary assertion more flexible

### DIFF
--- a/test/e2e/collection/security/container_security_test.go
+++ b/test/e2e/collection/security/container_security_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Tests of collector container security stance", func() {
 		result, _ = runInCollectorContainer("/usr/sbin/sysctl", "net.ipv4.ip_local_port_range=0")
 		Expect(result).To(Or(
 			ContainSubstring("sysctl: no such file"),
-			ContainSubstring("executable file `/usr/sbin/sysctl` not found in $PATH"),
+			ContainSubstring("executable file `/usr/sbin/sysctl` not found"),
 		))
 
 		By("disabling privilege escalation")


### PR DESCRIPTION
### Description
Update test to handle systems where the error message for a missing `sysctl`. The assertion now allows either of:
  • "sysctl: no such file"
  • "executable file `/usr/sbin/sysctl` not found"

This makes the test pass across different environments without relying on exact error message suffixes like `": No such file or directory"`.

Early test fail with:
```
[FAILED] Expected
      <string>: executable file `/usr/sbin/sysctl` not found: No such file or directory
      command terminated with exit code 255
  To satisfy at least one of these matchers: [%!s(*matchers.ContainSubstringMatcher=&{sysctl: no such file []}) %!s(*matchers.ContainSubstringMatcher=&{executable file `/usr/sbin/sysctl` not found in $PATH []})]
  In [It] at: /go/src/github.com/openshift/cluster-logging-operator/test/e2e/collection/security/container_security_test.go:124 @ 05/19/25 15:11:29.541
```


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:
