### PR TITLE
LOG-9381: Add 'client_secret_credential' type to AzureLogsIngestion sink auth

### DIFF
--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_common.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_common.toml
@@ -6,6 +6,7 @@ dcr_immutable_id = "dcr-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 stream_name = "Custom-MyTable_Logs_0_CL"
 
 [sinks.output_azure_log_ingestion.auth]
+azure_credential_kind = "client_secret_credential"
 azure_tenant_id = "a0b1c2d3-e4f5-a6b7-c8d9-e0f1a2b3c4d5"
 azure_client_id = "b1c2d3e4-f5a6-b7c8-d9e0-f1a2b3c4d5e6"
 azure_client_secret = "SECRET[kubernetes_secret.azure-log-ingestion-secret/client_secret]"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_timestamp_field.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_timestamp_field.toml
@@ -7,6 +7,7 @@ stream_name = "Custom-MyTable_Logs_0_CL"
 timestamp_field = "Timestamp"
 
 [sinks.output_azure_log_ingestion.auth]
+azure_credential_kind = "client_secret_credential"
 azure_tenant_id = "a0b1c2d3-e4f5-a6b7-c8d9-e0f1a2b3c4d5"
 azure_client_id = "b1c2d3e4-f5a6-b7c8-d9e0-f1a2b3c4d5e6"
 azure_client_secret = "SECRET[kubernetes_secret.azure-log-ingestion-secret/client_secret]"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_tls.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_tls.toml
@@ -6,6 +6,7 @@ dcr_immutable_id = "dcr-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 stream_name = "Custom-MyTable_Logs_0_CL"
 
 [sinks.output_azure_log_ingestion.auth]
+azure_credential_kind = "client_secret_credential"
 azure_tenant_id = "a0b1c2d3-e4f5-a6b7-c8d9-e0f1a2b3c4d5"
 azure_client_id = "b1c2d3e4-f5a6-b7c8-d9e0-f1a2b3c4d5e6"
 azure_client_secret = "SECRET[kubernetes_secret.azure-log-ingestion-secret/client_secret]"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_token_scope.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_token_scope.toml
@@ -7,6 +7,7 @@ stream_name = "Custom-MyTable_Logs_0_CL"
 token_scope = "https://monitor.azure.cn/.default"
 
 [sinks.output_azure_log_ingestion.auth]
+azure_credential_kind = "client_secret_credential"
 azure_tenant_id = "a0b1c2d3-e4f5-a6b7-c8d9-e0f1a2b3c4d5"
 azure_client_id = "b1c2d3e4-f5a6-b7c8-d9e0-f1a2b3c4d5e6"
 azure_client_secret = "SECRET[kubernetes_secret.azure-log-ingestion-secret/client_secret]"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_tuning.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_tuning.toml
@@ -6,6 +6,7 @@ dcr_immutable_id = "dcr-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 stream_name = "Custom-MyTable_Logs_0_CL"
 
 [sinks.output_azure_log_ingestion.auth]
+azure_credential_kind = "client_secret_credential"
 azure_tenant_id = "a0b1c2d3-e4f5-a6b7-c8d9-e0f1a2b3c4d5"
 azure_client_id = "b1c2d3e4-f5a6-b7c8-d9e0-f1a2b3c4d5e6"
 azure_client_secret = "SECRET[kubernetes_secret.azure-log-ingestion-secret/client_secret]"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azurelogsingestion.go
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azurelogsingestion.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	azureCredentialKindWorkloadIdentity = "workload_identity"
+	azureCredentialKindClientSecret     = "client_secret_credential"
 )
 
 func auth(s *sinks.AzureLogsIngestion, azli *obs.AzureLogsIngestion) {
@@ -48,6 +49,7 @@ func auth(s *sinks.AzureLogsIngestion, azli *obs.AzureLogsIngestion) {
 			}
 		}
 	default:
+		auth.AzureCredentialKind = azureCredentialKindClientSecret
 		if azliAuth.ClientSecret != nil {
 			auth.AzureTenantId = azliAuth.ClientSecret.TenantId
 			auth.AzureClientId = azliAuth.ClientSecret.ClientId


### PR DESCRIPTION
### Description
This PR adds the `azure_credential_kind` field to the `AzureLogsIngestion` sink. This field is now required when using `ClientSecret` authentication, whereas it was previously omitted.

> [!IMPORTANT]
> This PR depends on https://github.com/ViaQ/vector/pull/266 before tests will pass.

/cc @vparfonov 
/assign @jcantrill 

### Links
- Depending on PR(s): https://github.com/ViaQ/vector/pull/266
- JIRA: https://redhat.atlassian.net/browse/LOG-9381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Azure Log Ingestion authentication configuration now explicitly specifies credential type for client secret authentication. These updates have been applied consistently across all configuration templates to ensure reliable and predictable behavior.

* **Enhancements**
  * Authentication flow improvements ensure proper credential type specification in client secret scenarios across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->