### PR TITLE
LOG-8973: Enhance the log-file-metrics-exporter to be configurable with TLS Profile that includes curves

### DIFF
--- a/internal/metrics/logfilemetricexporter/factory.go
+++ b/internal/metrics/logfilemetricexporter/factory.go
@@ -113,9 +113,12 @@ func newLogMetricsExporterContainer(exporter loggingv1a1.LogFileMetricExporter, 
 		},
 	}
 	exporterContainer.Command = []string{"/bin/bash"}
+	// TODO: When openshift/api is updated with the Groups field in TLSProfileSpec,
+	// pass groups from the profile spec instead of nil.
 	exporterContainer.Args = []string{"-c",
 		"/usr/local/bin/log-file-metric-exporter -verbosity=2 -dir=/var/log/pods -http=:2112 -keyFile=/etc/logfilemetricexporter/metrics/tls.key -crtFile=/etc/logfilemetricexporter/metrics/tls.crt -tlsMinVersion=" +
-			tls.MinTLSVersion(tlsProfileSpec) + " -cipherSuites=" + strings.Join(tls.TLSCiphers(tlsProfileSpec), ",")}
+			tls.MinTLSVersion(tlsProfileSpec) + " -cipherSuites=" + strings.Join(tls.TLSCiphers(tlsProfileSpec), ",") +
+			" -groups=" + strings.Join(tls.TLSGroups(nil), ",")}
 
 	exporterContainer.VolumeMounts = []v1.VolumeMount{
 		{Name: logContainers, ReadOnly: true, MountPath: logContainersValue},

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -18,6 +18,10 @@ var (
 	DefaultTLSCiphers = configv1.TLSProfiles[DefaultTLSProfileType].Ciphers
 	// DefaultMinTLSVersion is the default minimum TLS version for API servers
 	DefaultMinTLSVersion = configv1.TLSProfiles[DefaultTLSProfileType].MinTLSVersion
+	// DefaultTLSGroups are the default TLS groups (elliptic curves) for key exchange.
+	// TODO: When openshift/api is updated to include Groups in TLSProfileSpec,
+	// read from configv1.TLSProfiles[DefaultTLSProfileType].Groups directly.
+	DefaultTLSGroups = []string{"X25519", "secp256r1", "secp384r1", "X25519MLKEM768"}
 )
 
 // FetchAPIServerTlsProfile fetches tlsSecurityProfile configured in APIServer
@@ -46,6 +50,16 @@ func MinTLSVersion(profile configv1.TLSProfileSpec) string {
 		return string(DefaultMinTLSVersion)
 	}
 	return string(profile.MinTLSVersion)
+}
+
+// TLSGroups returns the TLS groups for key exchange.
+// TODO: When openshift/api is updated with the Groups field in TLSProfileSpec,
+// update this to accept configv1.TLSProfileSpec like TLSCiphers and MinTLSVersion.
+func TLSGroups(groups []string) []string {
+	if len(groups) == 0 {
+		return DefaultTLSGroups
+	}
+	return groups
 }
 
 // GetClusterTLSProfileSpec returns TLSProfileSpec

--- a/internal/tls/tls_test.go
+++ b/internal/tls/tls_test.go
@@ -24,3 +24,16 @@ var _ = Describe("#MinTLSVersion", func() {
 		Expect(string(configv1.VersionTLS13)).To(Equal(MinTLSVersion(configv1.TLSProfileSpec{MinTLSVersion: configv1.VersionTLS13})))
 	})
 })
+
+var _ = Describe("#TLSGroups", func() {
+	It("should return the default groups when none are provided", func() {
+		Expect(TLSGroups(nil)).To(Equal(DefaultTLSGroups))
+	})
+	It("should return the default groups when an empty slice is provided", func() {
+		Expect(TLSGroups([]string{})).To(Equal(DefaultTLSGroups))
+	})
+	It("should return the provided groups when they are defined", func() {
+		groups := []string{"X25519", "secp256r1"}
+		Expect(TLSGroups(groups)).To(Equal([]string{"X25519", "secp256r1"}))
+	})
+})


### PR DESCRIPTION
## Summary
- Added support for TLS curves when it gets implemented in github.com/openshift/api/pull/2583.

This PR also depends on https://github.com/ViaQ/log-file-metric-exporter/pull/43 so that the LFME actually honors the curves.

Fixes [LOG-8973](https://redhat.atlassian.net/browse/LOG-8973)

## Details

Curves are implicitly supported through ECDHE cipher suites — Go's `crypto/tls` handles curve negotiation automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)