### PR TITLE
feat(alerts): add runbook_url for CollectorNodeDown alert

### DIFF
--- a/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -59,6 +59,7 @@ spec:
       annotations:
         description: Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod
           }} collector component for more than 10m.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-logging-operator/CollectorNodeDown.md
         summary: Collector cannot be scraped
       expr: |
         up{app_kubernetes_io_component = "collector", app_kubernetes_io_part_of = "cluster-logging"} == 0

--- a/config/prometheus/collector_alerts.yaml
+++ b/config/prometheus/collector_alerts.yaml
@@ -56,6 +56,7 @@ spec:
       annotations:
         description: "Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod }} collector component for more than 10m."
         summary: "Collector cannot be scraped"
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-logging-operator/CollectorNodeDown.md
       expr: |
         up{app_kubernetes_io_component = "collector", app_kubernetes_io_part_of = "cluster-logging"} == 0
       for: 10m


### PR DESCRIPTION
[LOG-7256](https://redhat.atlassian.net/browse/LOG-7256)

### Description
This PR:
*adds the runbook url for the CollectorNodeDownAlert
* depends on https://github.com/openshift/runbooks/pull/436

### Links
* https://redhat.atlassian.net/browse/LOG-7256

cc @vparfonov @Clee2691 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added runbook URL annotations to the CollectorNodeDown alert rule, enabling users to quickly access operational runbooks for troubleshooting collector node issues. Updates were applied across alerting configurations, providing direct remediation guidance links when alerts are triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->