### PR TITLE
LOG-7058: Add liveness probe to Vector collector container

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -3,6 +3,7 @@ data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
 
 [api]
 enabled = true
+address = "0.0.0.0:24686"
 
 # Load sensitive data from files
 [secret.kubernetes_secret]

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -3,6 +3,7 @@ data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
 
 [api]
 enabled = true
+address = "0.0.0.0:24686"
 
 # Load sensitive data from files
 [secret.kubernetes_secret]

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -3,6 +3,7 @@ data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
 
 [api]
 enabled = true
+address = "0.0.0.0:24686"
 
 # Load sensitive data from files
 [secret.kubernetes_secret]

--- a/internal/generator/vector/conf/global.go
+++ b/internal/generator/vector/conf/global.go
@@ -1,9 +1,11 @@
 package conf
 
 import (
+	"github.com/openshift/cluster-logging-operator/internal/collector"
 	"github.com/openshift/cluster-logging-operator/internal/collector/vector"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
+	"strconv"
 )
 
 func Global(namespace, forwarderName string) []framework.Element {
@@ -39,6 +41,7 @@ data_dir = "{{.DataDir}}"
 
 [api]
 enabled = true
+address = "0.0.0.0:` + strconv.Itoa(int(collector.HealthPort)) + `"
 {{end}}
 `
 }

--- a/internal/generator/vector/conf/global_test.go
+++ b/internal/generator/vector/conf/global_test.go
@@ -18,6 +18,7 @@ data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
 
 [api]
 enabled = true
+address = "0.0.0.0:24686"
 
 # Load sensitive data from files
 [secret.kubernetes_secret]
@@ -34,6 +35,7 @@ expire_metrics_secs = 60
 
 [api]
 enabled = true
+address = "0.0.0.0:24686"
 
 # Load sensitive data from files
 [secret.kubernetes_secret]

--- a/test/functional/misc/vector_api_cli_test.go
+++ b/test/functional/misc/vector_api_cli_test.go
@@ -25,7 +25,7 @@ var _ = Describe("[Functional][Misc][API_CLI] Functional test", func() {
 	Context("invoking vector CLI commands that talk to the vector API", func() {
 		It("should work", func() {
 			Expect(framework.Deploy()).To(BeNil())
-			out, _ := framework.RunCommand(constants.CollectorName, `curl`, `-sv`, `-m`, `5`, `--connect-timeout`, `3`, `http://127.0.0.1:8686/health`)
+			out, _ := framework.RunCommand(constants.CollectorName, `curl`, `-sv`, `-m`, `5`, `--connect-timeout`, `3`, `http://127.0.0.1:24686/health`)
 			Expect(out).To(ContainSubstring(`{"ok":true}`))
 		})
 	})


### PR DESCRIPTION
### Description
This PR adds a liveness probe to the Vector collector containers to improve pod health management.
The liveness probe periodically checks the Vector internal HTTP health endpoint (/health on port `24686`). If the probe fails repeatedly,   container will automatically restart.

Requires changes in Vector config to enable the `/health` endpoint:
```
[api]
enabled = true
address = "0.0.0.0:24686"
```

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @cahartma <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-7058
- Enhancement proposal:
