### PR TITLE
Correct 'Red Had' to 'Red Hat' in description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ compile-tests: generate
 ci-check: check
 	@echo
 	@git diff-index --name-status --exit-code HEAD || { \
-		echo -e '\nerror: files changed during "make check", not up-to-date\n' ; \
+		printf '\nerror: files changed during "make check", not up-to-date\n\n' ; \
 		exit 1 ; \
 	}
 
@@ -187,7 +187,7 @@ $(GEN_TIMESTAMP): $(shell find api -name '*.go')  $(OPERATOR_SDK) $(CONTROLLER_G
 	@$(CONTROLLER_GEN) object paths="./api/logging/v1alpha1"
 	@$(CONTROLLER_GEN) crd:crdVersions=v1 rbac:roleName=cluster-logging-operator paths="./api/observability/..." output:crd:artifacts:config=config/crd/bases
 	@$(CONTROLLER_GEN) crd:crdVersions=v1 rbac:roleName=cluster-logging-operator paths="./api/logging/v1alpha1" output:crd:artifacts:config=config/crd/bases
-	echo -e "package version\n\nvar Version = \"$(or $(CI_CONTAINER_VERSION),$(VERSION))\"" > version/version.go
+	printf 'package version\n\nvar Version = "%s"\n' "$(or $(CI_CONTAINER_VERSION),$(VERSION))" > version/version.go
 	@$(MAKE) fmt
 	@touch $@
 

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2026-05-20T19:24:21Z"
+    createdAt: "2026-05-28T18:38:48Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -2448,7 +2448,7 @@ spec:
       version: v1alpha1
   description: |-
     # Red Hat OpenShift Logging
-    The Red Hat OpenShift Logging Operator orchestrates log collection and forwarding to Red Had managed log stores and
+    The Red Hat OpenShift Logging Operator orchestrates log collection and forwarding to Red Hat managed log stores and
     other third-party receivers.
 
     ##Features

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -2371,7 +2371,7 @@ spec:
       version: v1alpha1
   description: |-
     # Red Hat OpenShift Logging
-    The Red Hat OpenShift Logging Operator orchestrates log collection and forwarding to Red Had managed log stores and
+    The Red Hat OpenShift Logging Operator orchestrates log collection and forwarding to Red Hat managed log stores and
     other third-party receivers.
 
     ##Features


### PR DESCRIPTION
Fix typo in the description of the OpenShift Logging Operator.

### Description
fix typo

### Links


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Fixed a spelling error in the cluster logging description.
  * Updated operator metadata timestamp to a current value.
  * Improved build/check tooling to produce more consistent version and check output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->