### PR TITLE
LOG-7311:fix for timestamp warning in collector when forwarding logs to Splunk with payloadKey

### DIFF
--- a/internal/generator/vector/output/splunk/splunk.go
+++ b/internal/generator/vector/output/splunk/splunk.go
@@ -105,7 +105,7 @@ endpoint = "{{.Endpoint}}"
 {{.Compression}}
 default_token = "{{.DefaultToken}}"
 {{kv .Index -}}
-timestamp_key = "@timestamp"
+timestamp_key = "._internal.timestamp"
 {{kv .IndexedFields}}
 {{kv .Source -}}
 {{kv .SourceType -}}
@@ -201,11 +201,11 @@ func sink(id string, o obs.OutputSpec, inputs []string, index string, secrets ob
 
 func FixTimestampFormat(componentID string, inputs []string) Element {
 	var vrl = `
-ts, err = parse_timestamp(.@timestamp,"%+")
+ts, err = parse_timestamp(._internal.timestamp,"%+")
 if err != null {
 	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
 } else {
-	.@timestamp = ts
+	._internal.timestamp = ts
 }
 `
 	return Remap{

--- a/internal/generator/vector/output/splunk/splunk_sink.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink.toml
@@ -3,13 +3,12 @@
 type = "remap"
 inputs = ["pipelineName"]
 source = '''
-ts, err = parse_timestamp(.@timestamp,"%+")
+ts, err = parse_timestamp(._internal.timestamp,"%+")
 if err != null {
 	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
 } else {
-	.@timestamp = ts
+	._internal.timestamp = ts
 }
-
 '''
 [transforms.splunk_hec_metadata]
 type = "remap"
@@ -33,7 +32,7 @@ inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
-timestamp_key = "@timestamp"
+timestamp_key = "._internal.timestamp"
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"
 host_key = "._internal.hostname"

--- a/internal/generator/vector/output/splunk/splunk_sink_payloadkey.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_payloadkey.toml
@@ -3,13 +3,12 @@
 type = "remap"
 inputs = ["pipelineName"]
 source = '''
-ts, err = parse_timestamp(.@timestamp,"%+")
+ts, err = parse_timestamp(._internal.timestamp,"%+")
 if err != null {
 	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
 } else {
-	.@timestamp = ts
+	._internal.timestamp = ts
 }
-
 '''
 [transforms.splunk_hec_metadata]
 type = "remap"
@@ -50,7 +49,7 @@ inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
-timestamp_key = "@timestamp"
+timestamp_key = "._internal.timestamp"
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"
 host_key = "._internal.hostname"

--- a/internal/generator/vector/output/splunk/splunk_sink_with_custom_index.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_custom_index.toml
@@ -3,13 +3,12 @@
 type = "remap"
 inputs = ["pipelineName"]
 source = '''
-ts, err = parse_timestamp(.@timestamp,"%+")
+ts, err = parse_timestamp(._internal.timestamp,"%+")
 if err != null {
 	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
 } else {
-	.@timestamp = ts
+	._internal.timestamp = ts
 }
-
 '''
 
 # Splunk Index
@@ -44,7 +43,7 @@ endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
 index = "{{ ._internal.splunk_hec_splunk_index }}"
-timestamp_key = "@timestamp"
+timestamp_key = "._internal.timestamp"
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"
 host_key = "._internal.hostname"

--- a/internal/generator/vector/output/splunk/splunk_sink_with_custom_index_dedot.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_custom_index_dedot.toml
@@ -3,13 +3,12 @@
 type = "remap"
 inputs = ["pipelineName"]
 source = '''
-ts, err = parse_timestamp(.@timestamp,"%+")
+ts, err = parse_timestamp(._internal.timestamp,"%+")
 if err != null {
 	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
 } else {
-	.@timestamp = ts
+	._internal.timestamp = ts
 }
-
 '''
 
 # Splunk Index
@@ -44,7 +43,7 @@ endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
 index = "{{ ._internal.splunk_hec_splunk_index }}"
-timestamp_key = "@timestamp"
+timestamp_key = "._internal.timestamp"
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"
 host_key = "._internal.hostname"

--- a/internal/generator/vector/output/splunk/splunk_sink_with_indexed_fields.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_indexed_fields.toml
@@ -3,13 +3,12 @@
 type = "remap"
 inputs = ["pipelineName"]
 source = '''
-ts, err = parse_timestamp(.@timestamp,"%+")
+ts, err = parse_timestamp(._internal.timestamp,"%+")
 if err != null {
 	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
 } else {
-	.@timestamp = ts
+	._internal.timestamp = ts
 }
-
 '''
 
 [transforms.splunk_hec_metadata]
@@ -54,7 +53,7 @@ inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
-timestamp_key = "@timestamp"
+timestamp_key = "._internal.timestamp"
 indexed_fields = ["log_source","kubernetes_namespace_labels_bar_baz0-9_test","annotations_authorization_k8s_io_decision"]
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"

--- a/internal/generator/vector/output/splunk/splunk_sink_with_indexed_fields_and_source.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_indexed_fields_and_source.toml
@@ -3,13 +3,12 @@
 type = "remap"
 inputs = ["pipelineName"]
 source = '''
-ts, err = parse_timestamp(.@timestamp,"%+")
+ts, err = parse_timestamp(._internal.timestamp,"%+")
 if err != null {
 	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
 } else {
-	.@timestamp = ts
+	._internal.timestamp = ts
 }
-
 '''
 
 [transforms.splunk_hec_metadata]
@@ -46,7 +45,7 @@ inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
-timestamp_key = "@timestamp"
+timestamp_key = "._internal.timestamp"
 indexed_fields = ["log_source","kubernetes_namespace_labels_bar_baz0-9_test","annotations_authorization_k8s_io_decision"]
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"

--- a/internal/generator/vector/output/splunk/splunk_sink_with_tls.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_tls.toml
@@ -3,13 +3,12 @@
 type = "remap"
 inputs = ["pipelineName"]
 source = '''
-ts, err = parse_timestamp(.@timestamp,"%+")
+ts, err = parse_timestamp(._internal.timestamp,"%+")
 if err != null {
 	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
 } else {
-	.@timestamp = ts
+	._internal.timestamp = ts
 }
-
 '''
 
 [transforms.splunk_hec_metadata]
@@ -35,7 +34,7 @@ inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
-timestamp_key = "@timestamp"
+timestamp_key = "._internal.timestamp"
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"
 host_key = "._internal.hostname"

--- a/internal/generator/vector/output/splunk/splunk_sink_with_tls_and_static_index.toml
+++ b/internal/generator/vector/output/splunk/splunk_sink_with_tls_and_static_index.toml
@@ -3,13 +3,12 @@
 type = "remap"
 inputs = ["pipelineName"]
 source = '''
-ts, err = parse_timestamp(.@timestamp,"%+")
+ts, err = parse_timestamp(._internal.timestamp,"%+")
 if err != null {
 	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
 } else {
-	.@timestamp = ts
+	._internal.timestamp = ts
 }
-
 '''
 
 # Splunk Index
@@ -44,7 +43,7 @@ endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
 index = "{{ ._internal.splunk_hec_splunk_index }}"
-timestamp_key = "@timestamp"
+timestamp_key = "._internal.timestamp"
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"
 host_key = "._internal.hostname"

--- a/internal/generator/vector/output/splunk/splunk_tune.toml
+++ b/internal/generator/vector/output/splunk/splunk_tune.toml
@@ -3,13 +3,12 @@
 type = "remap"
 inputs = ["pipelineName"]
 source = '''
-ts, err = parse_timestamp(.@timestamp,"%+")
+ts, err = parse_timestamp(._internal.timestamp,"%+")
 if err != null {
 	log("could not parse timestamp. err=" + err, rate_limit_secs: 0)
 } else {
-	.@timestamp = ts
+	._internal.timestamp = ts
 }
-
 '''
 
 [transforms.splunk_hec_metadata]
@@ -35,7 +34,7 @@ inputs = ["splunk_hec_metadata"]
 endpoint = "https://splunk-web:8088/endpoint"
 compression = "none"
 default_token = "SECRET[kubernetes_secret.vector-splunk-secret/hecToken]"
-timestamp_key = "@timestamp"
+timestamp_key = "._internal.timestamp"
 source = "{{ ._internal.splunk.source }}"
 sourcetype = "{{ ._internal.splunk.sourcetype }}"
 host_key = "._internal.hostname"

--- a/test/functional/outputs/splunk/forward_to_splunk_metadata_test.go
+++ b/test/functional/outputs/splunk/forward_to_splunk_metadata_test.go
@@ -233,6 +233,9 @@ var _ = Describe("Forwarding to Splunk with Metadata", func() {
 			Expect(err).To(BeNil(), "Expected no errors getting logs from splunk")
 			Expect(len(result)).To(BeEquivalentTo(1))
 			Expect(result[0]).To(ContainSubstring(`{"host":"acme.com"}`), "Expected to find match for host")
+			colLog, err := framework.ReadCollectorLogs()
+			Expect(err).To(BeNil(), "Expected no errors getting collectors log")
+			Expect(colLog).ToNot(ContainSubstring("Timestamp was not found. Deferring to Splunk to set the timestamp"))
 		})
 
 		DescribeTable("with user defined source", func(source, expSource string, inputType obs.InputType) {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

A "Timestamp not found" warning is generated in collector pods when forwarding logs to Splunk if a `payloadKey` is configured.

#### Problem:
The `timestamp_key` was set to `@timestamp` at the root level of the log event. However, when a `payloadKey` is is configuration `@timestamp` field will be out of message.

#### Fix: 
The `timestamp_key` is now set to `_internal.timestamp` this is allowed to use transfer correct timestamp of log event not depended on `payloadKey` settings. 

/cc @cahartma @Clee2691  <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @cahartma <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-7311
- Enhancement proposal:
