### PR TITLE
LOG-7279: Otel dataModel is enabled without the tech-preview annotation on CLF

### DIFF
--- a/internal/validations/observability/outputs/validate.go
+++ b/internal/validations/observability/outputs/validate.go
@@ -22,14 +22,13 @@ func Validate(context internalcontext.ForwarderContext) {
 		messages = append(messages, common.ValidateValueReference(configs, context.Secrets, context.ConfigMaps)...)
 		messages = append(messages, validateOutputIsReferencedByPipelines(out, pipelines)...)
 		// Validate by output type
-		// Note: type 'lokiStack' becomes 'otlp' output type when sending Otel otherwise it becomes 'loki'
 		switch out.Type {
 		case obs.OutputTypeCloudwatch:
 			messages = append(messages, ValidateCloudWatchAuth(out, context)...)
 		case obs.OutputTypeHTTP:
 			messages = append(messages, validateHttpContentTypeHeaders(out)...)
-		case obs.OutputTypeOTLP:
-			messages = append(messages, ValidateTechPreviewAnnotation(context)...)
+		case obs.OutputTypeLokiStack, obs.OutputTypeOTLP:
+			messages = append(messages, ValidateTechPreviewAnnotation(out, context)...)
 		}
 		// Set condition
 		if len(messages) > 0 {

--- a/internal/validations/observability/outputs/validate_tech_preview.go
+++ b/internal/validations/observability/outputs/validate_tech_preview.go
@@ -2,6 +2,7 @@ package outputs
 
 import (
 	"fmt"
+
 	log "github.com/ViaQ/logerr/v2/log/static"
 	obsv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
@@ -12,14 +13,14 @@ import (
 const MissingAnnotationMessage = "requires a valid tech-preview annotation"
 
 // ValidateTechPreviewAnnotation verifies the tech-preview annotation for outputs sending OTEL data
-func ValidateTechPreviewAnnotation(context internalcontext.ForwarderContext) (messages []string) {
+func ValidateTechPreviewAnnotation(out obsv1.OutputSpec, context internalcontext.ForwarderContext) (messages []string) {
 	enabled := common.IsEnabledAnnotation(context, constants.AnnotationOtlpOutputTechPreview)
-	for _, out := range context.Forwarder.Spec.Outputs {
-		if out.Type == obsv1.OutputTypeOTLP && !enabled {
-			log.V(3).Info("ValidateTechPreviewAnnotation failed", "reason", MissingAnnotationMessage)
-			messages = append(messages, fmt.Sprintf("output %q %v", out.Name, MissingAnnotationMessage))
-			return messages
-		}
+	if out.Type == obsv1.OutputTypeOTLP && !enabled {
+		log.V(3).Info("ValidateTechPreviewAnnotation failed", "reason", MissingAnnotationMessage)
+		messages = append(messages, fmt.Sprintf("output %q %v", out.Name, MissingAnnotationMessage))
+	} else if out.Type == obsv1.OutputTypeLokiStack && out.LokiStack != nil && out.LokiStack.DataModel == obsv1.LokiStackDataModelOpenTelemetry && !enabled {
+		log.V(3).Info("ValidateTechPreviewAnnotation failed", "reason", MissingAnnotationMessage)
+		messages = append(messages, fmt.Sprintf("output %q of type, %q, with dataModel, %q, %v", out.Name, obsv1.OutputTypeLokiStack, obsv1.LokiStackDataModelOpenTelemetry, MissingAnnotationMessage))
 	}
 	return messages
 }

--- a/internal/validations/observability/outputs/validate_tech_preview_test.go
+++ b/internal/validations/observability/outputs/validate_tech_preview_test.go
@@ -40,10 +40,10 @@ var _ = Describe("Validating tech-preview annotation", func() {
 			})
 			It("should pass validation when annotation is included with either value", func() {
 				forwarder.Annotations[constants.AnnotationOtlpOutputTechPreview] = "true"
-				Expect(ValidateTechPreviewAnnotation(context)).To(BeEmpty())
+				Expect(ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)).To(BeEmpty())
 
 				forwarder.Annotations[constants.AnnotationOtlpOutputTechPreview] = "enabled"
-				Expect(ValidateTechPreviewAnnotation(context)).To(BeEmpty())
+				Expect(ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)).To(BeEmpty())
 			})
 			It("should pass validation when including additional types", func() {
 				forwarder.Annotations[constants.AnnotationOtlpOutputTechPreview] = "enabled"
@@ -56,15 +56,15 @@ var _ = Describe("Validating tech-preview annotation", func() {
 					Type: obs.OutputTypeLoki,
 				}
 				forwarder.Spec.Outputs = []obs.OutputSpec{out, out2, out3}
-				Expect(ValidateTechPreviewAnnotation(context)).To(BeEmpty())
+				Expect(ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)).To(BeEmpty())
 			})
 			It("should fail validation when missing the annotation", func() {
-				results := ValidateTechPreviewAnnotation(context)
+				results := ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)
 				Expect(results).To(ContainElement(ContainSubstring(MissingAnnotationMessage)))
 			})
 			It("should fail validation when annotation has incorrect value", func() {
 				forwarder.Annotations[constants.AnnotationOtlpOutputTechPreview] = "false"
-				results := ValidateTechPreviewAnnotation(context)
+				results := ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)
 				Expect(results).To(ContainElement(ContainSubstring(MissingAnnotationMessage)))
 			})
 		})
@@ -91,12 +91,67 @@ var _ = Describe("Validating tech-preview annotation", func() {
 			It("should pass validation when type is not OTLP", func() {
 				out.Type = obs.OutputTypeHTTP
 				// Return value is empty when validation passes
-				Expect(ValidateTechPreviewAnnotation(context)).To(BeEmpty())
+				Expect(ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)).To(BeEmpty())
 			})
 		})
 
 		When("output type is LokiStack", func() {
-			// removing since lokistack type migrates internally to become either otlp or loki type
+			BeforeEach(func() {
+				out = obs.OutputSpec{
+					Name:      "my-lokistack",
+					Type:      obs.OutputTypeLokiStack,
+					LokiStack: &obs.LokiStack{DataModel: obs.LokiStackDataModelOpenTelemetry},
+				}
+				forwarder = obs.ClusterLogForwarder{
+					Spec: obs.ClusterLogForwarderSpec{
+						Outputs: []obs.OutputSpec{out},
+					},
+				}
+				forwarder.Annotations = map[string]string{"some.other.annotation/for-testing": "true"}
+				k8sClient = fake.NewFakeClient()
+				context = internalcontext.ForwarderContext{
+					Client:    k8sClient,
+					Reader:    k8sClient,
+					Forwarder: &forwarder,
+				}
+			})
+			It("should pass validation when missing annotation and Lokistack.DataModel == Viaq", func() {
+				forwarder.Spec.Outputs[0].LokiStack.DataModel = obs.LokiStackDataModelViaq
+				Expect(ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)).To(BeEmpty())
+			})
+			It("should pass validation when missing annotation and Lokistack.DataModel is not defined", func() {
+				forwarder.Spec.Outputs[0].LokiStack = &obs.LokiStack{}
+				Expect(ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)).To(BeEmpty())
+			})
+			It("should pass validation when annotation is included with either value and Lokistack.DataModel == Otel", func() {
+				forwarder.Annotations[constants.AnnotationOtlpOutputTechPreview] = "true"
+				Expect(ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)).To(BeEmpty())
+
+				forwarder.Annotations[constants.AnnotationOtlpOutputTechPreview] = "enabled"
+				Expect(ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)).To(BeEmpty())
+			})
+			It("should pass validation when including additional types", func() {
+				forwarder.Annotations[constants.AnnotationOtlpOutputTechPreview] = "enabled"
+				out2 := obs.OutputSpec{
+					Name: "my-out2",
+					Type: obs.OutputTypeCloudwatch,
+				}
+				out3 := obs.OutputSpec{
+					Name: "my-out3",
+					Type: obs.OutputTypeLoki,
+				}
+				forwarder.Spec.Outputs = []obs.OutputSpec{out, out2, out3}
+				Expect(ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)).To(BeEmpty())
+			})
+			It("should fail validation when missing the annotation", func() {
+				results := ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)
+				Expect(results).To(ContainElement(ContainSubstring(MissingAnnotationMessage)))
+			})
+			It("should fail validation when annotation has incorrect value", func() {
+				forwarder.Annotations[constants.AnnotationOtlpOutputTechPreview] = "false"
+				results := ValidateTechPreviewAnnotation(forwarder.Spec.Outputs[0], context)
+				Expect(results).To(ContainElement(ContainSubstring(MissingAnnotationMessage)))
+			})
 		})
 	})
 })


### PR DESCRIPTION
### Description
This PR fixes validation for Lokistack outputs that spec a data model of `Otel`. The tech preview annotation must be present when data model is `Otel` otherwise the `ClusterLogForwarder` is invalid.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-7279