### PR TITLE
LOG-8090: escape 'new line' (\n) in EventRouter message

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -725,10 +725,12 @@ source = '''
     } else {
       ._internal.event = parsed
       if exists(._internal.event.event) && is_object(._internal.event.event) {
-          ._internal.kubernetes.event = del(._internal.event.event)
-  		._internal.kubernetes.event.verb = ._internal.event.verb
-          ._internal.message = del(._internal.kubernetes.event.message)
-          ._internal."@timestamp" = .kubernetes.event.metadata.creationTimestamp
+        ._internal.kubernetes.event = del(._internal.event.event)
+        ._internal.kubernetes.event.verb = del(._internal.event.verb)
+        # escape 'new line' symbol see: LOG-8090
+        msg = to_string!(del(._internal.kubernetes.event.message))
+        ._internal.message = replace(msg, "\n", s'\n')
+        ._internal."@timestamp" = .kubernetes.event.metadata.creationTimestamp
       } else {
         log("Unable to merge EventRouter log message into record: " + err, level: "info")
       }

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -756,10 +756,12 @@ source = '''
     } else {
       ._internal.event = parsed
       if exists(._internal.event.event) && is_object(._internal.event.event) {
-          ._internal.kubernetes.event = del(._internal.event.event)
-  		._internal.kubernetes.event.verb = ._internal.event.verb
-          ._internal.message = del(._internal.kubernetes.event.message)
-          ._internal."@timestamp" = .kubernetes.event.metadata.creationTimestamp
+        ._internal.kubernetes.event = del(._internal.event.event)
+        ._internal.kubernetes.event.verb = del(._internal.event.verb)
+        # escape 'new line' symbol see: LOG-8090
+        msg = to_string!(del(._internal.kubernetes.event.message))
+        ._internal.message = replace(msg, "\n", s'\n')
+        ._internal."@timestamp" = .kubernetes.event.metadata.creationTimestamp
       } else {
         log("Unable to merge EventRouter log message into record: " + err, level: "info")
       }

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -305,10 +305,12 @@ source = '''
         } else {
           ._internal.event = parsed
           if exists(._internal.event.event) && is_object(._internal.event.event) {
-              ._internal.kubernetes.event = del(._internal.event.event)
-      		._internal.kubernetes.event.verb = ._internal.event.verb
-              ._internal.message = del(._internal.kubernetes.event.message)
-              ._internal."@timestamp" = .kubernetes.event.metadata.creationTimestamp
+            ._internal.kubernetes.event = del(._internal.event.event)
+      		._internal.kubernetes.event.verb = del(._internal.event.verb)
+            # escape 'new line' symbol see: LOG-8090
+            msg = to_string!(del(._internal.kubernetes.event.message))
+            ._internal.message = replace(msg, "\n", s'\n')
+            ._internal."@timestamp" = .kubernetes.event.metadata.creationTimestamp
           } else {
             log("Unable to merge EventRouter log message into record: " + err, level: "info")
           }

--- a/test/helpers/syslog/parser.go
+++ b/test/helpers/syslog/parser.go
@@ -1,0 +1,63 @@
+package syslog
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+type SyslogMessage struct {
+	Priority        int
+	Version         int
+	Timestamp       time.Time
+	Hostname        string
+	AppName         string
+	ProcID          string
+	MsgID           string
+	StructuredData  string
+	MessagePayload  string
+}
+
+// ParseRFC5424SyslogLogs takes raw output and returns structured SyslogMessage objects.
+func ParseRFC5424SyslogLogs(rawLog string) (*SyslogMessage, error) {
+	if rawLog == "" {
+		return &SyslogMessage{}, nil
+	}
+	rawLog = strings.TrimSpace(rawLog)
+	syslogRegex := regexp.MustCompile(
+		`^<(\d{1,3})>1\s` + //PRI VERSION
+			`([^\s]+)\s` + // TIMESTAMP
+			`([^\s]+)\s` + // HOSTNAME
+			`([^\s]+)\s` + // APP-NAME
+			`([^\s]+)\s` + // PROCID
+			`([^\s]+)\s` + // MSGID
+			`(-|\[[^\]]+\])\s` + // STRUCTURED-DATA
+			`(.*)$`)        // MESSAGE-PAYLOAD
+
+		matches := syslogRegex.FindStringSubmatch(rawLog)
+
+		if len(matches) != 9 {
+			return nil, fmt.Errorf("failed to parse Syslog line: expected 9 submatches (got %d) in line: %s", len(matches), rawLog)
+		}
+		priority, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return nil, err
+		}
+		ts, err := time.Parse(time.RFC3339Nano, matches[2])
+		if err != nil {
+			return nil, err
+		}
+		msg := &SyslogMessage{
+			Priority:        priority,
+			Version:         1,
+			Timestamp:       ts,
+			Hostname:        matches[3],
+			AppName:         matches[4],
+			ProcID:          matches[5],
+			MsgID:           matches[6],
+			StructuredData:  matches[7],
+			MessagePayload:  matches[8],
+		}
+	return msg, nil
+}

--- a/test/helpers/syslog/parser_test.go
+++ b/test/helpers/syslog/parser_test.go
@@ -1,0 +1,63 @@
+package syslog
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("[test][helpers][syslog] ParseRFC5424SyslogLogs", func() {
+
+	const (
+		testTime        = "2025-11-24T10:30:00.123456Z"
+		expectedAppName = "eventrouter"
+		expectedHost    = "my-test-node"
+	)
+
+	DescribeTable("should correctly parse valid RFC 5424 log lines",
+		func(rawLogLine, expectedJSONPayload, expectedStructuredData string, expectedPriority int) {
+			msg, err := ParseRFC5424SyslogLogs(rawLogLine)
+
+			Expect(err).NotTo(HaveOccurred(), "Parsing should succeed without error")
+			Expect(msg.Priority).To(Equal(expectedPriority), "Priority should match")
+			Expect(msg.Version).To(Equal(1), "Version should be 1")
+			Expect(msg.Hostname).To(Equal(expectedHost), "Hostname should match")
+			Expect(msg.AppName).To(Equal(expectedAppName), "App-Name should match")
+			Expect(msg.StructuredData).To(Equal(expectedStructuredData), "Structured Data should match")
+
+			expectedTime, _ := time.Parse(time.RFC3339Nano, testTime)
+			Expect(msg.Timestamp).To(BeTemporally("~", expectedTime, time.Second), "Timestamp should be correctly parsed")
+
+		},
+		Entry("when SD is hyphen and payload is simple JSON",
+			fmt.Sprintf("<14>1 %s %s %s - - - %s", testTime, expectedHost, expectedAppName, `{"key":"value","event":"added"}`),
+			`{"key":"value","event":"added"}`,
+			"-",
+			14,
+		),
+	)
+
+	It("should return an error for malformed Syslog lines", func() {
+		// A log line missing the version number
+		malformedLog := fmt.Sprintf("<14>%s %s %s - - - %s", testTime, expectedHost, expectedAppName, `{"key":"value"}`)
+		msg, err := ParseRFC5424SyslogLogs(malformedLog)
+		Expect(err).To(HaveOccurred(), "Parsing should fail for a malformed line")
+		Expect(msg).To(BeNil(), "Should not return any parsed messages")
+		Expect(err.Error()).To(ContainSubstring("expected 9 submatches"), "Error message should indicate regex failure")
+	})
+
+	It("should return an error for badly formatted timestamps", func() {
+		badTimeLog := fmt.Sprintf("<14>1 %s %s %s - - - %s", "24/11/2025 10:30", expectedHost, expectedAppName, `{"key":"value"}`)
+		msg, err := ParseRFC5424SyslogLogs(badTimeLog)
+		Expect(err).To(HaveOccurred(), "Parsing should fail due to bad timestamp format")
+		Expect(msg).To(BeNil(), "Should not return any parsed messages")
+	})
+})
+
+func TestSyslogParser(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Syslog Parser Unit Test Suite")
+}

--- a/test/helpers/syslog/sender.go
+++ b/test/helpers/syslog/sender.go
@@ -3,6 +3,7 @@ package syslog
 import (
 	_ "embed"
 	"fmt"
+
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"


### PR DESCRIPTION
### Description
This PR addresses a issue where Syslog output format corruption occurs if log messages generated by the `Eventrouter` contain newline characters (\n), this leads to malformed syslog data.
This fix ensures that the log message payload is properly escaped, preventing the introduction of malformed lines.

When JSON contains \\n that becomes a real newline after decoding; sending real newlines in syslog breaks framing and creates split events. This change escapes newline characters (\n) in message payloads so the syslog sink emits a single safe line. 

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @cahartma @kattz-kawa <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-8090
- Enhancement proposal:
