### PR TITLE
LOG-7299: Fix type of maximum OpenShift version

### DIFF
--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.20
+    value: "4.20"


### PR DESCRIPTION
### Description

Currently we pass in the maximum version as a number, which has worked for the previous releases, but stops working with 4.20, because it is parsed as `4.2`. This PR fixes this by changing the type to a string.

/cc @jcantrill

### Links

- JIRA: [LOG-7299](https://issues.redhat.com//browse/LOG-7299) [LOG-7266](https://issues.redhat.com//browse/LOG-7266)
