### PR TITLE
LOG-7502: Vector stops log forwarding when the TCP session is killed

### DIFF
--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -2,10 +2,11 @@ package syslog
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/api/observability"
-	commontemplate "github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common/template"
 	"net/url"
 	"strings"
+
+	"github.com/openshift/cluster-logging-operator/internal/api/observability"
+	commontemplate "github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common/template"
 
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common/tls"
@@ -95,6 +96,9 @@ type = "socket"
 inputs = {{.Inputs}}
 address = "{{.Address}}"
 mode = "{{.Mode}}"
+{{if eq .Mode "tcp"}}
+keepalive.time_secs = 60
+{{end}}
 {{end}}`
 }
 

--- a/internal/generator/vector/output/syslog/tcp_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_defaults.toml
@@ -30,6 +30,7 @@ type = "socket"
 inputs = ["example_parse_encoding"]
 address = "logserver:514"
 mode = "tcp"
+keepalive.time_secs = 60
 
 [sinks.example.encoding]
 codec = "syslog"

--- a/internal/generator/vector/output/syslog/tcp_with_tuning.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_tuning.toml
@@ -31,6 +31,7 @@ type = "socket"
 inputs = ["example_parse_encoding"]
 address = "logserver:514"
 mode = "tcp"
+keepalive.time_secs = 60
 
 [sinks.example.encoding]
 codec = "syslog"

--- a/internal/generator/vector/output/syslog/tls_with_field_references.toml
+++ b/internal/generator/vector/output/syslog/tls_with_field_references.toml
@@ -21,6 +21,7 @@ type = "socket"
 inputs = ["example_parse_encoding"]
 address = "logserver:6514"
 mode = "tcp"
+keepalive.time_secs = 60
 
 [sinks.example.encoding]
 codec = "syslog"


### PR DESCRIPTION
### Description

This PR adds the [keepalive.time_secs](https://vector.dev/docs/reference/configuration/sinks/socket/#keepalive.time_secs) option to the `Syslog` sink for TCP connections. This allows `Vector` to quickly detect and re-establish connections that have been silently closed by network devices (like firewalls), preventing data loss.

This parameter is not configurable and is defaulted to `60` seconds.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-7502
- Upstream Issue tracker: https://github.com/vectordotdev/vector/issues/4933
