### PR TITLE
Update skipRange to support direct upgrade from 6.2 to 6.6

### DIFF
--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -1,8 +1,8 @@
 updates:
   - file: "manifests/cluster-logging.clusterserviceversion.yaml" # relative to this file
     update_list:
-      - search: "olm.skipRange: '>=6.4.0-0 <6.6.0'"
-        replace: "olm.skipRange: '>=6.4.0-0 <6.6.0'"
+      - search: "olm.skipRange: '>=6.2.0-0 <6.6.0'"
+        replace: "olm.skipRange: '>=6.2.0-0 <6.6.0'"
       - search: "version: 6.6.0"
         replace: "version: 6.6.0"
       - search: "name: cluster-logging.v6.6.0"

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2026-05-28T18:38:48Z"
+    createdAt: "2026-06-17T14:13:34Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -95,7 +95,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=6.4.0-0 <6.6.0'
+    olm.skipRange: '>=6.2.0-0 <6.6.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |
       {

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=6.4.0-0 <6.6.0'
+    olm.skipRange: '>=6.2.0-0 <6.6.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |
       {


### PR DESCRIPTION
### Description

Adjusts the `skipRange` so that direct upgrades from Logging 6.2.0 and above are possible.

/cc @jcantrill 
/assign @xperimental 

### Links

- JIRA: [LOG-9508](https://redhat.atlassian.net/browse/LOG-9508)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator metadata to expand the upgrade compatibility range, allowing users on cluster logging versions 6.2.0 and later to upgrade to this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->