### PR TITLE
LOG-7603: Refactor ClusterLogForwarderReconciler to more thread safe

### DIFF
--- a/internal/controller/observability/clusterlogforwarder_controller_test.go
+++ b/internal/controller/observability/clusterlogforwarder_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"time"
 )
 
 var _ = Describe("#Reconcile", func() {
@@ -115,8 +116,13 @@ spec:
 				},
 			}
 			r := ClusterLogForwarderReconciler{
-				ForwarderContext: fContext,
+				PollInterval: 500 * time.Millisecond,
+				TimeOut:      1 * time.Second,
+				NewForwarderContext: func() obscontext.ForwarderContext {
+					return fContext
+				},
 			}
+
 			_, err := r.Reconcile(context.TODO(), ctrl.Request{
 				NamespacedName: types.NamespacedName{Namespace: clf.Namespace, Name: clf.Name},
 			})


### PR DESCRIPTION
### Description
This PR:
* Refactors ForwarderContext out of the ClusterLogForwarderReconciler
* Creates a ForwarderContext for each reconciliation attempt to make it more thread safe
* Makes the poll and timeout intervals injectable to reduce test time for the clf controller test

### Links
https://issues.redhat.com/browse/LOG-7603
