### PR TITLE
NO-JIRA: replace deprecated --slow-spec-threshold with --poll-progress flags

### DIFF
--- a/hack/testing-olm/test-030-collection.sh
+++ b/hack/testing-olm/test-030-collection.sh
@@ -57,7 +57,7 @@ for dir in $(ls -d $TEST_DIR| grep -E "${INCLUDES}"); do
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/collection/cleanup.sh $artifact_dir $GENERATOR_NS" \
     artifact_dir=$artifact_dir \
     GENERATOR_NS=$GENERATOR_NS \
-    ginkgo -p -procs=1 -v --no-color --trace --slow-spec-threshold=300s --timeout=60m "$dir" | tee -a "$artifact_dir/test.log" ; then
+    ginkgo -p -procs=1 -v --no-color --trace --poll-progress-after=300s --poll-progress-interval=30s --timeout=60m "$dir" | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "Collection $dir passed"
     os::log::info "======================================================="

--- a/hack/testing-olm/test-060-flowcontrol.sh
+++ b/hack/testing-olm/test-060-flowcontrol.sh
@@ -60,7 +60,7 @@ for dir in $(ls -d $TEST_DIR); do
   mkdir -p $artifact_dir
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/flowcontrol/cleanup.sh $artifact_dir" \
     artifact_dir=$artifact_dir \
-    ginkgo -p -procs=1 -v --no-color --trace --slow-spec-threshold=300s  --timeout=60m "$dir" | tee -a "$artifact_dir/test.log" ; then
+    ginkgo -p -procs=1 -v --no-color --trace --poll-progress-after=300s --poll-progress-interval=30s  --timeout=60m "$dir" | tee -a "$artifact_dir/test.log" ; then
 
     os::log::info "======================================================="
     os::log::info "Flowcontrol $dir passed"

--- a/hack/testing-olm/test-2227-input-selection.sh
+++ b/hack/testing-olm/test-2227-input-selection.sh
@@ -45,7 +45,7 @@ for dir in $(ls -d $TEST_DIR); do
   mkdir -p $artifact_dir
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/input_selection/cleanup.sh $artifact_dir" \
     artifact_dir=$artifact_dir \
-    ginkgo -p -procs=1 -v --no-color --trace --slow-spec-threshold=300s  --timeout=60m "$dir" | tee -a "$artifact_dir/test.log" ; then
+    ginkgo -p -procs=1 -v --no-color --trace --poll-progress-after=300s --poll-progress-interval=30s  --timeout=60m "$dir" | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "Collection Input Selection '$dir' passed"
     os::log::info "======================================================="

--- a/hack/testing-olm/test-367-logforwarding.sh
+++ b/hack/testing-olm/test-367-logforwarding.sh
@@ -65,7 +65,7 @@ for dir in $(eval echo $TEST_DIR); do
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/logforwarding/cleanup.sh $artifact_dir" \
     artifact_dir=$artifact_dir \
     SUCCESS_TIMEOUT=10m \
-    ginkgo -p -procs=1 -v --no-color --trace --slow-spec-threshold=600s --timeout=90m ${GINKGO_OPTS} "$dir" | tee -a "$artifact_dir/test.log" ; then
+    ginkgo -p -procs=1 -v --no-color --trace --poll-progress-after=600s --poll-progress-interval=30s --timeout=90m ${GINKGO_OPTS} "$dir" | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "Logforwarding $dir passed"
     os::log::info "======================================================="

--- a/hack/testing-olm/test-logfilesmetricexporter.sh
+++ b/hack/testing-olm/test-logfilesmetricexporter.sh
@@ -45,7 +45,7 @@ for dir in $(ls -d $TEST_DIR); do
   mkdir -p $artifact_dir
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/logfilesmetricexporter/cleanup.sh $artifact_dir" \
     artifact_dir=$artifact_dir \
-    ginkgo -p -procs=1 -v --no-color --trace --slow-spec-threshold=300s  --timeout=5m "$dir" | tee -a "$artifact_dir/test.log" ; then
+    ginkgo -p -procs=1 -v --no-color --trace --poll-progress-after=300s --poll-progress-interval=30s  --timeout=5m "$dir" | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="
     os::log::info "LogFilesMetricsExporter '$dir' passed"
     os::log::info "======================================================="


### PR DESCRIPTION
### Description
Replaced the deprecated Ginkgo flag `--slow-spec-threshold` (deprecated in Ginkgo v2) with the new progress reporting flags `--poll-progress-after` and `--poll-progress-interval`, because it generated excessive noise: 
```
You're using deprecated Ginkgo functionality:
=============================================
  --slow-spec-threshold is deprecated --slow-spec-threshold has been deprecated and will be removed in a future version of Ginkgo.  This feature has proved to be more noisy than useful.  You can use --poll-progress-after, instead, to get more actionable feedback about potentially slow specs and understand where they might be getting stuck.
```

Added:
`--poll-progress-after=300s` — starts showing progress if no spec completes for 300 seconds  (5 minutes)
`--poll-progress-interval=30s` — prints progress updates every 30 seconds afterward

Example:
`ginkgo -p -procs=1 -v --no-color --trace --poll-progress-after=300s --poll-progress-interval=30s --timeout=60m "$dir" | tee -a "$artifact_dir/test.log"`


/cc @Clee2691 @cahartma <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:
