### PR TITLE
LOG-7267: add fallback option if syslog appname calculation fail

### DIFF
--- a/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
@@ -7,13 +7,18 @@ if .log_type == "infrastructure" && .log_source == "node" {
    ._syslog.proc_id = to_string!(.systemd.t.PID || "")
 }
 if .log_source == "container" {
-   	._syslog.tag = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "")
-   	#Remove non-alphanumeric characters
-   	._syslog.tag = replace(._syslog.tag, r'[^a-zA-Z0-9]', "")
-	#Truncate the sanitized tag to 32 characters
-	._syslog.tag = truncate(._syslog.tag, 32)
-   	._syslog.severity = .level
-   	._syslog.facility = "user"
+   	._syslog.tag, err = join([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "")
+   	if err != null {
+   	   log("K8s metadata (namespace, pod, or container) missing; syslog.tag set to empty", level: "error")
+  	   ._syslog.tag = ""
+    } else {
+       #Remove non-alphanumeric characters
+       ._syslog.tag = replace(._syslog.tag, r'[^a-zA-Z0-9]', "")
+       #Truncate the sanitized tag to 32 characters
+       ._syslog.tag = truncate(._syslog.tag, 32)
+    }
+    ._syslog.severity = .level
+    ._syslog.facility = "user"
 }
 if .log_type == "audit" {
    ._syslog.tag = .log_source

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -40,15 +40,25 @@ const (
 	nodeProcIdRFC5424 = `._syslog.proc_id = to_string!(.systemd.t.PID || "-")`
 
 	// Default values for Syslog fields for application logType and infrastructure logType if source 'container'
-	containerAppName  = `._syslog.app_name = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")`
+	containerAppName = `._syslog.app_name, err = join([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+if err != null {
+  log("K8s metadata (namespace, pod, or container) missing; syslog.appname set to '-'", level: "error") 
+  ._syslog.app_name = "-"
+}
+`
 	containerFacility = `._syslog.facility = "user"`
 	containerSeverity = `._syslog.severity = .level`
 	containerProcId   = `._syslog.proc_id = to_string!(.kubernetes.pod_id || "-")`
-	containerTag      = `._syslog.tag = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "")
-#Remove non-alphanumeric characters
-._syslog.tag = replace(._syslog.tag, r'[^a-zA-Z0-9]', "")
-#Truncate the sanitized tag to 32 characters
-._syslog.tag = truncate(._syslog.tag, 32)
+	containerTag      = `._syslog.tag, err = join([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "")
+if err != null {
+  log("K8s metadata (namespace, pod, or container) missing; syslog.tag set to empty", level: "error") 
+  ._syslog.tag = ""
+} else {
+  #Remove non-alphanumeric characters
+  ._syslog.tag = replace(._syslog.tag, r'[^a-zA-Z0-9]', "")
+  #Truncate the sanitized tag to 32 characters
+  ._syslog.tag = truncate(._syslog.tag, 32)
+}
 `
 
 	// Default values for Syslog fields for audit logType

--- a/internal/generator/vector/output/syslog/tcp_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_defaults.toml
@@ -8,7 +8,11 @@ if .log_type == "infrastructure" && .log_source == "node" {
     ._syslog.proc_id = to_string!(.systemd.t.PID || "-")
 }
 if .log_source == "container" {
-   ._syslog.app_name = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   ._syslog.app_name, err = join([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   if err != null {
+     log("K8s metadata (namespace, pod, or container) missing; syslog.appname set to '-'", level: "error")
+  	 ._syslog.app_name = "-"
+   }
    ._syslog.proc_id = to_string!(.kubernetes.pod_id || "-")
    ._syslog.severity = .level
    ._syslog.facility = "user"

--- a/internal/generator/vector/output/syslog/tcp_with_tuning.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_tuning.toml
@@ -9,7 +9,11 @@ if .log_type == "infrastructure" && .log_source == "node" {
     ._syslog.proc_id = to_string!(.systemd.t.PID || "-")
 }
 if .log_source == "container" {
-   ._syslog.app_name = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   ._syslog.app_name, err = join([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   if err != null {
+     log("K8s metadata (namespace, pod, or container) missing; syslog.appname set to '-'", level: "error")
+  	 ._syslog.app_name = "-"
+   }
    ._syslog.proc_id = to_string!(.kubernetes.pod_id || "-")
    ._syslog.severity = .level
    ._syslog.facility = "user"

--- a/internal/generator/vector/output/syslog/xyz_defaults.toml
+++ b/internal/generator/vector/output/syslog/xyz_defaults.toml
@@ -8,7 +8,11 @@ if .log_type == "infrastructure" && .log_source == "node" {
    ._syslog.proc_id = to_string!(.systemd.t.PID || "-")
 }
 if .log_source == "container" {
-   ._syslog.app_name = join!([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   ._syslog.app_name, err = join([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")
+   if err != null {
+     log("K8s metadata (namespace, pod, or container) missing; syslog.appname set to '-'", level: "error")
+  	 ._syslog.app_name = "-"
+   }
    ._syslog.proc_id = to_string!(.kubernetes.pod_id || "-")
    ._syslog.severity = .level
    ._syslog.facility = "user"


### PR DESCRIPTION
### Description
This pull request addresses an issue where the default value calculation for the Syslog `appname` field would fail. This failure occurred specifically when a Prune filter removed one or more of the following Kubernetes metadata fields: `.kubernetes.namespace_name`, `.kubernetes.pod_name`, or `.kubernetes.container_name`.

The `join([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name])` VRL function would encounter an error in such scenarios, preventing the `appname` field from being correctly initialized.

To resolve this, an error check has been added. If the `join()` operation encounters an error (due to missing fields), the `appname` field will now be gracefully initialized with an empty string.

Similar things were added for Syslog tag field.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-7267
- Enhancement proposal:
