### PR TITLE
LOG-9424: Fix API flooding when MultiCLF shares the same serviceAccount

### DIFF
--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -15,17 +15,27 @@ const systemAuthDelegatorClusterRoleName = "system:auth-delegator"
 
 // ReconcileRBAC reconciles the RBAC specifically for the service account and SCC
 func ReconcileRBAC(k8sClient client.Client, rbacName, saNamespace, saName string, owner metav1.OwnerReference) error {
-	desiredCRB := NewMetaDataReaderClusterRoleBinding(saNamespace, saName, owner)
+	desiredCRB := NewMetaDataReaderClusterRoleBinding(saNamespace, saName)
 	if err := reconcile.ClusterRoleBinding(k8sClient, desiredCRB.Name, func() *rbacv1.ClusterRoleBinding { return desiredCRB }); err != nil {
 		return err
 	}
-	desiredSCCRole := NewServiceAccountSCCRole(saNamespace, saName, owner)
+	desiredSCCRole := NewServiceAccountSCCRole(saNamespace, rbacName, saName, owner)
 	if err := reconcile.Role(k8sClient, desiredSCCRole); err != nil {
 		return err
 	}
 
-	desiredSCCRoleBinding := NewServiceAccountSCCRoleBinding(saNamespace, rbacName, desiredSCCRole.Name, saName, owner)
-	return reconcile.RoleBinding(k8sClient, desiredSCCRoleBinding)
+	desiredSCCRoleBinding := NewServiceAccountSCCRoleBinding(saNamespace, rbacName, saName, owner)
+	if err := reconcile.RoleBinding(k8sClient, desiredSCCRoleBinding); err != nil {
+		return err
+	}
+
+	// Cleanup old resources with previous naming scheme
+	oldRoleName := fmt.Sprintf("%s-scc", saName)
+	if err := reconcile.DeleteRole(k8sClient, saNamespace, oldRoleName); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ReconcileMetricsAuthRBAC reconciles the ClusterRoleBinding that binds system:auth-delegator to the service account
@@ -57,7 +67,7 @@ func NewMetricsAuthClusterRoleBinding(name, saNamespace, saName string) *rbacv1.
 }
 
 // NewMetaDataReaderClusterRoleBinding stubs a clusterrolebinding to allow reading of pod metadata (i.e. labels)
-func NewMetaDataReaderClusterRoleBinding(saNamespace, saName string, owner metav1.OwnerReference) *rbacv1.ClusterRoleBinding {
+func NewMetaDataReaderClusterRoleBinding(saNamespace, saName string) *rbacv1.ClusterRoleBinding {
 	name := fmt.Sprintf("metadata-reader-%s-%s", saNamespace, saName)
 	desired := runtime.NewClusterRoleBinding(name,
 		rbacv1.RoleRef{
@@ -72,12 +82,11 @@ func NewMetaDataReaderClusterRoleBinding(saNamespace, saName string, owner metav
 		},
 	)
 
-	utils.AddOwnerRefToObject(desired, owner)
 	return desired
 }
 
-func NewServiceAccountSCCRole(namespace, name string, owner metav1.OwnerReference) *rbacv1.Role {
-	name = fmt.Sprintf("%s-scc", name)
+func NewServiceAccountSCCRole(namespace, name, saName string, owner metav1.OwnerReference) *rbacv1.Role {
+	roleName := fmt.Sprintf("%s-%s-scc", name, saName)
 	sccRule := rbacv1.PolicyRule{
 		APIGroups:     []string{"security.openshift.io"},
 		ResourceNames: []string{sccName},
@@ -85,13 +94,14 @@ func NewServiceAccountSCCRole(namespace, name string, owner metav1.OwnerReferenc
 		Verbs:         []string{"use"},
 	}
 
-	desired := runtime.NewRole(namespace, name, sccRule)
+	desired := runtime.NewRole(namespace, roleName, sccRule)
 
 	utils.AddOwnerRefToObject(desired, owner)
 	return desired
 }
 
-func NewServiceAccountSCCRoleBinding(namespace, name, roleName, saName string, owner metav1.OwnerReference) *rbacv1.RoleBinding {
+func NewServiceAccountSCCRoleBinding(namespace, name, saName string, owner metav1.OwnerReference) *rbacv1.RoleBinding {
+	roleName := fmt.Sprintf("%s-%s-scc", name, saName)
 	roleRef := rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,
 		Kind:     "Role",
@@ -104,8 +114,8 @@ func NewServiceAccountSCCRoleBinding(namespace, name, roleName, saName string, o
 		Namespace: namespace,
 	}
 
-	name = fmt.Sprintf("%s-scc", name)
-	desired := runtime.NewRoleBinding(namespace, name, roleRef, subject)
+	roleBindingName := fmt.Sprintf("%s-scc", name)
+	desired := runtime.NewRoleBinding(namespace, roleBindingName, roleRef, subject)
 
 	utils.AddOwnerRefToObject(desired, owner)
 	return desired

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/openshift/cluster-logging-operator/internal/reconcile"
@@ -31,8 +32,27 @@ func ReconcileRBAC(k8sClient client.Client, rbacName, saNamespace, saName string
 
 	// Cleanup old resources with previous naming scheme
 	oldRoleName := fmt.Sprintf("%s-scc", saName)
-	if err := reconcile.DeleteRole(k8sClient, saNamespace, oldRoleName); err != nil {
+
+	// List all RoleBindings in the namespace to check if any reference the old role
+	roleBindings := &rbacv1.RoleBindingList{}
+	if err := k8sClient.List(context.TODO(), roleBindings, client.InNamespace(saNamespace)); err != nil {
 		return err
+	}
+
+	// Check if any RoleBinding references the old role
+	hasReferences := false
+	for _, rb := range roleBindings.Items {
+		if rb.RoleRef.Name == oldRoleName {
+			hasReferences = true
+			break
+		}
+	}
+
+	// Only delete the old role if no RoleBindings reference it
+	if !hasReferences {
+		if err := reconcile.DeleteRole(k8sClient, saNamespace, oldRoleName); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("NewMetaDataReaderClusterRoleBinding", func() {
 	It("should stub a well-formed clusterrolebinding", func() {
-		Expect(test.YAMLString(auth.NewMetaDataReaderClusterRoleBinding(constants.OpenshiftNS, "logcollector", metav1.OwnerReference{}))).To(MatchYAML(
+		Expect(test.YAMLString(auth.NewMetaDataReaderClusterRoleBinding(constants.OpenshiftNS, "logcollector"))).To(MatchYAML(
 			`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -26,15 +26,20 @@ subjects:
   namespace: openshift-logging
 `))
 	})
+
+	It("should not have owner references", func() {
+		crb := auth.NewMetaDataReaderClusterRoleBinding(constants.OpenshiftNS, "logcollector")
+		Expect(crb.OwnerReferences).To(BeEmpty())
+	})
 })
 
 var _ = Describe("ServiceAccount SCC Role & RoleBinding", func() {
 	It("should stub a well-formed role", func() {
-		Expect(test.YAMLString(auth.NewServiceAccountSCCRole(constants.OpenshiftNS, "my-sa", metav1.OwnerReference{}))).To(MatchYAML(
+		Expect(test.YAMLString(auth.NewServiceAccountSCCRole(constants.OpenshiftNS, "my-clf", "my-sa", metav1.OwnerReference{}))).To(MatchYAML(
 			`apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: my-sa-scc
+  name: my-clf-my-sa-scc
   namespace: openshift-logging
 rules:
 - apiGroups:
@@ -49,19 +54,19 @@ rules:
 	})
 
 	It("should stub a well-formed roleBinding", func() {
-		Expect(test.YAMLString(auth.NewServiceAccountSCCRoleBinding(constants.OpenshiftNS, "my-sa", "customSA-scc", "customSA", metav1.OwnerReference{}))).To(MatchYAML(
+		Expect(test.YAMLString(auth.NewServiceAccountSCCRoleBinding(constants.OpenshiftNS, "my-clf", "my-sa", metav1.OwnerReference{}))).To(MatchYAML(
 			`apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: my-sa-scc
+  name: my-clf-scc
   namespace: openshift-logging
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: customSA-scc
+  name: my-clf-my-sa-scc
 subjects:
   - kind: ServiceAccount
-    name: customSA
+    name: my-sa
     namespace: openshift-logging
 `))
 	})

--- a/internal/reconcile/rbac.go
+++ b/internal/reconcile/rbac.go
@@ -79,3 +79,14 @@ func DeleteClusterRoleBinding(k8sClient client.Client, name string) error {
 	}
 	return err
 }
+
+func DeleteRole(k8sClient client.Client, namespace, name string) error {
+	object := runtime.NewRole(namespace, name)
+	log.V(3).Info("Deleting Role", "namespace", namespace, "name", name)
+	err := k8sClient.Delete(context.TODO(), object)
+	// Ignore NotFound errors - resource is already deleted
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}


### PR DESCRIPTION
## Problem

When multiple ClusterLogForwarders (CLFs) in the same namespace share the same `spec.serviceAccount`, the Cluster Logging Operator floods the API server with thousands of update requests within hours, causing cluster instability.

**Root Cause**: The operator was creating a Role named `{serviceAccountName}-scc` for SCC permissions. When multiple CLFs shared the same service account, they both tried to manage the same Role resource, continuously updating the ownerReferences to alternately point to each CLF, creating an infinite reconciliation loop.

## Solution

### 1. Changed SCC Role naming scheme
- **Old**: Role named `{sa}-scc` (shared, caused conflicts)
- **New**: Role named `{clfName}-{sa}-scc` (unique per CLF)
- Each CLF now gets its own Role, preventing reconciliation loops
- RoleBinding updated to reference the new Role name format
- Owner references remain on both resources for proper cleanup

### 2. Removed owner references from ClusterRoleBinding
- ClusterRoleBindings are cluster-scoped resources
- Namespaced resources (CLF) should not own cluster-scoped resources
- Follows Kubernetes best practices

### 3. Added cleanup logic
- Automatically deletes old Role resources using the legacy `{sa}-scc` naming
- Ensures smooth migration during upgrades

## Testing

- ✅ Unit tests pass (4/4 in auth package)
- ✅ Lint passes (0 issues)
- ✅ Build succeeds
- ✅ Added test to verify ClusterRoleBinding has no owner references

## Expected Outcome

After this fix:
1. Multiple CLFs can safely share the same service account without causing API floods
2. Each CLF manages its own unique SCC Role and RoleBinding
3. When a CLF is deleted, its RBAC resources are cleaned up via owner references
4. No reconciliation loops occur
5. Old resources are automatically cleaned up during upgrades
6. Follows Kubernetes best practices for resource ownership

## Related Issues

Resolves: https://redhat.atlassian.net/browse/LOG-9424

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [LOG-9424](https://redhat.atlassian.net/browse/LOG-9424) origin`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined RBAC configuration and adjusted cluster-level metadata reader binding behavior
  * Implemented automatic cleanup and safe removal of obsolete role entries during reconciliation
  * Standardized role naming for service-account scoped SCC access

* **Tests**
  * Updated tests to validate the revised RBAC behavior and naming conventions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->