### PR TITLE
LOG-7892: support format parameter for http sink

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -664,6 +664,21 @@ type HTTPTuningSpec struct {
 	Compression string `json:"compression,omitempty"`
 }
 
+// HTTPFormat is used to define the data format of data to be sent.
+//
+// +kubebuilder:validation:Enum:=json;ndjson
+type HTTPFormat string
+
+func (s HTTPFormat) String() string {
+	return string(s)
+}
+
+// HTTPFormat type constants, must match JSON tags of HTTPFormat fields.
+const (
+	HTTPFormatJSON   HTTPFormat = "json"
+	HTTPFormatNDJSON HTTPFormat = "ndjson"
+)
+
 // HTTP provided configuration for sending json encoded logs to a generic HTTP endpoint.
 type HTTP struct {
 	URLSpec `json:",inline"`
@@ -705,6 +720,12 @@ type HTTP struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == '' ||  isURL(self)", message="invalid URL"
 	ProxyURL string `json:"proxyURL,omitempty"`
+
+	// Format defines data format used to send data to remote destination.
+	//
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Format"
+	Format HTTPFormat `json:"format,omitempty"`
 }
 
 type KafkaTuningSpec struct {

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -2515,6 +2515,13 @@ spec:
                               - secretName
                               type: object
                           type: object
+                        format:
+                          description: Format defines data format used to send data
+                            to remote destination.
+                          enum:
+                          - json
+                          - ndjson
+                          type: string
                         headers:
                           additionalProperties:
                             type: string

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -1279,6 +1279,8 @@ NOTE1: `In` CANNOT contain `.log_type`, `.log_source` or `.message` as those fie
 
 NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` CANNOT be added to this list as it is a required field.
 
+NOTE3: If used in a pipeline with a Lokistack output type, see Lokistack output documentation for additional fields that cannot be pruned.
+
 |notIn|array|  `NotIn` is an array of dot-delimited field paths. All fields besides the ones listed here are removed from the log record.
 
 Each field path expression must start with a &#34;.&#34;
@@ -1302,6 +1304,8 @@ Examples:
 NOTE1: `NotIn` MUST contain `.log_type`, `.log_source` and `.message` as those fields are required and cannot be pruned.
 
 NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` MUST be added to this list as it is a required field.
+
+NOTE3: If used in a pipeline with a Lokistack output type, see Lokistack output documentation for additional fields that cannot be pruned.
 
 |======================
 
@@ -1859,6 +1863,13 @@ Type:: array
 
 |lokiStack|object|  LokiStack configures forwarding log events to a Red Hat managed Loki deployment
 using the Red Hat tenancy model
+
+The listed labelKeys cannot be pruned as they are required as default stream labels for LokiStack.
+1. .kubernetes.container_name
+2. .kubernetes.namespace_name
+3. .kubernetes.pod_name
+
+If these fields are not present in the log record, they will be set to the empty string.
 
 |name|string|  Name used to refer to the output from a `pipeline`.
 
@@ -2518,6 +2529,8 @@ The &#39;username@password&#39; part of `url` is ignored.
 
 |authentication|object|  Authentication sets credentials for authenticating the requests.
 
+|format|string|  Format defines data format used to send data to remote destination.
+
 |headers|object|  Headers specify optional headers to be sent with the request
 
 |method|string|  Method specifies the HTTP method to be used for sending logs. If not set, &#39;POST&#39; is used.
@@ -2840,8 +2853,6 @@ Type:: object
 Basic TLS is enabled if the URL scheme requires it (for example &#39;https&#39; or &#39;tls&#39;).
 The &#39;username@password&#39; part of `url` is ignored.
 
-|proxyURL|string|  ProxyURL URL of a HTTP or HTTPS proxy to be used instead of direct connection.
-
 |authentication|object|  Authentication sets credentials for authenticating the requests.
 
 |labelKeys|array|  LabelKeys can be used to customize which log record keys are mapped to Loki stream labels.
@@ -2876,6 +2887,8 @@ For example the default log record keys translate to these Loki labels:
 Note: the set of labels should be small, Loki imposes limits on the size and number of labels allowed.
 See https://grafana.com/docs/loki/latest/configuration/#limits_config for more.
 Loki queries can also query based on any log record field (not just labels) using query filters.
+
+|proxyURL|string|  ProxyURL URL of a HTTP or HTTPS proxy to be used instead of direct connection.
 
 |tenantKey|string|  TenantKey is the tenant for the logs. This supports vector&#39;s template syntax to allow dynamic per-event values.
 

--- a/internal/generator/vector/output/http/http.go
+++ b/internal/generator/vector/output/http/http.go
@@ -19,6 +19,7 @@ type Http struct {
 	URI         string
 	Method      string
 	Proxy       string
+	Format      obs.HTTPFormat
 	common.RootMixin
 }
 
@@ -33,6 +34,11 @@ type = "http"
 inputs = {{.Inputs}}
 uri = "{{.URI}}"
 method = "{{.Method}}"
+{{if eq .Format "` + string(obs.HTTPFormatJSON) + `"}}
+framing.method = "bytes"
+{{else if eq .Format "` + string(obs.HTTPFormatNDJSON) + `"}}
+framing.method = "newline_delimited"
+{{end}}
 {{with .Proxy -}}
 proxy.enabled = true
 proxy.http = "{{.}}"
@@ -81,6 +87,7 @@ func Output(id string, o obs.OutputSpec, inputs []string, secrets observability.
 		URI:         o.HTTP.URL,
 		Method:      Method(o.HTTP),
 		Proxy:       o.HTTP.ProxyURL,
+		Format:      o.HTTP.Format,
 		RootMixin:   common.NewRootMixin(nil),
 	}
 }

--- a/internal/generator/vector/output/http/http_test.go
+++ b/internal/generator/vector/output/http/http_test.go
@@ -143,6 +143,9 @@ var _ = Describe("Generate vector config", func() {
 					BaseOutputTuningSpec: *baseTune,
 				}
 			}, secrets, true, framework.NoOptions, "http_with_tuning.toml"),
+			Entry("with ndjson", func(spec *obs.OutputSpec) {
+				spec.HTTP.Format = obs.HTTPFormatNDJSON
+			}, secrets, true, framework.NoOptions, "http_with_ndjson.toml"),
 			Entry("with proxy", func(spec *obs.OutputSpec) {
 				spec.HTTP.ProxyURL = "http://somewhere.org/proxy"
 				spec.HTTP.Headers = nil

--- a/internal/generator/vector/output/http/http_with_ndjson.toml
+++ b/internal/generator/vector/output/http/http_with_ndjson.toml
@@ -1,0 +1,20 @@
+[sinks.http_receiver]
+type = "http"
+inputs = ["application"]
+uri = "https://my-logstore.com"
+method = "post"
+framing.method = "newline_delimited"
+
+[sinks.http_receiver.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.http_receiver.request]
+headers = {"h1"="v1","h2"="v2"}
+
+[sinks.http_receiver.auth]
+strategy = "basic"
+user = "SECRET[kubernetes_secret.http-receiver/username]"
+password = "SECRET[kubernetes_secret.http-receiver/password]"
+
+

--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -437,8 +437,14 @@ func (f *CollectorFunctionalFramework) addOutputContainers(b *runtime.PodBuilder
 				}
 			}
 		case obs.OutputTypeHTTP:
-			if err := f.AddVectorHttpOutput(b, output); err != nil {
-				return err
+			if output.HTTP.Format == obs.HTTPFormatNDJSON {
+				if err := f.AddVLOutput(b, output, nil); err != nil {
+					return err
+				}
+			} else {
+				if err := f.AddVectorHttpOutput(b, output); err != nil {
+					return err
+				}
 			}
 		case obs.OutputTypeSplunk:
 			if err := f.AddSplunkOutput(b, output); err != nil {

--- a/test/framework/functional/output_victorialogs.go
+++ b/test/framework/functional/output_victorialogs.go
@@ -19,16 +19,27 @@ func (f *CollectorFunctionalFramework) AddVLOutput(b *runtime.PodBuilder, output
 	log.V(2).Info("Adding output for victorialogs", "name", output.Name)
 	name := strings.ToLower(output.Name)
 
-	esURL, err := url.Parse(output.Elasticsearch.URL)
-	if err != nil {
-		return err
+	port := "9428"
+	switch output.Type {
+	case obs.OutputTypeElasticsearch:
+		u, err := url.Parse(output.Elasticsearch.URL)
+		if err != nil {
+			return err
+		}
+		port = u.Port()
+	case obs.OutputTypeHTTP:
+		u, err := url.Parse(output.HTTP.URL)
+		if err != nil {
+			return err
+		}
+		port = u.Port()
 	}
 
 	log.V(2).Info("Adding container", "name", name)
-	log.V(2).Info("Adding VictoriaLogs output container", "name", obs.OutputTypeElasticsearch)
+	log.V(2).Info("Adding VictoriaLogs output container", "name", output.Type)
 
 	cmdArgs := []string{
-		"-httpListenAddr=:" + esURL.Port(),
+		"-httpListenAddr=:" + port,
 		"-storageDataPath=/tmp/logs",
 	}
 	if len(args) > 0 {

--- a/test/functional/outputs/http/forward_to_victorialogs_test.go
+++ b/test/functional/outputs/http/forward_to_victorialogs_test.go
@@ -1,0 +1,79 @@
+package http
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
+	obstestruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
+)
+
+var _ = Describe("[Functional][Outputs][HTTP] Logforwarding to VictoriaLogs", func() {
+
+	var (
+		framework *functional.CollectorFunctionalFramework
+
+		// Template expected as output Log
+		outputLogTemplate = functional.NewApplicationLogTemplate()
+	)
+
+	Context("should write to victorialogs", func() {
+		DescribeTable("with custom headers", func(headers map[string]string) {
+			outputLogTemplate.ViaqIndexName = "app-write"
+			framework = functional.NewCollectorFunctionalFramework()
+			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+				FromInput(obs.InputTypeApplication).
+				ToHttpOutput(func(output *obs.OutputSpec) {
+					output.HTTP.URL = "http://0.0.0.0:9428/insert/jsonline"
+					output.HTTP.Format = obs.HTTPFormatNDJSON
+					output.HTTP.Headers = headers
+				})
+			defer framework.Cleanup()
+			Expect(framework.Deploy()).To(BeNil())
+			timestamp := functional.CRIOTime(time.Now())
+			ukr := "привіт "
+			jp := "こんにちは "
+			ch := "你好"
+			msg := functional.NewCRIOLogMessage(timestamp, ukr+jp+ch, false)
+			Expect(framework.WriteMessagesToApplicationLog(msg, 10)).To(BeNil())
+			Expect(framework.WriteMessagesWithNotUTF8SymbolsToLog()).To(BeNil())
+			requestHeaders := map[string]string{
+				"AccountID": "0",
+				"ProjectID": "0",
+			}
+			for headerName := range requestHeaders {
+				if v, ok := headers[headerName]; ok {
+					requestHeaders[headerName] = v
+				}
+			}
+			raw, err := framework.GetLogsFromVL(string(obs.OutputTypeHTTP), requestHeaders)
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			Expect(raw).To(Not(BeEmpty()))
+			// Parse log line
+			var logs []map[string]string
+			err = types.StrictlyParseLogsFromSlice(raw, &logs)
+			Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+			Expect(len(logs)).To(Equal(11))
+			//sort log by time before matching
+			sort.Slice(logs, func(i, j int) bool {
+				return strings.Compare(logs[i]["_time"], logs[j]["_time"]) < 0
+			})
+
+			Expect(logs[0]["_msg"]).To(Equal(ukr + jp + ch))
+			Expect(logs[10]["_msg"]).To(Equal("������������"))
+		},
+			Entry("Non-default tenant ID", map[string]string{
+				"AccountID":    "10",
+				"ProjectID":    "10",
+				"VL-Msg-Field": "message",
+			}),
+		)
+	})
+})


### PR DESCRIPTION
### Description
NDJSON (newline-delimited JSON) allows to send log events in a streaming fashion which results in a smaller memory footprint on a receiver side. Added `format` argument for HTTP sink, that accepts `json` and `ndjson` values to support NDJSON data ingestion

/cc @Clee2691 @cahartma @jcantrill
/assign @jcantrill