### PR TITLE
LOG-7596: Add feature deprecation alert

### DIFF
--- a/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -6,6 +6,20 @@ spec:
   groups:
   - name: logging_collector.alerts
     rules:
+    - alert: ClusterLogForwarderDeprecations
+      annotations:
+        message: The Cluster Logging Operator version {{$labels.version}} includes
+          deprecations to some feature of ClusterLogForwarder.
+        summary: "The Cluster Logging Operator version {{$labels.version}} includes
+          deprecations to some features of ClusterLogForwarder which \nwill be removed
+          in a future release.  Please see the release notes for details: \nhttps://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.4/html/release_notes/logging-release-notes"
+      expr: |
+        max by (version) (csv_succeeded{exported_namespace="openshift-logging", name=~"cluster-logging.*", version=~"6.4.*"})  > 0
+      for: 1h
+      labels:
+        namespace: openshift-logging
+        service: collector
+        severity: info
     - alert: CollectorNodeDown
       annotations:
         description: Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod

--- a/config/prometheus/collector_alerts.yaml
+++ b/config/prometheus/collector_alerts.yaml
@@ -7,6 +7,20 @@ spec:
   groups:
   - name: logging_collector.alerts
     rules:
+    - alert: ClusterLogForwarderDeprecations
+      annotations:
+        message: "The Cluster Logging Operator version {{$labels.version}} includes deprecations to some feature of ClusterLogForwarder."
+        summary: |-
+          The Cluster Logging Operator version {{$labels.version}} includes deprecations to some features of ClusterLogForwarder which 
+          will be removed in a future release.  Please see the release notes for details: 
+          https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.4/html/release_notes/logging-release-notes
+      expr: |
+        max by (version) (csv_succeeded{exported_namespace="openshift-logging", name=~"cluster-logging.*", version=~"6.4.*"})  > 0
+      for: 1h
+      labels:
+        namespace: openshift-logging
+        service: collector
+        severity: info
     - alert: CollectorNodeDown
       annotations:
         description: "Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod }} collector component for more than 10m."


### PR DESCRIPTION
### Description
This PR:
* Add an informational alert to notify administrators about deprecated ClusterLogForwarder features

### Links
https://issues.redhat.com/browse/LOG-7596

cc @xperimental @cahartma @r2d2rnd 

Upon install I see it is informational and pending which I'm not certain is the effect we desire.  Please advise:
<img width="1198" height="504" alt="image" src="https://github.com/user-attachments/assets/7f94f33d-35f7-4586-b6bc-30cf1bbe4904" />

