### PR TITLE
Fix image-reference for log-file-metric-exporter in ART configuration

### DIFF
--- a/bundle/image-references
+++ b/bundle/image-references
@@ -10,7 +10,7 @@ spec:
   - name: log-file-metric-exporter-rhel9
     from:
       kind: DockerImage
-      name: quay.io/openshift-logging/log-file-metric-exporter:latest
+      name: quay.io/openshift-logging/log-file-metric-exporter:6.1
   - name: cluster-logging-rhel9-operator
     from:
       kind: DockerImage


### PR DESCRIPTION
Fixup for #3233 

/cc @cahartma @jcantrill 
/assign @xperimental 
/label tide/merge-method-squash
