### PR TITLE
LOG-7312 re-enable the metrics server endpoint

### DIFF
--- a/bundle/manifests/cluster-logging-operator-metrics_v1_service.yaml
+++ b/bundle/manifests/cluster-logging-operator-metrics_v1_service.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     name: cluster-logging-operator
   name: cluster-logging-operator-metrics
@@ -15,5 +14,3 @@ spec:
     name: cluster-logging-operator
   sessionAffinity: None
   type: ClusterIP
-status:
-  loadBalancer: {}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,14 +82,15 @@ func main() {
 	var probeAddr string
 
 	var tlsOpts []func(*tls.Config)
-	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
-		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8686", "The address the metrics endpoint binds to. "+
+		"Use :8443 for HTTPS or :8686 for HTTP, or set to 0 to disable the metrics service.")
 
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&secureMetrics, "metrics-secure", true,
-		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
+
+	flag.BoolVar(&secureMetrics, "metrics-secure", false,
+		"The metrics endpoint is served via HTTP by default. Use --metrics-secure=true to use HTTPS instead.")
 
 	flag.Parse()
 

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: <operator-name>
+    app.kubernetes.io/name: cluster-logging-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system


### PR DESCRIPTION
### Description
The metrics server endpoint was disabled due to an upgrade and new https functionality.     I am not sure if the endpoint should be secure by default.   For now I have set this back to match what we have in previous v6 releases, which is insecure at port 8686.       

I'm curious though, how is this patch meant to be enabled by the user?

Also not sure if a test necessary here?  

/cc @Clee2691 @vparfonov @jcantrill
/assign @xperimental 

### Links
- https://issues.redhat.com/browse/LOG-7312


