### PR TITLE
LOG-7582: relax restriction of OTLP URL

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -1325,12 +1325,13 @@ type OTLPTuningSpec struct {
 type OTLP struct {
 	// URL to send log records to.
 	//
-	// An absolute URL, with a valid http scheme. Must terminate with `/v1/logs`
+	// An absolute URL, with a valid http scheme. The OTLP spec recommends it terminate with `/v1/logs` but
+	// that 'Non-default URL paths for requests MAY be configured on the client and server sides.'
 	//
 	// Basic TLS is enabled if the URL scheme requires it (for example 'https').
 	// The 'username@password' part of `url` is ignored.
 	//
-	// +kubebuilder:validation:Pattern:=`^(https?):\/\/\S+\/v1\/logs$`
+	// +kubebuilder:validation:Pattern:=`^(https?):\/\/\S+$`
 	// +kubebuilder:validation:XValidation:rule="isURL(self)", message="invalid URL"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Destination URL",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	URL string `json:"url"`

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -1387,7 +1387,8 @@ spec:
       - description: |-
           URL to send log records to.
 
-          An absolute URL, with a valid http scheme. Must terminate with `/v1/logs`
+          An absolute URL, with a valid http scheme. The OTLP spec recommends it terminate with `/v1/logs` but
+          that 'Non-default URL paths for requests MAY be configured on the client and server sides.'
 
           Basic TLS is enabled if the URL scheme requires it (for example 'https').
           The 'username@password' part of `url` is ignored.

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -3142,11 +3142,12 @@ spec:
                           description: |-
                             URL to send log records to.
 
-                            An absolute URL, with a valid http scheme. Must terminate with `/v1/logs`
+                            An absolute URL, with a valid http scheme. The OTLP spec recommends it terminate with `/v1/logs` but
+                            that 'Non-default URL paths for requests MAY be configured on the client and server sides.'
 
                             Basic TLS is enabled if the URL scheme requires it (for example 'https').
                             The 'username@password' part of `url` is ignored.
-                          pattern: ^(https?):\/\/\S+\/v1\/logs$
+                          pattern: ^(https?):\/\/\S+$
                           type: string
                           x-kubernetes-validations:
                           - message: invalid URL

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -3142,11 +3142,12 @@ spec:
                           description: |-
                             URL to send log records to.
 
-                            An absolute URL, with a valid http scheme. Must terminate with `/v1/logs`
+                            An absolute URL, with a valid http scheme. The OTLP spec recommends it terminate with `/v1/logs` but
+                            that 'Non-default URL paths for requests MAY be configured on the client and server sides.'
 
                             Basic TLS is enabled if the URL scheme requires it (for example 'https').
                             The 'username@password' part of `url` is ignored.
-                          pattern: ^(https?):\/\/\S+\/v1\/logs$
+                          pattern: ^(https?):\/\/\S+$
                           type: string
                           x-kubernetes-validations:
                           - message: invalid URL

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -1310,7 +1310,8 @@ spec:
       - description: |-
           URL to send log records to.
 
-          An absolute URL, with a valid http scheme. Must terminate with `/v1/logs`
+          An absolute URL, with a valid http scheme. The OTLP spec recommends it terminate with `/v1/logs` but
+          that 'Non-default URL paths for requests MAY be configured on the client and server sides.'
 
           Basic TLS is enabled if the URL scheme requires it (for example 'https').
           The 'username@password' part of `url` is ignored.

--- a/docs/features/logforwarding/outputs/otlp-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/otlp-forwarding.adoc
@@ -1,9 +1,11 @@
 = OTLP Output
 
-The OTLP output forwards logs using HTTP/JSON as defined by the OpenTelemetry Observability Framework.  This is a configuration guide for the `ClusterLogForwarder` spec introduced to send logs to OTLP receivers.
+The OTLP output forwards logs using HTTP/JSON as defined by the OpenTelemetry Observability Framework.
+This is a configuration guide for the `ClusterLogForwarder` spec introduced to send logs to OTLP receivers.
 
 
-*OTLP* describes the *protocol* for encoding, transporting, and delivering telemetry data between sources using the https://opentelemetry.io/docs/specs/otlp/[OpenTelemetry OTLP Specification]
+*OTLP* describes the *protocol* for encoding, transporting, and delivering telemetry data between sources using the
+https://opentelemetry.io/docs/specs/otlp/[OpenTelemetry OTLP Specification]
 
 .Technical Preview
 This feature is tech-preview and an annotation is required to enable it
@@ -51,7 +53,7 @@ spec:
 ----
 . Tech preview `annotation` must be enabled
 . `type` is '*otlp*'
-. `otlp` `url` specify a valid host:port of the otel receiver and *MUST* terminate with "*/v1/logs*"
+. `otlp` `url` specify a valid host:port of the otel receiver and *MAY* require termination with "*/v1/logs*" depending upon the configuration of the server
 . `otlp` `authentication` is optional and specifies a `token.from` and a value of '*serviceAccount*'
 .. The token can also be read from a secret
 .. Also available with `username` and `password` authentication spec (refer to HTTP Auth Specification for full scope)
@@ -74,7 +76,8 @@ NOTE: This option is *NOT* recommended for production configurations. If true, t
 === Semantic Convention
 The Semantic Conventions in OpenTelemetry (OTel) define a *Resource* as an immutable representation of the entity producing telemetry as *Attributes*.
 
-All *Attributes* are included in the *Resource* object. For example, a process producing telemetry that is running in a container has a container_name, a cluster_id, a pod_name, a namespace, and possibly a deployment or app_name.
+All *Attributes* are included in the *Resource* object. For example, a process producing telemetry that is running in a container has a container_name,
+a cluster_id, a pod_name, a namespace, and possibly a deployment or app_name.
 
 The grouping and reducing of common resource attributes is a key aspect of sending logs via OpenTelemetry.
 

--- a/docs/reference/operator/api_logging_v1alpha1.adoc
+++ b/docs/reference/operator/api_logging_v1alpha1.adoc
@@ -81,6 +81,10 @@ Type:: array
 |name|string|  Name must match the name of one entry in pod.spec.resourceClaims of
 the Pod where this field is used. It makes that resource available
 inside a container.
+|request|string|  *(optional)* Request is the name chosen for a request in the referenced claim.
+If empty, everything from the claim is made available, otherwise
+only the result of this request.
+
 |======================
 
 === .spec.resources.limits

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -2995,7 +2995,8 @@ Type:: object
 
 |url|string|  URL to send log records to.
 
-An absolute URL, with a valid http scheme. Must terminate with `/v1/logs`
+An absolute URL, with a valid http scheme. The OTLP spec recommends it terminate with `/v1/logs` but
+that &#39;Non-default URL paths for requests MAY be configured on the client and server sides.&#39;
 
 Basic TLS is enabled if the URL scheme requires it (for example &#39;https&#39;).
 The &#39;username@password&#39; part of `url` is ignored.

--- a/test/e2e/collection/apivalidations/api_validations_test.go
+++ b/test/e2e/collection/apivalidations/api_validations_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"os/exec"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
 	"github.com/openshift/cluster-logging-operator/test/helpers/cmd"
-	"os/exec"
 )
 
 var _ = Describe("", func() {
@@ -95,6 +96,12 @@ var _ = Describe("", func() {
 		}),
 		Entry("should pass for Cloudwatch with empty URL", "cloudwatch-empty-url.yaml", func(out string, err error) {
 			Expect(err).ToNot(HaveOccurred())
+		}),
+		Entry("should pass for OTLP with any http or https URL", "otlp_valid_url.yaml", func(out string, err error) {
+			Expect(err).ToNot(HaveOccurred())
+		}),
+		Entry("should fail for OTLP with non http URL", "otlp_valid_non_http.yaml", func(out string, err error) {
+			Expect(err).To(HaveOccurred())
 		}),
 	)
 })

--- a/test/e2e/collection/apivalidations/otlp_valid_non_http.yaml
+++ b/test/e2e/collection/apivalidations/otlp_valid_non_http.yaml
@@ -1,0 +1,20 @@
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: clf-validation-test
+spec:
+  outputs:
+    - name: output
+      otlp:
+        url: ftp://ahost:8976/api/v1/ingest/otlp
+      type: otlp
+  pipelines:
+  - inputRefs:
+      - infrastructure
+      - audit
+      - application
+    name: thepipeline
+    outputRefs:
+    - output
+  serviceAccount:
+    name: clf-validation-test

--- a/test/e2e/collection/apivalidations/otlp_valid_url.yaml
+++ b/test/e2e/collection/apivalidations/otlp_valid_url.yaml
@@ -1,0 +1,25 @@
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: clf-validation-test
+spec:
+  outputs:
+    - name: https
+      otlp:
+        url: https://ahost:8976/api/v1/ingest/otlp
+      type: otlp
+    - name: http
+      otlp:
+        url: http://ahost:8976/api/v1/ingest/otlp
+      type: otlp
+  pipelines:
+  - inputRefs:
+      - infrastructure
+      - audit
+      - application
+    name: thepipeline
+    outputRefs:
+    - https
+    - http
+  serviceAccount:
+    name: clf-validation-test

--- a/test/framework/functional/write.go
+++ b/test/framework/functional/write.go
@@ -167,7 +167,6 @@ func (f *CollectorFunctionalFramework) WriteMessagesToLogWithoutNewLine(msg stri
 	return err
 }
 
-
 func (f *CollectorFunctionalFramework) EmulateCreationNewLogFileForContainer() error {
 	filename := fmt.Sprintf("%s/%s_%s_%s/%s/0.log", fileLogPaths[applicationLog], f.Pod.Namespace, f.Pod.Name, f.Pod.UID, constants.CollectorName)
 	logPath := filepath.Dir(filename)


### PR DESCRIPTION
### Description
This PR:
* Relaxes the URL validation for OTLP to no longer require terminate with `v1/logs`
* Adds e2e API  tests to validate: any http, https protocol
* Removes brokerURL validation to allow and empty string
* Updates the feature doc

### Links
https://issues.redhat.com/browse/LOG-7582