### PR TITLE
LOG-9383: Normalize NO_PROXY entries for Vector compatibility

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"reflect"
@@ -328,6 +329,7 @@ func GetProxyEnvVars() []v1.EnvVar {
 				if len(constants.ExtraNoProxyList) > 0 {
 					value = strings.Join(constants.ExtraNoProxyList, ",") + "," + value
 				}
+				value = normalizeNoProxy(value)
 			}
 			envVars = append(envVars, v1.EnvVar{
 				Name:  strings.ToLower(envvar),
@@ -336,6 +338,43 @@ func GetProxyEnvVars() []v1.EnvVar {
 		}
 	}
 	return envVars
+}
+
+// normalizeNoProxy ensures that plain domain entries in a NO_PROXY value also
+// match subdomains when consumed by Vector's no-proxy crate, which unlike Go's
+// httpproxy only does exact matching for plain domains. For each plain domain
+// entry, a dot-prefixed duplicate is added so that Vector's WithDot matching
+// covers subdomains. IPs, CIDRs, wildcards, and already dot-prefixed entries
+// are left unchanged.
+// This is workaround can be removed after fixing https://github.com/jdrouet/no-proxy/pull/12
+func normalizeNoProxy(value string) string {
+	if value == "" {
+		return ""
+	}
+	entries := strings.Split(value, ",")
+	var result []string
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		result = append(result, entry)
+		if entry == "*" || strings.HasPrefix(entry, ".") {
+			continue
+		}
+		host := entry
+		if h, _, err := net.SplitHostPort(entry); err == nil {
+			host = h
+		}
+		if net.ParseIP(host) != nil {
+			continue
+		}
+		if _, _, err := net.ParseCIDR(entry); err == nil {
+			continue
+		}
+		result = append(result, "."+entry)
+	}
+	return strings.Join(result, ",")
 }
 
 // WrapError wraps some types of error to provide more informative Error() message.

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -160,9 +160,66 @@ var _ = Describe("GetProxyEnvVars", func() {
 		envvars := GetProxyEnvVars()
 		Expect(envvars).To(HaveLen(3)) //proxy,noproxy vars
 		for _, envvar := range envvars {
-			Expect(envvar.Name).To(Equal(envvar.Value), "Exp. the value to be set to the name for the test")
+			if envvar.Name == "no_proxy" {
+				Expect(envvar.Value).To(Equal("no_proxy,.no_proxy"), "Exp. no_proxy to be normalized with dot-prefixed duplicate")
+			} else {
+				Expect(envvar.Name).To(Equal(envvar.Value), "Exp. the value to be set to the name for the test")
+			}
 		}
 	})
+	It("should normalize no_proxy plain domains for Vector compatibility", func() {
+		Expect(os.Setenv("no_proxy", "apps.example.com,.cluster.local,10.0.0.1")).To(Succeed())
+		result := GetProxyEnvVars()
+		for _, envvar := range result {
+			if envvar.Name == "no_proxy" {
+				Expect(envvar.Value).To(Equal("apps.example.com,.apps.example.com,.cluster.local,10.0.0.1"))
+			}
+		}
+	})
+})
+
+var _ = Describe("normalizeNoProxy", func() {
+	DescribeTable("should normalize entries correctly",
+		func(input, expected string) {
+			Expect(normalizeNoProxy(input)).To(Equal(expected))
+		},
+		Entry("plain domain gets dot-prefixed duplicate",
+			"example.com",
+			"example.com,.example.com"),
+		Entry("multiple plain domains",
+			"example.com,apps.example.com",
+			"example.com,.example.com,apps.example.com,.apps.example.com"),
+		Entry("leading-dot entry unchanged",
+			".example.com",
+			".example.com"),
+		Entry("wildcard unchanged",
+			"*",
+			"*"),
+		Entry("IP address unchanged",
+			"10.0.0.1",
+			"10.0.0.1"),
+		Entry("IPv6 address unchanged",
+			"::1",
+			"::1"),
+		Entry("CIDR unchanged",
+			"10.0.0.0/24",
+			"10.0.0.0/24"),
+		Entry("localhost gets dot-prefixed duplicate",
+			"localhost",
+			"localhost,.localhost"),
+		Entry("mixed entries",
+			"apps.example.com,.cluster.local,10.0.0.1,*,169.254.169.254,10.128.0.0/14",
+			"apps.example.com,.apps.example.com,.cluster.local,10.0.0.1,*,169.254.169.254,10.128.0.0/14"),
+		Entry("entries with whitespace",
+			" example.com , .local , 10.0.0.1 ",
+			"example.com,.example.com,.local,10.0.0.1"),
+		Entry("empty string",
+			"",
+			""),
+		Entry("domain with port gets dot-prefixed duplicate",
+			"example.com:8080",
+			"example.com:8080,.example.com:8080"),
+	)
 })
 
 var _ = Describe("TestOwnership", func() {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

#### Summary
- Add `normalizeNoProxy()` to `GetProxyEnvVars()` that adds a dot-prefixed duplicate for each plain domain entry in `NO_PROXY`, so Vector's no-proxy crate matches subdomains correctly
- IPs, CIDRs, wildcards, and already dot-prefixed entries are left unchanged
- Example: `apps.example.com,.cluster.local,10.0.0.1` becomes `apps.example.com,.apps.example.com,.cluster.local,10.0.0.1`

#### Problem
When the OpenShift cluster-wide proxy sets noProxy: `apps.example.com`, Go-based components (using [httpproxy](https://pkg.go.dev/golang.org/x/net/http/httpproxy)) correctly bypass the proxy for `elasticsearch.apps.example.com`. However, Vector's `no-proxy` crate only does exact string matching for plain domain entries — subdomains are not matched. This means log forwarding traffic goes through the proxy when it should be bypassed. Users must use `.apps.example.com` (with leading dot) as a workaround, which differs from how everyother OpenShift component interprets noProxy.
  
 #### Root cause
The `no-proxy` crate's `NoProxyItem::Plain` variant does exact match only: `Self::Plain(source) => source == value`. Per Go's httpproxy, curl, Python, and Ruby conventions, `example.com` should match both the domain itself and all subdomains.

####  Workaround approach
This PR normalizes `NO_PROXY` values in CLO before passing them to the Vector container. For each plain domain entry, a `.domain` duplicate is added so Vector's `WithDot` matching covers subdomains.

  This is a workaround until the upstream fix lands:
  - Upstream issue/PR: https://github.com/jdrouet/no-proxy/pull/12
  - Vector discussion: https://github.com/vectordotdev/vector/discussions/25383

Once the no-proxy crate is fixed and Vector bumps the dependency, this normalization can be removed (marked with a comment in the code).

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9383
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy environment variable handling to ensure consistent normalization of exclusion lists across different entry formats (domains, IP addresses, CIDR notations).

* **Tests**
  * Expanded test coverage for proxy environment variable normalization with comprehensive test cases for various entry formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->