### PR TITLE
OBSDA-1243: Add test to verify forwarding to Elasticsearch 9

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -701,8 +701,8 @@ type Elasticsearch struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Log Index",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}
 	Index string `json:"index"`
 
-	// Version specifies the version of Elasticsearch to be used.
-	// Must be one of: 6-8
+	// Version specifies the API version of Elasticsearch to be used. Must be one of: 6-8
+	// The value of '8' should be used when forwarding to Elasticsearch version v8 or greater.
 	//
 	// +kubebuilder:validation:Minimum:=6
 	// +kubebuilder:validation:Maximum:=8

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2026-04-16T20:34:26Z"
+    createdAt: "2026-04-24T14:35:45Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -952,8 +952,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: |-
-          Version specifies the version of Elasticsearch to be used.
-          Must be one of: 6-8
+          Version specifies the API version of Elasticsearch to be used. Must be one of: 6-8
+          The value of '8' should be used when forwarding to Elasticsearch version v8 or greater.
         displayName: ElasticSearch Version
         path: outputs[0].elasticsearch.version
         x-descriptors:

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -2508,8 +2508,8 @@ spec:
                             rule: isURL(self)
                         version:
                           description: |-
-                            Version specifies the version of Elasticsearch to be used.
-                            Must be one of: 6-8
+                            Version specifies the API version of Elasticsearch to be used. Must be one of: 6-8
+                            The value of '8' should be used when forwarding to Elasticsearch version v8 or greater.
                           maximum: 8
                           minimum: 6
                           type: integer

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -2508,8 +2508,8 @@ spec:
                             rule: isURL(self)
                         version:
                           description: |-
-                            Version specifies the version of Elasticsearch to be used.
-                            Must be one of: 6-8
+                            Version specifies the API version of Elasticsearch to be used. Must be one of: 6-8
+                            The value of '8' should be used when forwarding to Elasticsearch version v8 or greater.
                           maximum: 8
                           minimum: 6
                           type: integer

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -875,8 +875,8 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
       - description: |-
-          Version specifies the version of Elasticsearch to be used.
-          Must be one of: 6-8
+          Version specifies the API version of Elasticsearch to be used. Must be one of: 6-8
+          The value of '8' should be used when forwarding to Elasticsearch version v8 or greater.
         displayName: ElasticSearch Version
         path: outputs[0].elasticsearch.version
         x-descriptors:

--- a/docs/features/collection.adoc
+++ b/docs/features/collection.adoc
@@ -37,6 +37,7 @@ a|
 - v6.8.1
 - v7.12.2
 - v8.6.1
+- v9.3.3
 |Google Cloud Logging||
 
 |Kafka|kafka 0.11

--- a/docs/features/logforwarding/outputs/elasticsearch-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/elasticsearch-forwarding.adoc
@@ -59,6 +59,9 @@ spec:
 <4> Use username and password to authenticate to the server
 <5> Enable Mutual Transport Layer Security (mTLS) between collector and elasticsearch, the spec identifies the keys and secret to the respective certificates that they represent.
 
+NOTE: The `version` field represents the Elasticsearch cluster's API version.  It should be set to `8` for
+Elasticsearch deployments of `v8` or greater.
+
 == Custom Index Configuration
 
 https://docs.openshift.com/container-platform/4.12/logging/log_collection_forwarding/cluster-logging-enabling-json-logging.html[Official Cluster Logging Operator Documentation on JSON Parsing]

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -2464,8 +2464,8 @@ Example:
 
 |tuning|object|  Tuning specs tuning for the output
 
-|version|int|  Version specifies the version of Elasticsearch to be used.
-Must be one of: 6-8
+|version|int|  Version specifies the API version of Elasticsearch to be used. Must be one of: 6-8
+The value of &#39;8&#39; should be used when forwarding to Elasticsearch version v8 or greater.
 
 |======================
 

--- a/internal/generator/vector/api/log_schema.go
+++ b/internal/generator/vector/api/log_schema.go
@@ -1,6 +1,6 @@
 package api
 
-//LogSchema default log schema for all events.
+// LogSchema default log schema for all events.
 type LogSchema struct {
 	// The name of the event field to treat as the host which sent the message.
 	HostKey string `json:"host_key,omitempty" yaml:"host_key,omitempty" toml:"host_key,omitempty"`

--- a/internal/generator/vector/api/sinks/elasticsearch_sink.go
+++ b/internal/generator/vector/api/sinks/elasticsearch_sink.go
@@ -7,13 +7,13 @@ import (
 )
 
 type Elasticsearch struct {
-	Type       types.SinkType     `json:"type,omitempty" yaml:"type,omitempty" toml:"type,omitempty"`
-	Inputs     []string           `json:"inputs,omitempty" yaml:"inputs,omitempty" toml:"inputs,omitempty"`
-	Endpoints  []string           `json:"endpoints,omitempty" yaml:"endpoints,omitempty" toml:"endpoints,omitempty"`
-	IdKey      string             `json:"id_key,omitempty" yaml:"id_key,omitempty" toml:"id_key,omitempty"`
-	ApiVersion string             `json:"api_version,omitempty" yaml:"api_version,omitempty" toml:"api_version,omitempty"`
-	Bulk       *Bulk              `json:"bulk,omitempty" yaml:"bulk,omitempty" toml:"bulk,omitempty"`
-	Auth       *ElasticsearchAuth `json:"auth,omitempty" yaml:"auth,omitempty" toml:"auth,omitempty"`
+	Type       types.SinkType          `json:"type,omitempty" yaml:"type,omitempty" toml:"type,omitempty"`
+	Inputs     []string                `json:"inputs,omitempty" yaml:"inputs,omitempty" toml:"inputs,omitempty"`
+	Endpoints  []string                `json:"endpoints,omitempty" yaml:"endpoints,omitempty" toml:"endpoints,omitempty"`
+	IdKey      string                  `json:"id_key,omitempty" yaml:"id_key,omitempty" toml:"id_key,omitempty"`
+	ApiVersion ElasticsearchApiVersion `json:"api_version,omitempty" yaml:"api_version,omitempty" toml:"api_version,omitempty"`
+	Bulk       *Bulk                   `json:"bulk,omitempty" yaml:"bulk,omitempty" toml:"bulk,omitempty"`
+	Auth       *ElasticsearchAuth      `json:"auth,omitempty" yaml:"auth,omitempty" toml:"auth,omitempty"`
 	BaseSink
 	Proxy *Proxy `json:"proxy,omitempty" yaml:"proxy,omitempty" toml:"proxy,omitempty"`
 }
@@ -38,6 +38,27 @@ func (s *Elasticsearch) SinkType() types.SinkType {
 type ElasticsearchAuth struct {
 	Strategy HttpAuthStrategy `json:"strategy,omitempty" yaml:"strategy,omitempty" toml:"strategy,omitempty"`
 	HttpAuthBasic
+}
+
+type ElasticsearchApiVersion string
+
+const (
+	ElasticsearchApiVersion6 ElasticsearchApiVersion = "v6"
+	ElasticsearchApiVersion7 ElasticsearchApiVersion = "v7"
+	ElasticsearchApiVersion8 ElasticsearchApiVersion = "v8"
+)
+
+func (v ElasticsearchApiVersion) Int() int {
+	switch v {
+	case ElasticsearchApiVersion6:
+		return 6
+	case ElasticsearchApiVersion7:
+		return 7
+	case ElasticsearchApiVersion8:
+		return 8
+	default:
+		return 8
+	}
 }
 
 type BulkActionType string

--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -36,7 +36,7 @@ if exists(.kubernetes.event.metadata.uid) {
 			Action: sinks.BulkActionCreate,
 			Index:  fmt.Sprintf("{{ _internal.%s }}", componentID),
 		}
-		s.ApiVersion = fmt.Sprintf("v%d", o.Elasticsearch.Version)
+		s.ApiVersion = apiVersionFrom(o.Elasticsearch.Version)
 		s.Encoding = common.NewApiEncoding("")
 		s.Batch = common.NewApiBatch(o)
 		s.Buffer = common.NewApiBuffer(o)
@@ -54,6 +54,19 @@ if exists(.kubernetes.event.metadata.uid) {
 		s.TLS = tls.NewTls(o, secrets, op)
 	}, componentID)
 	return id, sink, tfs
+}
+
+func apiVersionFrom(version int) sinks.ElasticsearchApiVersion {
+	switch version {
+	case 6:
+		return sinks.ElasticsearchApiVersion6
+	case 7:
+		return sinks.ElasticsearchApiVersion7
+	case 8:
+		return sinks.ElasticsearchApiVersion8
+	default:
+		return sinks.ElasticsearchApiVersion8
+	}
 }
 
 func elasticsearchAuth(s *sinks.Elasticsearch, o *adapters.Output, op utils.Options) {

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -35,10 +35,10 @@ if exists(._syslog.proc_id) && is_empty(strip_whitespace(string!(._syslog.proc_i
 	defAppNameRFC3164 = `to_string!(._syslog.app_name || "")`
 
 	// Default values for Syslog fields for infrastructure logType if source 'node'
-	nodeAppNameRFC5424  = `._syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "-")`
-	nodeAppNameRFC3164  = `._syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "")`
-	nodeProcIdRFC3164   = `._syslog.proc_id = to_string!(.systemd.t.PID || "")`
-	nodeProcIdRFC5424   = `._syslog.proc_id = to_string!(.systemd.t.PID || "-")`
+	nodeAppNameRFC5424 = `._syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "-")`
+	nodeAppNameRFC3164 = `._syslog.app_name = to_string!(.systemd.u.SYSLOG_IDENTIFIER || "")`
+	nodeProcIdRFC3164  = `._syslog.proc_id = to_string!(.systemd.t.PID || "")`
+	nodeProcIdRFC5424  = `._syslog.proc_id = to_string!(.systemd.t.PID || "-")`
 
 	// Default values for Syslog fields for application logType and infrastructure logType if source 'container'
 	containerAppNameRFC5424 = `._syslog.app_name, err = join([.kubernetes.namespace_name, .kubernetes.pod_name, .kubernetes.container_name], "_")

--- a/test/framework/functional/output_elasticsearch.go
+++ b/test/framework/functional/output_elasticsearch.go
@@ -26,6 +26,7 @@ const (
 	ElasticsearchVersion6 ElasticsearchVersion = 6
 	ElasticsearchVersion7 ElasticsearchVersion = 7
 	ElasticsearchVersion8 ElasticsearchVersion = 8
+	ElasticsearchVersion9 ElasticsearchVersion = 9 //this has the same API as 8
 	ElasticPassword                            = "default-password"
 	ElasticUsername                            = "elastic"
 )
@@ -36,6 +37,7 @@ var (
 		ElasticsearchVersion6: "quay.io/openshift-logging/elasticsearch:6.8.23",
 		ElasticsearchVersion7: "quay.io/openshift-logging/elasticsearch:7.17.28",
 		ElasticsearchVersion8: "quay.io/openshift-logging/elasticsearch:8.17.5",
+		ElasticsearchVersion9: "quay.io/openshift-logging/elasticsearch:9.3.3",
 	}
 )
 

--- a/test/functional/outputs/elasticsearch/forward_to_elasticsearch_test.go
+++ b/test/functional/outputs/elasticsearch/forward_to_elasticsearch_test.go
@@ -118,6 +118,7 @@ var _ = Describe("[Functional][Outputs][ElasticSearch] Logforwarding to ElasticS
 		Entry("Elasticsearch v6", functional.ElasticsearchVersion6),
 		Entry("Elasticsearch v7", functional.ElasticsearchVersion7),
 		Entry("Elasticsearch v8", functional.ElasticsearchVersion8),
+		Entry("Elasticsearch v9", functional.ElasticsearchVersion9),
 	)
 
 	Context("with tuning parameters", func() {


### PR DESCRIPTION
### Description
This PR:
* Adds a functional test of existing functionality to forward to Elasticsearch v9
* Updates API comments to clarify ES.Version represents the ES API version
* Updates documents to clarify ES.Version as ES API Version

### Links
* https://redhat.atlassian.net/browse/OBSDA-1243

cc @simonkrenger @vparfonov @Clee2691 
