### PR TITLE
LOG-7618: Modify lokistack datamodel to default to 'Otel' in lieu of 'Viaq'

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -834,10 +834,10 @@ type LokiStack struct {
 	//
 	// There are two different models to choose from:
 	//
-	//  - Viaq
+	//  - Viaq (DEPRECATED: To be ignored in a future release)
 	//  - Otel
 	//
-	// When the data model is not set, it currently defaults to the "Viaq" data model.
+	// When the data model is not set, it currently defaults to the "Otel" data model.
 	//
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Data Model"

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2025-09-03T01:08:59Z"
+    createdAt: "2025-09-11T16:25:19Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -1167,10 +1167,10 @@ spec:
 
           There are two different models to choose from:
 
-           - Viaq
+           - Viaq (DEPRECATED: To be ignored in a future release)
            - Otel
 
-          When the data model is not set, it currently defaults to the "Viaq" data model.
+          When the data model is not set, it currently defaults to the "Otel" data model.
         displayName: Data Model
         path: outputs[0].lokiStack.dataModel
       - description: |-

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -2838,10 +2838,10 @@ spec:
 
                             There are two different models to choose from:
 
-                             - Viaq
+                             - Viaq (DEPRECATED: To be ignored in a future release)
                              - Otel
 
-                            When the data model is not set, it currently defaults to the "Viaq" data model.
+                            When the data model is not set, it currently defaults to the "Otel" data model.
                           enum:
                           - Viaq
                           - Otel

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -2838,10 +2838,10 @@ spec:
 
                             There are two different models to choose from:
 
-                             - Viaq
+                             - Viaq (DEPRECATED: To be ignored in a future release)
                              - Otel
 
-                            When the data model is not set, it currently defaults to the "Viaq" data model.
+                            When the data model is not set, it currently defaults to the "Otel" data model.
                           enum:
                           - Viaq
                           - Otel

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -1090,10 +1090,10 @@ spec:
 
           There are two different models to choose from:
 
-           - Viaq
+           - Viaq (DEPRECATED: To be ignored in a future release)
            - Otel
 
-          When the data model is not set, it currently defaults to the "Viaq" data model.
+          When the data model is not set, it currently defaults to the "Otel" data model.
         displayName: Data Model
         path: outputs[0].lokiStack.dataModel
       - description: |-

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -2758,10 +2758,10 @@ Type:: object
 
 There are two different models to choose from:
 
-- Viaq
+- Viaq (DEPRECATED: To be ignored in a future release)
  - Otel
 
-When the data model is not set, it currently defaults to the &#34;Viaq&#34; data model.
+When the data model is not set, it currently defaults to the &#34;Otel&#34; data model.
 
 |labelKeys|object|  LabelKeys can be used to customize which log record keys are mapped to Loki stream labels.
 

--- a/internal/api/initialize/init_outputs.go
+++ b/internal/api/initialize/init_outputs.go
@@ -1,0 +1,23 @@
+package initialize
+
+import (
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/internal/validations/observability/common"
+)
+
+// MigrateOutputs initializes the outputs for a ClusterLogForwarder
+func MigrateOutputs(forwarder obs.ClusterLogForwarder, options utils.Options) obs.ClusterLogForwarder {
+	enabled := common.IsEnabledAnnotation(forwarder, constants.AnnotationOtlpOutputTechPreview)
+	for _, o := range forwarder.Spec.Outputs {
+		if enabled {
+			if o.Type == obs.OutputTypeLokiStack && o.LokiStack != nil && o.LokiStack.DataModel == "" {
+				o.LokiStack.DataModel = obs.LokiStackDataModelOpenTelemetry
+			}
+		} else if o.Type == obs.OutputTypeLokiStack && o.LokiStack != nil {
+			o.LokiStack.DataModel = obs.LokiStackDataModelViaq
+		}
+	}
+	return forwarder
+}

--- a/internal/api/initialize/init_outputs_test.go
+++ b/internal/api/initialize/init_outputs_test.go
@@ -1,0 +1,138 @@
+package initialize
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("migrateOutputs", func() {
+	var (
+		initContext utils.Options
+	)
+	BeforeEach(func() {
+		initContext = utils.Options{}
+	})
+	Context("for LokiStack outputs", func() {
+
+		Context("when the OTLP Tech-preview feature is not enabled", func() {
+			It("should set the datamodel to 'Viaq' regardless of of the value spec'd for the datamodel", func() {
+				forwarder := obs.ClusterLogForwarder{
+					Spec: obs.ClusterLogForwarderSpec{
+						Outputs: []obs.OutputSpec{
+							{
+								Name: "anOutput",
+								Type: obs.OutputTypeLokiStack,
+								LokiStack: &obs.LokiStack{
+									DataModel: obs.LokiStackDataModelOpenTelemetry,
+								}},
+						},
+					},
+				}
+				result := MigrateOutputs(forwarder, initContext)
+				Expect(result.Spec.Outputs).To(HaveLen(1))
+				Expect(result.Spec.Outputs[0]).To(Equal(obs.OutputSpec{
+					Name: "anOutput",
+					Type: obs.OutputTypeLokiStack,
+					LokiStack: &obs.LokiStack{
+						DataModel: obs.LokiStackDataModelViaq,
+					},
+				}))
+			})
+
+		})
+
+		Context("when the OTLP Tech-preview feature is enabled", func() {
+
+			It("should set the datamodel to 'Otel' when the datamodel is not spec'd", func() {
+				forwarder := obs.ClusterLogForwarder{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							constants.AnnotationOtlpOutputTechPreview: "enabled",
+						},
+					},
+					Spec: obs.ClusterLogForwarderSpec{
+						Outputs: []obs.OutputSpec{
+							{
+								Name:      "anOutput",
+								Type:      obs.OutputTypeLokiStack,
+								LokiStack: &obs.LokiStack{},
+							},
+						},
+					},
+				}
+				result := MigrateOutputs(forwarder, initContext)
+				Expect(result.Spec.Outputs).To(HaveLen(1))
+				Expect(result.Spec.Outputs[0]).To(Equal(obs.OutputSpec{
+					Name: "anOutput",
+					Type: obs.OutputTypeLokiStack,
+					LokiStack: &obs.LokiStack{
+						DataModel: obs.LokiStackDataModelOpenTelemetry,
+					},
+				}))
+			})
+			It("should honor the datamodel 'ViaQ' when the datamodel is spec'd to ViaQ", func() {
+				forwarder := obs.ClusterLogForwarder{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							constants.AnnotationOtlpOutputTechPreview: "true",
+						},
+					},
+					Spec: obs.ClusterLogForwarderSpec{
+						Outputs: []obs.OutputSpec{
+							{
+								Name: "anOutput",
+								Type: obs.OutputTypeLokiStack,
+								LokiStack: &obs.LokiStack{
+									DataModel: obs.LokiStackDataModelViaq,
+								},
+							},
+						},
+					},
+				}
+				result := MigrateOutputs(forwarder, initContext)
+				Expect(result.Spec.Outputs).To(HaveLen(1))
+				Expect(result.Spec.Outputs[0]).To(Equal(obs.OutputSpec{
+					Name: "anOutput",
+					Type: obs.OutputTypeLokiStack,
+					LokiStack: &obs.LokiStack{
+						DataModel: obs.LokiStackDataModelViaq,
+					},
+				}))
+			})
+			It("should honor the datamodel 'Otel' when the datamodel is spec'd to Otel", func() {
+				forwarder := obs.ClusterLogForwarder{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{
+							constants.AnnotationOtlpOutputTechPreview: "true",
+						},
+					},
+					Spec: obs.ClusterLogForwarderSpec{
+						Outputs: []obs.OutputSpec{
+							{
+								Name: "anOutput",
+								Type: obs.OutputTypeLokiStack,
+								LokiStack: &obs.LokiStack{
+									DataModel: obs.LokiStackDataModelOpenTelemetry,
+								},
+							},
+						},
+					},
+				}
+				result := MigrateOutputs(forwarder, initContext)
+				Expect(result.Spec.Outputs).To(HaveLen(1))
+				Expect(result.Spec.Outputs[0]).To(Equal(obs.OutputSpec{
+					Name: "anOutput",
+					Type: obs.OutputTypeLokiStack,
+					LokiStack: &obs.LokiStack{
+						DataModel: obs.LokiStackDataModelOpenTelemetry,
+					},
+				}))
+			})
+		})
+
+	})
+})

--- a/internal/api/initialize/initializations.go
+++ b/internal/api/initialize/initializations.go
@@ -16,6 +16,7 @@ const (
 var clfInitializers = []func(spec obs.ClusterLogForwarder, migrateContext utils.Options) obs.ClusterLogForwarder{
 	Resources,
 	MigrateInputs,
+	MigrateOutputs,
 }
 
 // ClusterLogForwarder initializes the forwarder for fields that must be set and are inferred from settings already defined.

--- a/internal/controller/observability/clusterlogforwarder_controller.go
+++ b/internal/controller/observability/clusterlogforwarder_controller.go
@@ -176,7 +176,6 @@ func initialize(cxt internalcontext.ForwarderContext) (internalcontext.Forwarder
 	cxt.AdditionalContext = utils.Options{}
 	migrated := internalinit.ClusterLogForwarder(*cxt.Forwarder, cxt.AdditionalContext)
 	cxt.Forwarder = &migrated
-
 	if cxt.Secrets, err = MapSecrets(cxt.Client, cxt.Forwarder.Namespace, cxt.Forwarder.Spec.Inputs, cxt.Forwarder.Spec.Outputs); err != nil {
 		return cxt, err
 	}

--- a/internal/validations/observability/common/validate.go
+++ b/internal/validations/observability/common/validate.go
@@ -2,11 +2,11 @@ package common
 
 import (
 	"fmt"
+	"strings"
+
 	obsv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
-	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
 	"github.com/openshift/cluster-logging-operator/internal/utils/sets"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 // ValidateValueReference checks for valid names and keys referenced in secrets and configMaps
@@ -49,9 +49,9 @@ func validateConfigMap(configMapName, key string, configMaps map[string]*corev1.
 }
 
 // IsEnabledAnnotation checks if an annotation is set to either "true" or "enabled"
-func IsEnabledAnnotation(context internalcontext.ForwarderContext, annotation string) bool {
+func IsEnabledAnnotation(forwarder obsv1.ClusterLogForwarder, annotation string) bool {
 	enabledValues := sets.NewString("true", "enabled")
-	if value, ok := context.Forwarder.Annotations[annotation]; ok {
+	if value, ok := forwarder.Annotations[annotation]; ok {
 		if enabledValues.Has(value) {
 			return true
 		}

--- a/internal/validations/observability/outputs/validate_tech_preview.go
+++ b/internal/validations/observability/outputs/validate_tech_preview.go
@@ -14,7 +14,7 @@ const MissingAnnotationMessage = "requires a valid tech-preview annotation"
 
 // ValidateTechPreviewAnnotation verifies the tech-preview annotation for outputs sending OTEL data
 func ValidateTechPreviewAnnotation(out obsv1.OutputSpec, context internalcontext.ForwarderContext) (messages []string) {
-	enabled := common.IsEnabledAnnotation(context, constants.AnnotationOtlpOutputTechPreview)
+	enabled := common.IsEnabledAnnotation(*context.Forwarder, constants.AnnotationOtlpOutputTechPreview)
 	if out.Type == obsv1.OutputTypeOTLP && !enabled {
 		log.V(3).Info("ValidateTechPreviewAnnotation failed", "reason", MissingAnnotationMessage)
 		messages = append(messages, fmt.Sprintf("output %q %v", out.Name, MissingAnnotationMessage))

--- a/test/e2e/logforwarding/lokistack/forward_to_lokistack_test.go
+++ b/test/e2e/logforwarding/lokistack/forward_to_lokistack_test.go
@@ -103,9 +103,7 @@ var _ = Describe("[ClusterLogForwarder] Forward to Lokistack", func() {
 			Fail(fmt.Sprintf("unable to deploy log generator %v.", err))
 		}
 	})
-
-	It("should send logs to lokistack's OTLP endpoint when dataModel == Otel", func() {
-		lokiStackOut.LokiStack.DataModel = obs.LokiStackDataModelOpenTelemetry
+	It("should send logs to lokistack's OTLP endpoint when dataModel is not spec'd", func() {
 		forwarder.Spec.Outputs = append(forwarder.Spec.Outputs, *lokiStackOut)
 
 		if err := e2e.CreateObservabilityClusterLogForwarder(forwarder); err != nil {
@@ -134,7 +132,8 @@ var _ = Describe("[ClusterLogForwarder] Forward to Lokistack", func() {
 		Expect(found).To(BeTrue())
 	})
 
-	It("should send logs to lokistack when dataModel is not spec'd", func() {
+	It("should send logs to lokistack when dataModel == Viaq", func() {
+		lokiStackOut.LokiStack.DataModel = obs.LokiStackDataModelViaq
 		forwarder.Spec.Outputs = append(forwarder.Spec.Outputs, *lokiStackOut)
 
 		if err := e2e.CreateObservabilityClusterLogForwarder(forwarder); err != nil {
@@ -164,6 +163,7 @@ var _ = Describe("[ClusterLogForwarder] Forward to Lokistack", func() {
 	})
 
 	It("should send logs to lokistack with otel equivalent default labels when data model is viaq", func() {
+		lokiStackOut.LokiStack.DataModel = obs.LokiStackDataModelViaq
 		forwarder.Spec.Outputs = append(forwarder.Spec.Outputs, *lokiStackOut)
 
 		if err := e2e.CreateObservabilityClusterLogForwarder(forwarder); err != nil {


### PR DESCRIPTION
### Description
This PR:
* Modifies the default datamodel when forwarding to LokiStack to be 'Otel'
* Updates the API documentation to identify 'Viaq' to be deprecated and not honored in a future release

### Links
https://issues.redhat.com/browse/LOG-7618