### PR TITLE
No JIRA: update prune filter description to match logic

### DIFF
--- a/api/observability/v1/filter_types.go
+++ b/api/observability/v1/filter_types.go
@@ -142,15 +142,15 @@ type PruneFilterSpec struct {
 	//
 	// Examples:
 	//
-	//  - `.kubernetes.namespace_name`
+	//  - `.kubernetes.namespace_id`
 	//
-	//  - `.log_type`
+	//  - `.hostname`
 	//
 	//  - '.kubernetes.labels.foobar'
 	//
 	//  - `.kubernetes.labels."foo-bar/baz"`
 	//
-	// NOTE1: `In` CANNOT contain `.log_type` or `.message` as those fields are required and cannot be pruned.
+	// NOTE1: `In` CANNOT contain `.log_type`, `.log_source` or `.message` as those fields are required and cannot be pruned.
 	//
 	// NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` CANNOT be added to this list as it is a required field.
 	//
@@ -172,11 +172,13 @@ type PruneFilterSpec struct {
 	//
 	//  - `.log_type`
 	//
-	//  - '.kubernetes.labels.foobar'
+	//  - '.log_source'
+	//
+	//  - '.message'
 	//
 	//  - `.kubernetes.labels."foo-bar/baz"`
 	//
-	// NOTE1: `NotIn` MUST contain `.log_type` and `.message` as those fields are required and cannot be pruned.
+	// NOTE1: `NotIn` MUST contain `.log_type`, `.log_source` and `.message` as those fields are required and cannot be pruned.
 	//
 	// NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` MUST be added to this list as it is a required field.
 	//

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1320,15 +1320,15 @@ spec:
 
                             Examples:
 
-                             - `.kubernetes.namespace_name`
+                             - `.kubernetes.namespace_id`
 
-                             - `.log_type`
+                             - `.hostname`
 
                              - '.kubernetes.labels.foobar'
 
                              - `.kubernetes.labels."foo-bar/baz"`
 
-                            NOTE1: `In` CANNOT contain `.log_type` or `.message` as those fields are required and cannot be pruned.
+                            NOTE1: `In` CANNOT contain `.log_type`, `.log_source` or `.message` as those fields are required and cannot be pruned.
 
                             NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` CANNOT be added to this list as it is a required field.
                           items:
@@ -1357,11 +1357,13 @@ spec:
 
                              - `.log_type`
 
-                             - '.kubernetes.labels.foobar'
+                             - '.log_source'
+
+                             - '.message'
 
                              - `.kubernetes.labels."foo-bar/baz"`
 
-                            NOTE1: `NotIn` MUST contain `.log_type` and `.message` as those fields are required and cannot be pruned.
+                            NOTE1: `NotIn` MUST contain `.log_type`, `.log_source` and `.message` as those fields are required and cannot be pruned.
 
                             NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` MUST be added to this list as it is a required field.
                           items:

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1320,15 +1320,15 @@ spec:
 
                             Examples:
 
-                             - `.kubernetes.namespace_name`
+                             - `.kubernetes.namespace_id`
 
-                             - `.log_type`
+                             - `.hostname`
 
                              - '.kubernetes.labels.foobar'
 
                              - `.kubernetes.labels."foo-bar/baz"`
 
-                            NOTE1: `In` CANNOT contain `.log_type` or `.message` as those fields are required and cannot be pruned.
+                            NOTE1: `In` CANNOT contain `.log_type`, `.log_source` or `.message` as those fields are required and cannot be pruned.
 
                             NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` CANNOT be added to this list as it is a required field.
                           items:
@@ -1357,11 +1357,13 @@ spec:
 
                              - `.log_type`
 
-                             - '.kubernetes.labels.foobar'
+                             - '.log_source'
+
+                             - '.message'
 
                              - `.kubernetes.labels."foo-bar/baz"`
 
-                            NOTE1: `NotIn` MUST contain `.log_type` and `.message` as those fields are required and cannot be pruned.
+                            NOTE1: `NotIn` MUST contain `.log_type`, `.log_source` and `.message` as those fields are required and cannot be pruned.
 
                             NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` MUST be added to this list as it is a required field.
                           items:

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -138,15 +138,15 @@ spec:
 
           Examples:
 
-           - `.kubernetes.namespace_name`
+           - `.kubernetes.namespace_id`
 
-           - `.log_type`
+           - `.hostname`
 
            - '.kubernetes.labels.foobar'
 
            - `.kubernetes.labels."foo-bar/baz"`
 
-          NOTE1: `In` CANNOT contain `.log_type` or `.message` as those fields are required and cannot be pruned.
+          NOTE1: `In` CANNOT contain `.log_type`, `.log_source` or `.message` as those fields are required and cannot be pruned.
 
           NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` CANNOT be added to this list as it is a required field.
         displayName: Fields to be dropped
@@ -166,11 +166,13 @@ spec:
 
            - `.log_type`
 
-           - '.kubernetes.labels.foobar'
+           - '.log_source'
+
+           - '.message'
 
            - `.kubernetes.labels."foo-bar/baz"`
 
-          NOTE1: `NotIn` MUST contain `.log_type` and `.message` as those fields are required and cannot be pruned.
+          NOTE1: `NotIn` MUST contain `.log_type`, `.log_source` and `.message` as those fields are required and cannot be pruned.
 
           NOTE2: If this filter is used in a pipeline with GoogleCloudLogging, `.hostname` MUST be added to this list as it is a required field.
         displayName: Fields to be kept

--- a/docs/contributing/how-to-add-new-output.md
+++ b/docs/contributing/how-to-add-new-output.md
@@ -37,10 +37,10 @@ The generator combines this fragment with others to create the complete collecto
 
 Relevant source files:
 
-[../api/observability/v1/clusterlogforwarder_types.go](../../api/observability/v1/clusterlog_forwarder_types.go)
+[../api/observability/v1/clusterlogforwarder_types.go](../../api/observability/v1/clusterlogforwarder_types.go)
 * Add the name of your output type to the `+kubebuilder:validation` comment on the `OutputSpec.Type` field.
 
-[../api/observability/v1/output_types.go](../../apis/observability/v1/output_types.go)
+[../api/observability/v1/output_types.go](../../api/observability/v1/output_types.go)
 * Add a constant for your output type name to the top of the file.
 * If necessary, add a struct for output-specific fields to `OutputTypeSpec`.
 

--- a/docs/features/logforwarding/filters/api-audit-filter.adoc
+++ b/docs/features/logforwarding/filters/api-audit-filter.adoc
@@ -11,7 +11,7 @@ The API Audit filter allows you to remove unwanted events and reduce event size 
 Audit policy is explained, with examples, in https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#audit-policy[Auditing Kubernetes].
 
 The ClusterLogForwarder audit filter also has some features that are extensions to the standard policy, see
-link:../../../../apis/observability/v1/filter_api_audit_types.go[the API documentation].
+link:../../../../api/observability/v1/filter_api_audit_types.go[the API documentation].
 
 Here is an example of a ClusterLogForwarder configuration using the example policy from
 https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/#audit-policy[Auditing Kubernetes].
@@ -25,16 +25,18 @@ metadata:
   name: instance
   namespace: openshift-logging
 spec:
+  serviceAccount:
+    name: logging-admin
   outputs:
-  - name: default
-    type: http
-    http:
-      url: https://my-default.foo.bar
+    - name: my-default
+      type: http
+      http:
+        url: https://my-default.foo.bar
   pipelines:
     - name: my-pipeline
       inputRefs: [application, infrastructure, audit]
       filterRefs: [my-policy]
-      outputRefs: [default]
+      outputRefs: [my-default]
   filters:
     - name: my-policy
       type: kubeAPIAudit

--- a/docs/features/logforwarding/filters/drop-filter.adoc
+++ b/docs/features/logforwarding/filters/drop-filter.adoc
@@ -25,14 +25,16 @@ Below is an example `ClusterLogForwarder` configuration specifying a custom drop
 
 [source,yaml]
 ----
-apiVersion: "observability.openshift.io/v1"
+apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
   name: instance 
   namespace: openshift-logging 
 spec:
+  serviceAccount:
+    name: logging-admin
   outputs:
-  - name: default
+  - name: my-default
     type: http
     http:
       url: https://my-default.foo.bar
@@ -73,7 +75,6 @@ spec:
 
 == Relevant Links:
 
-1. link:../../../../apis/observability/v1/filter_types.go[API documentation]
-2. https://github.com/openshift/enhancements/blob/a6a1feb9cceb0b61960bcf00f292cb0d04ee3753/enhancements/cluster-logging/content-filter.md#drop-filters[Enhancement Proposal]
-3. https://issues.redhat.com/browse/LOG-2803[Related JIRA]
-4. https://github.com/openshift/cluster-logging-operator/pull/2339[Related PR]
+. link:../../../../api/observability/v1/filter_types.go[API documentation]
+. https://issues.redhat.com/browse/LOG-2803[Related JIRA]
+. https://github.com/openshift/cluster-logging-operator/pull/2339[Related PR]

--- a/docs/features/logforwarding/filters/prune-filter.adoc
+++ b/docs/features/logforwarding/filters/prune-filter.adoc
@@ -16,54 +16,52 @@ The prune filter extends the filter API by adding a `prune` field and the `in`, 
 * Dot-delimited field path: A path to a field in the log record. It must start with a dot (`.`). The path can contain alpha-numeric characters and underscores `(a-zA-Z0-9_)`. If segments contain characters outside of this range, the segment must be quoted.
 ** Examples: `.kubernetes.namespace_name`, `.log_type`, `.kubernetes.labels.foobar`, `.kubernetes.labels."foo-bar/baz"`
 
-.Note #1
-[NOTE] 
-`notIn` takes precedence over `in`. That is, if both `in` and `notIn` are specified, vector will initially prune fields **NOT** listed in the `notIn` list followed by pruning fields specified in the `in` list.
-
-.Note #2
+.Precedence
 [NOTE]
-`in` **CANNOT** contain `.log_type` or `.message` as those fields are required and cannot be pruned. Additionally if this filter is used in a pipeline with `GoogleCloudLogging`, `.hostname` **CANNOT** be added to the `in` list as it is also a required field.
+`notIn` pruning takes precedence over `in`. If both `in` and `notIn` are specified, vector will first prune all fields *NOT* listed in the `notIn` list, followed by pruning fields specified in the `in` list.
 
-.Note #3
-[NOTE]
-`notIn` **MUST** contain `.log_type` and `.message` as those fields are required and cannot be pruned. Additionally if this filter is used in a pipeline with `GoogleCloudLogging`, `.hostname` **MUST** be added to the `notIn` list as it is also a required field.
+=== Required Fields
+The fields `.log_type`, `.log_source` and `.message` *CANNOT* be pruned and are required in all log events.    Additionally, `.hostname` field is also required if the filter is applied to a `GoogleCloudLogging` output.
 
-=== Example:
+[IMPORTANT]
+If specified, `notIn` *MUST* contain the required fields, and `in` *CANNOT* contain any of the required fields.
 
-Below is an example `ClusterLogForwarder` configuration specifying a custom prune filter called `my-prune`.
+=== Example
+A configuration specifying a custom prune filter called `my-prune`.
 
-
+.ClusterLogForwarder
 [source,yaml]
---
-apiVersion: "observability.openshift.io/v1"
+----
+apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
   name: instance 
   namespace: openshift-logging 
 spec:
   outputs:
-  - name: default
+  - name: my-default
     type: http
     http:
       url: https://my-default.foo.bar
   filters:
-    - name: my-prune
-      type: prune
-      prune:
-        in: [.level,.kubernetes.namespace_labels."test-dashes/slashes"]
-        notIn: [.log_type,.message,.kubernetes,."@timestamp",.openshift]
+  - name: my-prune
+    type: prune
+    prune:
+      notIn: [.log_type,.log_source,.message,.kubernetes]
+      in: [.kubernetes.container_id,.kubernetes.labels."test-dashes/slashes"]
   pipelines:
-   - name: app-prune
-     filterRefs:
-     - my-prune
-     inputRefs: 
-     - application
-     - infrastructure
-     outputRefs:
-     - default
---
-== Relevant Links:
+  - name: app-prune
+    filterRefs:
+    - my-prune
+    inputRefs:
+    - application
+    - infrastructure
+    outputRefs:
+    - my-default
+  serviceAccount:
+    name: logging-admin
+----
 
-1. link:../../../../apis/observability/v1/filter_types.go[API documentation]
-2. https://github.com/openshift/enhancements/blob/a6a1feb9cceb0b61960bcf00f292cb0d04ee3753/enhancements/cluster-logging/content-filter.md#prune-filters[Enhancement Proposal]
-3. https://issues.redhat.com/browse/LOG-3883[Related JIRA]
+== Relevant Links
+. link:../../../../api/observability/v1/filter_types.go[API documentation]
+. https://issues.redhat.com/browse/LOG-3883[Related JIRA]

--- a/docs/features/logforwarding/multiline-error-detection.adoc
+++ b/docs/features/logforwarding/multiline-error-detection.adoc
@@ -18,8 +18,8 @@ java.lang.NullPointerException: Cannot invoke "String.toString()" because "<para
 ----
 
 === Solution
-Include `detectMultilineException` filter when you create your Cluster Log Forwarder.
-Openshift Logging will detect multi-line exceptions and reassemble them into a single log entry.
+Include `detectMultilineException` filter type when you create your Cluster Log Forwarder.
+Openshift Logging will attempt to detect multi-line exceptions and reassemble them into a single log entry.
 
 .cluster-log-forwarder.yaml
 [source,yaml]
@@ -30,17 +30,24 @@ metadata:
   name: instance
   namespace: openshift-logging
 spec:
+  serviceAccount:
+    name: logging-admin
+  outputs:
+    - name: my-default
+      type: http
+      http:
+        url: https://my-default.foo.bar
   filters:
-  - name: detectMultilineException
-    type: detectMultilineException
+    - name: detect-exceptions
+      type: detectMultilineException
   pipelines:
     - name: my-app-logs
       inputRefs:
-      - application
+        - application
       outputRefs:
-      - anOutput
+        - my-default
       filterRefs:
-      - detectMultilineError
+        - detect-exceptions
 ----
 
 === Details

--- a/docs/features/logforwarding/outputs/cloudwatch-sts-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/cloudwatch-sts-forwarding.adoc
@@ -127,7 +127,8 @@ spec:
               secretName: foo-sts-secret
             token:
               from: secret # <7>
-                key: token # <7>
+              secret:
+                key: my-token # <7>
                 name: my-sa-token-secret # <7>
   pipelines:
     - name: app-logs


### PR DESCRIPTION
### Description
Updates the manifest and api description for the prune filter 'In' and 'NotIn' to also require '.log_source' field, matching the validation. 

/cc @Clee2691 @vparfonov
/assign @jcantrill

