### PR TITLE
fix(test): Fix flaky TLS Scanner e2e test timeout

### DIFF
--- a/hack/testing-olm/test-020-operator.sh
+++ b/hack/testing-olm/test-020-operator.sh
@@ -47,7 +47,7 @@ for dir in $(ls -d $TEST_DIR| grep -E "${INCLUDES}"); do
   mkdir -p $artifact_dir
   if CLEANUP_CMD="$( cd $( dirname ${BASH_SOURCE[0]} ) >/dev/null 2>&1 && pwd )/../../test/e2e/operator/cleanup.sh $artifact_dir" \
     artifact_dir=$artifact_dir \
-    go test --ginkgo.v --ginkgo.no-color \
+    go test -timeout=30m --ginkgo.v --ginkgo.no-color \
       --ginkgo.trace  --ginkgo.poll-progress-after=300s --ginkgo.poll-progress-interval=30s \
       --ginkgo.timeout=60m "$dir" | tee -a "$artifact_dir/test.log" ; then
     os::log::info "======================================================="

--- a/test/framework/e2e/tls/scanner.go
+++ b/test/framework/e2e/tls/scanner.go
@@ -101,6 +101,7 @@ func (s *Scanner) Deploy(scannerNamespace, targetNamespace string) (*batchv1.Job
 
 	// Create the Job
 	backoffLimit := int32(0)
+	activeDeadlineSeconds := int64(int(JobTimeout.Seconds()) - 60)
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -108,7 +109,8 @@ func (s *Scanner) Deploy(scannerNamespace, targetNamespace string) (*batchv1.Job
 			Namespace: scannerNamespace,
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: &backoffLimit,
+			BackoffLimit:          &backoffLimit,
+			ActiveDeadlineSeconds: &activeDeadlineSeconds,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					ServiceAccountName: sa.Name,
@@ -251,9 +253,39 @@ func (s *Scanner) WaitForCompletion(job *batchv1.Job, timeout time.Duration) err
 			return false, fmt.Errorf("TLS Scanner Job failed")
 		}
 
+		// Check pod status for early failure detection
+		if reason, podErr := s.checkPodStatus(job.Namespace, job.Name); podErr != nil {
+			return false, fmt.Errorf("TLS Scanner pod issue: %s: %w", reason, podErr)
+		}
+
 		clolog.V(3).Info("TLS Scanner Job still running", "job", job.Name, "active", currentJob.Status.Active)
 		return false, nil
 	})
+}
+
+// checkPodStatus checks the scanner pod for issues that would prevent the job from completing.
+// Returns a reason and non-nil error if a terminal issue is detected.
+func (s *Scanner) checkPodStatus(namespace, jobName string) (string, error) {
+	pods, err := s.KubeClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("job-name=%s", jobName),
+	})
+	if err != nil || len(pods.Items) == 0 {
+		return "", nil
+	}
+
+	pod := pods.Items[0]
+	for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+		if cs.State.Waiting != nil {
+			reason := cs.State.Waiting.Reason
+			switch reason {
+			case "ImagePullBackOff", "ErrImagePull", "InvalidImageName":
+				return reason, fmt.Errorf("%s: %s", reason, cs.State.Waiting.Message)
+			default:
+				clolog.V(2).Info("Scanner pod container waiting", "container", cs.Name, "reason", reason)
+			}
+		}
+	}
+	return "", nil
 }
 
 // GetResults retrieves and parses the scan results from the TLS Scanner Job logs


### PR DESCRIPTION
### Description

The go test binary was running with Go's default 10-minute timeout, which is insufficient for the TLS scanner job (up to 10 min) plus test setup time. Add explicit `-timeout=30m` to match other `e2e` scripts.

Also add `ActiveDeadlineSeconds` to the scanner Job so Kubernetes kills it if the scanner process hangs, and detect image pull failures early in `WaitForCompletion` instead of polling silently until timeout.


<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a 30-minute timeout to operator end-to-end test runs.
  * Improved job failure detection to terminate early for known terminal errors (for example, image pull failures).
  * Added automatic job deadline handling to better enforce overall test timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->