### PR TITLE
LOG-7620: The '.openshift.sequence' not getting pruned in Logging 6.3

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -33,6 +33,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null
@@ -174,6 +175,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 '''
 
 # Logs from openshift audit
@@ -200,6 +202,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 '''
 
 # Logs from ovn audit
@@ -222,6 +225,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null
@@ -353,6 +357,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null
@@ -463,6 +468,7 @@ source = '''
   ._internal.log_source = "node"
   ._internal.log_type = "infrastructure"
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if ._internal.PRIORITY == "8" || ._internal.PRIORITY == 8 {
   	._internal.level = "trace"
@@ -565,6 +571,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null
@@ -674,8 +681,7 @@ source = '''
 type = "remap"
 inputs = ["pipeline_pipeline_my_labels_0"]
 source = '''
-  if ._internal.log_type != "receiver" { ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")}
-   if exists(._internal.hostname) { .hostname = ._internal.hostname }
+  if exists(._internal.hostname) { .hostname = ._internal.hostname }
   .log_type = ._internal.log_type
   .log_source = ._internal.log_source
 

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -33,6 +33,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null
@@ -172,6 +173,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 '''
 
 # Logs from openshift audit
@@ -198,6 +200,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 '''
 
 # Logs from ovn audit
@@ -220,7 +223,8 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
-
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
+  
   if !exists(._internal.level) {
   level = null
   message = ._internal.message
@@ -350,7 +354,8 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
-
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
+  
   if !exists(._internal.level) {
   level = null
   message = ._internal.message
@@ -460,6 +465,7 @@ source = '''
   ._internal.log_source = "node"
   ._internal.log_type = "infrastructure"
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if ._internal.PRIORITY == "8" || ._internal.PRIORITY == 8 {
   	._internal.level = "trace"
@@ -567,6 +573,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 '''
 
 # Logs from containers (including openshift containers)
@@ -602,6 +609,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null
@@ -704,8 +712,7 @@ source = '''
 type = "remap"
 inputs = ["input_audit_host_meta","input_audit_kube_meta","input_audit_openshift_meta","input_audit_ovn_meta","input_infrastructure_container_meta","input_infrastructure_journal_meta","input_myreceiver_meta","input_mytestapp_container_meta"]
 source = '''
-  if ._internal.log_type != "receiver" { ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")}
-   if exists(._internal.hostname) { .hostname = ._internal.hostname }
+  if exists(._internal.hostname) { .hostname = ._internal.hostname }
   .log_type = ._internal.log_type
   .log_source = ._internal.log_source
 

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -46,6 +46,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null
@@ -177,6 +178,7 @@ source = '''
 
 ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
 ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
 if !exists(._internal.level) {
   level = null
@@ -286,8 +288,7 @@ source = '''
 type = "remap"
 inputs = ["pipeline_mypipeline_my_labels_0"]
 source = '''
-      if ._internal.log_type != "receiver" { ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")}
-       if exists(._internal.hostname) { .hostname = ._internal.hostname }
+      if exists(._internal.hostname) { .hostname = ._internal.hostname }
       .log_type = ._internal.log_type
       .log_source = ._internal.log_source
 

--- a/internal/generator/vector/filter/openshift/viaq/v1/filter.go
+++ b/internal/generator/vector/filter/openshift/viaq/v1/filter.go
@@ -2,12 +2,13 @@ package v1
 
 import (
 	"fmt"
+	"strings"
+
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	internalobs "github.com/openshift/cluster-logging-operator/internal/api/observability"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
-	"strings"
 )
 
 const (
@@ -18,7 +19,6 @@ const (
 func New(id string, inputs []string, inputSpecs []obs.InputSpec) framework.Element {
 
 	vrls := []string{
-		SetOpenShiftSequence,
 		SetHostnameOnRoot,
 		SetLogTypeOnRoot,
 		SetLogSourceOnRoot,

--- a/internal/generator/vector/filter/openshift/viaq/v1/normalize.go
+++ b/internal/generator/vector/filter/openshift/viaq/v1/normalize.go
@@ -149,5 +149,4 @@ if !exists(._internal.structured) {
 if exists(._internal.openshift) {.openshift = ._internal.openshift}
 if exists(._internal.dedot_openshift_labels) {.openshift.labels = del(._internal.dedot_openshift_labels) }
 `
-	SetOpenShiftSequence = `if ._internal.log_type != "receiver" { ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")}`
 )

--- a/internal/generator/vector/input/application.toml
+++ b/internal/generator/vector/input/application.toml
@@ -30,6 +30,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/application_exclude_container_from_infra.toml
+++ b/internal/generator/vector/input/application_exclude_container_from_infra.toml
@@ -31,6 +31,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/application_excludes_container.toml
+++ b/internal/generator/vector/input/application_excludes_container.toml
@@ -30,7 +30,8 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
-
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
+  
   if !exists(._internal.level) {
   level = null
   message = ._internal.message

--- a/internal/generator/vector/input/application_includes_container.toml
+++ b/internal/generator/vector/input/application_includes_container.toml
@@ -31,6 +31,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/application_with_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_includes_excludes.toml
@@ -31,6 +31,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/application_with_infra_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_excludes.toml
@@ -31,6 +31,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
@@ -31,6 +31,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/application_with_matchLabels.toml
+++ b/internal/generator/vector/input/application_with_matchLabels.toml
@@ -31,6 +31,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
@@ -31,6 +31,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/application_with_throttle.toml
+++ b/internal/generator/vector/input/application_with_throttle.toml
@@ -30,6 +30,7 @@ source = '''
 
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/audit.toml
+++ b/internal/generator/vector/input/audit.toml
@@ -18,6 +18,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null
@@ -159,6 +160,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 '''
 
 # Logs from openshift audit
@@ -185,6 +187,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 '''
 
 # Logs from ovn audit
@@ -207,6 +210,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/audit_host.toml
+++ b/internal/generator/vector/input/audit_host.toml
@@ -18,6 +18,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/audit_kube.toml
+++ b/internal/generator/vector/input/audit_kube.toml
@@ -22,4 +22,5 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 '''

--- a/internal/generator/vector/input/audit_openshift.toml
+++ b/internal/generator/vector/input/audit_openshift.toml
@@ -22,4 +22,5 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 '''

--- a/internal/generator/vector/input/audit_ovn.toml
+++ b/internal/generator/vector/input/audit_ovn.toml
@@ -18,6 +18,7 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/infrastructure.toml
+++ b/internal/generator/vector/input/infrastructure.toml
@@ -30,6 +30,7 @@ source = '''
   }
    ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
    ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+    ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
 if !exists(._internal.level) {
   level = null
@@ -141,6 +142,7 @@ source = '''
   ._internal.log_source = "node"
   ._internal.log_type = "infrastructure"
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if ._internal.PRIORITY == "8" || ._internal.PRIORITY == 8 {
     ._internal.level = "trace"

--- a/internal/generator/vector/input/infrastructure_container.toml
+++ b/internal/generator/vector/input/infrastructure_container.toml
@@ -30,6 +30,7 @@ source = '''
   }
     ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
     ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+    ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if !exists(._internal.level) {
   level = null

--- a/internal/generator/vector/input/infrastructure_journal.toml
+++ b/internal/generator/vector/input/infrastructure_journal.toml
@@ -10,6 +10,7 @@ source = '''
   ._internal.log_source = "node"
   ._internal.log_type = "infrastructure"
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 
   if ._internal.PRIORITY == "8" || ._internal.PRIORITY == 8 {
     ._internal.level = "trace"

--- a/internal/generator/vector/input/internal.go
+++ b/internal/generator/vector/input/internal.go
@@ -2,13 +2,15 @@ package input
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-logging-operator/internal/generator/vector/filter/openshift/viaq/v1"
+
+	v1 "github.com/openshift/cluster-logging-operator/internal/generator/vector/filter/openshift/viaq/v1"
+
+	"strings"
 
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/generator/framework"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/elements"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/helpers"
-	"strings"
 )
 
 const (
@@ -28,6 +30,7 @@ const (
 `
 
 	setClusterID            = `._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}`
+	setOpenshiftSequence    = `._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")`
 	setEnvelope             = `. = {"_internal": .}`
 	setEnvelopeToStructured = `. = {"_internal": {"structured": .}}`
 	setHostName             = `._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""`
@@ -44,6 +47,7 @@ func NewAuditInternalNormalization(id string, logSource obs.AuditSource, inputs 
 		fmt.Sprintf(fmtLogType, obs.InputTypeAudit),
 		setHostName,
 		setClusterID,
+		setOpenshiftSequence,
 	)
 	vrls = append(vrls, addVRLs...)
 	return elements.Remap{
@@ -65,6 +69,7 @@ func NewInternalNormalization(id string, logSource, logType interface{}, inputs 
 		logTypeVRL,
 		setHostName,
 		setClusterID,
+		setOpenshiftSequence,
 		v1.SetLogLevel,
 	}
 	vrls = append(vrls, addVRLs...)
@@ -82,6 +87,7 @@ func NewJournalInternalNormalization(id string, logSource interface{}, envelopeV
 		fmt.Sprintf(fmtLogSource, logSource),
 		fmt.Sprintf(fmtLogType, obs.InputTypeInfrastructure),
 		setClusterID,
+		setOpenshiftSequence,
 	}
 	vrls = append(vrls, addVRLs...)
 	return elements.Remap{

--- a/internal/generator/vector/input/receiver_http_audit.toml
+++ b/internal/generator/vector/input/receiver_http_audit.toml
@@ -34,4 +34,5 @@ source = '''
   ._internal.log_type = "audit"
   ._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""
   ._internal.openshift = { "cluster_id": "${OPENSHIFT_CLUSTER_ID:-}"}
+  ._internal.openshift.sequence = to_unix_timestamp(now(), unit: "nanoseconds")
 '''

--- a/test/functional/outputs/splunk/forward_to_splunk_metadata_test.go
+++ b/test/functional/outputs/splunk/forward_to_splunk_metadata_test.go
@@ -2,11 +2,15 @@ package splunk
 
 import (
 	"fmt"
-	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
-	"github.com/openshift/cluster-logging-operator/test/helpers/types"
-	obstestruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
 	"regexp"
 	"time"
+
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/test/helpers/splunk"
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
+	obstestruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
+
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,7 +19,6 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	v1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 var _ = Describe("Forwarding to Splunk with Metadata", func() {
@@ -53,7 +56,7 @@ var _ = Describe("Forwarding to Splunk with Metadata", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			WaitOnSplunk(framework)
+			splunk.WaitOnSplunk(framework)
 
 			// Write app logs
 			timestamp := "2020-11-04T18:13:59.061892+00:00"
@@ -108,7 +111,7 @@ var _ = Describe("Forwarding to Splunk with Metadata", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			WaitOnSplunk(framework)
+			splunk.WaitOnSplunk(framework)
 
 			// Write audit logs
 			writeAuditLogs := framework.WriteK8sAuditLog(2)
@@ -171,7 +174,7 @@ var _ = Describe("Forwarding to Splunk with Metadata", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			WaitOnSplunk(framework)
+			splunk.WaitOnSplunk(framework)
 
 			// Write app logs
 			timestamp := "2020-11-04T18:13:59.061892+00:00"
@@ -216,7 +219,7 @@ var _ = Describe("Forwarding to Splunk with Metadata", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			WaitOnSplunk(framework)
+			splunk.WaitOnSplunk(framework)
 
 			// Write app logs
 			timestamp := "2020-11-04T18:13:59.061892+00:00"
@@ -253,7 +256,7 @@ var _ = Describe("Forwarding to Splunk with Metadata", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			WaitOnSplunk(framework)
+			splunk.WaitOnSplunk(framework)
 
 			if inputType == obs.InputTypeApplication {
 				if expSource == "" {
@@ -319,7 +322,7 @@ var _ = Describe("Forwarding to Splunk with Metadata", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			WaitOnSplunk(framework)
+			splunk.WaitOnSplunk(framework)
 
 			// Write app logs
 			timestamp := "2020-11-04T18:13:59.061892+00:00"

--- a/test/functional/outputs/splunk/forward_to_splunk_test.go
+++ b/test/functional/outputs/splunk/forward_to_splunk_test.go
@@ -2,10 +2,14 @@ package splunk
 
 import (
 	"fmt"
+	"time"
+
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/test/helpers/splunk"
 	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	obstestruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
-	"time"
+
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,34 +18,9 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	v1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 const SplunkSecretName = "splunk-secret"
-
-func WaitOnSplunk(f *functional.CollectorFunctionalFramework) {
-	time.Sleep(20 * time.Second)
-	Eventually(func() string {
-		// Run the Splunk CLI status command to check if splunkd is running
-		output, err := f.SplunkHealthCheck()
-		if err != nil {
-			return output
-		}
-		return output
-	}, 90*time.Second, 3*time.Second).Should(ContainSubstring("HEC is healthy"))
-	time.Sleep(1 * time.Second)
-	Eventually(func() string {
-		// Run the Splunk CLI status command to check if splunkd is running
-		output, err := f.ReadSplunkStatus()
-		if err != nil {
-			return output
-		}
-		return output
-	}, 15*time.Second, 3*time.Second).Should(SatisfyAll(
-		ContainSubstring("splunkd is running"),
-		ContainSubstring("splunk helpers are running"),
-	))
-}
 
 var _ = Describe("Forwarding to Splunk", func() {
 	var (
@@ -73,7 +52,7 @@ var _ = Describe("Forwarding to Splunk", func() {
 		Expect(framework.Deploy()).To(BeNil())
 
 		// Wait for splunk to be ready
-		WaitOnSplunk(framework)
+		splunk.WaitOnSplunk(framework)
 
 		// Write app logs
 		timestamp := "2020-11-04T18:13:59.061892+00:00"
@@ -105,7 +84,7 @@ var _ = Describe("Forwarding to Splunk", func() {
 		Expect(framework.Deploy()).To(BeNil())
 
 		// Wait for splunk to be ready
-		WaitOnSplunk(framework)
+		splunk.WaitOnSplunk(framework)
 
 		// Write audit logs
 		timestamp, _ := time.Parse(time.RFC3339Nano, "2024-04-16T09:46:19.116+00:00")
@@ -149,7 +128,7 @@ var _ = Describe("Forwarding to Splunk", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			WaitOnSplunk(framework)
+			splunk.WaitOnSplunk(framework)
 
 			// Write app logs
 			timestamp := "2020-11-04T18:13:59.061892+00:00"
@@ -192,7 +171,7 @@ var _ = Describe("Forwarding to Splunk", func() {
 			Expect(framework.Deploy()).To(BeNil())
 
 			// Wait for splunk to be ready
-			WaitOnSplunk(framework)
+			splunk.WaitOnSplunk(framework)
 
 			// Write app logs
 			timestamp := "2020-11-04T18:13:59.061892+00:00"

--- a/test/helpers/splunk/splunk.go
+++ b/test/helpers/splunk/splunk.go
@@ -1,0 +1,33 @@
+package splunk
+
+import (
+	"time"
+
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	. "github.com/onsi/gomega"
+)
+
+// WaitOnSplunk waits for Splunk to be ready by checking HEC health and service status
+func WaitOnSplunk(f *functional.CollectorFunctionalFramework) {
+	time.Sleep(20 * time.Second)
+	Eventually(func() string {
+		// Run the Splunk CLI status command to check if splunkd is running
+		output, err := f.SplunkHealthCheck()
+		if err != nil {
+			return output
+		}
+		return output
+	}, 90*time.Second, 3*time.Second).Should(ContainSubstring("HEC is healthy"))
+	time.Sleep(1 * time.Second)
+	Eventually(func() string {
+		// Run the Splunk CLI status command to check if splunkd is running
+		output, err := f.ReadSplunkStatus()
+		if err != nil {
+			return output
+		}
+		return output
+	}, 15*time.Second, 3*time.Second).Should(SatisfyAll(
+		ContainSubstring("splunkd is running"),
+		ContainSubstring("splunk helpers are running"),
+	))
+}


### PR DESCRIPTION
### Description
This PR resolves a bug where the prune transform failed to remove the `.openshift.sequence` field from log events. The removal logic has been corrected to ensure this field is successfully pruned.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://issues.redhat.com/browse/LOG-7620
