### PR TITLE
LOG-9389: Payload Too Large errors when sending logs to Azure monitor using Log Ingestion API

### DIFF
--- a/docs/features/logforwarding/outputs/azure/azure-logs-ingestion-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/azure/azure-logs-ingestion-forwarding.adoc
@@ -4,7 +4,7 @@ https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-ov
 
 The `azureLogsIngestion` output type sends log events to Azure Monitor using the Logs Ingestion API and a Data Collection Rule (DCR). This is the recommended replacement for the legacy HTTP Data Collector API used by `azureMonitor`.
 
-Since the HTTP Data Collector API is deprecated, and will be removed in **September** 2026, it is recommended to use the Logs Ingestion API instead. The `AzureMonitor` output type will be removed in the future.
+Since the HTTP Data Collector API is deprecated, and will be removed in **September 14th 2026**, it is recommended to use the Logs Ingestion API instead. The `AzureMonitor` output type will be removed in the future.
 
 ==== Prerequisites
 
@@ -43,7 +43,7 @@ oc create secret generic azure-log-ingestion-secret -n openshift-logging \
 apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  name: instance
+  name: azure-logs-ingestion
   namespace: openshift-logging
 spec:
   serviceAccount:
@@ -80,7 +80,7 @@ Uses Azure AD Workload Identity federation, where the collector pod authenticate
 apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  name: instance
+  name: azure-logs-ingestion
   namespace: openshift-logging
 spec:
   serviceAccount:
@@ -184,10 +184,13 @@ Standard output tuning parameters are supported:
     azureLogsIngestion:
       tuning:
         deliveryMode: AtLeastOnce
-        maxWrite: 10M
+        maxWrite: 1M
         maxRetryDuration: 35s
         minRetryDuration: 20s
 ----
+
+CAUTION: The Azure Logs Ingestion API enforces a 1MB request body limit. The collector defaults to a batch size of 1,000,000 bytes (`max_bytes`), if unset, to stay within this limit. If `maxWrite` in `tuning` exceeds 1MB, requests may be rejected by Azure.
+See the https://learn.microsoft.com/en-us/azure/azure-monitor/fundamentals/service-limits#logs-ingestion-api[Azure Logs Ingestion API Service Limits] documentation for more information.
 
 ==== Field Reference
 

--- a/docs/features/logforwarding/outputs/azure/azure-monitor-log-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/azure/azure-monitor-log-forwarding.adoc
@@ -1,5 +1,7 @@
 === Steps to forward to Azure Monitor Log via HTTP Data Collector API
 
+WARNING: Forwarding Logs using the `AzureMonitor` output (HTTP Data Collector API) will be retired on **September 14, 2026**. Please use the link:azure-logs-ingestion-forwarding.adoc[AzureLogsIngestion] output type instead.
+
 (https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api?tabs=powershell)
 
 . Create a secret containing your `shared_key` using the following command (primary or the secondary key for the workspace that's making the request):

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_timestamp_field.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_timestamp_field.toml
@@ -14,3 +14,6 @@ azure_client_secret = "SECRET[kubernetes_secret.azure-log-ingestion-secret/clien
 
 [sinks.output_azure_log_ingestion.encoding]
 except_fields = ["_internal"]
+
+[sinks.output_azure_log_ingestion.batch]
+max_bytes = 1000000

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_tls.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_tls.toml
@@ -14,6 +14,9 @@ azure_client_secret = "SECRET[kubernetes_secret.azure-log-ingestion-secret/clien
 [sinks.output_azure_log_ingestion.encoding]
 except_fields = ["_internal"]
 
+[sinks.output_azure_log_ingestion.batch]
+max_bytes = 1000000
+
 [sinks.output_azure_log_ingestion.tls]
 verify_certificate = false
 verify_hostname = false

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_token_scope.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_token_scope.toml
@@ -14,3 +14,6 @@ azure_client_secret = "SECRET[kubernetes_secret.azure-log-ingestion-secret/clien
 
 [sinks.output_azure_log_ingestion.encoding]
 except_fields = ["_internal"]
+
+[sinks.output_azure_log_ingestion.batch]
+max_bytes = 1000000

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_tuning.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_tuning.toml
@@ -15,7 +15,7 @@ azure_client_secret = "SECRET[kubernetes_secret.azure-log-ingestion-secret/clien
 except_fields = ["_internal"]
 
 [sinks.output_azure_log_ingestion.batch]
-max_bytes = 10000000
+max_bytes = 1000000
 
 [sinks.output_azure_log_ingestion.buffer]
 type = "disk"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_tuning_under_limit.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_tuning_under_limit.toml
@@ -15,4 +15,13 @@ azure_client_secret = "SECRET[kubernetes_secret.azure-log-ingestion-secret/clien
 except_fields = ["_internal"]
 
 [sinks.output_azure_log_ingestion.batch]
-max_bytes = 1000000
+max_bytes = 512000
+
+[sinks.output_azure_log_ingestion.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.output_azure_log_ingestion.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_workload_identity.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_workload_identity.toml
@@ -13,3 +13,6 @@ token_file_path = "/var/run/ocp-collector/serviceaccount/token"
 
 [sinks.output_azure_log_ingestion.encoding]
 except_fields = ["_internal"]
+
+[sinks.output_azure_log_ingestion.batch]
+max_bytes = 1000000

--- a/internal/generator/vector/output/azure/azurelogsingestion/azurelogsingestion.go
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azurelogsingestion.go
@@ -19,6 +19,9 @@ import (
 const (
 	azureCredentialKindWorkloadIdentity = "workload_identity"
 	azureCredentialKindClientSecret     = "client_secret_credential"
+
+	// Azure Monitor Logs Ingestion API has a 1MB request body limit
+	AzureDefaultMaxBytes = 1_000_000
 )
 
 func auth(s *sinks.AzureLogsIngestion, azli *obs.AzureLogsIngestion) {
@@ -72,7 +75,14 @@ func New(id string, o *adapters.Output, inputs []string, secrets observability.S
 		s.TimestampField = azli.TimestampField
 		auth(s, azli)
 		s.Encoding = common.NewApiEncoding("")
-		s.Batch = common.NewApiBatch(o)
+		if batch := common.NewApiBatch(o); batch != nil {
+			if batch.MaxBytes > AzureDefaultMaxBytes {
+				batch.MaxBytes = AzureDefaultMaxBytes
+			}
+			s.Batch = batch
+		} else {
+			s.Batch = &sinks.Batch{MaxBytes: AzureDefaultMaxBytes}
+		}
 		s.Buffer = common.NewApiBuffer(o)
 		s.Request = common.NewApiRequest(o)
 		s.TLS = tls.NewTls(o, secrets, op)

--- a/internal/generator/vector/output/azure/azurelogsingestion/azurelogsingestion_test.go
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azurelogsingestion_test.go
@@ -140,10 +140,20 @@ var _ = Describe("Generating vector config for Azure Log Ingestion output:", fun
 		Entry("with tls settings", func(output *obs.OutputSpec) {
 			output.TLS = tlsSpec
 		}, false, "azli_tls.toml"),
-		Entry("with tuning parameters", func(output *obs.OutputSpec) {
+		Entry("with tuning parameters exceeding 1MB cap", func(output *obs.OutputSpec) {
 			output.AzureLogsIngestion.Tuning = &obs.AzureLogsIngestionTuningSpec{
 				BaseOutputTuningSpec: *baseTune,
 			}
 		}, true, "azli_tuning.toml"),
+		Entry("with tuning parameters under 1MB limit", func(output *obs.OutputSpec) {
+			output.AzureLogsIngestion.Tuning = &obs.AzureLogsIngestionTuningSpec{
+				BaseOutputTuningSpec: obs.BaseOutputTuningSpec{
+					DeliveryMode:     obs.DeliveryModeAtLeastOnce,
+					MaxWrite:         utils.GetPtr(resource.MustParse("500Ki")),
+					MaxRetryDuration: utils.GetPtr(time.Duration(35)),
+					MinRetryDuration: utils.GetPtr(time.Duration(20)),
+				},
+			}
+		}, true, "azli_tuning_under_limit.toml"),
 	)
 })

--- a/internal/validations/observability/outputs/validate.go
+++ b/internal/validations/observability/outputs/validate.go
@@ -31,6 +31,8 @@ func Validate(context internalcontext.ForwarderContext) {
 			messages = append(messages, validateHttpContentTypeHeaders(out)...)
 		case obs.OutputTypeElasticsearch:
 			messages = append(messages, validateElasticsearchHeaders(out)...)
+		case obs.OutputTypeAzureLogsIngestion:
+			messages = append(messages, validateAzureLogsIngestionMaxWrite(out)...)
 		}
 		// Set condition
 		if len(messages) > 0 {

--- a/internal/validations/observability/outputs/validate_azurelogsingestion.go
+++ b/internal/validations/observability/outputs/validate_azurelogsingestion.go
@@ -1,0 +1,22 @@
+package outputs
+
+import (
+	"fmt"
+
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/azure/azurelogsingestion"
+)
+
+func validateAzureLogsIngestionMaxWrite(output obs.OutputSpec) (results []string) {
+	if output.Type != obs.OutputTypeAzureLogsIngestion || output.AzureLogsIngestion == nil {
+		return results
+	}
+	if output.AzureLogsIngestion.Tuning == nil || output.AzureLogsIngestion.Tuning.MaxWrite == nil {
+		return results
+	}
+	maxWrite := output.AzureLogsIngestion.Tuning.MaxWrite.Value()
+	if maxWrite > azurelogsingestion.AzureDefaultMaxBytes {
+		results = append(results, fmt.Sprintf("maxWrite must not exceed %d bytes for AzureLogsIngestion, got %d bytes", azurelogsingestion.AzureDefaultMaxBytes, maxWrite))
+	}
+	return results
+}

--- a/internal/validations/observability/outputs/validate_azurelogsingestion_test.go
+++ b/internal/validations/observability/outputs/validate_azurelogsingestion_test.go
@@ -1,0 +1,70 @@
+package outputs
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var _ = Describe("[internal][validations] ClusterLogForwarder will validate maxWrite for AzureLogsIngestion output", func() {
+	var (
+		spec obs.OutputSpec
+	)
+	BeforeEach(func() {
+		spec = obs.OutputSpec{
+			Name:               "azureOutput",
+			Type:               obs.OutputTypeAzureLogsIngestion,
+			AzureLogsIngestion: &obs.AzureLogsIngestion{},
+		}
+	})
+
+	Context("#validateAzureLogsIngestionMaxWrite", func() {
+
+		It("should pass validation when no tuning is set", func() {
+			Expect(validateAzureLogsIngestionMaxWrite(spec)).To(BeEmpty())
+		})
+
+		It("should pass validation when maxWrite is nil", func() {
+			spec.AzureLogsIngestion.Tuning = &obs.AzureLogsIngestionTuningSpec{}
+			Expect(validateAzureLogsIngestionMaxWrite(spec)).To(BeEmpty())
+		})
+
+		It("should pass validation when maxWrite is under 1MB", func() {
+			spec.AzureLogsIngestion.Tuning = &obs.AzureLogsIngestionTuningSpec{
+				BaseOutputTuningSpec: obs.BaseOutputTuningSpec{
+					MaxWrite: utils.GetPtr(resource.MustParse("500Ki")),
+				},
+			}
+			Expect(validateAzureLogsIngestionMaxWrite(spec)).To(BeEmpty())
+		})
+
+		It("should pass validation when maxWrite is exactly 1MB", func() {
+			spec.AzureLogsIngestion.Tuning = &obs.AzureLogsIngestionTuningSpec{
+				BaseOutputTuningSpec: obs.BaseOutputTuningSpec{
+					MaxWrite: utils.GetPtr(resource.MustParse("1000000")),
+				},
+			}
+			Expect(validateAzureLogsIngestionMaxWrite(spec)).To(BeEmpty())
+		})
+
+		It("should fail validation when maxWrite exceeds 1MB", func() {
+			spec.AzureLogsIngestion.Tuning = &obs.AzureLogsIngestionTuningSpec{
+				BaseOutputTuningSpec: obs.BaseOutputTuningSpec{
+					MaxWrite: utils.GetPtr(resource.MustParse("10M")),
+				},
+			}
+			Expect(validateAzureLogsIngestionMaxWrite(spec)).ToNot(BeEmpty())
+		})
+
+		It("should pass validation when output is not AzureLogsIngestion", func() {
+			spec = obs.OutputSpec{
+				Name: "httpOutput",
+				Type: obs.OutputTypeHTTP,
+				HTTP: &obs.HTTP{},
+			}
+			Expect(validateAzureLogsIngestionMaxWrite(spec)).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
### Description

This PR sets the default `maxWrite` value to `1,000,000` bytes for the `AzureLogsIngestion` output tuning parameter. This aligns with the maximum size of an API call enforced by Azure’s [Logs Ingestion API service limits](https://learn.microsoft.com/en-us/azure/azure-monitor/fundamentals/service-limits#logs-ingestion-api).

/cc @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://redhat.atlassian.net/browse/LOG-9389


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Deprecation date for the legacy Azure HTTP Data Collector API set to September 14, 2026; Azure Monitor output flagged for retirement with migration guidance to Azure Logs Ingestion.
  * Examples updated and guidance added about Azure 1MB request body limit.

* **Configuration & Behavior**
  * Default batching/max request size for Azure Logs Ingestion capped at 1MB.

* **Tests & Validation**
  * Added validation and tests to enforce and verify the 1MB maxWrite limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->