### PR TITLE
LOG-8982: Remove ClusterLogForwarderDeprecations alert

### DIFF
--- a/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -38,20 +38,6 @@ spec:
       labels:
         service: clusterlogforwarder
         severity: critical
-    - alert: ClusterLogForwarderDeprecations
-      annotations:
-        message: The Cluster Logging Operator version {{$labels.version}} includes
-          deprecations to some feature of ClusterLogForwarder.
-        summary: "The Cluster Logging Operator version {{$labels.version}} includes
-          deprecations to some features of ClusterLogForwarder which \nwill be removed
-          in a future release.  Please see the release notes for details: \nhttps://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.4/html/release_notes"
-      expr: |
-        max by (version) (csv_succeeded{exported_namespace="openshift-logging", name=~"cluster-logging.*", version=~"6.4.*"})  > 0
-      for: 1m
-      labels:
-        namespace: openshift-logging
-        service: collector
-        severity: info
     - alert: ClusterLogForwarderAzureMonitorLogsDeprecation
       annotations:
         message: A ClusterLogForwarder, {{ $labels.namespace }}/{{ $labels.app_kubernetes_io_instance

--- a/config/prometheus/collector_alerts.yaml
+++ b/config/prometheus/collector_alerts.yaml
@@ -37,20 +37,6 @@ spec:
       labels:
         service: clusterlogforwarder
         severity: critical
-    - alert: ClusterLogForwarderDeprecations
-      annotations:
-        message: "The Cluster Logging Operator version {{$labels.version}} includes deprecations to some feature of ClusterLogForwarder."
-        summary: |-
-          The Cluster Logging Operator version {{$labels.version}} includes deprecations to some features of ClusterLogForwarder which 
-          will be removed in a future release.  Please see the release notes for details: 
-          https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.4/html/release_notes
-      expr: |
-        max by (version) (csv_succeeded{exported_namespace="openshift-logging", name=~"cluster-logging.*", version=~"6.4.*"})  > 0
-      for: 1m
-      labels:
-        namespace: openshift-logging
-        service: collector
-        severity: info
     - alert: ClusterLogForwarderAzureMonitorLogsDeprecation
       annotations:
         message: "A ClusterLogForwarder, {{ $labels.namespace }}/{{ $labels.app_kubernetes_io_instance }}, is configured to forward logs to Azure Monitor using the deprecated HTTP Data Collector API."


### PR DESCRIPTION
### Description
This PR:
* Removes the ClusterLogForwarderDeprecations alert which is no longer applicable for this release

### Links
* https://redhat.atlassian.net/browse/LOG-8982

cc @vparfonov @Clee2691 
