### PR TITLE
fix(generator): fix collectors crashloop when tuning with compression is enabled for LokiStack

### DIFF
--- a/internal/generator/vector/api/sinks/elasticsearch_sink.go
+++ b/internal/generator/vector/api/sinks/elasticsearch_sink.go
@@ -12,10 +12,10 @@ type Elasticsearch struct {
 	Endpoints  []string                `json:"endpoints,omitempty" yaml:"endpoints,omitempty" toml:"endpoints,omitempty"`
 	IdKey      string                  `json:"id_key,omitempty" yaml:"id_key,omitempty" toml:"id_key,omitempty"`
 	ApiVersion ElasticsearchApiVersion `json:"api_version,omitempty" yaml:"api_version,omitempty" toml:"api_version,omitempty"`
-	Bulk       *Bulk                   `json:"bulk,omitempty" yaml:"bulk,omitempty" toml:"bulk,omitempty"`
-	Auth       *ElasticsearchAuth      `json:"auth,omitempty" yaml:"auth,omitempty" toml:"auth,omitempty"`
 	BaseSink
-	Proxy *Proxy `json:"proxy,omitempty" yaml:"proxy,omitempty" toml:"proxy,omitempty"`
+	Bulk  *Bulk              `json:"bulk,omitempty" yaml:"bulk,omitempty" toml:"bulk,omitempty"`
+	Auth  *ElasticsearchAuth `json:"auth,omitempty" yaml:"auth,omitempty" toml:"auth,omitempty"`
+	Proxy *Proxy             `json:"proxy,omitempty" yaml:"proxy,omitempty" toml:"proxy,omitempty"`
 }
 
 func NewElasticsearch(url string, init func(s *Elasticsearch), inputs ...string) (s *Elasticsearch) {

--- a/internal/generator/vector/api/sinks/http_sink.go
+++ b/internal/generator/vector/api/sinks/http_sink.go
@@ -17,13 +17,12 @@ type Http struct {
 	Inputs        []string       `json:"inputs,omitempty" yaml:"inputs,omitempty" toml:"inputs,omitempty"`
 	URI           string         `json:"uri,omitempty" yaml:"uri,omitempty" toml:"uri,omitempty"`
 	Method        MethodType     `json:"method,omitempty" yaml:"method,omitempty" toml:"method,omitempty"`
-	Framing       *Framing       `json:"framing,omitempty" yaml:"framing,omitempty" toml:"framing,omitempty"`
 	PayloadPrefix string         `json:"payload_prefix,omitempty" yaml:"payload_prefix,omitempty" toml:"payload_prefix,omitempty"`
 	PayloadSuffix string         `json:"payload_suffix,omitempty" yaml:"payload_suffix,omitempty" toml:"payload_suffix,omitempty"`
-	Auth          *HttpAuth      `json:"auth,omitempty" yaml:"auth,omitempty" toml:"auth,omitempty"`
 	BaseSink
-
-	Proxy *Proxy `json:"proxy,omitempty" yaml:"proxy,omitempty" toml:"proxy,omitempty"`
+	Framing *Framing  `json:"framing,omitempty" yaml:"framing,omitempty" toml:"framing,omitempty"`
+	Auth    *HttpAuth `json:"auth,omitempty" yaml:"auth,omitempty" toml:"auth,omitempty"`
+	Proxy   *Proxy    `json:"proxy,omitempty" yaml:"proxy,omitempty" toml:"proxy,omitempty"`
 }
 
 func NewHttp(url string, init func(s *Http), inputs ...string) (s *Http) {

--- a/internal/generator/vector/api/sinks/loki_sink.go
+++ b/internal/generator/vector/api/sinks/loki_sink.go
@@ -18,11 +18,11 @@ type Loki struct {
 	Endpoint         string               `json:"endpoint,omitempty" yaml:"endpoint,omitempty" toml:"endpoint,omitempty"`
 	OutOfOrderAction LokiOutOfOrderAction `json:"out_of_order_action,omitempty" yaml:"out_of_order_action,omitempty" toml:"out_of_order_action,omitempty"`
 	TenantId         string               `json:"tenant_id,omitempty" yaml:"tenant_id,omitempty" toml:"tenant_id,omitempty"`
-	HealthCheck      *HealthCheck         `json:"healthcheck,omitempty" yaml:"healthcheck,omitempty" toml:"healthcheck,omitempty"`
-	Auth             *HttpAuth            `json:"auth,omitempty" yaml:"auth,omitempty" toml:"auth,omitempty"`
 	BaseSink
-	Proxy  *Proxy            `json:"proxy,omitempty" yaml:"proxy,omitempty" toml:"proxy,omitempty"`
-	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" toml:"labels,omitempty"`
+	HealthCheck *HealthCheck      `json:"healthcheck,omitempty" yaml:"healthcheck,omitempty" toml:"healthcheck,omitempty"`
+	Auth        *HttpAuth         `json:"auth,omitempty" yaml:"auth,omitempty" toml:"auth,omitempty"`
+	Proxy       *Proxy            `json:"proxy,omitempty" yaml:"proxy,omitempty" toml:"proxy,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" toml:"labels,omitempty"`
 }
 
 func NewLoki(endpoint string, init func(s *Loki), inputs ...string) (s *Loki) {

--- a/internal/generator/vector/output/loki/loki_conf_test.go
+++ b/internal/generator/vector/output/loki/loki_conf_test.go
@@ -194,8 +194,23 @@ var _ = Describe("Generate vector config", func() {
 			spec.Loki.Tuning = &obs.LokiTuningSpec{
 				BaseOutputTuningSpec: *baseTune,
 			}
-		}), Entry("with proxy", "with_proxy.toml", framework.NoOptions, func(spec *obs.OutputSpec) {
+		}),
+		Entry("with tuning and auth", "with_tuning_and_auth.toml", framework.Options{
+			framework.OptionServiceAccountTokenSecretName: "my-service-account-token",
+		}, func(spec *obs.OutputSpec) {
+			spec.Loki.Tuning = &obs.LokiTuningSpec{
+				BaseOutputTuningSpec: *baseTune,
+				Compression:          "gzip",
+			}
+			spec.Loki.Authentication = &obs.HTTPAuthentication{
+				Token: &obs.BearerToken{
+					From: obs.BearerTokenFromServiceAccount,
+				},
+			}
+		}),
+		Entry("with proxy", "with_proxy.toml", framework.NoOptions, func(spec *obs.OutputSpec) {
 			spec.Loki.ProxyURL = "http://somewhere.org/proxy"
 		}),
 	)
+
 })

--- a/internal/generator/vector/output/loki/with_tuning_and_auth.toml
+++ b/internal/generator/vector/output/loki/with_tuning_and_auth.toml
@@ -1,0 +1,63 @@
+[transforms.loki_receiver_remap]
+type = "remap"
+inputs = ["application"]
+source = '''
+  del(.tag)
+'''
+
+[transforms.loki_receiver_remap_label]
+type = "remap"
+inputs = ["loki_receiver_remap"]
+source = '''
+if !exists(.kubernetes.namespace_name) {
+  .kubernetes.namespace_name = ""
+}
+if !exists(.kubernetes.pod_name) {
+  .kubernetes.pod_name = ""
+}
+if !exists(.kubernetes.container_name) {
+  .kubernetes.container_name = ""
+}
+'''
+
+[sinks.loki_receiver]
+type = "loki"
+inputs = ["loki_receiver_remap_label"]
+endpoint = "https://logs-us-west1.grafana.net"
+out_of_order_action = "accept"
+compression = "gzip"
+
+[sinks.loki_receiver.healthcheck]
+enabled = false
+
+[sinks.loki_receiver.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.loki_receiver.batch]
+max_bytes = 10000000
+
+[sinks.loki_receiver.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.loki_receiver.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35
+
+[sinks.loki_receiver.auth]
+strategy = "bearer"
+token = "SECRET[kubernetes_secret.my-service-account-token/token]"
+
+[sinks.loki_receiver.labels]
+k8s_container_name = "{{kubernetes.container_name}}"
+k8s_namespace_name = "{{kubernetes.namespace_name}}"
+k8s_node_name = "${VECTOR_SELF_NODE_NAME}"
+k8s_pod_name = "{{kubernetes.pod_name}}"
+kubernetes_container_name = "{{kubernetes.container_name}}"
+kubernetes_host = "${VECTOR_SELF_NODE_NAME}"
+kubernetes_namespace_name = "{{kubernetes.namespace_name}}"
+kubernetes_pod_name = "{{kubernetes.pod_name}}"
+log_type = "{{log_type}}"
+openshift_log_type = "{{log_type}}"

--- a/test/matchers/generator_element.go
+++ b/test/matchers/generator_element.go
@@ -57,10 +57,24 @@ func (m *GeneratorElementMatcher) Match(expected interface{}) (_ bool, err error
 	if !castable {
 		return false, fmt.Errorf("actual can not be converted to an api.Config: %v", m.actual)
 	}
+
+	// Round-trip the actual config through TOML marshal/unmarshal to verify
+	// that serialization preserves all fields correctly. This catches bugs
+	// where struct field ordering causes fields to be nested under the wrong
+	// TOML table (e.g. LOG-9444: compression inside [auth]).
+	tomlStr, err := toml.Marshal(actualConfig)
+	if err != nil {
+		return false, fmt.Errorf("actual config can not be marshalled to TOML: %v", err)
+	}
+	roundTripped := &api.Config{}
+	if err = toml.Unmarshal(tomlStr, roundTripped); err != nil {
+		return false, fmt.Errorf("actual config TOML output can not be unmarshalled back: %v", err)
+	}
+
 	m.matcher = matchers.MatchYAMLMatcher{
 		YAMLToMatch: test.YAMLString(expConfig),
 	}
-	m.actual = test.YAMLString(actualConfig)
+	m.actual = test.YAMLString(roundTripped)
 	return m.matcher.Match(m.actual)
 }
 


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

`go-toml v1` with `OrderPreserve` serializes embedded struct fields at their declaration position. When `BaseSink` (containing `Compression`) was declared after struct pointer fields like `HealthCheck` or `Auth`, its scalar fields landed inside the preceding TOML table section, producing invalid config.

Move `BaseSink` before all struct pointer fields in `Loki`, `Elasticsearch`, and Http sink structs. Improve `EqualConfigFrom` matcher to round-trip configs through TOML `marshal/unmarshal`, catching serialization bugs across all sinks automatically.

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9444
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Loki sink configuration with tuning and bearer-token authentication.
  * Enhanced test matcher to normalize configurations through serialization before comparison, improving test accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->