### PR TITLE
LOG-7294: Refactoring collector OTLP output to use Vector 'opentelemetry' sink

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -1314,7 +1314,7 @@ type OTLPTuningSpec struct {
 	// Compression causes data to be compressed before sending over the network.
 	// It is an error if the compression type is not supported by the output.
 	//
-	// +kubebuilder:validation:Enum:=gzip;none
+	// +kubebuilder:validation:Enum:=gzip;snappy;zlib;zstd;none
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Compression",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Compression string `json:"compression,omitempty"`
 }

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -3103,6 +3103,9 @@ spec:
                                 It is an error if the compression type is not supported by the output.
                               enum:
                               - gzip
+                              - snappy
+                              - zlib
+                              - zstd
                               - none
                               type: string
                             deliveryMode:

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -3103,6 +3103,9 @@ spec:
                                 It is an error if the compression type is not supported by the output.
                               enum:
                               - gzip
+                              - snappy
+                              - zlib
+                              - zstd
                               - none
                               type: string
                             deliveryMode:

--- a/internal/generator/vector/output/lokistack/lokistack_otel.toml
+++ b/internal/generator/vector/output/lokistack/lokistack_otel.toml
@@ -120,21 +120,20 @@ source = '''
 '''
 
 [sinks.output_default_lokistack_application]
-type = "http"
+type = "opentelemetry"
 inputs = ["output_default_lokistack_application_resource_logs"]
-uri = "https://logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/application/otlp/v1/logs"
-method = "post"
-payload_prefix = "{\"resourceLogs\":"
-payload_suffix = "}"
+protocol.uri = "https://logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/application/otlp/v1/logs"
+protocol.type = "http"
+protocol.method = "post"
+protocol.encoding.codec = "json"
+protocol.encoding.except_fields = ["_internal"]
+protocol.payload_prefix = "{\"resourceLogs\":"
+protocol.payload_suffix = "}"
 
-[sinks.output_default_lokistack_application.encoding]
-codec = "json"
-except_fields = ["_internal"]
-
-[sinks.output_default_lokistack_application.tls]
+[sinks.output_default_lokistack_application.protocol.tls]
 ca_file = "/var/run/ocp-collector/config/openshift-service-ca.crt/ca-bundle.crt"
 
-[sinks.output_default_lokistack_application.auth]
+[sinks.output_default_lokistack_application.protocol.auth]
 strategy = "bearer"
 token = "SECRET[kubernetes_secret.test-sa-token/token]"
 
@@ -469,21 +468,20 @@ source = '''
 '''
 
 [sinks.output_default_lokistack_audit]
-type = "http"
+type = "opentelemetry"
 inputs = ["output_default_lokistack_audit_resource_logs"]
-uri = "https://logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/audit/otlp/v1/logs"
-method = "post"
-payload_prefix = "{\"resourceLogs\":"
-payload_suffix = "}"
+protocol.uri = "https://logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/audit/otlp/v1/logs"
+protocol.type = "http"
+protocol.method = "post"
+protocol.encoding.codec = "json"
+protocol.encoding.except_fields = ["_internal"]
+protocol.payload_prefix = "{\"resourceLogs\":"
+protocol.payload_suffix = "}"
 
-[sinks.output_default_lokistack_audit.encoding]
-codec = "json"
-except_fields = ["_internal"]
-
-[sinks.output_default_lokistack_audit.tls]
+[sinks.output_default_lokistack_audit.protocol.tls]
 ca_file = "/var/run/ocp-collector/config/openshift-service-ca.crt/ca-bundle.crt"
 
-[sinks.output_default_lokistack_audit.auth]
+[sinks.output_default_lokistack_audit.protocol.auth]
 strategy = "bearer"
 token = "SECRET[kubernetes_secret.test-sa-token/token]"
 
@@ -684,21 +682,19 @@ source = '''
 '''
 
 [sinks.output_default_lokistack_infrastructure]
-type = "http"
+type = "opentelemetry"
 inputs = ["output_default_lokistack_infrastructure_resource_logs"]
-uri = "https://logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/infrastructure/otlp/v1/logs"
-method = "post"
-payload_prefix = "{\"resourceLogs\":"
-payload_suffix = "}"
+protocol.uri = "https://logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/infrastructure/otlp/v1/logs"
+protocol.type = "http"
+protocol.method = "post"
+protocol.encoding.codec = "json"
+protocol.encoding.except_fields = ["_internal"]
+protocol.payload_prefix = "{\"resourceLogs\":"
+protocol.payload_suffix = "}"
 
-[sinks.output_default_lokistack_infrastructure.encoding]
-codec = "json"
-except_fields = ["_internal"]
-
-[sinks.output_default_lokistack_infrastructure.tls]
+[sinks.output_default_lokistack_infrastructure.protocol.tls]
 ca_file = "/var/run/ocp-collector/config/openshift-service-ca.crt/ca-bundle.crt"
 
-[sinks.output_default_lokistack_infrastructure.auth]
+[sinks.output_default_lokistack_infrastructure.protocol.auth]
 strategy = "bearer"
 token = "SECRET[kubernetes_secret.test-sa-token/token]"
-

--- a/internal/generator/vector/output/otlp/otlp_all.toml
+++ b/internal/generator/vector/output/otlp/otlp_all.toml
@@ -285,7 +285,7 @@ r.attributes = append(r.attributes,
   ]
 )
 if exists(.responseStatus.code) {
-  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})
 }
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
@@ -368,7 +368,7 @@ r.attributes = append(r.attributes,
   ]
 )
 if exists(.responseStatus.code) {
-  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})
 }
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
@@ -495,13 +495,12 @@ source = '''
 '''
 
 [sinks.output_otel_collector]
-type = "http"
+type = "opentelemetry"
 inputs = ["output_otel_collector_resource_logs"]
-uri = "http://localhost:4318/v1/logs"
-method = "post"
-payload_prefix = "{\"resourceLogs\":"
-payload_suffix = "}"
-
-[sinks.output_otel_collector.encoding]
-codec = "json"
-except_fields = ["_internal"]
+protocol.uri = "http://localhost:4318/v1/logs"
+protocol.type = "http"
+protocol.method = "post"
+protocol.encoding.codec = "json"
+protocol.encoding.except_fields = ["_internal"]
+protocol.payload_prefix = "{\"resourceLogs\":"
+protocol.payload_suffix = "}"

--- a/internal/generator/vector/output/otlp/otlp_test.go
+++ b/internal/generator/vector/output/otlp/otlp_test.go
@@ -2,21 +2,19 @@ package otlp
 
 import (
 	"fmt"
-	"time"
-
-	"github.com/openshift/cluster-logging-operator/internal/constants"
-	corev1 "k8s.io/api/core/v1"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/api/observability"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/test/helpers/outputs/adapter/fake"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"time"
 )
 
 var _ = Describe("Generate vector config", func() {

--- a/internal/generator/vector/output/otlp/otlp_tuning.toml
+++ b/internal/generator/vector/output/otlp/otlp_tuning.toml
@@ -285,7 +285,7 @@ r.attributes = append(r.attributes,
   ]
 )
 if exists(.responseStatus.code) {
-  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})
 }
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
@@ -368,7 +368,7 @@ r.attributes = append(r.attributes,
   ]
 )
 if exists(.responseStatus.code) {
-  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})
 }
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
@@ -495,19 +495,18 @@ source = '''
 '''
 
 [sinks.output_otel_collector]
-type = "http"
+type = "opentelemetry"
 inputs = ["output_otel_collector_resource_logs"]
-uri = "http://localhost:4318/v1/logs"
-method = "post"
-payload_prefix = "{\"resourceLogs\":"
-payload_suffix = "}"
-compression = "gzip"
+protocol.uri = "http://localhost:4318/v1/logs"
+protocol.type = "http"
+protocol.method = "post"
+protocol.encoding.codec = "json"
+protocol.encoding.except_fields = ["_internal"]
+protocol.payload_prefix = "{\"resourceLogs\":"
+protocol.payload_suffix = "}"
+protocol.compression = "gzip"
 
-[sinks.output_otel_collector.encoding]
-codec = "json"
-except_fields = ["_internal"]
-
-[sinks.output_otel_collector.batch]
+[sinks.output_otel_collector.protocol.batch]
 max_bytes = 10000000
 
 [sinks.output_otel_collector.buffer]
@@ -515,6 +514,6 @@ type = "disk"
 when_full = "block"
 max_size = 268435488
 
-[sinks.output_otel_collector.request]
+[sinks.output_otel_collector.protocol.request]
 retry_initial_backoff_secs = 20
 retry_max_duration_secs = 35

--- a/internal/generator/vector/output/otlp/otlp_with_auth_basic.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_basic.toml
@@ -285,7 +285,7 @@ r.attributes = append(r.attributes,
   ]
 )
 if exists(.responseStatus.code) {
-  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})
 }
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
@@ -368,7 +368,7 @@ r.attributes = append(r.attributes,
   ]
 )
 if exists(.responseStatus.code) {
-  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})
 }
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
@@ -495,18 +495,17 @@ source = '''
 '''
 
 [sinks.output_otel_collector]
-type = "http"
+type = "opentelemetry"
 inputs = ["output_otel_collector_resource_logs"]
-uri = "http://localhost:4318/v1/logs"
-method = "post"
-payload_prefix = "{\"resourceLogs\":"
-payload_suffix = "}"
+protocol.uri = "http://localhost:4318/v1/logs"
+protocol.type = "http"
+protocol.method = "post"
+protocol.encoding.codec = "json"
+protocol.encoding.except_fields = ["_internal"]
+protocol.payload_prefix = "{\"resourceLogs\":"
+protocol.payload_suffix = "}"
 
-[sinks.output_otel_collector.encoding]
-codec = "json"
-except_fields = ["_internal"]
-
-[sinks.output_otel_collector.auth]
+[sinks.output_otel_collector.protocol.auth]
 strategy = "basic"
 user = "SECRET[kubernetes_secret.otlp-receiver/username]"
 password = "SECRET[kubernetes_secret.otlp-receiver/password]"

--- a/internal/generator/vector/output/otlp/otlp_with_auth_sa_token.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_sa_token.toml
@@ -285,7 +285,7 @@ r.attributes = append(r.attributes,
   ]
 )
 if exists(.responseStatus.code) {
-  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})
 }
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
@@ -368,7 +368,7 @@ r.attributes = append(r.attributes,
   ]
 )
 if exists(.responseStatus.code) {
-  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})
 }
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
@@ -495,17 +495,16 @@ source = '''
 '''
 
 [sinks.output_otel_collector]
-type = "http"
+type = "opentelemetry"
 inputs = ["output_otel_collector_resource_logs"]
-uri = "http://localhost:4318/v1/logs"
-method = "post"
-payload_prefix = "{\"resourceLogs\":"
-payload_suffix = "}"
+protocol.uri = "http://localhost:4318/v1/logs"
+protocol.type = "http"
+protocol.method = "post"
+protocol.encoding.codec = "json"
+protocol.encoding.except_fields = ["_internal"]
+protocol.payload_prefix = "{\"resourceLogs\":"
+protocol.payload_suffix = "}"
 
-[sinks.output_otel_collector.encoding]
-codec = "json"
-except_fields = ["_internal"]
-
-[sinks.output_otel_collector.auth]
+[sinks.output_otel_collector.protocol.auth]
 strategy = "bearer"
 token = "SECRET[kubernetes_secret.my-service-account-token/token]"

--- a/internal/generator/vector/output/otlp/otlp_with_auth_token.toml
+++ b/internal/generator/vector/output/otlp/otlp_with_auth_token.toml
@@ -285,7 +285,7 @@ r.attributes = append(r.attributes,
   ]
 )
 if exists(.responseStatus.code) {
-  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})
 }
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
@@ -368,7 +368,7 @@ r.attributes = append(r.attributes,
   ]
 )
 if exists(.responseStatus.code) {
-  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})  
+  r.attributes = push(r.attributes,{"key": "k8s.audit.event.response.code", "value": {"intValue": to_string!(.responseStatus.code)}})
 }
 values = []
 for_each(array!(.user.groups)) -> |_index,group| {
@@ -495,17 +495,16 @@ source = '''
 '''
 
 [sinks.output_otel_collector]
-type = "http"
+type = "opentelemetry"
 inputs = ["output_otel_collector_resource_logs"]
-uri = "http://localhost:4318/v1/logs"
-method = "post"
-payload_prefix = "{\"resourceLogs\":"
-payload_suffix = "}"
+protocol.uri = "http://localhost:4318/v1/logs"
+protocol.type = "http"
+protocol.method = "post"
+protocol.encoding.codec = "json"
+protocol.encoding.except_fields = ["_internal"]
+protocol.payload_prefix = "{\"resourceLogs\":"
+protocol.payload_suffix = "}"
 
-[sinks.output_otel_collector.encoding]
-codec = "json"
-except_fields = ["_internal"]
-
-[sinks.output_otel_collector.auth]
+[sinks.output_otel_collector.protocol.auth]
 strategy = "bearer"
 token = "SECRET[kubernetes_secret.otlp-receiver/token]"

--- a/test/functional/outputs/otlp/container_test.go
+++ b/test/functional/outputs/otlp/container_test.go
@@ -125,6 +125,7 @@ var _ = Describe("[Functional][Outputs][OTLP] Functional tests", func() {
 		},
 			Entry("should pass with gzip", "gzip"),
 			Entry("should pass with zlib", "zlib"),
+			Entry("should pass with zstd", "zstd"),
 			Entry("should pass with no compression", "none"))
 	})
 })


### PR DESCRIPTION
### Description
This PR addressed to switch to use native 'opentelemetry' sink form Vector instead of pure HTTP sink.  

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-7294
- Enhancement proposal:
