### PR TITLE
Correct 'Red Had' to 'Red Hat' in YAML description

### DIFF
--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -2448,7 +2448,7 @@ spec:
       version: v1alpha1
   description: |-
     # Red Hat OpenShift Logging
-    The Red Hat OpenShift Logging Operator orchestrates log collection and forwarding to Red Had managed log stores and
+    The Red Hat OpenShift Logging Operator orchestrates log collection and forwarding to Red Hat managed log stores and
     other third-party receivers.
 
     ##Features


### PR DESCRIPTION
Fix typo in description of OpenShift Logging Operator.

### Description
Fix typo

### Links
n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the cluster logging description text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->