### PR TITLE
fix: sort Elasticsearch canonical headers deterministically

### DIFF
--- a/internal/validations/observability/outputs/validate_elasticsearch_headers.go
+++ b/internal/validations/observability/outputs/validate_elasticsearch_headers.go
@@ -2,7 +2,9 @@ package outputs
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"strings"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
@@ -29,11 +31,14 @@ func validateElasticsearchHeaders(output obs.OutputSpec) (results []string) {
 			canonicalHeaders[canonicalName] = append(canonicalHeaders[canonicalName], headerName)
 		}
 		if len(invalidHeaders) > 0 {
+			slices.Sort(invalidHeaders)
 			log.V(3).Info("validateElasticsearchHeaders failed", "reason", "invalid headers found: ", strings.Join(invalidHeaders, ","))
 			results = append(results, fmt.Sprintf("invalid headers found: %s", strings.Join(invalidHeaders, ",")))
 		}
-		for canonicalName, originals := range canonicalHeaders {
+		for _, canonicalName := range slices.Sorted(maps.Keys(canonicalHeaders)) {
+			originals := canonicalHeaders[canonicalName]
 			if len(originals) > 1 {
+				slices.Sort(originals)
 				log.V(3).Info("validateElasticsearchHeaders failed", "reason", "duplicate case-variant headers", "headers", originals)
 				results = append(results, fmt.Sprintf("duplicate case-variant headers '%s' found, use canonical form '%s'", strings.Join(originals, "', '"), canonicalName))
 			}

--- a/internal/validations/observability/outputs/validate_elasticsearch_headers_test.go
+++ b/internal/validations/observability/outputs/validate_elasticsearch_headers_test.go
@@ -107,5 +107,52 @@ var _ = Describe("[internal][validations] ClusterLogForwarder will validate head
 			Expect(results[0]).To(ContainSubstring("duplicate case-variant headers"))
 			Expect(results[0]).To(ContainSubstring("X-Custom-Header"))
 		})
+
+		It("should produce deterministic messages for multiple forbidden headers", func() {
+			spec.Elasticsearch.Headers = map[string]string{
+				"Content-Type":  "text/plain",
+				"Authorization": "test",
+			}
+			expected := validateElasticsearchHeaders(spec)
+			for i := 0; i < 100; i++ {
+				Expect(validateElasticsearchHeaders(spec)).To(Equal(expected),
+					"validation messages should be stable across invocations")
+			}
+		})
+
+		It("should produce deterministic messages for multiple duplicate header groups", func() {
+			spec.Elasticsearch.Headers = map[string]string{
+				"Accept":          "application/json",
+				"accept":          "text/plain",
+				"X-Custom-Header": "value1",
+				"x-custom-header": "value2",
+			}
+			expected := validateElasticsearchHeaders(spec)
+			for i := 0; i < 100; i++ {
+				Expect(validateElasticsearchHeaders(spec)).To(Equal(expected),
+					"validation messages should be stable across invocations")
+			}
+		})
+
+		It("should produce sorted header names in forbidden headers message", func() {
+			spec.Elasticsearch.Headers = map[string]string{
+				"Content-Type":  "text/plain",
+				"Authorization": "test",
+			}
+			results := validateElasticsearchHeaders(spec)
+			Expect(results).To(HaveLen(1))
+			Expect(results[0]).To(Equal("invalid headers found: Authorization,Content-Type"))
+		})
+
+		It("should produce sorted variant names in duplicate headers message", func() {
+			spec.Elasticsearch.Headers = map[string]string{
+				"X-Custom-Header": "value1",
+				"x-custom-header": "value1",
+				"X-CUSTOM-HEADER": "value1",
+			}
+			results := validateElasticsearchHeaders(spec)
+			Expect(results).To(HaveLen(1))
+			Expect(results[0]).To(Equal("duplicate case-variant headers 'X-CUSTOM-HEADER', 'X-Custom-Header', 'x-custom-header' found, use canonical form 'X-Custom-Header'"))
+		})
 	})
 })


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
Follow-up to #3217: Sort map keys deterministically to prevent flaky validations


/cc @cahartma @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://issues.redhat.com/browse/LOG-8581
- Enhancement proposal:
