### PR TITLE
feat(metrics): Add CLF Ready condition alert

### DIFF
--- a/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -55,6 +55,21 @@ spec:
       labels:
         service: clusterlogforwarder
         severity: warning
+    - alert: ClusterLogForwarderNotReady
+      annotations:
+        message: ClusterLogForwarder {{ $labels.resource_namespace }}/{{ $labels.resource_name
+          }} is not ready.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-logging-operator/ClusterLogForwarderNotReady.md
+        summary: |-
+          The ClusterLogForwarder {{ $labels.resource_namespace }}/{{ $labels.resource_name }} has been in a not ready state
+          for more than 1 minute. This typically indicates a validation error in the ClusterLogForwarder spec.
+          Check the ClusterLogForwarder status conditions for details.
+      expr: |
+        log_forwarder_ready{status="False"} == 1
+      for: 1m
+      labels:
+        service: clusterlogforwarder
+        severity: error
     - alert: CollectorNodeDown
       annotations:
         description: Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod

--- a/config/prometheus/collector_alerts.yaml
+++ b/config/prometheus/collector_alerts.yaml
@@ -52,6 +52,20 @@ spec:
       labels:
         service: clusterlogforwarder
         severity: warning
+    - alert: ClusterLogForwarderNotReady
+      annotations:
+        message: "ClusterLogForwarder {{ $labels.resource_namespace }}/{{ $labels.resource_name }} is not ready."
+        summary: |-
+          The ClusterLogForwarder {{ $labels.resource_namespace }}/{{ $labels.resource_name }} has been in a not ready state
+          for more than 1 minute. This typically indicates a validation error in the ClusterLogForwarder spec.
+          Check the ClusterLogForwarder status conditions for details.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-logging-operator/ClusterLogForwarderNotReady.md
+      expr: |
+        log_forwarder_ready{status="False"} == 1
+      for: 1m
+      labels:
+        service: clusterlogforwarder
+        severity: error
     - alert: CollectorNodeDown
       annotations:
         description: "Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod }} collector component for more than 10m."

--- a/docs/administration/collector-metrics-and-alerts.adoc
+++ b/docs/administration/collector-metrics-and-alerts.adoc
@@ -128,6 +128,11 @@ You can view this alerts in the OpenShift Container Platform web console.
 
 image::buffer-alert.png[Fired allert]
 
+=== ClusterLogForwarderNotReady
+Will be fired if a ClusterLogForwarder has been in a not ready state for more than 1 minute.
+This typically indicates a validation error in the ClusterLogForwarder spec.
+Check the ClusterLogForwarder status conditions for details.
+
 === CollectorNodeDown
 Will be fired if collector component was offline for more than 10m
 


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Add `ClusterLogForwarderNotReady` alert that fires when a CLF has been in a not ready state for more than 1 minutes. 

Depends on [LOG-7718](https://redhat.atlassian.net/browse/LOG-7718) which adds the `log_forwarder_ready` metric.

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s): 
   - https://github.com/openshift/cluster-logging-operator/pull/3287
   - https://github.com/openshift/runbooks/pull/437
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-7719 
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a monitoring alert "ClusterLogForwarderNotReady" that fires after 1 minute when the cluster log forwarder is not ready; it raises an error-level notification and tags the event with service=clusterlogforwarder.

* **Documentation**
  * Updated Collector alerts docs with the new alert, guidance on likely causes, and links to the runbook for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->