### PR TITLE
LOG-9384: Operator metrics ServiceMonitor missing bearerTokenFile

### DIFF
--- a/bundle/manifests/cluster-logging-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/cluster-logging-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -6,7 +6,8 @@ metadata:
   name: cluster-logging-operator-metrics-monitor
 spec:
   endpoints:
-  - port: https-metrics
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    port: https-metrics
     scheme: https
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt

--- a/config/prometheus/servicemonitor.yaml
+++ b/config/prometheus/servicemonitor.yaml
@@ -8,6 +8,7 @@ spec:
   endpoints:
     - port: https-metrics
       scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         # Service serving certificates are signed by the service-ca which is not a CA in the
         # kube-root-ca.crt bundle. Use the service-ca.crt from the ConfigMap created by the


### PR DESCRIPTION
### Description
This PR adds `bearerTokenFile` to the operator's `ServiceMonitor` endpoint so Prometheus authenticates when scraping operator metrics, fixing `401` errors.

/cc @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://redhat.atlassian.net/browse/LOG-9384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated monitoring configuration for the cluster-logging operator to include proper authentication with service account tokens. This enhances security for metrics scraping over HTTPS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->