### PR TITLE
[release-6.3]LOG-7386: add validation  that the kafka URLs should be tcp or tls

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -692,7 +692,7 @@ type Kafka struct {
 	//
 	// The 'username@password' part of `url` is ignored.
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:XValidation:rule="self == '' ||  isURL(self)", message="invalid URL"
+	// +kubebuilder:validation:XValidation:rule="self == '' || (isURL(self) && (self.startsWith('tcp://') || self.startsWith('tls://')))",message="must be a valid URL with a tcp or tls scheme"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Destination URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	URL string `json:"url,omitempty"`
 
@@ -740,11 +740,11 @@ type Kafka struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Kafka Brokers"
-	Brokers []URL `json:"brokers,omitempty"`
+	Brokers []BrokerURL `json:"brokers,omitempty"`
 }
 
-// +kubebuilder:validation:XValidation:rule="isURL(self)", message="invalid URL"
-type URL string
+// +kubebuilder:validation:XValidation:rule="self == ” || (isURL(self) && (self.startsWith('tcp://') || self.startsWith('tls://')))",message="each broker must be a valid URL with a tcp or tls scheme"
+type BrokerURL string
 
 type LokiTuningSpec struct {
 	BaseOutputTuningSpec `json:",inline"`

--- a/api/observability/v1/zz_generated.deepcopy.go
+++ b/api/observability/v1/zz_generated.deepcopy.go
@@ -887,7 +887,7 @@ func (in *Kafka) DeepCopyInto(out *Kafka) {
 	}
 	if in.Brokers != nil {
 		in, out := &in.Brokers, &out.Brokers
-		*out = make([]URL, len(*in))
+		*out = make([]BrokerURL, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -2531,8 +2531,10 @@ spec:
                           items:
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid URL
-                              rule: isURL(self)
+                            - message: each broker must be a valid URL with a tcp
+                                or tls scheme
+                              rule: self == '' || (isURL(self) && (self.startsWith('tcp://')
+                                || self.startsWith('tls://')))
                           type: array
                         topic:
                           description: |-
@@ -2592,8 +2594,9 @@ spec:
                             The 'username@password' part of `url` is ignored.
                           type: string
                           x-kubernetes-validations:
-                          - message: invalid URL
-                            rule: self == '' ||  isURL(self)
+                          - message: must be a valid URL with a tcp or tls scheme
+                            rule: self == '' || (isURL(self) && (self.startsWith('tcp://')
+                              || self.startsWith('tls://')))
                       type: object
                       x-kubernetes-validations:
                       - message: URL or brokers required

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -2531,8 +2531,10 @@ spec:
                           items:
                             type: string
                             x-kubernetes-validations:
-                            - message: invalid URL
-                              rule: isURL(self)
+                            - message: each broker must be a valid URL with a tcp
+                                or tls scheme
+                              rule: self == '' || (isURL(self) && (self.startsWith('tcp://')
+                                || self.startsWith('tls://')))
                           type: array
                         topic:
                           description: |-
@@ -2592,8 +2594,9 @@ spec:
                             The 'username@password' part of `url` is ignored.
                           type: string
                           x-kubernetes-validations:
-                          - message: invalid URL
-                            rule: self == '' ||  isURL(self)
+                          - message: must be a valid URL with a tcp or tls scheme
+                            rule: self == '' || (isURL(self) && (self.startsWith('tcp://')
+                              || self.startsWith('tls://')))
                       type: object
                       x-kubernetes-validations:
                       - message: URL or brokers required

--- a/internal/generator/vector/output/kafka/kafka_test.go
+++ b/internal/generator/vector/output/kafka/kafka_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Generate vector config", func() {
 		Entry("with NOT tls brokers", "kafka_not_tls_brokers.toml", framework.NoOptions, false, func(spec *obs.OutputSpec) {
 			spec.Kafka.URL = ""
 			spec.Kafka.Topic = ""
-			spec.Kafka.Brokers = []obs.URL{`tcp://broker1:9092`, `tcp://broker2:9092`, `tcp://broker3:9092`}
+			spec.Kafka.Brokers = []obs.BrokerURL{`tcp://broker1:9092`, `tcp://broker2:9092`, `tcp://broker3:9092`}
 		}),
 		Entry("with tuning", "kafka_tuning.toml", framework.NoOptions, true, func(spec *obs.OutputSpec) {
 			spec.Kafka.URL = "tcp://broker1-kafka.svc.messaging.cluster.local:9092/topic"

--- a/test/e2e/collection/apivalidations/api_validations_test.go
+++ b/test/e2e/collection/apivalidations/api_validations_test.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"os/exec"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
 	"github.com/openshift/cluster-logging-operator/test/helpers/cmd"
+	"os/exec"
 )
 
 var _ = Describe("", func() {
@@ -69,10 +68,13 @@ var _ = Describe("", func() {
 			Expect(err.Error()).To(MatchRegexp(".*URL.*brokers.*required.*"))
 		}),
 		Entry("should fail for kafka with invalid URL", "kafka_invalid_url.yaml", func(out string, err error) {
-			Expect(err.Error()).To(MatchRegexp("invalid URL"))
+			Expect(err.Error()).To(MatchRegexp("must be a valid URL with a tcp or tls scheme"))
 		}),
 		Entry("should fail for kafka invalid broker URL", "kafka_invalid_broker_url.yaml", func(out string, err error) {
-			Expect(err.Error()).To(MatchRegexp("invalid URL"))
+			Expect(err).To(HaveOccurred())
+			//occurrenceCount := strings.Count(err.Error(), "each broker must be a valid URL with a tcp or tls scheme")
+			//Expect(occurrenceCount).To(Equal(2), "expect validation error appear twice")
+			Expect(err.Error()).To(ContainSubstring("each broker must be a valid URL with a tcp or tls scheme"))
 		}),
 		Entry("LOG-5788: for multilineException filter should not fail", "log5788_mulitiline_ex_filter.yaml", func(out string, err error) {
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/collection/apivalidations/kafka_valid_url_and_brokers.yaml
+++ b/test/e2e/collection/apivalidations/kafka_valid_url_and_brokers.yaml
@@ -7,10 +7,10 @@ spec:
     - name: kafka
       kafka:
         topic: clo-app-topic
-        url: http://foo
+        url: tcp://foo
         brokers:
-        - http://foo
-        - http://bar
+        - tls://foo
+        - tcp://bar
       type: kafka
   pipelines:
   - inputRefs:


### PR DESCRIPTION
### Description
Backport: https://github.com/openshift/cluster-logging-operator/pull/3071
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-7386
- Enhancement proposal:
