### PR TITLE
fix(alerts): correct DiskBufferUsage template variable and severity casing

### DIFF
--- a/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -86,7 +86,7 @@ spec:
       annotations:
         description: 'Collectors potentially consuming too much node disk, {{ $value
           }}% '
-        summary: Detected consuming too much node disk on $labels.hostname host
+        summary: Detected consuming too much node disk on {{ $labels.hostname }} host
       expr: "(label_replace(sum by(hostname) (vector_buffer_byte_size{component_kind='sink',
         buffer_type='disk'}), 'instance', '$1', 'hostname', '(.*)') \n/ on(instance)
         group_left() sum by(instance) (node_filesystem_size_bytes{mountpoint='/var'}))
@@ -94,7 +94,7 @@ spec:
       for: 5m
       labels:
         service: collector
-        severity: Warning
+        severity: warning
     - alert: CollectorSourceDiscardedLogs
       annotations:
         description: |-

--- a/config/prometheus/collector_alerts.yaml
+++ b/config/prometheus/collector_alerts.yaml
@@ -80,14 +80,14 @@ spec:
     - alert: DiskBufferUsage
       annotations:
         description: "Collectors potentially consuming too much node disk, {{ $value }}% "
-        summary: "Detected consuming too much node disk on $labels.hostname host"
+        summary: "Detected consuming too much node disk on {{ $labels.hostname }} host"
       expr: |
         (label_replace(sum by(hostname) (vector_buffer_byte_size{component_kind='sink', buffer_type='disk'}), 'instance', '$1', 'hostname', '(.*)') 
         / on(instance) group_left() sum by(instance) (node_filesystem_size_bytes{mountpoint='/var'})) * 100  > 15
       for: 5m
       labels:
         service: collector
-        severity: Warning
+        severity: warning
     - alert: CollectorSourceDiscardedLogs
       annotations:
         description: |-


### PR DESCRIPTION
## Summary

The `DiskBufferUsage` alert in the `collector` PrometheusRule has two issues:

1. **Broken template variable in summary:** The summary annotation uses `$labels.hostname` without Go template braces `{{ }}`, causing the alert summary to display the literal string `$labels.hostname` instead of the actual node hostname.

2. **Inconsistent severity casing:** The severity label is set to `Warning` (capital W) while all other collector and Loki alerts use lowercase (`warning`, `critical`, `error`).

## Changes

- **`config/prometheus/collector_alerts.yaml`**: Fix template variable (`$labels.hostname` → `{{ $labels.hostname }}`) and severity casing (`Warning` → `warning`).
- **`bundle/manifests/collector_monitoring.coreos.com_v1_prometheusrule.yaml`**: Same two fixes in the bundled copy.

## Impact

Purely cosmetic — only the human-readable summary annotation and the severity label are updated. No changes to PromQL expressions, `for` clauses, or alert firing behavior. Zero operational impact on clusters.

## Note

The `$labels.hostname` issue was also visible in [LOG-5645](https://redhat.atlassian.net/browse/LOG-5645), but the fix at that time only addressed the expression threshold and did not correct the template variable or severity casing.

## References

- Jira: [LOG-9461](https://redhat.atlassian.net/browse/LOG-9461)
- Source file: [config/prometheus/collector_alerts.yaml](https://github.com/openshift/cluster-logging-operator/blob/master/config/prometheus/collector_alerts.yaml)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the DiskBufferUsage alert to properly display the hostname variable in alert message summaries.
  * Standardized alert severity levels to use lowercase naming convention for consistency across monitoring alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->