### PR TITLE
LOG-7266: Update maximum OpenShift version to match supported range

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.19
+    value: 4.20


### PR DESCRIPTION
### Description

Updates the maximum OpenShift version to match the supported range of Logging 6.3

/cc @jcantrill

### Links

- JIRA: [LOG-7266](https://issues.redhat.com//browse/LOG-7266)
