### PR TITLE
Add functional tests for log collection edge cases

### DIFF
--- a/docs/administration/troubleshooting.md
+++ b/docs/administration/troubleshooting.md
@@ -4,8 +4,9 @@
 
 ## Frequently Asked Questions (FAQs)
 
-1. I've made changes to my `ClusterLogForwarder` (CLF) instance but the collectors are not redeployed/updated. Why is that?
-    - There could be an issue with one of the inputs, outputs, or pipelines of the CLF. Check the CLF status in one of 2 ways:
+### 1. I've made changes to my `ClusterLogForwarder` (CLF) instance but the collectors are not redeployed/updated. Why is that?
+    
+   - There could be an issue with one of the inputs, outputs, or pipelines of the CLF. Check the CLF status in one of 2 ways:
         1. Streamed events of the CLF.
             
             ```$ oc describe clf --show-events=true```
@@ -13,3 +14,33 @@
         2. Check the `status` section of the CLF instance `YAML` output.
         
             ```$ oc get clf -oyaml```
+
+### 2. Warning Message: `Currently ignoring file too small to fingerprint`
+If you see this warning message in your logs, here is an explanation of what it means and what actions you should take.
+This message appears because the file, at the moment it was checked, did not contain a complete line of text.
+The default strategy for identifying files is to read the first complete line. A "complete line" is a sequence of text 
+that must end with a newline character (\n). This is designed to prevent the system from accidentally processing a log 
+entry that is still being written to disk.
+
+### Common Scenario: Container Logs and `conmon`
+In container environments that use runtime like CRI-O, a utility called `conmon` manages container I/O.
+A key behavior of `conmon` is that it immediately creates an empty log file the moment a container starts, even before 
+the application inside the container has written its first log message.
+Because the log file exists but is empty (0 bytes), the log collector will find it, see that it doesn't contain a complete line,
+and expected to generate this warning.
+
+#### Is This an Error?
+Usually, no. In most cases, this is normal and expected behavior.
+It typically happens when a file is being created or/and actively written to. An application writes a burst of text but 
+has not yet finished the line with a newline character. The system checks the file at this exact moment, sees the incomplete line,
+logs the warning, and simply waits to check again. On the next check, the line will likely be complete, and the message will disappear.
+This warning might indicate a problem only if it persists for a very long time for a file that you know is no longer being written to.
+This could suggest that the application generating the log is not correctly terminating its lines.
+#### What to Do
+**Observe**: For an actively changing log file, see if the warning appears once, no action is needed. Your system is working perfectly.
+
+**Check the file content**: If the warning persists, open the file mentioned in the message. Look at the very last line.
+Does it have a newline character at the end? If not, the application writing the log is not properly terminating its lines.
+
+**Check the source application**: Ensure that the application generating the logs is configured to append a newline character 
+(\n) to every log entry. This is standard practice for most logging libraries and systems.

--- a/test/framework/functional/write.go
+++ b/test/framework/functional/write.go
@@ -154,6 +154,30 @@ func (f *CollectorFunctionalFramework) WriteMessagesToLog(msg string, numOfLogs 
 	return err
 }
 
+// WriteMessagesToLogWithoutNewLine write one log message without ending new line symbol
+// need in some specific use cases
+func (f *CollectorFunctionalFramework) WriteMessagesToLogWithoutNewLine(msg string) error {
+	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fileLogPaths[applicationLog], f.Pod.Namespace, f.Pod.Name, f.Pod.UID, constants.CollectorName)
+	logPath := filepath.Dir(filename)
+	encoded := base64.StdEncoding.EncodeToString([]byte(msg))
+	cmd := fmt.Sprintf("mkdir -p %s;for n in {1..%d};do echo -n \"$(echo %s|base64 -d)\" >> %s;sleep 1s;done", logPath, 1, encoded, filename)
+	log.V(3).Info("Writing messages to log with command", "cmd", cmd)
+	result, err := f.RunCommand(constants.CollectorName, "bash", "-c", cmd)
+	log.V(3).Info("WriteMessagesToLogWithoutNewLine", "namespace", f.Pod.Namespace, "result", result, "err", err)
+	return err
+}
+
+
+func (f *CollectorFunctionalFramework) EmulateCreationNewLogFileForContainer() error {
+	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fileLogPaths[applicationLog], f.Pod.Namespace, f.Pod.Name, f.Pod.UID, constants.CollectorName)
+	logPath := filepath.Dir(filename)
+	cmd := fmt.Sprintf("mkdir -p %s; touch %s", logPath, filename)
+	log.V(3).Info("Create log file with command", "cmd", cmd)
+	result, err := f.RunCommand(constants.CollectorName, "bash", "-c", cmd)
+	log.V(3).Info("EmulateCreationNewLogFileForContainer", "namespace", f.Pod.Namespace, "result", result, "err", err)
+	return err
+}
+
 // WriteMessagesWithNotUTF8SymbolsToLog write 12 symbols in ISO-8859-1 encoding
 // need to use small hack with 'sed' replacement because if try to use something like:
 // 'echo -e \xC0\xC1' Go always convert every undecodeable byte into '\ufffd'.

--- a/test/functional/misc/generic_logs_test.go
+++ b/test/functional/misc/generic_logs_test.go
@@ -1,0 +1,84 @@
+package misc
+
+import (
+	"github.com/onsi/gomega/format"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	"github.com/openshift/cluster-logging-operator/test/helpers/rand"
+	"github.com/openshift/cluster-logging-operator/test/matchers"
+	testruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+)
+
+var _ = Describe("[Functional][Misc] ", func() {
+
+	const WarnFileTooSmall = "Currently ignoring file too small to fingerprint"
+	var (
+		framework *functional.CollectorFunctionalFramework
+		timestamp = "2021-03-31T12:59:28.573159188+00:00"
+	)
+
+	BeforeEach(func() {
+		framework = functional.NewCollectorFunctionalFramework()
+		testruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+			FromInput(obs.InputTypeApplication).
+			ToHttpOutput()
+		Expect(framework.Deploy()).To(BeNil())
+	})
+	AfterEach(func() {
+		framework.Cleanup()
+	})
+
+	It("should to proceed small file with new line", func() {
+		msg := functional.NewCRIOLogMessage(timestamp, "A", false)
+		matchers.ExpectOK(framework.WriteMessagesToApplicationLog(msg, 1),
+			"Expected no errors writing the logs")
+
+		logs, err := framework.ReadApplicationLogsFrom(string(obs.OutputTypeHTTP))
+		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+		Expect(len(logs)).To(Equal(1))
+		Expect(logs[0].Message).Should(Equal("A"))
+		collectorLogs, err := framework.ReadCollectorLogs()
+		Expect(err).To(BeNil(), "Expected no errors read collector logs")
+		Expect(collectorLogs).ToNot(ContainSubstring(WarnFileTooSmall))
+	})
+
+	It("validate what collector emmit warning for big logs without new line", func() {
+		big := rand.Word(1000)
+		msg := functional.NewCRIOLogMessage(timestamp, string(big), false)
+		// writing log, without new line symbol at the end
+		matchers.ExpectOK(framework.WriteMessagesToLogWithoutNewLine(msg),
+			"Expected no errors writing the logs")
+
+		time.Sleep(20 * time.Second)
+
+		format.MaxLength = 0
+		collectorLogs, err := framework.ReadCollectorLogs()
+		Expect(err).To(BeNil(), "Expected no errors read collector logs")
+		Expect(collectorLogs).To(ContainSubstring(WarnFileTooSmall))
+
+		// continue writing log, now with new line symbol, normal usecase
+		msg = functional.NewCRIOLogMessage(timestamp, "New msg", false)
+		matchers.ExpectOK(framework.WriteMessagesToApplicationLog(msg, 1),
+			"Expected no errors writing the logs")
+
+		logs, err := framework.ReadApplicationLogsFrom(string(obs.OutputTypeHTTP))
+		Expect(err).To(BeNil(), "Expected no errors parsing the logs")
+		Expect(len(logs)).To(Equal(1))
+	})
+
+	It("validate what collector emmit warning on creating new log file for container", func() {
+		matchers.ExpectOK(framework.EmulateCreationNewLogFileForContainer(), "Expected no errors")
+
+		time.Sleep(20 * time.Second)
+
+		format.MaxLength = 0
+		collectorLogs, err := framework.ReadCollectorLogs()
+		Expect(err).To(BeNil(), "Expected no errors read collector logs")
+		Expect(collectorLogs).To(ContainSubstring(WarnFileTooSmall))
+	})
+
+})


### PR DESCRIPTION
### Description
This PR introduces three new functional tests for log collection. These tests are addressed to verify the edge case behavior of Vector's file fingerprinting mechanism.

The tests confirm that CLO correctly handles both very short (but complete) log lines and very long (but incomplete) log lines.

#### How Vector's file fingerprinting works
To understand the purpose of these tests, it's important to know how Vector's fingerprinting strategy works. 

**The default strategy is line-based**:  While Vector's documentation states the default `fingerprint.strategy` is `checksum`, the source code shows that this legacy strategy is internally mapped to behave exactly like the modern `first_lines_checksum` strategy (`FirstLinesChecksum`). Therefore, the effective default behavior is to identify files based on their first complete line(s).

**The meaning of "file too small"**: A log file is considered "too small to fingerprint" if it does not yet contain a complete line, which means a line terminated by a newline character (`\n`). A file can be very large in terms of byte size, but if it lacks a final `\n`, Vector will consider it incomplete and wait before processing it. Similarly, **an empty (0-byte)** file is also considered "too small" because it too lacks a complete line.

This line-based approach is more robust for logs because a "line" represents a complete "event". It prevents Vector from ingesting partial log entries that are still being written to disk. 

#### Three new functional test cases have been added:
Test 1: short but complete line
Writes a single-character line followed by a newline (a\n) to a log file. This confirms that a file is considered valid as long as it contains a complete line, regardless of its small byte size.

Test 2: large but incomplete line
Writes a long string (1000+ characters) to a log file without a terminating newline character, confirms Vector emits a `Currently ignoring file too small to fingerprint` warning and does not ingest the log. On next step, writes normal log message, confirms system works as expected: log event send to the output.

Test 3: empty file creation 
Creates a new, empty (0-byte) log file, confirm that Vector emits a `Currently ignoring file too small to fingerprint` warning. This confirms that the default fingerprinting strategy requires content (at least one complete line) and will not process empty files immediately upon creation, which is the desired behavior.


Additionally, updates FAQs in `docs/administration/troubleshooting.md`

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 @cahartma <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-7075
- Enhancement proposal:
