### PR TITLE
LOG-9391: Azure reserved keyword 'kind' causes attribute loss for audit logs

### DIFF
--- a/docs/features/logforwarding/outputs/azure/azure-logs-ingestion-forwarding.adoc
+++ b/docs/features/logforwarding/outputs/azure/azure-logs-ingestion-forwarding.adoc
@@ -192,6 +192,24 @@ Standard output tuning parameters are supported:
 CAUTION: The Azure Logs Ingestion API enforces a 1MB request body limit. The collector defaults to a batch size of 1,000,000 bytes (`max_bytes`), if unset, to stay within this limit. If `maxWrite` in `tuning` exceeds 1MB, requests may be rejected by Azure.
 See the https://learn.microsoft.com/en-us/azure/azure-monitor/fundamentals/service-limits#logs-ingestion-api[Azure Logs Ingestion API Service Limits] documentation for more information.
 
+==== Azure Reserved Keywords
+
+Azure Monitor silently drops fields whose names conflict with reserved or standard column names. The Logs Ingestion API returns HTTP 200 (success) even when fields are dropped, making this data loss invisible.
+
+To prevent data loss, the Cluster Logging Operator automatically renames the `kind` field to `openshift_kind` before forwarding. This affects OpenShift audit logs, where `kind` is always set to `"Event"`.
+
+[NOTE]
+====
+If you define a custom table schema in Azure, use the column name `openshift_kind` instead of `kind` to capture this field.
+====
+
+If you prefer a different name, you can rename `openshift_kind` to any non-reserved name using a https://learn.microsoft.com/en-us/azure/azure-monitor/data-collection/data-collection-transformations[data collection transformation] in your `Data Collection Rule`.
+
+For more information on Azure reserved and standard column names, see:
+
+* https://learn.microsoft.com/en-us/azure/azure-monitor/logs/create-custom-table[Add or delete tables and columns in Azure Monitor Logs] -- lists system and reserved columns that cannot be used as custom column names.
+* https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-standard-columns[Standard columns in Azure Monitor Logs] -- documents the standard columns present in every table.
+
 ==== Field Reference
 
 |===

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_common.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_common.toml
@@ -1,6 +1,15 @@
+[transforms.output_azure_log_ingestion_remap_reserved_keywords]
+type = "remap"
+inputs = ["pipelineName"]
+source = '''
+if exists(.kind) {
+  .openshift_kind = del(.kind)
+}
+'''
+
 [sinks.output_azure_log_ingestion]
 type = "azure_logs_ingestion"
-inputs = ["pipelineName"]
+inputs = ["output_azure_log_ingestion_remap_reserved_keywords"]
 endpoint = "https://my-dce-abcdefghij.westus-1.ingest.monitor.azure.com"
 dcr_immutable_id = "dcr-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 stream_name = "Custom-MyTable_Logs_0_CL"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_timestamp_field.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_timestamp_field.toml
@@ -1,6 +1,15 @@
+[transforms.output_azure_log_ingestion_remap_reserved_keywords]
+type = "remap"
+inputs = ["pipelineName"]
+source = '''
+if exists(.kind) {
+  .openshift_kind = del(.kind)
+}
+'''
+
 [sinks.output_azure_log_ingestion]
 type = "azure_logs_ingestion"
-inputs = ["pipelineName"]
+inputs = ["output_azure_log_ingestion_remap_reserved_keywords"]
 endpoint = "https://my-dce-abcdefghij.westus-1.ingest.monitor.azure.com"
 dcr_immutable_id = "dcr-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 stream_name = "Custom-MyTable_Logs_0_CL"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_tls.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_tls.toml
@@ -1,6 +1,15 @@
+[transforms.output_azure_log_ingestion_remap_reserved_keywords]
+type = "remap"
+inputs = ["pipelineName"]
+source = '''
+if exists(.kind) {
+  .openshift_kind = del(.kind)
+}
+'''
+
 [sinks.output_azure_log_ingestion]
 type = "azure_logs_ingestion"
-inputs = ["pipelineName"]
+inputs = ["output_azure_log_ingestion_remap_reserved_keywords"]
 endpoint = "https://my-dce-abcdefghij.westus-1.ingest.monitor.azure.com"
 dcr_immutable_id = "dcr-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 stream_name = "Custom-MyTable_Logs_0_CL"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_token_scope.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_token_scope.toml
@@ -1,6 +1,15 @@
+[transforms.output_azure_log_ingestion_remap_reserved_keywords]
+type = "remap"
+inputs = ["pipelineName"]
+source = '''
+if exists(.kind) {
+  .openshift_kind = del(.kind)
+}
+'''
+
 [sinks.output_azure_log_ingestion]
 type = "azure_logs_ingestion"
-inputs = ["pipelineName"]
+inputs = ["output_azure_log_ingestion_remap_reserved_keywords"]
 endpoint = "https://my-dce-abcdefghij.westus-1.ingest.monitor.azure.com"
 dcr_immutable_id = "dcr-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 stream_name = "Custom-MyTable_Logs_0_CL"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_tuning.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_tuning.toml
@@ -1,6 +1,15 @@
+[transforms.output_azure_log_ingestion_remap_reserved_keywords]
+type = "remap"
+inputs = ["pipelineName"]
+source = '''
+if exists(.kind) {
+  .openshift_kind = del(.kind)
+}
+'''
+
 [sinks.output_azure_log_ingestion]
 type = "azure_logs_ingestion"
-inputs = ["pipelineName"]
+inputs = ["output_azure_log_ingestion_remap_reserved_keywords"]
 endpoint = "https://my-dce-abcdefghij.westus-1.ingest.monitor.azure.com"
 dcr_immutable_id = "dcr-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 stream_name = "Custom-MyTable_Logs_0_CL"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_tuning_under_limit.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_tuning_under_limit.toml
@@ -1,6 +1,15 @@
+[transforms.output_azure_log_ingestion_remap_reserved_keywords]
+type = "remap"
+inputs = ["pipelineName"]
+source = '''
+if exists(.kind) {
+  .openshift_kind = del(.kind)
+}
+'''
+
 [sinks.output_azure_log_ingestion]
 type = "azure_logs_ingestion"
-inputs = ["pipelineName"]
+inputs = ["output_azure_log_ingestion_remap_reserved_keywords"]
 endpoint = "https://my-dce-abcdefghij.westus-1.ingest.monitor.azure.com"
 dcr_immutable_id = "dcr-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 stream_name = "Custom-MyTable_Logs_0_CL"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azli_workload_identity.toml
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azli_workload_identity.toml
@@ -1,6 +1,15 @@
+[transforms.output_azure_log_ingestion_remap_reserved_keywords]
+type = "remap"
+inputs = ["pipelineName"]
+source = '''
+if exists(.kind) {
+  .openshift_kind = del(.kind)
+}
+'''
+
 [sinks.output_azure_log_ingestion]
 type = "azure_logs_ingestion"
-inputs = ["pipelineName"]
+inputs = ["output_azure_log_ingestion_remap_reserved_keywords"]
 endpoint = "https://my-dce-abcdefghij.westus-1.ingest.monitor.azure.com"
 dcr_immutable_id = "dcr-a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
 stream_name = "Custom-MyTable_Logs_0_CL"

--- a/internal/generator/vector/output/azure/azurelogsingestion/azurelogsingestion.go
+++ b/internal/generator/vector/output/azure/azurelogsingestion/azurelogsingestion.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/adapters"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/api"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/api/sinks"
+	"github.com/openshift/cluster-logging-operator/internal/generator/vector/api/transforms"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/api/types"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/common/tls"
 	"github.com/openshift/cluster-logging-operator/internal/generator/vector/output/common"
@@ -23,6 +24,15 @@ const (
 	// Azure Monitor Logs Ingestion API has a 1MB request body limit
 	AzureDefaultMaxBytes = 1_000_000
 )
+
+// RemapReservedKeywords renames fields that Azure silently drops as reserved keywords (HTTP 200, no error).
+func RemapReservedKeywords(inputs ...string) types.Transform {
+	return transforms.NewRemap(`
+if exists(.kind) {
+  .openshift_kind = del(.kind)
+}
+`, inputs...)
+}
 
 func auth(s *sinks.AzureLogsIngestion, azli *obs.AzureLogsIngestion) {
 	if azli == nil || azli.Authentication == nil {
@@ -66,6 +76,12 @@ func auth(s *sinks.AzureLogsIngestion, azli *obs.AzureLogsIngestion) {
 }
 
 func New(id string, o *adapters.Output, inputs []string, secrets observability.Secrets, op utils.Options) (_ string, sink types.Sink, tfs api.Transforms) {
+	tfs = api.Transforms{}
+
+	remapReservedKeywordsID := vectorhelpers.MakeID(id, "remap_reserved_keywords")
+	tfs[remapReservedKeywordsID] = RemapReservedKeywords(inputs...)
+	inputs = []string{remapReservedKeywordsID}
+
 	azli := o.AzureLogsIngestion
 	sink = sinks.NewAzureLogsIngestion(func(s *sinks.AzureLogsIngestion) {
 		s.Endpoint = azli.URL

--- a/test/functional/outputs/azurelogsingestion/forward_to_azurelogsingestion_test.go
+++ b/test/functional/outputs/azurelogsingestion/forward_to_azurelogsingestion_test.go
@@ -11,8 +11,10 @@ import (
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/test/client"
 	"github.com/openshift/cluster-logging-operator/test/framework/functional"
 	"github.com/openshift/cluster-logging-operator/test/helpers/azure/logsingestion"
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 	"github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
@@ -25,8 +27,8 @@ var _ = Describe("Forwarding to Azure Log Ingestion", func() {
 		framework *functional.CollectorFunctionalFramework
 	)
 
-	BeforeEach(func() {
-		framework = functional.NewCollectorFunctionalFramework()
+	setupFramework := func(inputType obs.InputType, testOptions ...client.TestOption) {
+		framework = functional.NewCollectorFunctionalFramework(testOptions...)
 		secret := runtime.NewSecret(framework.Namespace, logsingestion.SecretName,
 			map[string][]byte{
 				logsingestion.ClientSecretKeyName: []byte("fake-client-secret-for-testing"),
@@ -35,46 +37,106 @@ var _ = Describe("Forwarding to Azure Log Ingestion", func() {
 		framework.Secrets = append(framework.Secrets, secret)
 
 		obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
-			FromInput(obs.InputTypeApplication).
+			FromInput(inputType).
 			ToAzureLogsIngestionOutput()
 		Expect(framework.DeployWithVisitor(func(b *runtime.PodBuilder) error {
 			return logsingestion.NewMockoonVisitor(b, framework)
 		})).To(BeNil())
-	})
+	}
 
 	AfterEach(func() {
 		framework.Cleanup()
 	})
 
-	It("should accept application logs", func() {
-		// Write application logs
-		timestamp := "2020-11-04T18:13:59.061892+00:00"
-		nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
-		message := "This is my new test message"
-		appLogTemplate := functional.NewApplicationLogTemplate()
-		appLogTemplate.TimestampLegacy = nanoTime
-		appLogTemplate.Message = message
-		appLogTemplate.Level = "default"
-		appLogTemplate.Kubernetes.PodName = framework.Pod.Name
-		appLogTemplate.Kubernetes.ContainerName = constants.CollectorName
-		appLogTemplate.Kubernetes.NamespaceName = framework.Namespace
+	Context("with application logs", func() {
+		BeforeEach(func() {
+			setupFramework(obs.InputTypeApplication)
+		})
 
-		applicationLogLine := functional.NewCRIOLogMessage(timestamp, message, false)
-		Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 3)).To(BeNil())
-		time.Sleep(30 * time.Second)
+		It("should accept application logs", func() {
+			timestamp := "2020-11-04T18:13:59.061892+00:00"
+			nanoTime, _ := time.Parse(time.RFC3339Nano, timestamp)
+			message := "This is my new test message"
+			appLogTemplate := functional.NewApplicationLogTemplate()
+			appLogTemplate.TimestampLegacy = nanoTime
+			appLogTemplate.Message = message
+			appLogTemplate.Level = "default"
+			appLogTemplate.Kubernetes.PodName = framework.Pod.Name
+			appLogTemplate.Kubernetes.ContainerName = constants.CollectorName
+			appLogTemplate.Kubernetes.NamespaceName = framework.Namespace
 
-		// Read log from collector container and verify no service call failures
-		collectorLog, err := framework.ReadCollectorLogs()
-		Expect(err).To(BeNil())
-		Expect(strings.Count(collectorLog, failedReason)).To(BeEquivalentTo(0))
+			applicationLogLine := functional.NewCRIOLogMessage(timestamp, message, false)
+			Expect(framework.WriteMessagesToApplicationLog(applicationLogLine, 3)).To(BeNil())
 
-		// Read log from mock server container and validate it
-		appLogs, err := logsingestion.ReadApplicationLog(framework)
-		Expect(err).To(BeNil())
-		Expect(appLogs).ToNot(BeNil())
-		Expect(appLogs).To(HaveLen(3))
-		for i := range 3 {
-			Expect(appLogs[i]).To(matchers.FitLogFormatTemplate(appLogTemplate))
-		}
+			var appLogs []types.ApplicationLog
+			Eventually(func(g Gomega) {
+				collectorLog, err := framework.ReadCollectorLogs()
+				g.Expect(err).To(BeNil())
+				g.Expect(strings.Count(collectorLog, failedReason)).To(BeEquivalentTo(0))
+
+				appLogs, err = logsingestion.ReadApplicationLog(framework)
+				g.Expect(err).To(BeNil())
+				g.Expect(appLogs).To(HaveLen(3))
+			}, 30*time.Second, time.Second).Should(Succeed())
+			for i := range 3 {
+				Expect(appLogs[i]).To(matchers.FitLogFormatTemplate(appLogTemplate))
+			}
+		})
+	})
+
+	Context("with infrastructure logs", func() {
+		BeforeEach(func() {
+			setupFramework(obs.InputTypeInfrastructure, client.UseInfraNamespaceTestOption)
+		})
+
+		It("should accept infrastructure logs", func() {
+			Expect(framework.WritesInfraContainerLogs(3)).To(BeNil())
+
+			Eventually(func(g Gomega) {
+				collectorLog, err := framework.ReadCollectorLogs()
+				g.Expect(err).To(BeNil())
+				g.Expect(strings.Count(collectorLog, failedReason)).To(BeEquivalentTo(0))
+
+				infraLogs, err := logsingestion.ReadInfraLog(framework)
+				g.Expect(err).To(BeNil())
+				g.Expect(infraLogs).To(HaveLen(3))
+				for i := range 3 {
+					g.Expect(infraLogs[i].LogType).To(Equal("infrastructure"))
+				}
+			}, 30*time.Second, time.Second).Should(Succeed())
+		})
+	})
+
+	Context("with audit logs", func() {
+		BeforeEach(func() {
+			setupFramework(obs.InputTypeAudit)
+		})
+
+		It("should accept kubernetes audit logs", func() {
+			Expect(framework.WriteK8sAuditLog(3)).To(BeNil())
+
+			var auditLogs []types.AuditLogCommon
+			var rawLogs []map[string]interface{}
+			Eventually(func(g Gomega) {
+				collectorLog, err := framework.ReadCollectorLogs()
+				g.Expect(err).To(BeNil())
+				g.Expect(strings.Count(collectorLog, failedReason)).To(BeEquivalentTo(0))
+
+				auditLogs, err = logsingestion.ReadAuditLog(framework)
+				g.Expect(err).To(BeNil())
+				g.Expect(auditLogs).To(HaveLen(3))
+
+				rawLogs, err = logsingestion.ReadRawLogs(framework)
+				g.Expect(err).To(BeNil())
+				g.Expect(rawLogs).To(HaveLen(3))
+			}, 30*time.Second, time.Second).Should(Succeed())
+
+			for i := range 3 {
+				Expect(auditLogs[i].LogType).To(Equal("audit"))
+				Expect(auditLogs[i].AuditID).ToNot(BeEmpty())
+				Expect(rawLogs[i]).ToNot(HaveKey("kind"), "kind should be renamed to openshift_kind")
+				Expect(rawLogs[i]).To(HaveKeyWithValue("openshift_kind", "Event"))
+			}
+		})
 	})
 })

--- a/test/helpers/azure/logsingestion/log_ingestion.go
+++ b/test/helpers/azure/logsingestion/log_ingestion.go
@@ -82,32 +82,67 @@ func NewMockoonVisitor(pb *runtime.PodBuilder, framework *functional.CollectorFu
 // ReadApplicationLog reads and parses application logs from the
 // Mockoon container used for the Azure Log Ingestion API mock.
 func ReadApplicationLog(framework *functional.CollectorFunctionalFramework) ([]types.ApplicationLog, error) {
-	output, err := oc.Literal().From("oc logs -n %s pod/%s -c %s", framework.Test.NS.Name, framework.Name, mockoon.ContainerName).Run()
+	output, err := readMockoonLogs(framework)
 	if err != nil {
 		return nil, err
 	}
-	return extractLogs(output)
+	return extractLogsAs[types.ApplicationLog](output)
 }
 
-func extractLogs(output string) ([]types.ApplicationLog, error) {
+// ReadAuditLog reads and parses audit logs from the
+// Mockoon container used for the Azure Log Ingestion API mock.
+func ReadAuditLog(framework *functional.CollectorFunctionalFramework) ([]types.AuditLogCommon, error) {
+	output, err := readMockoonLogs(framework)
+	if err != nil {
+		return nil, err
+	}
+	return extractLogsAs[types.AuditLogCommon](output)
+}
+
+// ReadInfraLog reads and parses infrastructure logs from the
+// Mockoon container used for the Azure Log Ingestion API mock.
+func ReadInfraLog(framework *functional.CollectorFunctionalFramework) ([]types.InfraLog, error) {
+	output, err := readMockoonLogs(framework)
+	if err != nil {
+		return nil, err
+	}
+	return extractLogsAs[types.InfraLog](output)
+}
+
+// ReadRawLogs reads logs as raw maps from the Mockoon container, preserving
+// all fields regardless of struct tags. Useful for asserting on renamed or
+// non-standard field names (e.g. openshift_kind).
+func ReadRawLogs(framework *functional.CollectorFunctionalFramework) ([]map[string]interface{}, error) {
+	output, err := readMockoonLogs(framework)
+	if err != nil {
+		return nil, err
+	}
+	return extractLogsAs[map[string]interface{}](output)
+}
+
+func readMockoonLogs(framework *functional.CollectorFunctionalFramework) (string, error) {
+	return oc.Literal().From("oc logs -n %s pod/%s -c %s", framework.Test.NS.Name, framework.Name, mockoon.ContainerName).Run()
+}
+
+func extractLogsAs[T any](output string) ([]T, error) {
 	logs, err := mockoon.DecodeLogs(output)
 	if err != nil {
 		return nil, err
 	}
 
-	var appLogs []types.ApplicationLog
+	var result []T
 	for _, log := range logs {
 		if log.RequestMethod == "POST" && log.ResponseStatus == 204 &&
 			strings.Contains(log.RequestPath, "dataCollectionRules") {
-			appLog := log.Transaction.Request.Body
-			var tmp []types.ApplicationLog
-			if err := types.ParseLogsFrom(utils.ToJsonLogs([]string{appLog}), &tmp, false); err != nil {
+			body := log.Transaction.Request.Body
+			var tmp []T
+			if err := types.ParseLogsFrom(utils.ToJsonLogs([]string{body}), &tmp, false); err != nil {
 				fmt.Printf("error parsing log: %v\n", err)
 				continue
 			}
-			appLogs = append(appLogs, tmp...)
+			result = append(result, tmp...)
 		}
 	}
 
-	return appLogs, nil
+	return result, nil
 }

--- a/test/helpers/azure/logsingestion/log_ingestion_test.go
+++ b/test/helpers/azure/logsingestion/log_ingestion_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/cluster-logging-operator/test/helpers/mockoon"
+	"github.com/openshift/cluster-logging-operator/test/helpers/types"
 )
 
 //go:embed test_mockoon_log_ingestion.log
@@ -15,7 +16,7 @@ var logData string
 var _ = Describe("Parsing Mockoon logs for Azure Log Ingestion API", func() {
 
 	It("should parse application logs from test data", func() {
-		logs, err := extractLogs(logData)
+		logs, err := extractLogsAs[types.ApplicationLog](logData)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logs).To(HaveLen(3))
 
@@ -28,7 +29,7 @@ var _ = Describe("Parsing Mockoon logs for Azure Log Ingestion API", func() {
 	It("should ignore OAuth2 token requests", func() {
 		input := mockoon.NewLogLine("POST", "/test-tenant/oauth2/v2.0/token", 200,
 			`[{"log_type":"application","message":"should be ignored"}]`)
-		logs, err := extractLogs(input)
+		logs, err := extractLogsAs[types.ApplicationLog](input)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logs).To(BeEmpty())
 	})
@@ -36,7 +37,7 @@ var _ = Describe("Parsing Mockoon logs for Azure Log Ingestion API", func() {
 	It("should ignore GET requests", func() {
 		input := mockoon.NewLogLine("GET", "/dataCollectionRules/dcr-test/streams/Custom-Test_CL", 204,
 			`[{"log_type":"application","message":"should be ignored"}]`)
-		logs, err := extractLogs(input)
+		logs, err := extractLogsAs[types.ApplicationLog](input)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logs).To(BeEmpty())
 	})
@@ -44,7 +45,7 @@ var _ = Describe("Parsing Mockoon logs for Azure Log Ingestion API", func() {
 	It("should ignore non-204 responses", func() {
 		input := mockoon.NewLogLine("POST", "/dataCollectionRules/dcr-test/streams/Custom-Test_CL", 500,
 			`[{"log_type":"application","message":"should be ignored"}]`)
-		logs, err := extractLogs(input)
+		logs, err := extractLogsAs[types.ApplicationLog](input)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logs).To(BeEmpty())
 	})
@@ -52,21 +53,21 @@ var _ = Describe("Parsing Mockoon logs for Azure Log Ingestion API", func() {
 	It("should ignore requests to non-dataCollectionRules paths", func() {
 		input := mockoon.NewLogLine("POST", "/some-other-endpoint", 204,
 			`[{"log_type":"application","message":"should be ignored"}]`)
-		logs, err := extractLogs(input)
+		logs, err := extractLogsAs[types.ApplicationLog](input)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logs).To(BeEmpty())
 	})
 
 	It("should return empty for server-started-only output", func() {
 		input := `{"app":"mockoon-server","level":"info","message":"Server started on port 3000","timestamp":"2024-02-21T10:45:23.445Z"}`
-		logs, err := extractLogs(input)
+		logs, err := extractLogsAs[types.ApplicationLog](input)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logs).To(BeEmpty())
 	})
 
 	It("should skip malformed body without error", func() {
 		input := mockoon.NewLogLine("POST", "/dataCollectionRules/dcr-test/streams/Custom-Test_CL", 204, `not-valid-json`)
-		logs, err := extractLogs(input)
+		logs, err := extractLogsAs[types.ApplicationLog](input)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logs).To(BeEmpty())
 	})
@@ -78,11 +79,39 @@ var _ = Describe("Parsing Mockoon logs for Azure Log Ingestion API", func() {
 			`[{"log_type":"application","message":"batch2-msg1"}]`)
 		input := strings.Join([]string{line1, line2}, "\n")
 
-		logs, err := extractLogs(input)
+		logs, err := extractLogsAs[types.ApplicationLog](input)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(logs).To(HaveLen(3))
 		Expect(logs[0].Message).To(Equal("batch1-msg1"))
 		Expect(logs[1].Message).To(Equal("batch1-msg2"))
 		Expect(logs[2].Message).To(Equal("batch2-msg1"))
+	})
+
+	It("should parse audit logs", func() {
+		input := mockoon.NewLogLine("POST", "/dataCollectionRules/dcr-audit/streams/Custom-Audit_CL", 204,
+			`[{"log_type":"audit","verb":"get","requestURI":"/api/v1/namespaces","message":"audit msg 1"},`+
+				`{"log_type":"audit","verb":"list","requestURI":"/api/v1/pods","message":"audit msg 2"}]`)
+		logs, err := extractLogsAs[types.AuditLogCommon](input)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(logs).To(HaveLen(2))
+		Expect(logs[0].Verb).To(Equal("get"))
+		Expect(logs[0].RequestURI).To(Equal("/api/v1/namespaces"))
+		Expect(logs[1].Verb).To(Equal("list"))
+		Expect(logs[1].RequestURI).To(Equal("/api/v1/pods"))
+	})
+
+	It("should parse infrastructure logs", func() {
+		input := mockoon.NewLogLine("POST", "/dataCollectionRules/dcr-infra/streams/Custom-Infra_CL", 204,
+			`[{"log_type":"infrastructure","message":"infra msg 1","level":"info","hostname":"node-1"},`+
+				`{"log_type":"infrastructure","message":"infra msg 2","level":"warn","hostname":"node-2"}]`)
+		logs, err := extractLogsAs[types.InfraLog](input)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(logs).To(HaveLen(2))
+		Expect(logs[0].Message).To(Equal("infra msg 1"))
+		Expect(logs[0].Level).To(Equal("info"))
+		Expect(logs[0].Hostname).To(Equal("node-1"))
+		Expect(logs[1].Message).To(Equal("infra msg 2"))
+		Expect(logs[1].Level).To(Equal("warn"))
+		Expect(logs[1].Hostname).To(Equal("node-2"))
 	})
 })


### PR DESCRIPTION
### Description
This PR introduces a VRL transform that renames the reserved keyword `kind` to `openshift_kind` to prevent attribute loss for audit logs when forwarding to `AzureLogsIngestion` output.

### Summary:
- Added VRL transform
- Updated `AzureLogsIngestion` doc with information about reserved keywords
- Updated `AzureLogsIngestion` functional tests to include infra and audit logs.

/cc @vparfonov 
/assign @jcantrill 

- JIRA: https://redhat.atlassian.net/browse/LOG-9391


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Azure Reserved Keywords section explaining field-name handling for Azure Logs Ingestion.

* **Bug Fixes**
  * Azure Logs Ingestion now automatically renames the `kind` field to `openshift_kind` to prevent field drops due to Azure reserved column names.

* **Tests**
  * Enhanced test coverage for infrastructure and audit logs in Azure Logs Ingestion with field-renaming verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->