### PR TITLE
LOG-9400: API description does not list possible values for deliveryMode

### DIFF
--- a/api/observability/v1/output_types.go
+++ b/api/observability/v1/output_types.go
@@ -256,6 +256,8 @@ type BaseOutputTuningSpec struct {
 // In-memory buffers offer the highest performance due to low latency, but they have two limitations:
 // they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
 //
+// Valid values are: AtLeastOnce, AtMostOnce.
+//
 // +kubebuilder:validation:Enum:=AtLeastOnce;AtMostOnce
 type DeliveryMode string
 

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1989,6 +1989,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2088,6 +2090,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2332,6 +2336,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2490,6 +2496,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2646,6 +2654,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2804,6 +2814,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2940,6 +2952,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -3120,6 +3134,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -3354,6 +3370,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -3491,6 +3509,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -3774,6 +3794,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -3951,6 +3973,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -4156,6 +4180,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1989,6 +1989,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2088,6 +2090,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2332,6 +2336,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2490,6 +2496,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2646,6 +2654,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2804,6 +2814,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -2940,6 +2952,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -3120,6 +3134,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -3354,6 +3370,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -3491,6 +3509,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -3774,6 +3794,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -3951,6 +3973,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce
@@ -4156,6 +4180,8 @@ spec:
                                 This optional setting. When it is left unset, the system defaults to using an in-memory buffer.
                                 In-memory buffers offer the highest performance due to low latency, but they have two limitations:
                                 they will consume memory, and they do not provide durability — buffered data is lost on process termination or failure.
+
+                                Valid values are: AtLeastOnce, AtMostOnce.
                               enum:
                               - AtLeastOnce
                               - AtMostOnce


### PR DESCRIPTION
### Description
This PR adds the possible values for `DeliveryMode`.

/cc @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://redhat.atlassian.net/browse/LOG-9400


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified valid `DeliveryMode` values (`AtLeastOnce` and `AtMostOnce`) in documentation comments and schema descriptions across multiple output configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->