### PR TITLE
[release-6.2]LOG-8137:cleanup hard setting for IMAGE_LOGGING_VECTOR to quay.io/openshift-logging/vector:v0.47.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,7 @@ export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(OPERATOR_NAME):$(CURRENT_BRA
 export LOGGING_VERSION?=6.2
 export VERSION=$(LOGGING_VERSION).0
 export NAMESPACE?=openshift-logging
-# TODO: IMAGE_LOGGING_VECTOR?=quay.io/openshift-logging/vector:v0.47.0 after merging https://github.com/openshift/release/pull/71825
-IMAGE_LOGGING_VECTOR=quay.io/openshift-logging/vector:v0.47.0
+IMAGE_LOGGING_VECTOR?=quay.io/openshift-logging/vector:v0.47.0
 IMAGE_LOGFILEMETRICEXPORTER?=quay.io/openshift-logging/log-file-metric-exporter:6.1
 IMAGE_LOGGING_EVENTROUTER?=quay.io/openshift-logging/eventrouter:0.3
 


### PR DESCRIPTION
### Description
Cleanup temporary hard setting Vector version here https://github.com/openshift/cluster-logging-operator/pull/3161/commits/552a001d4431d9eb6176f1ab9b8f94bd9035f84b  
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:
