### PR TITLE
Implement terminationMessagePolicy on all containers

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -177,6 +177,7 @@ func (f *Factory) NewPodSpec(trustedCABundle *v1.ConfigMap, spec obs.ClusterLogF
 // to be a unique list
 func (f *Factory) NewCollectorContainer(inputs internalobs.Inputs, outputs internalobs.Outputs, secretVolumes, configmapVolumes []string, clusterID string) *v1.Container {
 	collector := runtime.NewContainer(constants.CollectorName, utils.GetComponentImage(f.ImageName), v1.PullIfNotPresent, f.CollectorSpec.Resources)
+	collector.TerminationMessagePolicy = v1.TerminationMessageFallbackToLogsOnError
 	collector.Ports = []v1.ContainerPort{
 		{
 			Name:          MetricsPortName,

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -130,6 +130,10 @@ var _ = Describe("Factory#Daemonset", func() {
 							MountPath: constants.ServiceAccountSecretPath}))
 				})
 			})
+
+			It("should set terminationMessagePolicy to 'FallbackToLogsOnError'", func() {
+				Expect(collector.TerminationMessagePolicy).To(Equal(v1.TerminationMessageFallbackToLogsOnError))
+			})
 		})
 
 		Describe("when creating the podSpec", func() {


### PR DESCRIPTION
### Description
This PR sets the `terminationMessagePolicy` of the collector container to `FallbackToLogsOnError`. Originally it was set to `File`.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-7063

