### PR TITLE
LOG-9365: fix regression in maxOpenShift version to allow OCP v4.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ coverage: test-unit
 test-cluster:
 	go test  -cover -race ./test/... -- -root=$(CURDIR)
 
-OPENSHIFT_VERSIONS?="v4.16-v4.19"
+OPENSHIFT_VERSIONS?="v4.16-v4.20"
 # Generate bundle manifests and metadata, then validate generated files.
 BUNDLE_VERSION?=$(VERSION)
 CHANNEL=stable-${LOGGING_VERSION}

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -16,7 +16,7 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.16-v4.19"
+LABEL com.redhat.openshift.versions="v4.16-v4.20"
 
 LABEL \
     com.redhat.component="cluster-logging-operator" \

--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.19
+    value: "4.20"


### PR DESCRIPTION
### Description
This PR:
* fixes the regression to keep the operator from blocking cluster upgrade to  OCP v4.20

### Links
https://redhat.atlassian.net/browse/LOG-9365
