### PR TITLE
feat(metrics): Expose CLF Ready condition as a Prometheus metric

### DIFF
--- a/internal/metrics/telemetry/collector.go
+++ b/internal/metrics/telemetry/collector.go
@@ -39,6 +39,7 @@ func (t *telemetryCollector) Describe(descs chan<- *prometheus.Desc) {
 	descs <- forwarderPipelinesDesc
 	descs <- forwarderInputTypeDesc
 	descs <- forwarderOutputTypeDesc
+	descs <- forwarderReadyDesc
 }
 
 func (t *telemetryCollector) Collect(m chan<- prometheus.Metric) {
@@ -96,6 +97,16 @@ func (t *telemetryCollector) collectForwarder(m chan<- prometheus.Metric) error 
 			m <- prometheus.MustNewConstMetric(forwarderOutputTypeDesc, prometheus.GaugeValue, float64(c),
 				t.version, clf.Namespace, clf.Name, string(output))
 		}
+
+		readyStatus := readyConditionStatus(clf.Status.Conditions)
+		for _, s := range []string{string(metav1.ConditionTrue), string(metav1.ConditionFalse), string(metav1.ConditionUnknown)} {
+			val := 0.0
+			if s == readyStatus {
+				val = 1.0
+			}
+			m <- prometheus.MustNewConstMetric(forwarderReadyDesc, prometheus.GaugeValue, val,
+				clf.Namespace, clf.Name, s)
+		}
 	}
 
 	return nil
@@ -141,4 +152,14 @@ func hasReadyCondition(conditions []metav1.Condition) bool {
 	}
 
 	return false
+}
+
+func readyConditionStatus(conditions []metav1.Condition) string {
+	for _, c := range conditions {
+		if c.Type == observabilityv1.ConditionTypeReady {
+			return string(c.Status)
+		}
+	}
+
+	return string(metav1.ConditionUnknown)
 }

--- a/internal/metrics/telemetry/collector_test.go
+++ b/internal/metrics/telemetry/collector_test.go
@@ -107,6 +107,11 @@ log_forwarder_output_type{output="lokiStack",resource_name="test-name",resource_
 # HELP log_forwarder_pipelines Metric counting the number of pipelines in a forwarder.
 # TYPE log_forwarder_pipelines gauge
 log_forwarder_pipelines{resource_name="test-name",resource_namespace="test-namespace",version="test-version"} 1
+# HELP log_forwarder_ready Shows the ready condition status of a forwarder. Value is 1 for the current status, 0 otherwise.
+# TYPE log_forwarder_ready gauge
+log_forwarder_ready{resource_name="test-name",resource_namespace="test-namespace",status="False"} 0
+log_forwarder_ready{resource_name="test-name",resource_namespace="test-namespace",status="True"} 1
+log_forwarder_ready{resource_name="test-name",resource_namespace="test-namespace",status="Unknown"} 0
 `
 
 				ctx := context.Background()
@@ -115,6 +120,82 @@ log_forwarder_pipelines{resource_name="test-name",resource_namespace="test-names
 
 				metricsReader := strings.NewReader(wantMetrics)
 				err := testutil.CollectAndCompare(collector, metricsReader)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("with ClusterLogForwarder Ready=False", func() {
+			It("should show ready status as false", func() {
+				clf := &observabilityv1.ClusterLogForwarder{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-name",
+					},
+					Spec: observabilityv1.ClusterLogForwarderSpec{
+						Pipelines: []observabilityv1.PipelineSpec{
+							{
+								Name:       "pipeline",
+								InputRefs:  []string{"application"},
+								OutputRefs: []string{"output"},
+							},
+						},
+					},
+					Status: observabilityv1.ClusterLogForwarderStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   observabilityv1.ConditionTypeReady,
+								Status: metav1.ConditionFalse,
+							},
+						},
+					},
+				}
+				wantMetrics := `# HELP log_forwarder_ready Shows the ready condition status of a forwarder. Value is 1 for the current status, 0 otherwise.
+# TYPE log_forwarder_ready gauge
+log_forwarder_ready{resource_name="test-name",resource_namespace="test-namespace",status="False"} 1
+log_forwarder_ready{resource_name="test-name",resource_namespace="test-namespace",status="True"} 0
+log_forwarder_ready{resource_name="test-name",resource_namespace="test-namespace",status="Unknown"} 0
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient(clf)
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader, "log_forwarder_ready")
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("with ClusterLogForwarder without Ready condition", func() {
+			It("should default to unknown status", func() {
+				clf := &observabilityv1.ClusterLogForwarder{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test-namespace",
+						Name:      "test-name",
+					},
+					Spec: observabilityv1.ClusterLogForwarderSpec{
+						Pipelines: []observabilityv1.PipelineSpec{
+							{
+								Name:       "pipeline",
+								InputRefs:  []string{"application"},
+								OutputRefs: []string{"output"},
+							},
+						},
+					},
+				}
+				wantMetrics := `# HELP log_forwarder_ready Shows the ready condition status of a forwarder. Value is 1 for the current status, 0 otherwise.
+# TYPE log_forwarder_ready gauge
+log_forwarder_ready{resource_name="test-name",resource_namespace="test-namespace",status="False"} 0
+log_forwarder_ready{resource_name="test-name",resource_namespace="test-namespace",status="True"} 0
+log_forwarder_ready{resource_name="test-name",resource_namespace="test-namespace",status="Unknown"} 1
+`
+
+				ctx := context.Background()
+				k8s := fake.NewFakeClient(clf)
+				collector := newTelemetryCollector(ctx, k8s, testVersion)
+
+				metricsReader := strings.NewReader(wantMetrics)
+				err := testutil.CollectAndCompare(collector, metricsReader, "log_forwarder_ready")
 				Expect(err).To(BeNil())
 			})
 		})

--- a/internal/metrics/telemetry/telemetry.go
+++ b/internal/metrics/telemetry/telemetry.go
@@ -20,6 +20,7 @@ const (
 
 	labelInput  = "input"
 	labelOutput = "output"
+	labelStatus = "status"
 )
 
 var (
@@ -43,6 +44,11 @@ var (
 		metricsPrefix+"forwarder_output_type",
 		"Shows which output types a forwarder uses.",
 		[]string{labelVersion, labelResourceNamespace, labelResourceName, labelOutput}, nil,
+	)
+	forwarderReadyDesc = prometheus.NewDesc(
+		metricsPrefix+"forwarder_ready",
+		"Shows the ready condition status of a forwarder. Value is 1 for the current status, 0 otherwise.",
+		[]string{labelResourceNamespace, labelResourceName, labelStatus}, nil,
 	)
 )
 


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Add `log_forwarder_ready` gauge metric that surfaces the ClusterLogForwarder Ready condition status (True/False/Unknown) so alerts can detect validation errors. 

#### Example output:
```
  log_forwarder_ready{resource_name="instance",resource_namespace="openshift-logging",status="True"} 1
  log_forwarder_ready{resource_name="instance",resource_namespace="openshift-logging",status="False"} 0
  log_forwarder_ready{resource_name="instance",resource_namespace="openshift-logging",status="Unknown"} 0
```

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-7718
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `log_forwarder_ready` Prometheus metric to monitor log forwarder readiness status.
  * Reports ready, not-ready, and unknown condition states for each forwarder, enabling improved observability of forwarder health across your clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->