### PR TITLE
LOG-7358: 'Ready' condition is not present in status on a valid CLF

### DIFF
--- a/internal/controller/observability/clusterlogforwarder_controller.go
+++ b/internal/controller/observability/clusterlogforwarder_controller.go
@@ -221,10 +221,10 @@ func validateForwarder(forwarderContext internalcontext.ForwarderContext) (valid
 }
 
 func updateStatus(k8Client client.Client, instance *obsv1.ClusterLogForwarder, ready metav1.Condition) {
+	internalobs.SetCondition(&instance.Status.Conditions, ready)
 	jsonPatch, _ := json.Marshal(map[string]interface{}{
 		"status": instance.Status,
 	})
-	internalobs.SetCondition(&instance.Status.Conditions, ready)
 	if err := k8Client.Status().Patch(context.TODO(), instance, client.RawPatch(types.MergePatchType, jsonPatch)); err != nil {
 		log.Error(err, "Error updating status", "status", instance.Status)
 	}


### PR DESCRIPTION
### Description
This PR fixes an issue where the `Ready` condition in the CLF status was not being correctly reported.

To ensure the status is accurate, the CLF instance is now updated with the `Ready` condition before the `jsonPatch` for the status update is created. This guarantees that the patch includes the correct readiness state.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-7358
