### PR TITLE
fix(doc): Improve the CLF API text for indicating that messages are dropped when used Rate Limit in the inputs

### DIFF
--- a/api/observability/v1/clusterlogforwarder_types.go
+++ b/api/observability/v1/clusterlogforwarder_types.go
@@ -208,7 +208,8 @@ type PipelineSpec struct {
 
 type LimitSpec struct {
 	// MaxRecordsPerSecond is the maximum number of log records
-	// allowed per input/output in a pipeline
+	// allowed per input/output in a pipeline.
+	// Log records exceeding this limit are dropped.
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum:=0

--- a/api/observability/v1/input_types.go
+++ b/api/observability/v1/input_types.go
@@ -97,6 +97,7 @@ type ContainerInputTuningSpec struct {
 
 	// RateLimitPerContainer is the limit applied to each container
 	// by this input. This limit is applied per collector deployment.
+	// Log records exceeding the rate limit are dropped.
 	//
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Per-Container Rate Limit"

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -366,11 +366,13 @@ spec:
       - description: |-
           RateLimitPerContainer is the limit applied to each container
           by this input. This limit is applied per collector deployment.
+          Log records exceeding the rate limit are dropped.
         displayName: Per-Container Rate Limit
         path: inputs[0].application.tuning.rateLimitPerContainer
       - description: |-
           MaxRecordsPerSecond is the maximum number of log records
-          allowed per input/output in a pipeline
+          allowed per input/output in a pipeline.
+          Log records exceeding this limit are dropped.
         displayName: Max Records Per Second
         path: inputs[0].application.tuning.rateLimitPerContainer.maxRecordsPerSecond
         x-descriptors:
@@ -417,11 +419,13 @@ spec:
       - description: |-
           RateLimitPerContainer is the limit applied to each container
           by this input. This limit is applied per collector deployment.
+          Log records exceeding the rate limit are dropped.
         displayName: Per-Container Rate Limit
         path: inputs[0].infrastructure.tuning.container.rateLimitPerContainer
       - description: |-
           MaxRecordsPerSecond is the maximum number of log records
-          allowed per input/output in a pipeline
+          allowed per input/output in a pipeline.
+          Log records exceeding this limit are dropped.
         displayName: Max Records Per Second
         path: inputs[0].infrastructure.tuning.container.rateLimitPerContainer.maxRecordsPerSecond
         x-descriptors:
@@ -1719,7 +1723,8 @@ spec:
         path: outputs[0].rateLimit
       - description: |-
           MaxRecordsPerSecond is the maximum number of log records
-          allowed per input/output in a pipeline
+          allowed per input/output in a pipeline.
+          Log records exceeding this limit are dropped.
         displayName: Max Records Per Second
         path: outputs[0].rateLimit.maxRecordsPerSecond
         x-descriptors:

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1568,11 +1568,13 @@ spec:
                               description: |-
                                 RateLimitPerContainer is the limit applied to each container
                                 by this input. This limit is applied per collector deployment.
+                                Log records exceeding the rate limit are dropped.
                               properties:
                                 maxRecordsPerSecond:
                                   description: |-
                                     MaxRecordsPerSecond is the maximum number of log records
-                                    allowed per input/output in a pipeline
+                                    allowed per input/output in a pipeline.
+                                    Log records exceeding this limit are dropped.
                                   exclusiveMinimum: true
                                   format: int64
                                   minimum: 0
@@ -1652,11 +1654,13 @@ spec:
                                   description: |-
                                     RateLimitPerContainer is the limit applied to each container
                                     by this input. This limit is applied per collector deployment.
+                                    Log records exceeding the rate limit are dropped.
                                   properties:
                                     maxRecordsPerSecond:
                                       description: |-
                                         MaxRecordsPerSecond is the maximum number of log records
-                                        allowed per input/output in a pipeline
+                                        allowed per input/output in a pipeline.
+                                        Log records exceeding this limit are dropped.
                                       exclusiveMinimum: true
                                       format: int64
                                       minimum: 0
@@ -3595,7 +3599,8 @@ spec:
                         maxRecordsPerSecond:
                           description: |-
                             MaxRecordsPerSecond is the maximum number of log records
-                            allowed per input/output in a pipeline
+                            allowed per input/output in a pipeline.
+                            Log records exceeding this limit are dropped.
                           exclusiveMinimum: true
                           format: int64
                           minimum: 0

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1568,11 +1568,13 @@ spec:
                               description: |-
                                 RateLimitPerContainer is the limit applied to each container
                                 by this input. This limit is applied per collector deployment.
+                                Log records exceeding the rate limit are dropped.
                               properties:
                                 maxRecordsPerSecond:
                                   description: |-
                                     MaxRecordsPerSecond is the maximum number of log records
-                                    allowed per input/output in a pipeline
+                                    allowed per input/output in a pipeline.
+                                    Log records exceeding this limit are dropped.
                                   exclusiveMinimum: true
                                   format: int64
                                   minimum: 0
@@ -1652,11 +1654,13 @@ spec:
                                   description: |-
                                     RateLimitPerContainer is the limit applied to each container
                                     by this input. This limit is applied per collector deployment.
+                                    Log records exceeding the rate limit are dropped.
                                   properties:
                                     maxRecordsPerSecond:
                                       description: |-
                                         MaxRecordsPerSecond is the maximum number of log records
-                                        allowed per input/output in a pipeline
+                                        allowed per input/output in a pipeline.
+                                        Log records exceeding this limit are dropped.
                                       exclusiveMinimum: true
                                       format: int64
                                       minimum: 0
@@ -3595,7 +3599,8 @@ spec:
                         maxRecordsPerSecond:
                           description: |-
                             MaxRecordsPerSecond is the maximum number of log records
-                            allowed per input/output in a pipeline
+                            allowed per input/output in a pipeline.
+                            Log records exceeding this limit are dropped.
                           exclusiveMinimum: true
                           format: int64
                           minimum: 0

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -289,11 +289,13 @@ spec:
       - description: |-
           RateLimitPerContainer is the limit applied to each container
           by this input. This limit is applied per collector deployment.
+          Log records exceeding the rate limit are dropped.
         displayName: Per-Container Rate Limit
         path: inputs[0].application.tuning.rateLimitPerContainer
       - description: |-
           MaxRecordsPerSecond is the maximum number of log records
-          allowed per input/output in a pipeline
+          allowed per input/output in a pipeline.
+          Log records exceeding this limit are dropped.
         displayName: Max Records Per Second
         path: inputs[0].application.tuning.rateLimitPerContainer.maxRecordsPerSecond
         x-descriptors:
@@ -340,11 +342,13 @@ spec:
       - description: |-
           RateLimitPerContainer is the limit applied to each container
           by this input. This limit is applied per collector deployment.
+          Log records exceeding the rate limit are dropped.
         displayName: Per-Container Rate Limit
         path: inputs[0].infrastructure.tuning.container.rateLimitPerContainer
       - description: |-
           MaxRecordsPerSecond is the maximum number of log records
-          allowed per input/output in a pipeline
+          allowed per input/output in a pipeline.
+          Log records exceeding this limit are dropped.
         displayName: Max Records Per Second
         path: inputs[0].infrastructure.tuning.container.rateLimitPerContainer.maxRecordsPerSecond
         x-descriptors:
@@ -1642,7 +1646,8 @@ spec:
         path: outputs[0].rateLimit
       - description: |-
           MaxRecordsPerSecond is the maximum number of log records
-          allowed per input/output in a pipeline
+          allowed per input/output in a pipeline.
+          Log records exceeding this limit are dropped.
         displayName: Max Records Per Second
         path: outputs[0].rateLimit.maxRecordsPerSecond
         x-descriptors:

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -1459,6 +1459,7 @@ Type:: object
 partial log lines are merged.  Messages exceeding this limit are dropped.
 |rateLimitPerContainer|object|  RateLimitPerContainer is the limit applied to each container
 by this input. This limit is applied per collector deployment.
+Log records exceeding the rate limit are dropped.
 
 |======================
 
@@ -1537,7 +1538,8 @@ Type:: object
 |Property|Type|Description
 
 |maxRecordsPerSecond|int|  MaxRecordsPerSecond is the maximum number of log records
-allowed per input/output in a pipeline
+allowed per input/output in a pipeline.
+Log records exceeding this limit are dropped.
 
 |======================
 
@@ -1645,6 +1647,7 @@ Type:: object
 partial log lines are merged.  Messages exceeding this limit are dropped.
 |rateLimitPerContainer|object|  RateLimitPerContainer is the limit applied to each container
 by this input. This limit is applied per collector deployment.
+Log records exceeding the rate limit are dropped.
 
 |======================
 
@@ -1723,7 +1726,8 @@ Type:: object
 |Property|Type|Description
 
 |maxRecordsPerSecond|int|  MaxRecordsPerSecond is the maximum number of log records
-allowed per input/output in a pipeline
+allowed per input/output in a pipeline.
+Log records exceeding this limit are dropped.
 
 |======================
 
@@ -3637,7 +3641,8 @@ Type:: object
 |Property|Type|Description
 
 |maxRecordsPerSecond|int|  MaxRecordsPerSecond is the maximum number of log records
-allowed per input/output in a pipeline
+allowed per input/output in a pipeline.
+Log records exceeding this limit are dropped.
 
 |======================
 


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Improve the CLF API text for indicating that messages are dropped when used Rate Limit in the inputs
Additionally regenerate docs to align other API changes

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9367
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that log records exceeding configured rate limits are dropped, and that limits apply per input/output in a pipeline (including per-container limits).

* **New Features**
  * Added a Prometheus alert to warn when collector sources discard or fail to read log lines over a 10-minute window.

* **Tests**
  * Added tests to validate the new collector discard alert’s presence and its referenced metrics/labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->