### PR TITLE
fix(spelling): replace check-spelling with crate-ci/typos for spell checking

### DIFF
--- a/.github/actions/spelling/_typos.toml
+++ b/.github/actions/spelling/_typos.toml
@@ -1,0 +1,130 @@
+[files]
+extend-exclude = [
+    "vendor/",
+    ".bingo/",
+    ".github/actions/spelling/",
+    "bundle/",
+    "*.go",
+    "*.yaml",
+    "*.yml",
+    "*.json",
+    "*.sh",
+    "*.bash",
+    "*.toml",
+    "*.sum",
+    "*.mod",
+    "*.png",
+    "*.jpg",
+    "*.svg",
+    "*.ico",
+    "*.pb.go",
+    "*.pb",
+    "*.proto",
+    "*.csv",
+    "*.log",
+    "*.lock",
+    "*.cfg",
+    "*.conf",
+    "*.ini",
+    "*.xml",
+    "Makefile",
+    "Dockerfile*",
+    "LICENSE",
+    "go.sum",
+    "go.mod",
+    ".cache/",
+    "tmp/",
+    "config/",
+    "hack/",
+    "test/",
+    "internal/",
+    "api/",
+    "cmd/",
+    "must-gather/collection-scripts/",
+]
+
+[default]
+check-filename = false
+
+[default.extend-words]
+# Carry forward from .codespellignore
+coo = "coo"
+notin = "notin"
+fileds = "fileds"
+
+# Project-specific terms
+CLF = "CLF"
+CLO = "CLO"
+VIAQ = "VIAQ"
+viaq = "viaq"
+DCR = "DCR"
+dcr = "dcr"
+Dcr = "Dcr"
+HEC = "HEC"
+hec = "hec"
+OTLP = "OTLP"
+otlp = "otlp"
+SASL = "SASL"
+sasl = "sasl"
+OIDC = "OIDC"
+OVN = "OVN"
+WIF = "WIF"
+
+# Syslog/systemd fields
+CMDLINE = "CMDLINE"
+DEVLINK = "DEVLINK"
+DEVNODE = "DEVNODE"
+LOGINUID = "LOGINUID"
+MSGID = "MSGID"
+PROCID = "PROCID"
+SYSNAME = "SYSNAME"
+UDEV = "UDEV"
+
+# Timestamp format strings
+SSSSSSZ = "SSSSSSZ"
+SSSZ = "SSSZ"
+
+# TLS cipher suite components
+DHE = "DHE"
+
+# Protocol and format terms
+ASIM = "ASIM"
+iostream = "iostream"
+uucp = "uucp"
+
+# Code/config identifiers in doc examples
+baz = "baz"
+containerspass = "containerspass"
+grault = "grault"
+inputname = "inputname"
+lpr = "lpr"
+nologformat = "nologformat"
+plugh = "plugh"
+waldo = "waldo"
+Otel = "Otel"
+
+# Fragments from camelCase/PascalCase splitting
+Ded = "Ded"
+DETERMIN = "DETERMIN"
+
+# Technical terms
+gnuplot = "gnuplot"
+adoc = "adoc"
+deconflict = "deconflict"
+nolint = "nolint"
+govet = "govet"
+templated = "templated"
+topk = "topk"
+zstd = "zstd"
+unparseable = "unparseable"
+
+# Kubernetes/OpenShift terms
+clusterrole = "clusterrole"
+configmap = "configmap"
+rolebinding = "rolebinding"
+serviceaccount = "serviceaccount"
+containername = "containername"
+podname = "podname"
+apiservers = "apiservers"
+sourcetype = "sourcetype"
+bucketnames = "bucketnames"

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -18,32 +18,17 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      actions: read
-      security-events: write
     runs-on: ubuntu-latest
-    if: "contains(github.event_name, 'pull_request') || github.event_name == 'push'"
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     steps:
-      - name: check-spelling
-        id: spelling
-        uses: check-spelling/check-spelling@cfb6f7e75bbfc89c71eaa30366d0c166f1bd9c8c # v0.0.26
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          config: .github/actions/spelling
-          check_file_names: 1
-          only_check_changed_files: 1
-          suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
-          checkout: true
-          post_comment: 0
-          use_sarif: ${{ (!github.event.pull_request || (github.event.pull_request.head.repo.full_name == github.repository)) && 1 }}
-          extra_dictionaries: |
-            cspell:k8s/dict/k8s.txt
-            cspell:golang/dict/go.txt
-            cspell:docker/src/docker-words.txt
-            cspell:shell/dict/shell-all-words.txt
-            cspell:html/dict/html.txt
-            cspell:filetypes/filetypes.txt
-            cspell:software-terms/dict/softwareTerms.txt
-          extra_dictionary_limit: 10
-          check_extra_dictionaries: ""
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Spell Check
+        uses: crate-ci/typos@v1.33.1
+        continue-on-error: true
+        with:
+          config: .github/actions/spelling/_typos.toml

--- a/api/observability/v1/filter_api_audit_types.go
+++ b/api/observability/v1/filter_api_audit_types.go
@@ -54,7 +54,7 @@ import auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 // - User events (ie. non-system and non-serviceaccount) are forwarded
 // - Read-only system events (get/list/watch etc) are dropped
 // - Service account write events that occur within the same namespace as the service account are dropped
-// - All other events are forwarded, subject to any configured [rate limits][#rate-lmiting]
+// - All other events are forwarded, subject to any configured [rate limits][#rate-limiting]
 //
 // If you want to disable these defaults, end your rules list with rule that has only a `level` field.
 // An empty rule matches any event, and prevents the defaults from taking effect.

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -1165,7 +1165,7 @@ spec:
                         - User events (ie. non-system and non-serviceaccount) are forwarded
                         - Read-only system events (get/list/watch etc) are dropped
                         - Service account write events that occur within the same namespace as the service account are dropped
-                        - All other events are forwarded, subject to any configured [rate limits][#rate-lmiting]
+                        - All other events are forwarded, subject to any configured [rate limits][#rate-limiting]
 
                         If you want to disable these defaults, end your rules list with rule that has only a `level` field.
                         An empty rule matches any event, and prevents the defaults from taking effect.

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -1165,7 +1165,7 @@ spec:
                         - User events (ie. non-system and non-serviceaccount) are forwarded
                         - Read-only system events (get/list/watch etc) are dropped
                         - Service account write events that occur within the same namespace as the service account are dropped
-                        - All other events are forwarded, subject to any configured [rate limits][#rate-lmiting]
+                        - All other events are forwarded, subject to any configured [rate limits][#rate-limiting]
 
                         If you want to disable these defaults, end your rules list with rule that has only a `level` field.
                         An empty rule matches any event, and prevents the defaults from taking effect.

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -762,7 +762,7 @@ Events that do not match any rule in the policy are filtered as follows:
 - User events (ie. non-system and non-serviceaccount) are forwarded
 - Read-only system events (get/list/watch etc) are dropped
 - Service account write events that occur within the same namespace as the service account are dropped
-- All other events are forwarded, subject to any configured [rate limits][#rate-lmiting]
+- All other events are forwarded, subject to any configured [rate limits][#rate-limiting]
 
 If you want to disable these defaults, end your rules list with rule that has only a `level` field.
 An empty rule matches any event, and prevents the defaults from taking effect.


### PR DESCRIPTION
### Description

The `check-spelling` action (`v0.0.26`) is no longer maintained due to a security incident affecting the maintainer's account. Replace with `crate-ci/typos` (`v1.33.1`), a maintained Rust-based spell checker.

```
Error: Found security advisory for version 0.0.26: 'Sorry. https://github.com/jsoref/2026-06-16-credential-leak/blob/main/README.md'
Error: This is a fatal error ... asking Action Host to kill our workflow
Error: Process completed with exit code 200.
```

Changes:
- Replace dead `check-spelling@v0.0.26` with `crate-ci/typos@v1.33.1`
- Add `_typos.toml` config with same word allowlist as previous setup
- Fix typo: rate-lmiting → rate-limiting in Go source and generated docs

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:
