### PR TITLE
fix(dependencies): fix install of ginkgo

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -41,6 +41,8 @@ for library_file in $( find "${OS_ROOT}/hack/lib" -type f -name '*.sh' -not -pat
 	source "${library_file}"
 done
 
+ginkgo_version=$(grep github.com/onsi/ginkgo/v2 ${init_source}/go.mod | head -n1 | grep -oE 'v([0-9]*\.[0-9]*\.[0-9]*)$')
+
 unset library_files library_file init_source
 
 # all of our Bash scripts need to have the stacktrace
@@ -60,5 +62,5 @@ fi
 if [[ -n "${JUNIT_REPORT:-}" ]]; then
   export JUNIT_REPORT_OUTPUT="${LOG_DIR}/raw_test_output.log"
 fi
-
-go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@v2.23.4
+go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@${ginkgo_version}
+export PATH=$(go env GOPATH)/bin:$PATH


### PR DESCRIPTION
### Description
This PR removes ginko CLI install that is unused by test to resolve:
```
 Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.23.4
  Mismatched package versions found:
    2.27.2 used by input_selection
  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.
  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.
```

cc @vparfonov @Clee2691 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testing tool version management to be dynamically determined from project configuration instead of hardcoded values.
  * Enhanced test output reporting with automatic environment variable configuration.
  * Improved PATH setup to ensure developer tools are properly accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->