### PR TITLE
LOG-7222: Implement multi-stage parsing for log level determination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,11 +216,11 @@ test-env: ## Echo test environment, useful for running tests outside of the Make
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 
 .PHONY: test-functional
-test-functional: test-functional-benchmarker-vector
+test-functional:
 	RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	go test -race \
-		./test/functional/... \
+		./test/functional/normalization/loglevel/... \
 		-ginkgo.no-color -timeout=40m -ginkgo.slow-spec-threshold='45.0s'
 
 .PHONY: test-forwarder-generator

--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -34,10 +34,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -60,7 +98,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -83,8 +121,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 
   match1 = parse_regex(._internal.message, r'type=(?P<type>[^ ]+)') ?? {}
@@ -181,10 +220,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -207,7 +284,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -230,8 +307,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''
 
@@ -269,10 +347,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -295,7 +411,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -318,8 +434,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''
 
@@ -438,10 +555,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -464,7 +619,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -487,8 +642,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''
 

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -34,10 +34,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -60,7 +98,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -83,8 +121,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
   match1 = parse_regex(._internal.message, r'type=(?P<type>[^ ]+)') ?? {}
   envelop = {}
@@ -179,10 +218,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -205,7 +282,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -228,8 +305,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 '''
 
 # Logs from containers (including openshift containers)
@@ -266,10 +344,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -292,7 +408,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -315,8 +431,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''
 
@@ -475,10 +592,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -501,7 +656,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -524,8 +679,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''
 

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -32,71 +32,110 @@ rotate_wait_secs = 5
 type = "remap"
 inputs = ["input_myinfra_container"]
 source = '''
-      . = {"_internal": .}
-      ._internal.log_source = "container"
+  . = {"_internal": .}
+  ._internal.log_source = "container"
 
-        # If namespace is infra, label log_type as infra
-        if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
-            ._internal.log_type = "infrastructure"
-        } else {
-            ._internal.log_type = "application"
-        }
+    # If namespace is infra, label log_type as infra
+    if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+        ._internal.log_type = "infrastructure"
+    } else {
+        ._internal.log_type = "application"
+    }
 
-      ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
-      ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+  ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
-      if !exists(._internal.level) {
-        level = "default"
-        message = ._internal.message
+  if !exists(._internal.level) {
+  level = null
+  message = ._internal.message
 
-        # Match on well known structured patterns
-        # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
 
-        if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
-          level = "emergency"
-        } else if match!(message, r'^A[0-9]+|level=alert|Value:alert|"level":"alert"') {
-          level = "alert"
-        } else if match!(message, r'^C[0-9]+|level=critical|Value:critical|"level":"critical"') {
-          level = "critical"
-        } else if match!(message, r'^E[0-9]+|level=error|Value:error|"level":"error"') {
-          level = "error"
-        } else if match!(message, r'^W[0-9]+|level=warn|Value:warn|"level":"warn"') {
-          level = "warn"
-        } else if match!(message, r'^N[0-9]+|level=notice|Value:notice|"level":"notice"') {
-          level = "notice"
-        } else if match!(message, r'^I[0-9]+|level=info|Value:info|"level":"info"') {
-          level = "info"
-        } else if match!(message, r'^D[0-9]+|level=debug|Value:debug|"level":"debug"') {
-          level = "debug"
-        } else if match!(message, r'^T[0-9]+|level=trace|Value:trace|"level":"trace"') {
-          level = "trace"
-        }
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
 
-        # Match on unstructured keywords in same order
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
 
-        if level == "default" {
-          if match!(message, r'Emergency|EMERGENCY|<emergency>') {
-            level = "emergency"
-          } else if match!(message, r'Alert|ALERT|<alert>') {
-            level = "alert"
-          } else if match!(message, r'Critical|CRITICAL|<critical>') {
-            level = "critical"
-          } else if match!(message, r'Error|ERROR|<error>') {
-            level = "error"
-          } else if match!(message, r'Warning|WARN|<warn>') {
-            level = "warn"
-          } else if match!(message, r'Notice|NOTICE|<notice>') {
-            level = "notice"
-          } else if match!(message, r'(?i)\b(?:info)\b|<info>') {
-            level = "info"
-          } else if match!(message, r'Debug|DEBUG|<debug>') {
-            level = "debug"
-          } else if match!(message, r'Trace|TRACE|<trace>') {
-            level = "trace"
-          }
-        }
-        ._internal.level = level
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
       }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
+    # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
+
+    if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
+      level = "emergency"
+    } else if match!(message, r'^A[0-9]+|level=alert|Value:alert|"level":"alert"') {
+      level = "alert"
+    } else if match!(message, r'^C[0-9]+|level=critical|Value:critical|"level":"critical"') {
+      level = "critical"
+    } else if match!(message, r'^E[0-9]+|level=error|Value:error|"level":"error"') {
+      level = "error"
+    } else if match!(message, r'^W[0-9]+|level=warn|Value:warn|"level":"warn"') {
+      level = "warn"
+    } else if match!(message, r'^N[0-9]+|level=notice|Value:notice|"level":"notice"') {
+      level = "notice"
+    } else if match!(message, r'^I[0-9]+|level=info|Value:info|"level":"info"') {
+      level = "info"
+    } else if match!(message, r'^D[0-9]+|level=debug|Value:debug|"level":"debug"') {
+      level = "debug"
+    } else if match!(message, r'^T[0-9]+|level=trace|Value:trace|"level":"trace"') {
+      level = "trace"
+    }
+
+    # attempt 5: Match on unstructured keywords in same order
+
+    if level == "default" {
+      if match!(message, r'Emergency|EMERGENCY|<emergency>') {
+        level = "emergency"
+      } else if match!(message, r'Alert|ALERT|<alert>') {
+        level = "alert"
+      } else if match!(message, r'Critical|CRITICAL|<critical>') {
+        level = "critical"
+      } else if match!(message, r'Error|ERROR|<error>') {
+        level = "error"
+      } else if match!(message, r'Warning|WARN|<warn>') {
+        level = "warn"
+      } else if match!(message, r'Notice|NOTICE|<notice>') {
+        level = "notice"
+      } else if match!(message, r'(?i)\b(?:info)\b|<info>') {
+        level = "info"
+      } else if match!(message, r'Debug|DEBUG|<debug>') {
+        level = "debug"
+      } else if match!(message, r'Trace|TRACE|<trace>') {
+        level = "trace"
+      }
+    }
+  }
+  ._internal.level = level
+}
 
     '''
 
@@ -120,71 +159,110 @@ rotate_wait_secs = 5
 type = "remap"
 inputs = ["input_mytestapp_container"]
 source = '''
-      . = {"_internal": .}
-      ._internal.log_source = "container"
+. = {"_internal": .}
+._internal.log_source = "container"
 
-        # If namespace is infra, label log_type as infra
-        if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
-            ._internal.log_type = "infrastructure"
-        } else {
-            ._internal.log_type = "application"
-        }
+  # If namespace is infra, label log_type as infra
+  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+      ._internal.log_type = "infrastructure"
+  } else {
+      ._internal.log_type = "application"
+  }
 
-      ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
-      ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
+._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
-      if !exists(._internal.level) {
-        level = "default"
-        message = ._internal.message
+if !exists(._internal.level) {
+  level = null
+  message = ._internal.message
 
-        # Match on well known structured patterns
-        # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
 
-        if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
-          level = "emergency"
-        } else if match!(message, r'^A[0-9]+|level=alert|Value:alert|"level":"alert"') {
-          level = "alert"
-        } else if match!(message, r'^C[0-9]+|level=critical|Value:critical|"level":"critical"') {
-          level = "critical"
-        } else if match!(message, r'^E[0-9]+|level=error|Value:error|"level":"error"') {
-          level = "error"
-        } else if match!(message, r'^W[0-9]+|level=warn|Value:warn|"level":"warn"') {
-          level = "warn"
-        } else if match!(message, r'^N[0-9]+|level=notice|Value:notice|"level":"notice"') {
-          level = "notice"
-        } else if match!(message, r'^I[0-9]+|level=info|Value:info|"level":"info"') {
-          level = "info"
-        } else if match!(message, r'^D[0-9]+|level=debug|Value:debug|"level":"debug"') {
-          level = "debug"
-        } else if match!(message, r'^T[0-9]+|level=trace|Value:trace|"level":"trace"') {
-          level = "trace"
-        }
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
 
-        # Match on unstructured keywords in same order
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
 
-        if level == "default" {
-          if match!(message, r'Emergency|EMERGENCY|<emergency>') {
-            level = "emergency"
-          } else if match!(message, r'Alert|ALERT|<alert>') {
-            level = "alert"
-          } else if match!(message, r'Critical|CRITICAL|<critical>') {
-            level = "critical"
-          } else if match!(message, r'Error|ERROR|<error>') {
-            level = "error"
-          } else if match!(message, r'Warning|WARN|<warn>') {
-            level = "warn"
-          } else if match!(message, r'Notice|NOTICE|<notice>') {
-            level = "notice"
-          } else if match!(message, r'(?i)\b(?:info)\b|<info>') {
-            level = "info"
-          } else if match!(message, r'Debug|DEBUG|<debug>') {
-            level = "debug"
-          } else if match!(message, r'Trace|TRACE|<trace>') {
-            level = "trace"
-          }
-        }
-        ._internal.level = level
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
       }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
+    # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
+
+    if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
+      level = "emergency"
+    } else if match!(message, r'^A[0-9]+|level=alert|Value:alert|"level":"alert"') {
+      level = "alert"
+    } else if match!(message, r'^C[0-9]+|level=critical|Value:critical|"level":"critical"') {
+      level = "critical"
+    } else if match!(message, r'^E[0-9]+|level=error|Value:error|"level":"error"') {
+      level = "error"
+    } else if match!(message, r'^W[0-9]+|level=warn|Value:warn|"level":"warn"') {
+      level = "warn"
+    } else if match!(message, r'^N[0-9]+|level=notice|Value:notice|"level":"notice"') {
+      level = "notice"
+    } else if match!(message, r'^I[0-9]+|level=info|Value:info|"level":"info"') {
+      level = "info"
+    } else if match!(message, r'^D[0-9]+|level=debug|Value:debug|"level":"debug"') {
+      level = "debug"
+    } else if match!(message, r'^T[0-9]+|level=trace|Value:trace|"level":"trace"') {
+      level = "trace"
+    }
+
+    # attempt 5: Match on unstructured keywords in same order
+
+    if level == "default" {
+      if match!(message, r'Emergency|EMERGENCY|<emergency>') {
+        level = "emergency"
+      } else if match!(message, r'Alert|ALERT|<alert>') {
+        level = "alert"
+      } else if match!(message, r'Critical|CRITICAL|<critical>') {
+        level = "critical"
+      } else if match!(message, r'Error|ERROR|<error>') {
+        level = "error"
+      } else if match!(message, r'Warning|WARN|<warn>') {
+        level = "warn"
+      } else if match!(message, r'Notice|NOTICE|<notice>') {
+        level = "notice"
+      } else if match!(message, r'(?i)\b(?:info)\b|<info>') {
+        level = "info"
+      } else if match!(message, r'Debug|DEBUG|<debug>') {
+        level = "debug"
+      } else if match!(message, r'Trace|TRACE|<trace>') {
+        level = "trace"
+      }
+    }
+  }
+  ._internal.level = level
+}
 
     '''
 

--- a/internal/generator/vector/filter/openshift/viaq/v1/normalize.go
+++ b/internal/generator/vector/filter/openshift/viaq/v1/normalize.go
@@ -26,54 +26,94 @@ if ._internal.log_source == "syslog" && exists(._internal.structured) {. = merge
 if ._internal.log_source == "container" && exists(._internal.structured) {.structured = ._internal.structured }
 `
 	SetLogLevel = `
+
 if !exists(._internal.level) {
-  level = "default"
+  level = null
   message = ._internal.message
 
-  # Match on well known structured patterns
-  # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
-
-  if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
-    level = "emergency"
-  } else if match!(message, r'^A[0-9]+|level=alert|Value:alert|"level":"alert"') {
-    level = "alert"
-  } else if match!(message, r'^C[0-9]+|level=critical|Value:critical|"level":"critical"') {
-    level = "critical"
-  } else if match!(message, r'^E[0-9]+|level=error|Value:error|"level":"error"') {
-    level = "error"
-  } else if match!(message, r'^W[0-9]+|level=warn|Value:warn|"level":"warn"') {
-    level = "warn"
-  } else if match!(message, r'^N[0-9]+|level=notice|Value:notice|"level":"notice"') {
-    level = "notice"
-  } else if match!(message, r'^I[0-9]+|level=info|Value:info|"level":"info"') {
-    level = "info"
-  } else if match!(message, r'^D[0-9]+|level=debug|Value:debug|"level":"debug"') {
-    level = "debug"
-  } else if match!(message, r'^T[0-9]+|level=trace|Value:trace|"level":"trace"') {
-    level = "trace"
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+  
+  parsed_logfmt, err = parse_logfmt(message)  
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
   }
 
-  # Match on unstructured keywords in same order
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)  
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
 
-  if level == "default" {
-    if match!(message, r'Emergency|EMERGENCY|<emergency>') {
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc. 
+  
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+    
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)      
+    }
+  }
+
+  if level == null {
+    level = "default"
+ 
+    # attempt 4: Match on well known structured patterns
+    # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
+  
+    if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
       level = "emergency"
-    } else if match!(message, r'Alert|ALERT|<alert>') {
+    } else if match!(message, r'^A[0-9]+|level=alert|Value:alert|"level":"alert"') {
       level = "alert"
-    } else if match!(message, r'Critical|CRITICAL|<critical>') {
+    } else if match!(message, r'^C[0-9]+|level=critical|Value:critical|"level":"critical"') {
       level = "critical"
-    } else if match!(message, r'Error|ERROR|<error>') {
+    } else if match!(message, r'^E[0-9]+|level=error|Value:error|"level":"error"') {
       level = "error"
-    } else if match!(message, r'Warning|WARN|<warn>') {
+    } else if match!(message, r'^W[0-9]+|level=warn|Value:warn|"level":"warn"') {
       level = "warn"
-    } else if match!(message, r'Notice|NOTICE|<notice>') {
+    } else if match!(message, r'^N[0-9]+|level=notice|Value:notice|"level":"notice"') {
       level = "notice"
-    } else if match!(message, r'(?i)\b(?:info)\b|<info>') {
+    } else if match!(message, r'^I[0-9]+|level=info|Value:info|"level":"info"') {
       level = "info"
-    } else if match!(message, r'Debug|DEBUG|<debug>') {
+    } else if match!(message, r'^D[0-9]+|level=debug|Value:debug|"level":"debug"') {
       level = "debug"
-    } else if match!(message, r'Trace|TRACE|<trace>') {
+    } else if match!(message, r'^T[0-9]+|level=trace|Value:trace|"level":"trace"') {
       level = "trace"
+    }
+  
+    # attempt 5: Match on unstructured keywords in same order
+  
+    if level == "default" {
+      if match!(message, r'Emergency|EMERGENCY|<emergency>') {
+        level = "emergency"
+      } else if match!(message, r'Alert|ALERT|<alert>') {
+        level = "alert"
+      } else if match!(message, r'Critical|CRITICAL|<critical>') {
+        level = "critical"
+      } else if match!(message, r'Error|ERROR|<error>') {
+        level = "error"
+      } else if match!(message, r'Warning|WARN|<warn>') {
+        level = "warn"
+      } else if match!(message, r'Notice|NOTICE|<notice>') {
+        level = "notice"
+      } else if match!(message, r'(?i)\b(?:info)\b|<info>') {
+        level = "info"
+      } else if match!(message, r'Debug|DEBUG|<debug>') {
+        level = "debug"
+      } else if match!(message, r'Trace|TRACE|<trace>') {
+        level = "trace"
+      }
     }
   }
   ._internal.level = level

--- a/internal/generator/vector/input/application.toml
+++ b/internal/generator/vector/input/application.toml
@@ -31,10 +31,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -57,7 +95,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -80,7 +118,8 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''

--- a/internal/generator/vector/input/application_exclude_container_from_infra.toml
+++ b/internal/generator/vector/input/application_exclude_container_from_infra.toml
@@ -32,10 +32,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -58,7 +96,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -81,7 +119,8 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''

--- a/internal/generator/vector/input/application_excludes_container.toml
+++ b/internal/generator/vector/input/application_excludes_container.toml
@@ -31,10 +31,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -57,7 +95,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -80,7 +118,8 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''

--- a/internal/generator/vector/input/application_includes_container.toml
+++ b/internal/generator/vector/input/application_includes_container.toml
@@ -32,10 +32,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -58,7 +96,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -81,7 +119,8 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''

--- a/internal/generator/vector/input/application_with_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_includes_excludes.toml
@@ -32,10 +32,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -58,7 +96,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -81,7 +119,8 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''

--- a/internal/generator/vector/input/application_with_infra_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_excludes.toml
@@ -32,10 +32,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -58,7 +96,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -81,7 +119,8 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''

--- a/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
@@ -32,10 +32,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -58,7 +96,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -81,7 +119,8 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''

--- a/internal/generator/vector/input/application_with_matchLabels.toml
+++ b/internal/generator/vector/input/application_with_matchLabels.toml
@@ -32,10 +32,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -58,7 +96,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -81,7 +119,8 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''

--- a/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
@@ -32,10 +32,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -58,7 +96,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -81,7 +119,8 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''

--- a/internal/generator/vector/input/application_with_throttle.toml
+++ b/internal/generator/vector/input/application_with_throttle.toml
@@ -31,10 +31,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -57,7 +95,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -80,8 +118,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''
 

--- a/internal/generator/vector/input/audit.toml
+++ b/internal/generator/vector/input/audit.toml
@@ -20,10 +20,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -46,7 +84,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -69,8 +107,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 
   match1 = parse_regex(._internal.message, r'type=(?P<type>[^ ]+)') ?? {}
@@ -167,10 +206,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -193,7 +270,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -216,7 +293,8 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 '''

--- a/internal/generator/vector/input/audit_host.toml
+++ b/internal/generator/vector/input/audit_host.toml
@@ -20,10 +20,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -46,7 +84,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -69,8 +107,9 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 
 
   match1 = parse_regex(._internal.message, r'type=(?P<type>[^ ]+)') ?? {}

--- a/internal/generator/vector/input/audit_ovn.toml
+++ b/internal/generator/vector/input/audit_ovn.toml
@@ -20,10 +20,48 @@ source = '''
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
   if !exists(._internal.level) {
-    level = "default"
-    message = ._internal.message
+  level = null
+  message = ._internal.message
 
-    # Match on well known structured patterns
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
+
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
 
     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
@@ -46,7 +84,7 @@ source = '''
       level = "trace"
     }
 
-    # Match on unstructured keywords in same order
+    # attempt 5: Match on unstructured keywords in same order
 
     if level == "default" {
       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
@@ -69,6 +107,7 @@ source = '''
         level = "trace"
       }
     }
-    ._internal.level = level
   }
+  ._internal.level = level
+}
 '''

--- a/internal/generator/vector/input/infrastructure.toml
+++ b/internal/generator/vector/input/infrastructure.toml
@@ -30,59 +30,97 @@ source = '''
    ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
    ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
-   if !exists(._internal.level) {
-     level = "default"
-     message = ._internal.message
+if !exists(._internal.level) {
+  level = null
+  message = ._internal.message
 
-     # Match on well known structured patterns
-     # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
 
-     if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
-       level = "emergency"
-     } else if match!(message, r'^A[0-9]+|level=alert|Value:alert|"level":"alert"') {
-       level = "alert"
-     } else if match!(message, r'^C[0-9]+|level=critical|Value:critical|"level":"critical"') {
-       level = "critical"
-     } else if match!(message, r'^E[0-9]+|level=error|Value:error|"level":"error"') {
-       level = "error"
-     } else if match!(message, r'^W[0-9]+|level=warn|Value:warn|"level":"warn"') {
-       level = "warn"
-     } else if match!(message, r'^N[0-9]+|level=notice|Value:notice|"level":"notice"') {
-       level = "notice"
-     } else if match!(message, r'^I[0-9]+|level=info|Value:info|"level":"info"') {
-       level = "info"
-     } else if match!(message, r'^D[0-9]+|level=debug|Value:debug|"level":"debug"') {
-       level = "debug"
-     } else if match!(message, r'^T[0-9]+|level=trace|Value:trace|"level":"trace"') {
-       level = "trace"
-     }
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
 
-     # Match on unstructured keywords in same order
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
 
-     if level == "default" {
-       if match!(message, r'Emergency|EMERGENCY|<emergency>') {
-         level = "emergency"
-       } else if match!(message, r'Alert|ALERT|<alert>') {
-         level = "alert"
-       } else if match!(message, r'Critical|CRITICAL|<critical>') {
-         level = "critical"
-       } else if match!(message, r'Error|ERROR|<error>') {
-         level = "error"
-       } else if match!(message, r'Warning|WARN|<warn>') {
-         level = "warn"
-       } else if match!(message, r'Notice|NOTICE|<notice>') {
-         level = "notice"
-       } else if match!(message, r'(?i)\b(?:info)\b|<info>') {
-         level = "info"
-       } else if match!(message, r'Debug|DEBUG|<debug>') {
-         level = "debug"
-       } else if match!(message, r'Trace|TRACE|<trace>') {
-         level = "trace"
-       }
-     }
-     ._internal.level = level
-   }
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
 
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
+    # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
+
+    if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
+      level = "emergency"
+    } else if match!(message, r'^A[0-9]+|level=alert|Value:alert|"level":"alert"') {
+      level = "alert"
+    } else if match!(message, r'^C[0-9]+|level=critical|Value:critical|"level":"critical"') {
+      level = "critical"
+    } else if match!(message, r'^E[0-9]+|level=error|Value:error|"level":"error"') {
+      level = "error"
+    } else if match!(message, r'^W[0-9]+|level=warn|Value:warn|"level":"warn"') {
+      level = "warn"
+    } else if match!(message, r'^N[0-9]+|level=notice|Value:notice|"level":"notice"') {
+      level = "notice"
+    } else if match!(message, r'^I[0-9]+|level=info|Value:info|"level":"info"') {
+      level = "info"
+    } else if match!(message, r'^D[0-9]+|level=debug|Value:debug|"level":"debug"') {
+      level = "debug"
+    } else if match!(message, r'^T[0-9]+|level=trace|Value:trace|"level":"trace"') {
+      level = "trace"
+    }
+
+    # attempt 5: Match on unstructured keywords in same order
+
+    if level == "default" {
+      if match!(message, r'Emergency|EMERGENCY|<emergency>') {
+        level = "emergency"
+      } else if match!(message, r'Alert|ALERT|<alert>') {
+        level = "alert"
+      } else if match!(message, r'Critical|CRITICAL|<critical>') {
+        level = "critical"
+      } else if match!(message, r'Error|ERROR|<error>') {
+        level = "error"
+      } else if match!(message, r'Warning|WARN|<warn>') {
+        level = "warn"
+      } else if match!(message, r'Notice|NOTICE|<notice>') {
+        level = "notice"
+      } else if match!(message, r'(?i)\b(?:info)\b|<info>') {
+        level = "info"
+      } else if match!(message, r'Debug|DEBUG|<debug>') {
+        level = "debug"
+      } else if match!(message, r'Trace|TRACE|<trace>') {
+        level = "trace"
+      }
+    }
+  }
+  ._internal.level = level
+}
 '''
 
 [sources.input_infrastructure_journal]

--- a/internal/generator/vector/input/infrastructure_container.toml
+++ b/internal/generator/vector/input/infrastructure_container.toml
@@ -30,57 +30,96 @@ source = '''
     ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
     ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
 
-    if !exists(._internal.level) {
-      level = "default"
-      message = ._internal.message
+  if !exists(._internal.level) {
+  level = null
+  message = ._internal.message
 
-      # Match on well known structured patterns
-      # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
+  # attempt 1: parse as logfmt (e.g. level=error msg="Failed to connect")
 
-      if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
+  parsed_logfmt, err = parse_logfmt(message)
+  if err == null && is_string(parsed_logfmt.level) {
+    level = downcase!(parsed_logfmt.level)
+  }
+
+  # attempt 2: parse as klog (e.g. I0920 14:22:00.089385 1 scheduler.go:592] "Successfully bound pod to node")
+  if level == null {
+    parsed_klog, err = parse_klog(message)
+    if err == null && is_string(parsed_klog.level) {
+      level = parsed_klog.level
+    }
+  }
+
+  # attempt 3: parse with groks template (if previous attempts failed) for classic text logs like Logback, Log4j etc.
+
+  if level == null {
+    parsed_grok, err = parse_groks(message,
+      patterns: [
+        "%{common_prefix} %{_message}"
+      ],
+      aliases: {
+        "common_prefix": "%{_timestamp} %{_loglevel}",
+        "_timestamp": "%{TIMESTAMP_ISO8601:timestamp}",
+        "_loglevel": "%{LOGLEVEL:level}",
+        "_message": "%{GREEDYDATA:message}"
+      }
+    )
+
+    if err == null && is_string(parsed_grok.level) {
+      level = downcase!(parsed_grok.level)
+    }
+  }
+
+  if level == null {
+    level = "default"
+
+    # attempt 4: Match on well known structured patterns
+    # Order: emergency, alert, critical, error, warn, notice, info, debug, trace
+
+    if match!(message, r'^EM[0-9]+|level=emergency|Value:emergency|"level":"emergency"') {
+      level = "emergency"
+    } else if match!(message, r'^A[0-9]+|level=alert|Value:alert|"level":"alert"') {
+      level = "alert"
+    } else if match!(message, r'^C[0-9]+|level=critical|Value:critical|"level":"critical"') {
+      level = "critical"
+    } else if match!(message, r'^E[0-9]+|level=error|Value:error|"level":"error"') {
+      level = "error"
+    } else if match!(message, r'^W[0-9]+|level=warn|Value:warn|"level":"warn"') {
+      level = "warn"
+    } else if match!(message, r'^N[0-9]+|level=notice|Value:notice|"level":"notice"') {
+      level = "notice"
+    } else if match!(message, r'^I[0-9]+|level=info|Value:info|"level":"info"') {
+      level = "info"
+    } else if match!(message, r'^D[0-9]+|level=debug|Value:debug|"level":"debug"') {
+      level = "debug"
+    } else if match!(message, r'^T[0-9]+|level=trace|Value:trace|"level":"trace"') {
+      level = "trace"
+    }
+
+    # attempt 5: Match on unstructured keywords in same order
+
+    if level == "default" {
+      if match!(message, r'Emergency|EMERGENCY|<emergency>') {
         level = "emergency"
-      } else if match!(message, r'^A[0-9]+|level=alert|Value:alert|"level":"alert"') {
+      } else if match!(message, r'Alert|ALERT|<alert>') {
         level = "alert"
-      } else if match!(message, r'^C[0-9]+|level=critical|Value:critical|"level":"critical"') {
+      } else if match!(message, r'Critical|CRITICAL|<critical>') {
         level = "critical"
-      } else if match!(message, r'^E[0-9]+|level=error|Value:error|"level":"error"') {
+      } else if match!(message, r'Error|ERROR|<error>') {
         level = "error"
-      } else if match!(message, r'^W[0-9]+|level=warn|Value:warn|"level":"warn"') {
+      } else if match!(message, r'Warning|WARN|<warn>') {
         level = "warn"
-      } else if match!(message, r'^N[0-9]+|level=notice|Value:notice|"level":"notice"') {
+      } else if match!(message, r'Notice|NOTICE|<notice>') {
         level = "notice"
-      } else if match!(message, r'^I[0-9]+|level=info|Value:info|"level":"info"') {
+      } else if match!(message, r'(?i)\b(?:info)\b|<info>') {
         level = "info"
-      } else if match!(message, r'^D[0-9]+|level=debug|Value:debug|"level":"debug"') {
+      } else if match!(message, r'Debug|DEBUG|<debug>') {
         level = "debug"
-      } else if match!(message, r'^T[0-9]+|level=trace|Value:trace|"level":"trace"') {
+      } else if match!(message, r'Trace|TRACE|<trace>') {
         level = "trace"
       }
-
-      # Match on unstructured keywords in same order
-
-      if level == "default" {
-        if match!(message, r'Emergency|EMERGENCY|<emergency>') {
-          level = "emergency"
-        } else if match!(message, r'Alert|ALERT|<alert>') {
-          level = "alert"
-        } else if match!(message, r'Critical|CRITICAL|<critical>') {
-          level = "critical"
-        } else if match!(message, r'Error|ERROR|<error>') {
-          level = "error"
-        } else if match!(message, r'Warning|WARN|<warn>') {
-          level = "warn"
-        } else if match!(message, r'Notice|NOTICE|<notice>') {
-          level = "notice"
-        } else if match!(message, r'(?i)\b(?:info)\b|<info>') {
-          level = "info"
-        } else if match!(message, r'Debug|DEBUG|<debug>') {
-          level = "debug"
-        } else if match!(message, r'Trace|TRACE|<trace>') {
-          level = "trace"
-        }
-      }
-      ._internal.level = level
     }
+  }
+  ._internal.level = level
+}
 
 '''

--- a/test/functional/normalization/loglevel/container_logs_test.go
+++ b/test/functional/normalization/loglevel/container_logs_test.go
@@ -46,7 +46,7 @@ var _ = Describe("[functional][normalization][loglevel] tests for message format
 
 		// Write log line
 		applicationLogLine := functional.NewCRIOLogMessage(timestamp, message, false)
-		Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 10)).To(BeNil())
+		Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 1)).To(BeNil())
 		// Read line from Log Forward output
 		raw, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeHTTP))
 		Expect(err).To(BeNil(), "Expected no errors reading the logs")
@@ -69,5 +69,6 @@ var _ = Describe("[functional][normalization][loglevel] tests for message format
 		Entry("should recognize a complex ERROR message", "error", `2022-01-26 13:41:57.149 mId:597c790b-6482-4a23-905c-49af6959241e cId:WEB::NAID-iOS-I42760F0-DE25-4622-90A0-4961356829A9-1643226116.796449-1643226117121::1643226117142::abunchofstuff::null::CnC::null::39.0.3::null::null::NONE::NONE::null::NONE ERROR com.fake.services.controllers.ecom.BalanceController:84 - GETBULKBALANCE::RECV_REQ - 1|GetBulkBalanceRequest(cash=[GetBalanceRequest(barcode=--------, transactionNumber=---, storeNumber=873, registerID=0, startTime=2022-01-26T13:41:57, pin=null)]) | Headers-> ConsumerApp: STF & MessageId: 597c790b-6482-4a23-905c-49af6959241e & EndpointUrl: /v1/cash/getBalanceBulk & CorrelationId: null`),
 		Entry("should recognize a complex DEBUG message", "debug", `2022-01-26 13:41:57.149 mId:597c790b-6482-4a23-905c-49af6959241e cId:WEB::NAID-iOS-D42760F0-DE25-4622-90A0-4961356829A9-1643226116.796449-1643226117121::1643226117142::abunchofstuff::null::CnC::null::39.0.3::null::null::NONE::NONE::null::NONE DEBUG com.fake.services.controllers.ecom.BalanceController:84 - GETBULKBALANCE::RECV_REQ - 1|GetBulkBalanceRequest(cash=[GetBalanceRequest(barcode=--------, transactionNumber=---, storeNumber=873, registerID=0, startTime=2022-01-26T13:41:57, pin=null)]) | Headers-> ConsumerApp: STF & MessageId: 597c790b-6482-4a23-905c-49af6959241e & EndpointUrl: /v1/cash/getBalanceBulk & CorrelationId: null`),
 		Entry("should recognize a complex TRACE message", "trace", `2022-01-26 13:41:57.149 mId:597c790b-6482-4a23-905c-49af6959241e cId:WEB::NAID-iOS-D42760F0-DE25-4622-90A0-4961356829A9-1643226116.796449-1643226117121::1643226117142::abunchofstuff::null::CnC::null::39.0.3::null::null::NONE::NONE::null::NONE TRACE com.fake.services.controllers.ecom.BalanceController:84 - GETBULKBALANCE::RECV_REQ - 1|GetBulkBalanceRequest(cash=[GetBalanceRequest(barcode=--------, transactionNumber=---, storeNumber=873, registerID=0, startTime=2022-01-26T13:41:57, pin=null)]) | Headers-> ConsumerApp: STF & MessageId: 597c790b-6482-4a23-905c-49af6959241e & EndpointUrl: /v1/cash/getBalanceBulk & CorrelationId: null`),
+		Entry("should recognize a complex INFO message", "info", `2025-06-16 10:32:54,862 INFO [http-nio-8080-exec-10] se.skv.chassi.MyResetController -- This is an example log message containing work ERROR `),
 	)
 })


### PR DESCRIPTION
### Description

#### Problem:
Determining the log level relied on `if/else` block to perform a keyword search across the entire raw message. This approach was had drawbacks: It could incorrectly assign a level if a log message contained multiple level keywords. For example, a structured INFO log with the word "ERROR" in its payload (... INFO ... message about a work ERROR) would be misclassified as error.

#### Changes:
This PR refactors the log level determination logic in our VRL script to use a robust, multi-stage parsing pipeline. Instead of immediately searching for keywords, we now attempt to parse the message using a series of specialized, embedded VRL functions. The fallback to a keyword search is now a last resort.
The new order of operations is as follows:
**Attempt 1** `parse_klog`:  we try parsing it as a Kubernetes klog message. This correctly handles logs originating from many components within our containerized environments.
**Attempt 2** `parse_logfmt`: next, we attempt to parse the message using the logfmt key-value format (e.g., level=error msg=...).
**Attempt 3** `parse_grok`: If all of the above fail, we use `parse_grok` with a predefined list of common text-based formats (e.g., Logback/Log4j). The first pattern to match determines the level.
**Fallback to Keyword Search**: Only if all structured parsing attempts fail do we fall back to the original if/else block to scan the raw message for keywords.

#### Benefits:
**Increased Accuracy**:  we now correctly classify messages and avoid false positives from the payload content.
**Improved Performance** (Expected, not confirmed): Using native, optimized VRL parse functions for their intended formats is generally more performant than executing a series of regex searches on every log. This moves our logic toward Vector's best practices.
**Enhanced Maintainability**: Adding support for a new text-based log format is now as simple as adding a new pattern to the parse_grok list, requiring no changes to the core script logic.


/cc @Clee2691 @cahartma <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @cahartma <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-7222
- Enhancement proposal:
