### PR TITLE
LOG-9190: Azure Monitor Logs Deprecation Alert

### DIFF
--- a/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -52,6 +52,23 @@ spec:
         namespace: openshift-logging
         service: collector
         severity: info
+    - alert: ClusterLogForwarderAzureMonitorLogsDeprecation
+      annotations:
+        message: A ClusterLogForwarder, {{ $labels.namespace }}/{{ $labels.app_kubernetes_io_instance
+          }}, is configured to forward logs to Azure Monitor using the deprecated
+          HTTP Data Collector API.
+        summary: |-
+          The Azure Monitor HTTP Data Collector API used by the azureMonitor output type will be retired on September 14, 2026.
+          After this date, log forwarding to Azure Monitor using this output type will stop functioning.
+          Administrators must migrate to the Azure Monitor Logs Ingestion output.
+          See the Microsoft migration guide: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/custom-logs-migrate
+          See the Microsoft Logs Ingestion API documentation: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview
+      expr: |
+        log_forwarder_output_type{output="azureMonitor"} > 0
+      for: 1m
+      labels:
+        service: clusterlogforwarder
+        severity: warning
     - alert: CollectorNodeDown
       annotations:
         description: Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod

--- a/config/prometheus/collector_alerts.yaml
+++ b/config/prometheus/collector_alerts.yaml
@@ -51,6 +51,21 @@ spec:
         namespace: openshift-logging
         service: collector
         severity: info
+    - alert: ClusterLogForwarderAzureMonitorLogsDeprecation
+      annotations:
+        message: "A ClusterLogForwarder, {{ $labels.namespace }}/{{ $labels.app_kubernetes_io_instance }}, is configured to forward logs to Azure Monitor using the deprecated HTTP Data Collector API."
+        summary: |-
+          The Azure Monitor HTTP Data Collector API used by the azureMonitor output type will be retired on September 14, 2026.
+          After this date, log forwarding to Azure Monitor using this output type will stop functioning.
+          Administrators must migrate to the Azure Monitor Logs Ingestion output.
+          See the Microsoft migration guide: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/custom-logs-migrate
+          See the Microsoft Logs Ingestion API documentation: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview
+      expr: |
+        log_forwarder_output_type{output="azureMonitor"} > 0
+      for: 1m
+      labels:
+        service: clusterlogforwarder
+        severity: warning
     - alert: CollectorNodeDown
       annotations:
         description: "Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod }} collector component for more than 10m."


### PR DESCRIPTION
### Description
Added alert for `AzureMonitorLogs` deprecation in favor of `AzureLogsIngestion` output.

/cc @cahartma @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://redhat.atlassian.net/browse/LOG-9190
