### PR TITLE
LOG-7806: Manual port of LOG-7622 to release-6.3

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -261,6 +261,7 @@ type = "remap"
 inputs = ["input_infrastructure_container"]
 source = '''
   . = {"_internal": .}
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
 
     # If namespace is infra, label log_type as infra
@@ -433,6 +434,7 @@ type = "remap"
 inputs = ["input_mytestapp_container"]
 source = '''
   . = {"_internal": .}
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
 
     # If namespace is infra, label log_type as infra
@@ -586,7 +588,6 @@ source = '''
     ._internal.dedot_openshift_labels = set!(._internal.dedot_openshift_labels,[newkey],value)
   }}
   .kubernetes = ._internal.kubernetes
-  .kubernetes.container_iostream = ._internal.stream
   if exists(._internal.dedot_labels) {.kubernetes.labels = del(._internal.dedot_labels) }
   if exists(._internal.dedot_namespace_labels) {.kubernetes.namespace_labels = del(._internal.dedot_namespace_labels) }
   del(.kubernetes.node_labels)

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -258,6 +258,7 @@ type = "remap"
 inputs = ["input_infrastructure_container"]
 source = '''
   . = {"_internal": .}
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
 
     # If namespace is infra, label log_type as infra
@@ -471,6 +472,7 @@ type = "remap"
 inputs = ["input_mytestapp_container"]
 source = '''
   . = {"_internal": .}
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
 
     # If namespace is infra, label log_type as infra
@@ -617,7 +619,6 @@ source = '''
     ._internal.dedot_openshift_labels = set!(._internal.dedot_openshift_labels,[newkey],value)
   }}
   .kubernetes = ._internal.kubernetes
-  .kubernetes.container_iostream = ._internal.stream
   if exists(._internal.dedot_labels) {.kubernetes.labels = del(._internal.dedot_labels) }
   if exists(._internal.dedot_namespace_labels) {.kubernetes.namespace_labels = del(._internal.dedot_namespace_labels) }
   del(.kubernetes.node_labels)

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -33,8 +33,9 @@ use_apiserver_cache = true
 type = "remap"
 inputs = ["input_myinfra_container"]
 source = '''
-      . = {"_internal": .}
-      ._internal.log_source = "container"
+  . = {"_internal": .}
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+  ._internal.log_source = "container"
 
         # If namespace is infra, label log_type as infra
         if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
@@ -123,8 +124,9 @@ use_apiserver_cache = true
 type = "remap"
 inputs = ["input_mytestapp_container"]
 source = '''
-      . = {"_internal": .}
-      ._internal.log_source = "container"
+. = {"_internal": .}
+if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+._internal.log_source = "container"
 
         # If namespace is infra, label log_type as infra
         if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
@@ -250,7 +252,6 @@ source = '''
         ._internal.dedot_openshift_labels = set!(._internal.dedot_openshift_labels,[newkey],value)
       }}
       .kubernetes = ._internal.kubernetes
-      .kubernetes.container_iostream = ._internal.stream
       if exists(._internal.dedot_labels) {.kubernetes.labels = del(._internal.dedot_labels) }
       if exists(._internal.dedot_namespace_labels) {.kubernetes.namespace_labels = del(._internal.dedot_namespace_labels) }
       del(.kubernetes.node_labels)

--- a/internal/generator/vector/filter/openshift/viaq/v1/normalize.go
+++ b/internal/generator/vector/filter/openshift/viaq/v1/normalize.go
@@ -90,7 +90,6 @@ if ._internal.log_type != "audit" && exists(._internal.level) {
 	SetLogSourceOnRoot  = ".log_source = ._internal.log_source"
 	SetKubernetesOnRoot = `
 .kubernetes = ._internal.kubernetes
-.kubernetes.container_iostream = ._internal.stream
 if exists(._internal.dedot_labels) {.kubernetes.labels = del(._internal.dedot_labels) }
 if exists(._internal.dedot_namespace_labels) {.kubernetes.namespace_labels = del(._internal.dedot_namespace_labels) }
 del(.kubernetes.node_labels)

--- a/internal/generator/vector/input/application.toml
+++ b/internal/generator/vector/input/application.toml
@@ -19,7 +19,7 @@ type = "remap"
 inputs = ["input_application_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {

--- a/internal/generator/vector/input/application_exclude_container_from_infra.toml
+++ b/internal/generator/vector/input/application_exclude_container_from_infra.toml
@@ -20,7 +20,7 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {

--- a/internal/generator/vector/input/application_excludes_container.toml
+++ b/internal/generator/vector/input/application_excludes_container.toml
@@ -19,7 +19,7 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {

--- a/internal/generator/vector/input/application_includes_container.toml
+++ b/internal/generator/vector/input/application_includes_container.toml
@@ -20,7 +20,7 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {

--- a/internal/generator/vector/input/application_with_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_includes_excludes.toml
@@ -20,7 +20,7 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {

--- a/internal/generator/vector/input/application_with_infra_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_excludes.toml
@@ -20,7 +20,7 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {

--- a/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
@@ -20,7 +20,7 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {

--- a/internal/generator/vector/input/application_with_matchLabels.toml
+++ b/internal/generator/vector/input/application_with_matchLabels.toml
@@ -20,7 +20,7 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {

--- a/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
@@ -20,7 +20,7 @@ type = "remap"
 inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {

--- a/internal/generator/vector/input/application_with_throttle.toml
+++ b/internal/generator/vector/input/application_with_throttle.toml
@@ -19,7 +19,7 @@ type = "remap"
 inputs = ["input_application_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {

--- a/internal/generator/vector/input/infrastructure.toml
+++ b/internal/generator/vector/input/infrastructure.toml
@@ -20,6 +20,7 @@ type = "remap"
 inputs = ["input_infrastructure_container"]
 source = '''
   . = {"_internal": .}
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
 
   # If namespace is infra, label log_type as infra

--- a/internal/generator/vector/input/infrastructure_container.toml
+++ b/internal/generator/vector/input/infrastructure_container.toml
@@ -20,7 +20,7 @@ type = "remap"
 inputs = ["input_myinfra_container"]
 source = '''
   . = {"_internal": .}
-
+  if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
   if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {


### PR DESCRIPTION
### Description
This is a manual port of [LOG-7622](https://issues.redhat.com/browse/LOG-7622) to `release-6.3`.

#### Original Description:

This PR resolves a bug where the prune transform failed to remove the `.kubernetes.container_iostream` field from log events. The removal logic has been corrected to ensure this field is successfully pruned.

/cc @cahartma @vparfonov 
/assign @jcantrill

### Links
- JIRA: https://issues.redhat.com/browse/LOG-7806
