### PR TITLE
fix(test): Fix flaky metrics and input selection e2e tests

### DIFF
--- a/test/client/watch.go
+++ b/test/client/watch.go
@@ -89,6 +89,7 @@ func (c *Client) waitFor(o runtime.Object, condition Condition, w watch.Interfac
 	defer logBeginEnd(msg, o, &err)()
 	start := time.Now()
 	defer w.Stop()
+	deadline := time.After(c.Timeout())
 	for {
 		select {
 		case e, ok := <-w.ResultChan():
@@ -112,7 +113,7 @@ func (c *Client) waitFor(o runtime.Object, condition Condition, w watch.Interfac
 			} else if err != nil {
 				return err
 			}
-		case <-time.After(c.Timeout()):
+		case <-deadline:
 			return ErrTimeout
 		}
 	}

--- a/test/e2e/collection/metrics/profile_test.go
+++ b/test/e2e/collection/metrics/profile_test.go
@@ -105,19 +105,16 @@ var _ = Describe("[e2e][collection][metrics] Metrics Collection Profiles", Order
 
 	Context("Full profile scraping", func() {
 		It("should have all collector metrics available in Prometheus under the full profile", func() {
-			By("waiting for collector metrics to appear in Thanos")
+			By("waiting for collector metrics to appear in Thanos and verifying non-allowlisted metric is also present")
 			Eventually(func(g Gomega) {
 				response, err := prometheus.Query(fmt.Sprintf(`%s{namespace="%s"}`, allowlistedMetric, constants.OpenshiftNS))
 				g.Expect(err).NotTo(HaveOccurred(), "Failed to query allowlisted metric")
-				g.Expect(prometheus.HasResults(response)).To(BeTrue())
-			}, 5*time.Minute, 30*time.Second).Should(Succeed(), "Allowlisted metric should be present under full profile")
+				g.Expect(prometheus.HasResults(response)).To(BeTrue(), "Allowlisted metric should be present under full profile")
 
-			By("verifying a non-allowlisted metric is also present under full profile")
-			Eventually(func(g Gomega) {
-				response, err := prometheus.Query(fmt.Sprintf(`%s{namespace="%s"}`, nonAllowlistedMetric, constants.OpenshiftNS))
+				response, err = prometheus.Query(fmt.Sprintf(`%s{namespace="%s"}`, nonAllowlistedMetric, constants.OpenshiftNS))
 				g.Expect(err).NotTo(HaveOccurred(), "Failed to query non-allowlisted metric")
-				g.Expect(prometheus.HasResults(response)).To(BeTrue())
-			}, 5*time.Minute, 15*time.Second).Should(Succeed(), "Non-allowlisted metric should also be present under full profile")
+				g.Expect(prometheus.HasResults(response)).To(BeTrue(), "Non-allowlisted metric should also be present under full profile")
+			}, 5*time.Minute, 15*time.Second).Should(Succeed())
 		})
 	})
 })

--- a/test/e2e/input_selection/input_selection_test.go
+++ b/test/e2e/input_selection/input_selection_test.go
@@ -2,6 +2,8 @@ package input_selection
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -102,7 +104,7 @@ var _ = Describe("[e2e][InputSelection]", func() {
 			nil,
 			func() {
 				Expect(receiver.ListJournalLogs()).ToNot(HaveLen(0), "exp only journal logs to be collected")
-				Expect(receiver.ListNamespaces()).To(HaveLen(0), "exp no containers logs to be collected")
+				Expect(receiver.ListNamespaces(15*time.Second)).To(HaveLen(0), "exp no containers logs to be collected")
 			}),
 		Entry("infrastructure inputs should allow specifying only container logs",
 			obs.InputSpec{
@@ -114,7 +116,7 @@ var _ = Describe("[e2e][InputSelection]", func() {
 			nil,
 			func() {
 				Expect(receiver.ListNamespaces()).To(HaveEach(MatchRegexp("^(openshift.*|kube.*|default)$")))
-				Expect(receiver.ListJournalLogs()).To(HaveLen(0), "exp no journal logs to be collected")
+				Expect(receiver.ListJournalLogs(15*time.Second)).To(HaveLen(0), "exp no journal logs to be collected")
 			}),
 		Entry("application inputs should only collect from matching pod label 'notin' expressions",
 			obs.InputSpec{

--- a/test/framework/e2e/http_vector.go
+++ b/test/framework/e2e/http_vector.go
@@ -219,8 +219,12 @@ type Query struct {
 	files []string
 }
 
-func (v VectorHttpReceiverLogStore) ListNamespaces() (namespaces []string) {
-	q, err := v.Query(nil)
+func (v VectorHttpReceiverLogStore) ListNamespaces(timeout ...time.Duration) (namespaces []string) {
+	var t *time.Duration
+	if len(timeout) > 0 {
+		t = &timeout[0]
+	}
+	q, err := v.Query(t)
 	if err != nil {
 		log.Error(err, "Error checking receiver")
 	}
@@ -245,8 +249,12 @@ func isFileDoesNotExistError(out string) bool {
 	return strings.Contains(out, "No such file or directory")
 }
 
-func (v VectorHttpReceiverLogStore) ListJournalLogs() ([]types.JournalLog, error) {
-	result, err := v.RunCmd("head -n 10 /tmp/journal/journal.json", nil)
+func (v VectorHttpReceiverLogStore) ListJournalLogs(timeout ...time.Duration) ([]types.JournalLog, error) {
+	var t *time.Duration
+	if len(timeout) > 0 {
+		t = &timeout[0]
+	}
+	result, err := v.RunCmd("head -n 10 /tmp/journal/journal.json", t)
 	if err != nil {
 		return nil, err
 	}

--- a/test/framework/e2e/http_vector.go
+++ b/test/framework/e2e/http_vector.go
@@ -227,6 +227,7 @@ func (v VectorHttpReceiverLogStore) ListNamespaces(timeout ...time.Duration) (na
 	q, err := v.Query(t)
 	if err != nil {
 		log.Error(err, "Error checking receiver")
+		return namespaces
 	}
 	for _, m := range q.Meta {
 		namespaces = append(namespaces, m.Namespace)
@@ -238,6 +239,7 @@ func (v VectorHttpReceiverLogStore) ListContainers() (containers []string) {
 	q, err := v.Query(nil)
 	if err != nil {
 		log.Error(err, "Error checking receiver")
+		return containers
 	}
 	for _, m := range q.Meta {
 		containers = append(containers, m.ContainerName)


### PR DESCRIPTION
### Description
Metrics profile_test: Combined two sequential 5-minute `Eventually` blocks into a single one to share the timeout budget prevents exceeding external limits when the first metric takes 3+ minutes to appear in Thanos.

Input selection test: RunCmd was retrying all errors (including stable "No such file or directory") for 2 minutes, causing negative assertions to waste full timeouts. Added optional timeout parameters to `ListJournalLogs` and `ListNamespaces`.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test reliability with configurable timeouts for log and metric queries, including reduced timeouts for specific checks.
  * Improved test descriptions and assertion messages for clearer failure diagnostics when metrics or query results are missing.
  * Optimized internal test timeout handling to reuse timers and avoid repeated allocations, improving stability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->