### PR TITLE
LOG-9423: Remove kubernetes field from non-container logs

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -783,6 +783,10 @@ if ._internal.log_source == "node" {
   }
 }
 
+if .log_source != "container" && exists(.kubernetes) {
+  del(.kubernetes)
+}
+
 if ._internal.log_type == "audit" && exists(._internal.structured) {. = merge!(.,._internal.structured) }
 if ._internal.log_source == "syslog" && exists(._internal.structured) {. = merge!(.,._internal.structured) }
 if ._internal.log_source == "container" && exists(._internal.structured) {.structured = ._internal.structured }

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -843,6 +843,9 @@ source = '''
   .log_source = "node"
   }
 
+  if .log_source != "container" && exists(.kubernetes) {
+    del(.kubernetes)
+  }
 
   if ._internal.log_type == "audit" && exists(._internal.structured) {. = merge!(.,._internal.structured) }
   if ._internal.log_source == "syslog" && exists(._internal.structured) {. = merge!(.,._internal.structured) }

--- a/internal/generator/vector/filter/openshift/viaq/v1/filter.go
+++ b/internal/generator/vector/filter/openshift/viaq/v1/filter.go
@@ -32,6 +32,7 @@ func New(inputs []string, inputSpecs []obs.InputSpec) types.Transform {
 	vrls = journalSource(vrls, inputSpecs)
 	vrls = receiverSource(vrls, inputSpecs)
 	vrls = append(vrls,
+		RemoveKubernetesForNonContainerLogs,
 		MergeStructuredIntoRoot,
 		`.timestamp = ._internal.timestamp`,
 		`."@timestamp" = ._internal.timestamp`,

--- a/internal/generator/vector/filter/openshift/viaq/v1/normalize.go
+++ b/internal/generator/vector/filter/openshift/viaq/v1/normalize.go
@@ -153,6 +153,11 @@ del(.kubernetes.node_labels)
 del(.kubernetes.container_image_id)
 del(.kubernetes.pod_ips)
 `
+	RemoveKubernetesForNonContainerLogs = `
+if .log_source != "container" && exists(.kubernetes) {
+  del(.kubernetes)
+}
+`
 	SetMessageOnRoot = `
 if !exists(._internal.structured) {
   .message = ._internal.message

--- a/test/functional/normalization/viaq_audit_logs_format_test.go
+++ b/test/functional/normalization/viaq_audit_logs_format_test.go
@@ -68,6 +68,10 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 			results := strings.Join(raw, " ")
 			Expect(results).To(MatchRegexp("kind.*Event.*level.*Metadata.*k8s_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
 
+			// LOG-9423: audit logs must not contain a kubernetes field
+			for _, log := range raw {
+				Expect(log).ToNot(ContainSubstring(`"kubernetes"`), "audit logs should not have a kubernetes field")
+			}
 		})
 		It("should parse openshift audit log format correctly", func() {
 			// Log message data
@@ -107,6 +111,11 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 				results := strings.Join(raw, " ")
 				Expect(results).To(MatchRegexp("kind.*Event.*level.*Metadata.*openshift_audit_level.*Metadata"), "Message should contain the audit log: %v", raw)
 			}
+
+			// LOG-9423: audit logs must not contain a kubernetes field
+			for _, log := range raw {
+				Expect(log).ToNot(ContainSubstring(`"kubernetes"`), "audit logs should not have a kubernetes field")
+			}
 		})
 		It("should parse linux audit log format correctly", func() {
 			// Log message data
@@ -144,6 +153,11 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 			Expect(outputTestLog).To(FitLogFormatTemplate(outputLogTemplate))
 			results := strings.Join(raw, " ")
 			Expect(results).To(MatchRegexp("format=enriched kernel="), "Message should contain the audit log: %v", raw)
+
+			// LOG-9423: audit logs must not contain a kubernetes field
+			for _, log := range raw {
+				Expect(log).ToNot(ContainSubstring(`"kubernetes"`), "audit logs should not have a kubernetes field")
+			}
 		})
 		It("should parse ovn audit log correctly", func() {
 			// Log message data
@@ -182,6 +196,11 @@ var _ = Describe("[Functional][LogForwarding][Normalization] message format test
 			results := strings.Join(raw, " ")
 			Expect(results).To(MatchRegexp("name=verify-audit-logging_deny-all"), "Message should contain the audit log: %v", raw)
 			Expect(outputTestLog.TimestampLegacy).To(Equal(outputTestLog.Timestamp))
+
+			// LOG-9423: audit logs must not contain a kubernetes field
+			for _, log := range raw {
+				Expect(log).ToNot(ContainSubstring(`"kubernetes"`), "audit logs should not have a kubernetes field")
+			}
 		})
 
 		AfterEach(func() {

--- a/test/functional/normalization/viaq_journal_logs_test.go
+++ b/test/functional/normalization/viaq_journal_logs_test.go
@@ -49,5 +49,10 @@ var _ = Describe("[functional][normalization] ViaQ message format of journal log
 		Expect(outputTestLog.ViaQCommon).To(FitLogFormatTemplate(expLog.ViaQCommon))
 		Expect(outputTestLog.Systemd.T).NotTo(Equal(types.T{}), "Exp. to be populated with something")
 		Expect(outputTestLog.Systemd.U).NotTo(Equal(types.U{}), "Exp. to be populated with something")
+
+		// LOG-9423: journal logs must not contain a kubernetes field
+		for _, log := range raw {
+			Expect(log).ToNot(ContainSubstring(`"kubernetes"`), "journal logs should not have a kubernetes field")
+		}
 	})
 })


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Non-container logs (journal, audit) should not have a `kubernetes` root key since they are not container log formats.


/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9423
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed log data cleanup to remove the `.kubernetes` field from non-container log sources, ensuring cleaner and more accurate log records when data is forwarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->