### PR TITLE
LOG-7506: Allow TLS with CA certificate only for Kafka outputs

### DIFF
--- a/internal/generator/vector/common/tls/suite_test.go
+++ b/internal/generator/vector/common/tls/suite_test.go
@@ -1,0 +1,13 @@
+package tls
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTLS(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TLS Suite")
+}

--- a/internal/generator/vector/common/tls/tls.go
+++ b/internal/generator/vector/common/tls/tls.go
@@ -20,7 +20,7 @@ var (
 
 func NewTlsEnabled(comp observability.TransportLayerSecurity, secrets observability.Secrets, op utils.Options, options ...framework.Option) *transport.TlsEnabled {
 	tls := NewTls(comp, secrets, op, options...)
-	if tls != nil && tls.CRTFile != "" {
+	if tls != nil && (tls.CAFile != "" || (tls.CRTFile != "" && tls.KeyFile != "")) {
 		return &transport.TlsEnabled{
 			TLS:     *tls,
 			Enabled: true,

--- a/internal/generator/vector/common/tls/tls_test.go
+++ b/internal/generator/vector/common/tls/tls_test.go
@@ -1,0 +1,154 @@
+package tls
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/adapters"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("NewTlsEnabled", func() {
+	const secretName = "test-tls"
+
+	var secrets map[string]*corev1.Secret
+
+	BeforeEach(func() {
+		secrets = map[string]*corev1.Secret{
+			secretName: {
+				Data: map[string][]byte{
+					constants.TrustedCABundleKey: []byte("ca-cert"),
+					constants.ClientCertKey:      []byte("client-cert"),
+					constants.ClientPrivateKey:   []byte("client-key"),
+				},
+			},
+		}
+	})
+
+	It("should return TlsEnabled when CAFile is set", func() {
+		adapter := adapters.NewOutput(obs.OutputSpec{
+			Name: "test",
+			Type: obs.OutputTypeKafka,
+			TLS: &obs.OutputTLSSpec{
+				TLSSpec: obs.TLSSpec{
+					CA: &obs.ValueReference{
+						Key:        constants.TrustedCABundleKey,
+						SecretName: secretName,
+					},
+				},
+			},
+		})
+		result := NewTlsEnabled(adapter, secrets, utils.NoOptions)
+		Expect(result).NotTo(BeNil())
+		Expect(result.Enabled).To(BeTrue())
+		Expect(result.TLS.CAFile).NotTo(BeEmpty())
+	})
+
+	It("should return TlsEnabled when both CRTFile and KeyFile are set", func() {
+		adapter := adapters.NewOutput(obs.OutputSpec{
+			Name: "test",
+			Type: obs.OutputTypeKafka,
+			TLS: &obs.OutputTLSSpec{
+				TLSSpec: obs.TLSSpec{
+					Certificate: &obs.ValueReference{
+						Key:        constants.ClientCertKey,
+						SecretName: secretName,
+					},
+					Key: &obs.SecretReference{
+						Key:        constants.ClientPrivateKey,
+						SecretName: secretName,
+					},
+				},
+			},
+		})
+		result := NewTlsEnabled(adapter, secrets, utils.NoOptions)
+		Expect(result).NotTo(BeNil())
+		Expect(result.Enabled).To(BeTrue())
+		Expect(result.TLS.CRTFile).NotTo(BeEmpty())
+		Expect(result.TLS.KeyFile).NotTo(BeEmpty())
+	})
+
+	It("should return TlsEnabled when CAFile, CRTFile and KeyFile are all set", func() {
+		adapter := adapters.NewOutput(obs.OutputSpec{
+			Name: "test",
+			Type: obs.OutputTypeKafka,
+			TLS: &obs.OutputTLSSpec{
+				TLSSpec: obs.TLSSpec{
+					CA: &obs.ValueReference{
+						Key:        constants.TrustedCABundleKey,
+						SecretName: secretName,
+					},
+					Certificate: &obs.ValueReference{
+						Key:        constants.ClientCertKey,
+						SecretName: secretName,
+					},
+					Key: &obs.SecretReference{
+						Key:        constants.ClientPrivateKey,
+						SecretName: secretName,
+					},
+				},
+			},
+		})
+		result := NewTlsEnabled(adapter, secrets, utils.NoOptions)
+		Expect(result).NotTo(BeNil())
+		Expect(result.Enabled).To(BeTrue())
+		Expect(result.TLS.CAFile).NotTo(BeEmpty())
+		Expect(result.TLS.CRTFile).NotTo(BeEmpty())
+		Expect(result.TLS.KeyFile).NotTo(BeEmpty())
+	})
+
+	It("should return nil when only KeyFile is set (without CRTFile)", func() {
+		adapter := adapters.NewOutput(obs.OutputSpec{
+			Name: "test",
+			Type: obs.OutputTypeKafka,
+			TLS: &obs.OutputTLSSpec{
+				TLSSpec: obs.TLSSpec{
+					Key: &obs.SecretReference{
+						Key:        constants.ClientPrivateKey,
+						SecretName: secretName,
+					},
+				},
+			},
+		})
+		result := NewTlsEnabled(adapter, secrets, utils.NoOptions)
+		Expect(result).To(BeNil())
+	})
+
+	It("should return nil when only CRTFile is set (without KeyFile)", func() {
+		adapter := adapters.NewOutput(obs.OutputSpec{
+			Name: "test",
+			Type: obs.OutputTypeKafka,
+			TLS: &obs.OutputTLSSpec{
+				TLSSpec: obs.TLSSpec{
+					Certificate: &obs.ValueReference{
+						Key:        constants.ClientCertKey,
+						SecretName: secretName,
+					},
+				},
+			},
+		})
+		result := NewTlsEnabled(adapter, secrets, utils.NoOptions)
+		Expect(result).To(BeNil())
+	})
+
+	It("should return nil when no TLS config is provided", func() {
+		adapter := adapters.NewOutput(obs.OutputSpec{
+			Name: "test",
+			Type: obs.OutputTypeKafka,
+		})
+		result := NewTlsEnabled(adapter, secrets, utils.NoOptions)
+		Expect(result).To(BeNil())
+	})
+
+	It("should return nil when TLS spec is empty", func() {
+		adapter := adapters.NewOutput(obs.OutputSpec{
+			Name: "test",
+			Type: obs.OutputTypeKafka,
+			TLS:  &obs.OutputTLSSpec{},
+		})
+		result := NewTlsEnabled(adapter, secrets, utils.NoOptions)
+		Expect(result).To(BeNil())
+	})
+})

--- a/internal/generator/vector/output/kafka/kafka.go
+++ b/internal/generator/vector/output/kafka/kafka.go
@@ -24,6 +24,8 @@ import (
 const (
 	defaultKafkaTopic  = "topic"
 	SASLMechanismPlain = "PLAIN"
+	SASL_SCRAM_512     = "SCRAM-SHA-512"
+	SASL_SCRAM_256     = "SCRAM-SHA-256"
 )
 
 func New(id string, o *adapters.Output, inputs []string, secrets observability.Secrets, op utils.Options) (string, types.Sink, api.Transforms) {

--- a/internal/generator/vector/output/kafka/kafka_sasl_ca_with_tls.toml
+++ b/internal/generator/vector/output/kafka/kafka_sasl_ca_with_tls.toml
@@ -1,0 +1,30 @@
+[transforms.kafka_receiver_topic]
+type = "remap"
+inputs = ["pipeline_1", "pipeline_2"]
+source = '''
+._internal.kafka_receiver_topic = "topic"
+'''
+
+[sinks.kafka_receiver]
+type = "kafka"
+inputs = ["kafka_receiver_topic"]
+bootstrap_servers = "broker1-kafka.svc.messaging.cluster.local:9092"
+topic = "{{ _internal.kafka_receiver_topic }}"
+
+[sinks.kafka_receiver.healthcheck]
+enabled = false
+
+[sinks.kafka_receiver.encoding]
+codec = "json"
+timestamp_format = "rfc3339"
+except_fields = ["_internal"]
+
+[sinks.kafka_receiver.sasl]
+enabled = true
+username = "SECRET[kubernetes_secret.kafka-receiver-1/username]"
+password = "SECRET[kubernetes_secret.kafka-receiver-1/password]"
+mechanism = "SCRAM-SHA-256"
+
+[sinks.kafka_receiver.tls]
+enabled = true
+ca_file = "/var/run/ocp-collector/secrets/kafka-receiver-1/ca-bundle.crt"

--- a/internal/generator/vector/output/kafka/kafka_test.go
+++ b/internal/generator/vector/output/kafka/kafka_test.go
@@ -129,5 +129,21 @@ var _ = Describe("Generate vector config", func() {
 				MaxWrite:     utils.GetPtr(resource.MustParse("10M")),
 			}
 		}),
+		Entry("with tls sasl, with SCRAM-SHA-256 mechanism to single topic and custom CA", "kafka_sasl_ca_with_tls.toml", framework.NoOptions, func(spec *obs.OutputSpec) {
+			spec.Kafka.URL = "tls://broker1-kafka.svc.messaging.cluster.local:9092/mytopic"
+			spec.Kafka.Topic = "topic"
+			spec.TLS = &obs.OutputTLSSpec{
+				TLSSpec: obs.TLSSpec{
+					CA: &obs.ValueReference{
+						Key:        constants.TrustedCABundleKey,
+						SecretName: secretName,
+					},
+				},
+			}
+			spec.Kafka.Authentication = &obs.KafkaAuthentication{
+				SASL: saslAuth,
+			}
+			spec.Kafka.Authentication.SASL.Mechanism = SASL_SCRAM_256
+		}),
 	)
 })


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Fix TLS configuration validation to allow `CA-only` certificates for Kafka outputs with SASL authentication. 
Previously, TLS was only enabled when both certificate and key files were present, causing CA-only configurations to be silently dropped.

#### Changes

- Update `NewTlsEnabled` to enable TLS when either:
- - CA certificate is configured (for server trust verification)
- - Both certificate and key are configured (for mutual TLS)
- Add test coverage (`kafka_test.go`)
- New test case for Kafka with `SASL SCRAM-SHA` + `CA-only TLS`

  
/cc @cahartma @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-7506
- Enhancement proposal:
