### PR TITLE
Allow specification of a maximum line size to be applied after merging

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -324,6 +324,7 @@ source = '''
 [sources.input_infrastructure_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/default_*/*/*.log", "/var/log/pods/kube*_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log"]
@@ -536,6 +537,7 @@ source = '''
 [sources.input_mytestapp_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/test-ns_*/*/*.log"]

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -321,6 +321,7 @@ source = '''
 [sources.input_infrastructure_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/default_*/*/*.log", "/var/log/pods/kube*_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log"]
@@ -573,6 +574,7 @@ source = '''
 [sources.input_mytestapp_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/test-ns_*/*/*.log"]

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -17,6 +17,7 @@ type = "internal_metrics"
 [sources.input_myinfra_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/default_*/*/*.log", "/var/log/pods/kube*_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log"]
@@ -148,6 +149,7 @@ source = '''
 [sources.input_mytestapp_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/test-ns_*/*/*.log"]

--- a/internal/generator/vector/input/application.toml
+++ b/internal/generator/vector/input/application.toml
@@ -2,6 +2,7 @@
 [sources.input_application_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.log.*", "/var/log/pods/*/*/*.tmp", "/var/log/pods/default_*/*/*.log", "/var/log/pods/kube*_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log"]

--- a/internal/generator/vector/input/application_exclude_container_from_infra.toml
+++ b/internal/generator/vector/input/application_exclude_container_from_infra.toml
@@ -2,6 +2,7 @@
 [sources.input_my_app_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/openshift-logging_*/*/*.log"]

--- a/internal/generator/vector/input/application_excludes_container.toml
+++ b/internal/generator/vector/input/application_excludes_container.toml
@@ -2,6 +2,7 @@
 [sources.input_my_app_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.log.*", "/var/log/pods/*/*/*.tmp", "/var/log/pods/*/log-*/*.log", "/var/log/pods/default_*/*/*.log", "/var/log/pods/kube*_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log"]

--- a/internal/generator/vector/input/application_includes_container.toml
+++ b/internal/generator/vector/input/application_includes_container.toml
@@ -2,6 +2,7 @@
 [sources.input_my_app_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/*/log-*/*.log"]

--- a/internal/generator/vector/input/application_with_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_includes_excludes.toml
@@ -2,6 +2,7 @@
 [sources.input_my_app_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/test-ns-bar_*/*/*.log", "/var/log/pods/test-ns-foo_*/*/*.log"]

--- a/internal/generator/vector/input/application_with_infra_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_excludes.toml
@@ -2,6 +2,7 @@
 [sources.input_my_app_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/kube-apiserver_*/mesh/*.log", "/var/log/pods/openshift-logging_*/mesh/*.log", "/var/log/pods/test-ns-foo_*/mesh/*.log"]

--- a/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
@@ -2,6 +2,7 @@
 [sources.input_my_app_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/kube-apiserver_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log", "/var/log/pods/test-ns-foo_*/*/*.log"]

--- a/internal/generator/vector/input/application_with_matchLabels.toml
+++ b/internal/generator/vector/input/application_with_matchLabels.toml
@@ -2,6 +2,7 @@
 [sources.input_my_app_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.log.*", "/var/log/pods/*/*/*.tmp", "/var/log/pods/default_*/*/*.log", "/var/log/pods/kube*_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log"]

--- a/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
@@ -2,6 +2,7 @@
 [sources.input_my_app_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/kube-apiserver_*/*/*.log", "/var/log/pods/openshift-logging_*/*/*.log", "/var/log/pods/test-ns-foo_*/*/*.log"]

--- a/internal/generator/vector/input/application_with_throttle.toml
+++ b/internal/generator/vector/input/application_with_throttle.toml
@@ -2,6 +2,7 @@
 [sources.input_application_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 exclude_paths_glob_patterns = ["/var/log/pods/*/*/*.gz", "/var/log/pods/*/*/*.log.*", "/var/log/pods/*/*/*.tmp", "/var/log/pods/default_*/*/*.log", "/var/log/pods/kube*_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log"]

--- a/internal/generator/vector/input/infrastructure.toml
+++ b/internal/generator/vector/input/infrastructure.toml
@@ -2,6 +2,7 @@
 [sources.input_infrastructure_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/default_*/*/*.log", "/var/log/pods/kube*_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log"]

--- a/internal/generator/vector/input/infrastructure_container.toml
+++ b/internal/generator/vector/input/infrastructure_container.toml
@@ -2,6 +2,7 @@
 [sources.input_myinfra_container]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/default_*/*/*.log", "/var/log/pods/kube*_*/*/*.log", "/var/log/pods/openshift*_*/*/*.log"]

--- a/internal/generator/vector/source/kubernetes_logs.go
+++ b/internal/generator/vector/source/kubernetes_logs.go
@@ -29,6 +29,7 @@ func (kl KubernetesLogs) Template() string {
 [sources.{{.ComponentID}}]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 {{- if gt (len .IncludePaths) 0}}

--- a/internal/generator/vector/source/kubernetes_logs_no_includes_excludes.toml
+++ b/internal/generator/vector/source/kubernetes_logs_no_includes_excludes.toml
@@ -2,6 +2,7 @@
 [sources.source_foo]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 pod_annotation_fields.pod_labels = "kubernetes.labels"

--- a/internal/generator/vector/source/kubernetes_logs_with_includes.toml
+++ b/internal/generator/vector/source/kubernetes_logs_with_includes.toml
@@ -2,6 +2,7 @@
 [sources.source_foo]
 type = "kubernetes_logs"
 max_read_bytes = 3145728
+max_merged_line_bytes = 65536
 glob_minimum_cooldown_ms = 15000
 auto_partial_merge = true
 include_paths_glob_patterns = ["/var/log/pods/foo"]


### PR DESCRIPTION
### Description
This PR adds the max_merged_line_bytes setting to the Vector collector configuration.
More information: [kubernetes_logs/#max_merged_line_bytes](https://vector.dev/docs/reference/configuration/sources/kubernetes_logs/#max_merged_line_bytes)

Currently, this parameter is not configurable via the Cluster Logging Forwarder spec and is hardcoded to 65536 bytes — which is twice the default value of [max_line_bytes](https://vector.dev/docs/reference/configuration/sources/kubernetes_logs/#max_line_bytes).

Using it helps prevent Vector from failing with the following error:
`vector::topology: An error occurred that Vector couldn't handle: failed to encode record: BufferTooSmall.
`

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-7347
- Enhancement proposal:
