### PR TITLE
LOG-7196: Enable annotations for kubeapi caching and configurable maxUnavailable

### DIFF
--- a/api/observability/v1/conditions.go
+++ b/api/observability/v1/conditions.go
@@ -17,7 +17,6 @@ package v1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
-
 	// ConditionTrue means the condition is met
 	ConditionTrue = metav1.ConditionTrue
 
@@ -30,7 +29,14 @@ const (
 	// ConditionTypeAuthorized identifies the state of authorization for the service
 	ConditionTypeAuthorized = GroupName + "/Authorized"
 
+	// ConditionTypeLogLevel validates the value of the log-level annotation
 	ConditionTypeLogLevel = GroupName + "/LogLevel"
+
+	// ConditionTypeMaxUnavailable validates the value of the max-unavailable-rollout annotation
+	ConditionTypeMaxUnavailable = GroupName + "/MaxUnavailableAnnotation"
+
+	// ConditionTypeUseKubeCache validates the value of the use-apiserver-cache annotation
+	ConditionTypeUseKubeCache = GroupName + "/UseKubeCacheAnnotation"
 
 	// ConditionTypeReady indicates the service is ready.
 	//
@@ -77,8 +83,14 @@ const (
 	// ReasonMissingSpec applies when a type is specified without a defined spec (e.g. type application without obs.Application)
 	ReasonMissingSpec = "MissingSpec"
 
-	// ReasonLogLevelSupported indicates the support for the log level annotation value
+	// ReasonLogLevelSupported indicates the support for the log-level annotation value
 	ReasonLogLevelSupported = "LogLevelSupported"
+
+	// ReasonMaxUnavailableSupported indicates the support for the max-unavailable-rollout annotation value
+	ReasonMaxUnavailableSupported = "MaxUnavailableAnnotationSupported"
+
+	// ReasonKubeCacheSupported indicates the support for the use-apiserver-cache annotation value
+	ReasonKubeCacheSupported = "KubeCacheAnnotationSupported"
 
 	// ReasonReconciliationComplete when the operator has initialized, validated, and deployed the resources for the workload
 	ReasonReconciliationComplete = "ReconciliationComplete"

--- a/internal/constants/annotations.go
+++ b/internal/constants/annotations.go
@@ -17,4 +17,17 @@ const (
 	AnnotationOtlpOutputTechPreview = "observability.openshift.io/tech-preview-otlp-output"
 
 	AnnotationSecretHash = "observability.openshift.io/secret-hash"
+
+	// AnnotationKubeCache is used to enable caching for requests to the kube-apiserver using vector kubernetes_logs source.
+	// Tech-Preview feature
+	//
+	// While enabling cache can significantly reduce Kubernetes control plane
+	// memory pressure, the trade-off is a chance of receiving stale data.
+	AnnotationKubeCache = "observability.openshift.io/use-apiserver-cache"
+
+	// AnnotationMaxUnavailable configures the maximum number of DaemonSet pods that can be unavailable during a rolling update.
+	// Tech-Preview feature
+	//
+	// This can be an absolute number (e.g., 1) or a percentage (e.g., 10%). Default is 100%.
+	AnnotationMaxUnavailable = "observability.openshift.io/max-unavailable-rollout"
 )

--- a/internal/controller/observability/collector.go
+++ b/internal/controller/observability/collector.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/runtime/serviceaccount"
 	"github.com/openshift/cluster-logging-operator/internal/tls"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/internal/validations/observability"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -42,6 +43,11 @@ func ReconcileCollector(context internalcontext.ForwarderContext, pollInterval, 
 	if context.AdditionalContext != nil {
 		options = context.AdditionalContext
 	}
+
+	// Set kubeapi and rollout options based on annotation (LOG-7196)
+	// TODO: replace with API fields
+	SetKubeCacheOption(context.Forwarder.Annotations, options)
+	SetMaxUnavailableRolloutOption(context.Forwarder.Annotations, options)
 
 	if internalobs.Outputs(context.Forwarder.Spec.Outputs).NeedServiceAccountToken() {
 		// temporarily create SA token until collector is capable of dynamically reloading a projected serviceaccount token
@@ -100,28 +106,41 @@ func ReconcileCollector(context internalcontext.ForwarderContext, pollInterval, 
 
 	isDaemonSet := !internalobs.DeployAsDeployment(*context.Forwarder)
 	log.V(3).Info("Deploying as DaemonSet", "isDaemonSet", isDaemonSet)
-	factory := collector.New(collectorConfHash, context.ClusterID, context.Forwarder.Spec.Collector, context.Secrets, context.ConfigMaps, context.Forwarder.Spec, resourceNames, isDaemonSet, LogLevel(context.Forwarder.Annotations))
-	if err = factory.ReconcileCollectorConfig(context.Client, context.Reader, context.Forwarder.Namespace, collectorConfig, ownerRef); err != nil {
+	collectorFactory := collector.New(
+		collectorConfHash,
+		context.ClusterID,
+		context.Forwarder.Spec.Collector,
+		context.Secrets, context.ConfigMaps,
+		context.Forwarder.Spec,
+		resourceNames,
+		isDaemonSet,
+		LogLevel(context.Forwarder.Annotations),
+		factory.IncludesKubeCacheOption(options),
+		factory.GetMaxUnavailableValue(options),
+	)
+
+	if err = collectorFactory.ReconcileCollectorConfig(context.Client, context.Reader, context.Forwarder.Namespace, collectorConfig, ownerRef); err != nil {
 		log.Error(err, "collector.ReconcileCollectorConfig")
 		return
 	}
 
-	reconcileWorkload := factory.ReconcileDaemonset
+	reconcileWorkload := collectorFactory.ReconcileDaemonset
 	if !isDaemonSet {
-		reconcileWorkload = factory.ReconcileDeployment
+		reconcileWorkload = collectorFactory.ReconcileDeployment
 	}
+
 	if err := reconcileWorkload(context.Client, context.Forwarder.Namespace, trustedCABundle, ownerRef); err != nil {
 		log.Error(err, "Error reconciling the deployment of the collector")
 		return err
 	}
 
-	if err := factory.ReconcileInputServices(context.Client, context.Reader, context.Forwarder.Namespace, ownerRef, factory.CommonLabelInitializer); err != nil {
+	if err := collectorFactory.ReconcileInputServices(context.Client, context.Reader, context.Forwarder.Namespace, ownerRef, collectorFactory.CommonLabelInitializer); err != nil {
 		log.Error(err, "collector.ReconcileInputServices")
 		return err
 	}
 
 	// Reconcile resources to support metrics gathering
-	if err := network.ReconcileService(context.Client, context.Forwarder.Namespace, resourceNames.CommonName, context.Forwarder.Name, constants.CollectorName, collector.MetricsPortName, resourceNames.SecretMetrics, collector.MetricsPort, ownerRef, factory.CommonLabelInitializer); err != nil {
+	if err := network.ReconcileService(context.Client, context.Forwarder.Namespace, resourceNames.CommonName, context.Forwarder.Name, constants.CollectorName, collector.MetricsPortName, resourceNames.SecretMetrics, collector.MetricsPort, ownerRef, collectorFactory.CommonLabelInitializer); err != nil {
 		log.Error(err, "collector.ReconcileService")
 		return err
 	}
@@ -134,12 +153,12 @@ func ReconcileCollector(context internalcontext.ForwarderContext, pollInterval, 
 	return nil
 }
 
-func GenerateConfig(k8Client client.Client, spec obs.ClusterLogForwarder, resourceNames factory.ForwarderResourceNames, secrets internalobs.Secrets, op framework.Options) (config string, err error) {
+func GenerateConfig(k8Client client.Client, clf obs.ClusterLogForwarder, resourceNames factory.ForwarderResourceNames, secrets internalobs.Secrets, op framework.Options) (config string, err error) {
 	tlsProfile, _ := tls.FetchAPIServerTlsProfile(k8Client)
 	op[framework.ClusterTLSProfileSpec] = tls.GetClusterTLSProfileSpec(tlsProfile)
 	//EvaluateAnnotationsForEnabledCapabilities(clusterRequest.Forwarder, op)
 	g := forwardergenerator.New()
-	generatedConfig, err := g.GenerateConf(secrets, spec.Spec, spec.Namespace, spec.Name, resourceNames, op)
+	generatedConfig, err := g.GenerateConf(secrets, clf.Spec, clf.Namespace, clf.Name, resourceNames, op)
 
 	if err != nil {
 		log.Error(err, "Unable to generate log configuration")
@@ -161,6 +180,16 @@ func EvaluateAnnotationsForEnabledCapabilities(annotations map[string]string, op
 			if strings.ToLower(value) == "true" {
 				options[generatorhelpers.EnableDebugOutput] = "true"
 			}
+		case constants.AnnotationKubeCache:
+			// Matching the validate_annotations logic
+			if observability.IsEnabledValue(value) {
+				options[framework.UseKubeCacheOption] = "true"
+			}
+		case constants.AnnotationMaxUnavailable:
+			// Matching the validate_annotations logic
+			if observability.IsPercentOrWholeNumber(value) {
+				options[framework.MaxUnavailableOption] = value
+			}
 		}
 	}
 }
@@ -170,4 +199,22 @@ func LogLevel(annotations map[string]string) string {
 		return level
 	}
 	return "warn"
+}
+
+func SetKubeCacheOption(annotations map[string]string, options framework.Options) {
+	if value, found := annotations[constants.AnnotationKubeCache]; found {
+		if observability.IsEnabledValue(value) {
+			log.V(3).Info("Kube cache annotation found")
+			options[framework.UseKubeCacheOption] = "true"
+		}
+	}
+}
+
+func SetMaxUnavailableRolloutOption(annotations map[string]string, options framework.Options) {
+	if value, found := annotations[constants.AnnotationMaxUnavailable]; found {
+		if observability.IsPercentOrWholeNumber(value) {
+			log.V(3).Info("Max Unavailable annotation found")
+			options[framework.MaxUnavailableOption] = value
+		}
+	}
 }

--- a/internal/controller/observability/collector_features_test.go
+++ b/internal/controller/observability/collector_features_test.go
@@ -38,6 +38,15 @@ var _ = Describe("#EvaluateAnnotationsForEnabledCapabilities", func() {
 		Entry("enables debug for true", helpers.EnableDebugOutput, "true", AnnotationDebugOutput, "true"),
 		Entry("enables debug for True", helpers.EnableDebugOutput, "true", AnnotationDebugOutput, "True"),
 		Entry("disables debug for anything else", "", "", AnnotationDebugOutput, "abcdef"),
+
+		Entry("enables kube-cache for true", framework.UseKubeCacheOption, "true", AnnotationKubeCache, "true"),
+		Entry("enables kube-cache for True", framework.UseKubeCacheOption, "true", AnnotationKubeCache, "True"),
+		Entry("enables kube-cache for enabled", framework.UseKubeCacheOption, "true", AnnotationKubeCache, "enabled"),
+		Entry("disables kube-cache for anything else", "", "", AnnotationKubeCache, "bubbles"),
+
+		Entry("enables max-unavailable for value '10'", framework.MaxUnavailableOption, "10", AnnotationMaxUnavailable, "10"),
+		Entry("enables max-unavailable for value '99%'", framework.MaxUnavailableOption, "99%", AnnotationMaxUnavailable, "99%"),
+		Entry("disables max-unavailable option for anything not a number or percentage", "", "", AnnotationMaxUnavailable, "fluffy"),
 	)
 
 })

--- a/internal/factory/daemonset.go
+++ b/internal/factory/daemonset.go
@@ -1,26 +1,26 @@
 package factory
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/internal/validations/observability"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // NewDaemonSet stubs an instance of a daemonset
-func NewDaemonSet(namespace, daemonsetName, instanceName, component, impl string, podSpec core.PodSpec, visitors ...func(o runtime.Object)) *apps.DaemonSet {
+func NewDaemonSet(namespace, daemonsetName, instanceName, component, impl, maxUnavailable string, podSpec core.PodSpec, visitors ...func(o runtime.Object)) *apps.DaemonSet {
 	selectors := runtime.Selectors(instanceName, component, impl)
 	annotations := map[string]string{
 		"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
 	}
-
+	intOrStringValue := intstr.Parse(maxUnavailable)
 	strategy := apps.DaemonSetUpdateStrategy{
 		Type: apps.RollingUpdateDaemonSetStrategyType,
 		RollingUpdate: &apps.RollingUpdateDaemonSet{
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.String,
-				StrVal: "100%",
-			},
+			MaxUnavailable: &intOrStringValue,
 		},
 	}
 	ds := runtime.NewDaemonSet(namespace, daemonsetName, visitors...)
@@ -30,4 +30,14 @@ func NewDaemonSet(namespace, daemonsetName, instanceName, component, impl string
 		WithUpdateStrategy(strategy).
 		WithPodSpec(podSpec)
 	return ds
+}
+
+// GetMaxUnavailableValue checks the framework options for the flag maxUnavailableRollout
+// Default is 100%
+func GetMaxUnavailableValue(op framework.Options) string {
+	value, _ := utils.GetOption(op, framework.MaxUnavailableOption, "100%")
+	if !observability.IsPercentOrWholeNumber(value) {
+		value = "100%"
+	}
+	return value
 }

--- a/internal/factory/daemonset_test.go
+++ b/internal/factory/daemonset_test.go
@@ -3,6 +3,7 @@ package factory
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -11,20 +12,57 @@ import (
 var _ = Describe("#NewDaemonSet", func() {
 
 	var (
-		daemonSet    *apps.DaemonSet
-		expSelectors = runtime.Selectors("theinstancename", "thecomponent", "thecomponent")
+		daemonSet      *apps.DaemonSet
+		expSelectors   = runtime.Selectors("theinstancename", "thecomponent", "thecomponent")
+		op             = framework.Options{}
+		maxUnavailable string
 	)
 
-	BeforeEach(func() {
-		daemonSet = NewDaemonSet("thenamespace", "thenname", "theinstancename", "thecomponent", "thecomponent", core.PodSpec{})
+	Context("with common properties and maxUnavailable empty", func() {
+		BeforeEach(func() {
+			daemonSet = NewDaemonSet(
+				"thenamespace",
+				"thenname",
+				"theinstancename",
+				"thecomponent",
+				"thecomponent",
+				maxUnavailable,
+				core.PodSpec{},
+			)
+		})
+
+		It("should leave the MinReadySeconds as the default", func() {
+			Expect(daemonSet.Spec.MinReadySeconds).ToNot(Equal(0), "Exp. the MinReadySeconds to be the default")
+		})
+
+		It("should only include the kubernetes common labels in the selector", func() {
+			Expect(daemonSet.Spec.Selector.MatchLabels).To(Equal(expSelectors), "Exp. the selector to contain kubernetes common labels")
+		})
 	})
 
-	It("should leave the MinReadySeconds as the default", func() {
-		Expect(daemonSet.Spec.MinReadySeconds).ToNot(Equal(0), "Exp. the MinReadySeconds to be the default")
-	})
-
-	It("should only include the kubernetes common labels in the selector", func() {
-		Expect(daemonSet.Spec.Selector.MatchLabels).To(Equal(expSelectors), "Exp. the selector to contain kubernetes common labels")
-	})
-
+	// This option should never be set as invalid since there is validation on the setter. This unit test
+	// ensures the ds method handles it properly regardless
+	DescribeTable("with maxUnavailable option", func(op framework.Options, exp string) {
+		maxUnavailable = GetMaxUnavailableValue(op)
+		daemonSet = NewDaemonSet(
+			"thenamespace",
+			"thenname",
+			"theinstancename",
+			"thecomponent",
+			"thecomponent",
+			maxUnavailable,
+			core.PodSpec{},
+		)
+		Expect(daemonSet.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.String()).To(Equal(exp), "Exp. the maxUnavailable value to match")
+	},
+		Entry("missing", op, "100%"),
+		Entry("set to empty string", framework.Options{framework.MaxUnavailableOption: ""}, "100%"),
+		Entry("set to invalid value 'blue'", framework.Options{framework.MaxUnavailableOption: "blue"}, "100%"),
+		Entry("set to invalid zero", framework.Options{framework.MaxUnavailableOption: "0"}, "100%"),
+		Entry("set to invalid decimal", framework.Options{framework.MaxUnavailableOption: "2.5"}, "100%"),
+		Entry("set to invalid percentage", framework.Options{framework.MaxUnavailableOption: "200%"}, "100%"),
+		Entry("set to whole number", framework.Options{framework.MaxUnavailableOption: "50"}, "50"),
+		Entry("set to percentage", framework.Options{framework.MaxUnavailableOption: "99%"}, "99%"),
+		Entry("set to '100%'", framework.Options{framework.MaxUnavailableOption: "100%"}, "100%"),
+	)
 })

--- a/internal/factory/options.go
+++ b/internal/factory/options.go
@@ -1,0 +1,13 @@
+package factory
+
+import (
+	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+)
+
+func IncludesKubeCacheOption(op framework.Options) bool {
+	_, found := utils.GetOption(op, framework.UseKubeCacheOption, "")
+	log.V(3).Info("Kube caching option enabled")
+	return found
+}

--- a/internal/generator/framework/options.go
+++ b/internal/generator/framework/options.go
@@ -5,14 +5,14 @@ import (
 )
 
 const (
-	ClusterTLSProfileSpec = "tlsProfileSpec"
-
-	MinTLSVersion = "minTLSVersion"
-	Ciphers       = "ciphers"
-
+	ClusterTLSProfileSpec               = "tlsProfileSpec"
+	MinTLSVersion                       = "minTLSVersion"
+	Ciphers                             = "ciphers"
 	URL                                 = "url"
 	OptionServiceAccountTokenSecretName = "serviceAccountTokenSecretName"
 	OptionForwarderName                 = "forwarderName"
+	UseKubeCacheOption                  = "useKubeCache"
+	MaxUnavailableOption                = "maxUnavailableRollout"
 )
 
 // Options is a map of Options used to customize the config generation. E.g. Debugging, legacy config generation

--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -250,6 +250,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"
@@ -419,6 +420,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_mytestapp_container_meta]
 type = "remap"

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -247,6 +247,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"
@@ -456,6 +457,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_mytestapp_container_meta]
 type = "remap"

--- a/internal/generator/vector/conf/conf_test.go
+++ b/internal/generator/vector/conf/conf_test.go
@@ -3,7 +3,6 @@ package conf
 import (
 	_ "embed"
 	"fmt"
-
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 
 	"github.com/openshift/cluster-logging-operator/internal/factory"
@@ -70,7 +69,9 @@ var _ = Describe("Testing Complete Config Generation", func() {
 		conf := Conf(secrets, spec, constants.OpenshiftNS, "my-forwarder", factory.ForwarderResourceNames{CommonName: constants.CollectorName}, op)
 		Expect(string(exp)).To(EqualConfigFrom(conf))
 	},
-		Entry("with spec for containers", "container.toml", nil,
+		Entry("with spec for containers and kube-cache enabled",
+			"container.toml",
+			framework.Options{framework.UseKubeCacheOption: "true"},
 			obs.ClusterLogForwarderSpec{
 				Inputs: []obs.InputSpec{
 					{
@@ -112,7 +113,9 @@ var _ = Describe("Testing Complete Config Generation", func() {
 					},
 				},
 			}),
-		Entry("with complex spec", "complex.toml", nil,
+		Entry("with complex spec",
+			"complex.toml",
+			nil,
 			obs.ClusterLogForwarderSpec{
 				Inputs: []obs.InputSpec{
 					{
@@ -159,7 +162,9 @@ var _ = Describe("Testing Complete Config Generation", func() {
 				},
 			},
 		),
-		Entry("with complex spec && http audit receiver as input source", "complex_http_receiver.toml", nil,
+		Entry("with complex spec && http audit receiver as input source",
+			"complex_http_receiver.toml",
+			nil,
 			obs.ClusterLogForwarderSpec{
 				Inputs: []obs.InputSpec{
 					{

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -27,6 +27,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = true
 
 [transforms.input_myinfra_container_meta]
 type = "remap"
@@ -115,6 +116,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = true
 
 [transforms.input_mytestapp_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application.toml
+++ b/internal/generator/vector/input/application.toml
@@ -12,6 +12,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_application_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_exclude_container_from_infra.toml
+++ b/internal/generator/vector/input/application_exclude_container_from_infra.toml
@@ -13,6 +13,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_excludes_container.toml
+++ b/internal/generator/vector/input/application_excludes_container.toml
@@ -12,6 +12,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_includes_container.toml
+++ b/internal/generator/vector/input/application_includes_container.toml
@@ -13,6 +13,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_includes_excludes.toml
@@ -13,6 +13,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_infra_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_excludes.toml
@@ -13,6 +13,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
@@ -13,6 +13,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_matchLabels.toml
+++ b/internal/generator/vector/input/application_with_matchLabels.toml
@@ -13,6 +13,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
@@ -13,6 +13,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_my_app_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/application_with_throttle.toml
+++ b/internal/generator/vector/input/application_with_throttle.toml
@@ -12,6 +12,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_application_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/container.go
+++ b/internal/generator/vector/input/container.go
@@ -37,7 +37,7 @@ var (
 )
 
 // NewContainerSource generates config elements and the id reference of this input and normalizes
-func NewContainerSource(spec obs.InputSpec, namespace, includes, excludes string, logType obs.InputType, logSource interface{}) ([]framework.Element, []string) {
+func NewContainerSource(spec obs.InputSpec, namespace, includes, excludes string, logType obs.InputType, logSource interface{}, useCache bool) ([]framework.Element, []string) {
 	base := helpers.MakeInputID(spec.Name, "container")
 	var selector *metav1.LabelSelector
 	if spec.Application != nil {
@@ -51,6 +51,7 @@ func NewContainerSource(spec obs.InputSpec, namespace, includes, excludes string
 			IncludePaths:       includes,
 			ExcludePaths:       excludes,
 			ExtraLabelSelector: source.LabelSelectorFrom(selector),
+			UseKubeCache:       useCache,
 		},
 		NewInternalNormalization(metaID, logSource, logType, base),
 	}

--- a/internal/generator/vector/input/infrastructure.toml
+++ b/internal/generator/vector/input/infrastructure.toml
@@ -13,6 +13,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_infrastructure_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/infrastructure_container.toml
+++ b/internal/generator/vector/input/infrastructure_container.toml
@@ -13,6 +13,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false
 
 [transforms.input_myinfra_container_meta]
 type = "remap"

--- a/internal/generator/vector/input/source.go
+++ b/internal/generator/vector/input/source.go
@@ -14,6 +14,9 @@ import (
 func NewSource(input obs.InputSpec, collectorNS string, resNames factory.ForwarderResourceNames, secrets internalobs.Secrets, op framework.Options) ([]framework.Element, []string) {
 	els := []framework.Element{}
 	ids := []string{}
+	// LOG-7196 temporary fix to set vector caching config
+	// TODO: remove annotation logic and add to spec
+	useCache := factory.IncludesKubeCacheOption(op)
 	switch input.Type {
 	case obs.InputTypeApplication:
 		ib := source.NewContainerPathGlobBuilder()
@@ -60,7 +63,7 @@ func NewSource(input obs.InputSpec, collectorNS string, resNames factory.Forward
 		eb.AddExtensions(excludeExtensions...)
 		includes := ib.Build()
 		excludes := eb.Build(infraNamespaces...)
-		return NewContainerSource(input, collectorNS, includes, excludes, obs.InputTypeApplication, obs.InfrastructureSourceContainer)
+		return NewContainerSource(input, collectorNS, includes, excludes, obs.InputTypeApplication, obs.InfrastructureSourceContainer, useCache)
 	case obs.InputTypeInfrastructure:
 		sources := set.Set[obs.InfrastructureSource]{}
 		if input.Infrastructure == nil {
@@ -73,7 +76,7 @@ func NewSource(input obs.InputSpec, collectorNS string, resNames factory.Forward
 		}
 		if sources.Has(obs.InfrastructureSourceContainer) {
 			infraIncludes := source.NewContainerPathGlobBuilder().AddNamespaces(infraNamespaces...).Build()
-			cels, cids := NewContainerSource(input, collectorNS, infraIncludes, loggingExcludes, obs.InputTypeInfrastructure, obs.InfrastructureSourceContainer)
+			cels, cids := NewContainerSource(input, collectorNS, infraIncludes, loggingExcludes, obs.InputTypeInfrastructure, obs.InfrastructureSourceContainer, useCache)
 			els = append(els, cels...)
 			ids = append(ids, cids...)
 		}

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -16,6 +16,7 @@ type KubernetesLogs struct {
 	IncludePaths       string
 	ExcludePaths       string
 	ExtraLabelSelector string
+	UseKubeCache       bool
 }
 
 func (kl KubernetesLogs) Name() string {
@@ -46,6 +47,7 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = {{.UseKubeCache}}
 {{end}}`
 }
 

--- a/internal/generator/vector/source/kubernetes_logs_no_includes_excludes.toml
+++ b/internal/generator/vector/source/kubernetes_logs_no_includes_excludes.toml
@@ -11,3 +11,4 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false

--- a/internal/generator/vector/source/kubernetes_logs_with_includes.toml
+++ b/internal/generator/vector/source/kubernetes_logs_with_includes.toml
@@ -13,3 +13,4 @@ pod_annotation_fields.pod_uid = "kubernetes.pod_id"
 pod_annotation_fields.pod_node_name = "hostname"
 namespace_annotation_fields.namespace_uid = "kubernetes.namespace_id"
 rotate_wait_secs = 5
+use_apiserver_cache = false

--- a/internal/metrics/logfilemetricexporter/factory.go
+++ b/internal/metrics/logfilemetricexporter/factory.go
@@ -28,6 +28,7 @@ const (
 	logPods                         = "varlogpods"
 	logPodsValue                    = "/var/log/pods"
 	metricsVolumePath               = "/etc/logfilemetricexporter/metrics"
+	lfmeMaxUnavailable              = "100%"
 )
 
 // resourceRequirements returns the resource requirements for a given metric-exporter implementation
@@ -69,7 +70,7 @@ func tolerations(exporter loggingv1a1.LogFileMetricExporter) []v1.Toleration {
 
 func NewDaemonSet(exporter loggingv1a1.LogFileMetricExporter, namespace, name string, tlsProfileSpec configv1.TLSProfileSpec, visitors ...func(o runtime.Object)) *apps.DaemonSet {
 	podSpec := NewPodSpec(exporter, tlsProfileSpec)
-	ds := coreFactory.NewDaemonSet(namespace, name, exporter.Name, constants.LogfilesmetricexporterName, constants.LogfilesmetricexporterName, *podSpec, visitors...)
+	ds := coreFactory.NewDaemonSet(namespace, name, exporter.Name, constants.LogfilesmetricexporterName, constants.LogfilesmetricexporterName, lfmeMaxUnavailable, *podSpec, visitors...)
 	return ds
 }
 

--- a/internal/pkg/generator/forwarder/generator.go
+++ b/internal/pkg/generator/forwarder/generator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/api/initialize"
+	controller "github.com/openshift/cluster-logging-operator/internal/controller/observability"
 	"github.com/openshift/cluster-logging-operator/internal/factory"
 	forwardergenerator "github.com/openshift/cluster-logging-operator/internal/generator/forwarder"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
@@ -49,6 +50,7 @@ func Generate(clfYaml string, debugOutput bool, client client.Client) (string, e
 	op := framework.Options{}
 	//k8shandler.EvaluateAnnotationsForEnabledCapabilities(forwarder.Annotations, op)
 	op[framework.ClusterTLSProfileSpec] = tls.GetClusterTLSProfileSpec(nil)
+	controller.SetKubeCacheOption(forwarder.Annotations, op)
 
 	configGenerator := forwardergenerator.New()
 	if configGenerator == nil {

--- a/internal/validations/observability/validate.go
+++ b/internal/validations/observability/validate.go
@@ -12,7 +12,9 @@ import (
 
 var (
 	clfValidators = []func(internalcontext.ForwarderContext){
-		validateAnnotations,
+		validateLogLevelAnnotation,
+		validateMaxUnavailableAnnotation,
+		validateUseKubeCacheAnnotation,
 		ValidatePermissions,
 		inputs.Validate,
 		outputs.Validate,

--- a/internal/validations/observability/validate_annotations_test.go
+++ b/internal/validations/observability/validate_annotations_test.go
@@ -26,19 +26,19 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder annotatio
 
 	Context("#validateLogLevel", func() {
 		It("should pass validation if no annotations are set", func() {
-			validateAnnotations(context)
+			validateLogLevelAnnotation(context)
 			Expect(clf.Status.Conditions).To(BeEmpty())
 		})
 
 		It("should fail validation if log level is not supported", func() {
 			clf.Annotations = map[string]string{constants.AnnotationVectorLogLevel: "foo"}
-			validateAnnotations(context)
+			validateLogLevelAnnotation(context)
 			Expect(clf.Status.Conditions).To(HaveCondition(obs.ConditionTypeLogLevel, false, obs.ReasonLogLevelSupported, ".*must be one of.*"))
 		})
 
 		DescribeTable("valid log levels", func(level string) {
 			clf.Annotations = map[string]string{constants.AnnotationVectorLogLevel: level}
-			validateAnnotations(context)
+			validateLogLevelAnnotation(context)
 			Expect(clf.Status.Conditions).To(BeEmpty())
 		},
 			Entry("should pass with level trace", "trace"),
@@ -47,5 +47,64 @@ var _ = Describe("[internal][validations] validate clusterlogforwarder annotatio
 			Entry("should pass with level warn", "warn"),
 			Entry("should pass with level error", "error"),
 			Entry("should pass with level off", "off"))
+	})
+
+	Context("#validateMaxUnavailable", func() {
+		It("should pass validation if no annotations are set", func() {
+			validateMaxUnavailableAnnotation(context)
+			Expect(clf.Status.Conditions).To(BeEmpty())
+		})
+
+		DescribeTable("invalid maxUnavailable values", func(value string) {
+			clf.Annotations = map[string]string{constants.AnnotationMaxUnavailable: value}
+			validateMaxUnavailableAnnotation(context)
+			Expect(clf.Status.Conditions).To(HaveCondition(obs.ConditionTypeMaxUnavailable, false, obs.ReasonMaxUnavailableSupported, ".*must be an absolute number or a valid percentage.*"))
+		},
+			Entry("should fail with empty value", ""),
+			Entry("should fail with value 0", "0"),
+			Entry("should fail with value 01", "01"),
+			Entry("should fail with value 0%", "0%"),
+			Entry("should fail with value 101%", "101%"),
+			Entry("should fail with value '-1'", "-1"),
+			Entry("should fail with value '5.5'", "5.5"),
+			Entry("should fail with value 'foo'", "foo"))
+
+		DescribeTable("valid maxUnavailable values", func(value string) {
+			clf.Annotations = map[string]string{constants.AnnotationMaxUnavailable: value}
+			validateMaxUnavailableAnnotation(context)
+			Expect(clf.Status.Conditions).To(BeEmpty())
+		},
+			Entry("should pass with value 1", "1"),
+			Entry("should pass with value 1%", "1%"),
+			Entry("should pass with value 100", "100"),
+			Entry("should pass with value 100%", "100%"))
+	})
+
+	Context("#validateUseKubeCacheAnnotation", func() {
+		It("should pass validation if no annotations are set", func() {
+			validateUseKubeCacheAnnotation(context)
+			Expect(clf.Status.Conditions).To(BeEmpty())
+		})
+
+		DescribeTable("invalid kube-cache values", func(value string) {
+			clf.Annotations = map[string]string{constants.AnnotationKubeCache: value}
+			validateUseKubeCacheAnnotation(context)
+			Expect(clf.Status.Conditions).To(HaveCondition(obs.ConditionTypeUseKubeCache, false, obs.ReasonKubeCacheSupported, ".*must be one of.*"))
+		},
+			Entry("should fail with empty value", ""),
+			Entry("should fail with value 0", "0"),
+			Entry("should fail with value false", "false"),
+			Entry("should fail with value disabled", "disabled"),
+			Entry("should fail with value 'foo'", "foo"))
+
+		DescribeTable("valid kube-cache values", func(value string) {
+			clf.Annotations = map[string]string{constants.AnnotationKubeCache: value}
+			validateUseKubeCacheAnnotation(context)
+			Expect(clf.Status.Conditions).To(BeEmpty())
+		},
+			Entry("should pass with value true", "true"),
+			Entry("should pass with value True", "True"),
+			Entry("should pass with value enabled", "enabled"),
+			Entry("should pass with value Enabled", "Enabled"))
 	})
 })


### PR DESCRIPTION
### Description
This feature adds the `use_apiserver_cache` config to the vector.toml and a configurable rollout strategy `maxUnavailable` to the DS. 
 Both of these are currently enabled via annotations in the CLF.      Future effort will move these to the forwarder spec.


### Verifying
Besides collector conditions and status, the following commands can be used to verify the two options:
`oc get cm/my-forwarder-config -o jsonpath='{.data.vector\.toml}' |grep  use_apiserver_cache`
`oc get ds/my-forwarder -oyaml -o jsonpath='{.spec.updateStrategy.rollingUpdate.maxUnavailable}'`


/cc @Clee2691 @vparfonov @jcantrill
/assign @xperimental 

### Links
- https://issues.redhat.com/browse/LOG-7196
