### PR TITLE
fix(vector config): Compression field incorrectly nested under TLS in OpenTelemetryProtocol TOML serialization, causing collector crashloops with LokiStack + Otel + tuning.

### DIFF
--- a/internal/generator/vector/api/sinks/opentelemetry_sink.go
+++ b/internal/generator/vector/api/sinks/opentelemetry_sink.go
@@ -36,8 +36,8 @@ type OpenTelemetryProtocol struct {
 	Method        MethodType      `json:"method,omitempty" yaml:"method,omitempty" toml:"method,omitempty"`
 	PayloadPrefix string          `json:"payload_prefix,omitempty" yaml:"payload_prefix,omitempty" toml:"payload_prefix,omitempty"`
 	PayloadSuffix string          `json:"payload_suffix,omitempty" yaml:"payload_suffix,omitempty" toml:"payload_suffix,omitempty"`
-	TLS           *transport.TLS  `json:"tls,omitempty" yaml:"tls,omitempty" toml:"tls,omitempty"`
 	Compression   CompressionType `json:"compression,omitempty" yaml:"compression,omitempty" toml:"compression,omitempty"`
+	TLS           *transport.TLS  `json:"tls,omitempty" yaml:"tls,omitempty" toml:"tls,omitempty"`
 	Encoding      *Encoding       `json:"encoding,omitempty" yaml:"encoding,omitempty" toml:"encoding,omitempty"`
 	Auth          *HttpAuth       `json:"auth,omitempty" yaml:"auth,omitempty" toml:"auth,omitempty"`
 	Request       *Request        `json:"request,omitempty" yaml:"request,omitempty" toml:"request,omitempty"`

--- a/internal/generator/vector/output/lokistack/lokistack_otel_tuning.toml
+++ b/internal/generator/vector/output/lokistack/lokistack_otel_tuning.toml
@@ -1,0 +1,882 @@
+# Extract trace context from log messages
+[transforms.output_default_lokistack_trace_context]
+type = "remap"
+inputs = ["pipeline_fake"]
+source = '''
+trace_context = {}
+# 1. Try to extract trace context from structured log fields
+if exists(._internal.structured) {
+	if exists(._internal.structured.trace_id) {
+		trace_context.trace_id = ._internal.structured.trace_id
+	}
+	if exists(._internal.structured.span_id) {
+		trace_context.span_id = ._internal.structured.span_id
+	}
+	if exists(._internal.structured.trace_flags) {
+		trace_context.trace_flags = ._internal.structured.trace_flags
+	}
+}
+
+# 2. If not structured, try parsing the message as JSON
+if !exists(._internal.structured) {
+	parsed, err = parse_json(._internal.message)
+	if err == null {
+		if exists(parsed.trace_id) {
+			trace_context.trace_id = parsed.trace_id
+		}
+		if exists(parsed.span_id) {
+			trace_context.span_id = parsed.span_id
+		}
+		if exists(parsed.trace_flags) {
+			trace_context.trace_flags = parsed.trace_flags
+		}
+	}
+}
+
+# 3. Fall back to regex for any fields still missing
+if trace_context.trace_id == null {
+	parsed, err = parse_regex(._internal.message, r'(?i)(trace_id|traceId|traceID|trace\-id|trace\.id)[=:]\s*["\']?(?<trace_id>[0-9a-f]{32})["\']?')
+	if err == null && exists(parsed.trace_id) {
+		trace_context.trace_id = parsed.trace_id
+	}
+}
+if trace_context.span_id == null {
+	parsed, err = parse_regex(._internal.message, r'(?i)(span_id|spanId|spanID|span\-id|span\.id)[=:]\s*["\']?(?<span_id>[0-9a-f]{16})["\']?')
+	if err == null && exists(parsed.span_id) {
+		trace_context.span_id = parsed.span_id
+	}
+}
+if trace_context.trace_flags == null {
+	parsed, err = parse_regex(._internal.message, r'(?i)(trace_flags|traceFlags|flags|trace\-flags|trace\.flags)[=:]\s*["\']?(?<trace_flags>[0-9a-f]{1,2})["\']?')
+	if err == null && exists(parsed.trace_flags) {
+		trace_context.trace_flags = parsed.trace_flags
+	}
+}
+
+# 4. Validate and set each trace context field
+if trace_context.trace_id != null {
+	trace_id_str = downcase(to_string!(trace_context.trace_id))
+	if match(trace_id_str, r'^[0-9a-f]{32}$') {
+		._internal.trace_id = trace_id_str
+	}
+}
+if trace_context.span_id != null {
+	span_id_str = downcase(to_string!(trace_context.span_id))
+	if match(span_id_str, r'^[0-9a-f]{16}$') {
+		._internal.span_id = span_id_str
+	}
+}
+if trace_context.trace_flags != null {
+	trace_flags_str = downcase(to_string!(trace_context.trace_flags))
+	if match(trace_flags_str, r'^0?[01]$') {
+		._internal.trace_flags = trace_flags_str
+	}
+}
+'''
+
+[transforms.output_default_lokistack_route]
+type = "route"
+inputs = ["output_default_lokistack_trace_context"]
+route.application = '.log_type == "application"'
+route.audit = '.log_type == "audit"'
+route.infrastructure = '.log_type == "infrastructure"'
+
+[transforms.output_default_lokistack_route_unmatched]
+inputs = ["output_default_lokistack_route._unmatched"]
+type = "log_to_metric"
+
+[[transforms.output_default_lokistack_route_unmatched.metrics]]
+field = "message"
+kind = "incremental"
+name = "component_event_unmatched_count"
+namespace = "logcollector"
+tags = {component_id = "output_default_lokistack_route", log_source = "{{ log_source }}", log_type = "{{ log_type }}", output_type = "lokistack"}
+type = "counter"
+
+# Route logs separately by log_source
+[transforms.output_default_lokistack_application_reroute]
+type = "route"
+inputs = ["output_default_lokistack_route.application"]
+route.container = '.log_source == "container"'
+
+[transforms.output_default_lokistack_application_reroute_unmatched]
+inputs = ["output_default_lokistack_application_reroute._unmatched"]
+type = "log_to_metric"
+
+[[transforms.output_default_lokistack_application_reroute_unmatched.metrics]]
+field = "message"
+kind = "incremental"
+name = "component_event_unmatched_count"
+namespace = "logcollector"
+tags = {component_id = "output_default_lokistack_application_reroute", log_source = "{{ log_source }}", log_type = "{{ log_type }}", output_type = "lokistack"}
+type = "counter"
+
+# Normalize container log records to OTLP semantic conventions
+[transforms.output_default_lokistack_application_container]
+type = "remap"
+inputs = ["output_default_lokistack_application_reroute.container"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+resource.attributes = append( resource.attributes,
+  [
+    {"key": "k8s.pod.name", "value": {"stringValue": .kubernetes.pod_name}},
+	{"key": "k8s.pod.uid", "value": {"stringValue": .kubernetes.pod_id}},
+    {"key": "k8s.container.name", "value": {"stringValue": .kubernetes.container_name}},
+    {"key": "k8s.namespace.name", "value": {"stringValue": .kubernetes.namespace_name}}
+  ]
+)
+if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "k8s.pod.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Append backward compatibility attributes for container logs
+resource.attributes = append( resource.attributes,
+	[{"key": "kubernetes.pod_name", "value": {"stringValue": .kubernetes.pod_name}},
+	{"key": "kubernetes.container_name", "value": {"stringValue": .kubernetes.container_name}},
+	{"key": "kubernetes.namespace_name", "value": {"stringValue": .kubernetes.namespace_name}}]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+r.severityText = .level
+# Create body from original message or structured
+value = .message
+if (value == null) { value = encode_json(.structured) }
+r.body = {"stringValue": string!(value)}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+r.attributes = append(r.attributes,
+  [
+	{"key": "log.iostream", "value": {"stringValue": .kubernetes.container_iostream}},
+	{"key": "level", "value": {"stringValue": .level}}
+  ]
+)
+  # Openshift and kubernetes objects for grouping containers (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "cluster_id": .openshift.cluster_id
+  }
+  .kubernetes = {
+      "namespace_name": .kubernetes.namespace_name,
+      "pod_name": .kubernetes.pod_name,
+      "container_name": .kubernetes.container_name
+  }
+  . = {
+    "openshift": o,
+    "kubernetes": .kubernetes,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Merge container logs and group by namespace, pod and container
+[transforms.output_default_lokistack_application_groupby_container]
+type = "reduce"
+inputs = ["output_default_lokistack_application_container"]
+expire_after_ms = 15000
+max_events = 1
+group_by = [".openshift.cluster_id",".kubernetes.namespace_name",".kubernetes.pod_name",".kubernetes.container_name"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Create new resource object for OTLP JSON payload
+[transforms.output_default_lokistack_application_resource_logs]
+type = "remap"
+inputs = ["output_default_lokistack_application_groupby_container"]
+source = '''
+  . = {
+        "resource": {
+           "attributes": .resource.attributes,
+        },
+        "scopeLogs": [
+          {"logRecords": .logRecords}
+        ]
+      }
+'''
+
+[sinks.output_default_lokistack_application]
+type = "opentelemetry"
+inputs = ["output_default_lokistack_application_resource_logs"]
+
+[sinks.output_default_lokistack_application.protocol]
+uri = "https://logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/application/otlp/v1/logs"
+type = "http"
+method = "post"
+payload_prefix = "{\"resourceLogs\":"
+payload_suffix = "}"
+compression = "gzip"
+
+[sinks.output_default_lokistack_application.protocol.tls]
+ca_file = "/var/run/ocp-collector/config/openshift-service-ca.crt/ca-bundle.crt"
+
+[sinks.output_default_lokistack_application.protocol.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.output_default_lokistack_application.protocol.auth]
+strategy = "bearer"
+token = "SECRET[kubernetes_secret.test-sa-token/token]"
+
+[sinks.output_default_lokistack_application.protocol.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35
+
+[sinks.output_default_lokistack_application.batch]
+max_bytes = 10000000
+
+[sinks.output_default_lokistack_application.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+# Route logs separately by log_source
+[transforms.output_default_lokistack_audit_reroute]
+type = "route"
+inputs = ["output_default_lokistack_route.audit"]
+route.auditd = '.log_source == "auditd"'
+route.kubeapi = '.log_source == "kubeAPI"'
+route.openshiftapi = '.log_source == "openshiftAPI"'
+route.ovn = '.log_source == "ovn"'
+
+[transforms.output_default_lokistack_audit_reroute_unmatched]
+inputs = ["output_default_lokistack_audit_reroute._unmatched"]
+type = "log_to_metric"
+
+[[transforms.output_default_lokistack_audit_reroute_unmatched.metrics]]
+field = "message"
+kind = "incremental"
+name = "component_event_unmatched_count"
+namespace = "logcollector"
+tags = {component_id = "output_default_lokistack_audit_reroute", log_source = "{{ log_source }}", log_type = "{{ log_type }}", output_type = "lokistack"}
+type = "counter"
+
+# Normalize audit log record to OTLP semantic conventions
+[transforms.output_default_lokistack_audit_auditd]
+type = "remap"
+inputs = ["output_default_lokistack_audit_reroute.auditd"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+# Create body from internal message
+r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+# Fill up auditd logRecord object
+if exists(.level) { r.severityText = .level }
+kv = parse_key_value!(to_string!(get!(.,["_internal","message"])))
+if exists(kv.type) {
+    r.attributes = push(r.attributes, {"key": "auditd.type", "value": {"stringValue": kv.type }})
+}
+if exists(kv.msg) {
+    msg_str = ""
+    if is_array(kv.msg) {
+        msg_str = kv.msg[0]
+    } else {
+        msg_str = kv.msg
+    }
+    trimmed = slice!(msg_str, find!(msg_str, "(") + 1, -2)
+    parts = split!(trimmed, ":")
+    r.attributes = push(r.attributes, {"key": "log.sequence", "value": {"stringValue": parts[1] }})
+}
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": .openshift.cluster_id
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+'''
+
+# Normalize audit log kube record to OTLP semantic conventions
+[transforms.output_default_lokistack_audit_kubeapi]
+type = "remap"
+inputs = ["output_default_lokistack_audit_reroute.kubeapi"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+# Create body from internal message
+r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": .openshift.cluster_id
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+'''
+
+# Normalize audit openshiftAPI record to OTLP semantic conventions
+[transforms.output_default_lokistack_audit_openshiftapi]
+type = "remap"
+inputs = ["output_default_lokistack_audit_reroute.openshiftapi"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+# Create body from internal message
+r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": .openshift.cluster_id
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+'''
+
+# Normalize audit log ovn records to OTLP semantic conventions
+[transforms.output_default_lokistack_audit_ovn]
+type = "remap"
+inputs = ["output_default_lokistack_audit_reroute.ovn"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+# Create body from internal message
+r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+# Fill up OVN logRecord object
+if exists(.level) { r.severityText = .level }
+ovnTokens = split(to_string!(get!(.,["_internal","message"])),"|")
+if 0 < length(ovnTokens) { r.attributes = push(r.attributes, {"key": "log.sequence", "value": {"stringValue": ovnTokens[1] }})}
+if 1 < length(ovnTokens) { r.attributes = push(r.attributes, {"key": "k8s.ovn.component", "value": {"stringValue": ovnTokens[2] }})}
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": .openshift.cluster_id
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+'''
+
+# Merge audit api and node logs and group by log_source
+[transforms.output_default_lokistack_audit_groupby_source]
+type = "reduce"
+inputs = ["output_default_lokistack_audit_kubeapi","output_default_lokistack_audit_openshiftapi","output_default_lokistack_audit_ovn"]
+expire_after_ms = 15000
+max_events = 1
+group_by = [".openshift.cluster_id",".openshift.log_type",".openshift.log_source"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Merge auditd host logs and group by hostname
+[transforms.output_default_lokistack_audit_groupby_host]
+type = "reduce"
+inputs = ["output_default_lokistack_audit_auditd"]
+expire_after_ms = 15000
+max_events = 1
+group_by = [".openshift.cluster_id",".openshift.hostname",".openshift.log_type",".openshift.log_source"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Create new resource object for OTLP JSON payload
+[transforms.output_default_lokistack_audit_resource_logs]
+type = "remap"
+inputs = ["output_default_lokistack_audit_groupby_host","output_default_lokistack_audit_groupby_source"]
+source = '''
+  . = {
+        "resource": {
+           "attributes": .resource.attributes,
+        },
+        "scopeLogs": [
+          {"logRecords": .logRecords}
+        ]
+      }
+'''
+
+[sinks.output_default_lokistack_audit]
+type = "opentelemetry"
+inputs = ["output_default_lokistack_audit_resource_logs"]
+
+[sinks.output_default_lokistack_audit.protocol]
+uri = "https://logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/audit/otlp/v1/logs"
+type = "http"
+method = "post"
+payload_prefix = "{\"resourceLogs\":"
+payload_suffix = "}"
+compression = "gzip"
+
+[sinks.output_default_lokistack_audit.protocol.tls]
+ca_file = "/var/run/ocp-collector/config/openshift-service-ca.crt/ca-bundle.crt"
+
+[sinks.output_default_lokistack_audit.protocol.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.output_default_lokistack_audit.protocol.auth]
+strategy = "bearer"
+token = "SECRET[kubernetes_secret.test-sa-token/token]"
+
+[sinks.output_default_lokistack_audit.protocol.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35
+
+[sinks.output_default_lokistack_audit.batch]
+max_bytes = 10000000
+
+[sinks.output_default_lokistack_audit.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+# Route logs separately by log_source
+[transforms.output_default_lokistack_infrastructure_reroute]
+type = "route"
+inputs = ["output_default_lokistack_route.infrastructure"]
+route.container = '.log_source == "container"'
+route.node = '.log_source == "node"'
+
+[transforms.output_default_lokistack_infrastructure_reroute_unmatched]
+inputs = ["output_default_lokistack_infrastructure_reroute._unmatched"]
+type = "log_to_metric"
+
+[[transforms.output_default_lokistack_infrastructure_reroute_unmatched.metrics]]
+field = "message"
+kind = "incremental"
+name = "component_event_unmatched_count"
+namespace = "logcollector"
+tags = {component_id = "output_default_lokistack_infrastructure_reroute", log_source = "{{ log_source }}", log_type = "{{ log_type }}", output_type = "lokistack"}
+type = "counter"
+
+# Normalize container log records to OTLP semantic conventions
+[transforms.output_default_lokistack_infrastructure_container]
+type = "remap"
+inputs = ["output_default_lokistack_infrastructure_reroute.container"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+resource.attributes = append( resource.attributes,
+  [
+    {"key": "k8s.pod.name", "value": {"stringValue": .kubernetes.pod_name}},
+	{"key": "k8s.pod.uid", "value": {"stringValue": .kubernetes.pod_id}},
+    {"key": "k8s.container.name", "value": {"stringValue": .kubernetes.container_name}},
+    {"key": "k8s.namespace.name", "value": {"stringValue": .kubernetes.namespace_name}}
+  ]
+)
+if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "k8s.pod.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Append backward compatibility attributes for container logs
+resource.attributes = append( resource.attributes,
+	[{"key": "kubernetes.pod_name", "value": {"stringValue": .kubernetes.pod_name}},
+	{"key": "kubernetes.container_name", "value": {"stringValue": .kubernetes.container_name}},
+	{"key": "kubernetes.namespace_name", "value": {"stringValue": .kubernetes.namespace_name}}]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+r.severityText = .level
+# Create body from original message or structured
+value = .message
+if (value == null) { value = encode_json(.structured) }
+r.body = {"stringValue": string!(value)}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+r.attributes = append(r.attributes,
+  [
+	{"key": "log.iostream", "value": {"stringValue": .kubernetes.container_iostream}},
+	{"key": "level", "value": {"stringValue": .level}}
+  ]
+)
+  # Openshift and kubernetes objects for grouping containers (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "cluster_id": .openshift.cluster_id
+  }
+  .kubernetes = {
+      "namespace_name": .kubernetes.namespace_name,
+      "pod_name": .kubernetes.pod_name,
+      "container_name": .kubernetes.container_name
+  }
+  . = {
+    "openshift": o,
+    "kubernetes": .kubernetes,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Merge container logs and group by namespace, pod and container
+[transforms.output_default_lokistack_infrastructure_groupby_container]
+type = "reduce"
+inputs = ["output_default_lokistack_infrastructure_container"]
+expire_after_ms = 15000
+max_events = 1
+group_by = [".openshift.cluster_id",".kubernetes.namespace_name",".kubernetes.pod_name",".kubernetes.container_name"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Normalize node log events to OTLP semantic conventions
+[transforms.output_default_lokistack_infrastructure_node]
+type = "remap"
+inputs = ["output_default_lokistack_infrastructure_reroute.node"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+resource.attributes = append(resource.attributes,
+  [
+	{"key": "process.command_line", "value": {"stringValue": .systemd.t.CMDLINE}},
+	{"key": "process.executable.name", "value": {"stringValue": .systemd.t.COMM}},
+	{"key": "process.executable.path", "value": {"stringValue": .systemd.t.EXE}},
+	{"key": "process.pid", "value": {"stringValue": .systemd.t.PID}},
+	{"key": "service.name", "value": {"stringValue": .systemd.t.SYSTEMD_UNIT}}
+  ]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+r.severityText = .level
+# Create body from original message or structured
+value = .message
+if (value == null) { value = encode_json(.structured) }
+r.body = {"stringValue": string!(value)}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+r.attributes = append(r.attributes, [{"key": "level", "value": {"stringValue": .level}}])
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": .openshift.cluster_id
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+'''
+
+# Merge auditd host logs and group by hostname
+[transforms.output_default_lokistack_infrastructure_groupby_host]
+type = "reduce"
+inputs = ["output_default_lokistack_infrastructure_node"]
+expire_after_ms = 15000
+max_events = 1
+group_by = [".openshift.cluster_id",".openshift.hostname",".openshift.log_type",".openshift.log_source"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Create new resource object for OTLP JSON payload
+[transforms.output_default_lokistack_infrastructure_resource_logs]
+type = "remap"
+inputs = ["output_default_lokistack_infrastructure_groupby_container","output_default_lokistack_infrastructure_groupby_host"]
+source = '''
+  . = {
+        "resource": {
+           "attributes": .resource.attributes,
+        },
+        "scopeLogs": [
+          {"logRecords": .logRecords}
+        ]
+      }
+'''
+
+[sinks.output_default_lokistack_infrastructure]
+type = "opentelemetry"
+inputs = ["output_default_lokistack_infrastructure_resource_logs"]
+
+[sinks.output_default_lokistack_infrastructure.protocol]
+uri = "https://logging-loki-gateway-http.openshift-logging.svc:8080/api/logs/v1/infrastructure/otlp/v1/logs"
+type = "http"
+method = "post"
+payload_prefix = "{\"resourceLogs\":"
+payload_suffix = "}"
+compression = "gzip"
+
+[sinks.output_default_lokistack_infrastructure.protocol.tls]
+ca_file = "/var/run/ocp-collector/config/openshift-service-ca.crt/ca-bundle.crt"
+
+[sinks.output_default_lokistack_infrastructure.protocol.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.output_default_lokistack_infrastructure.protocol.auth]
+strategy = "bearer"
+token = "SECRET[kubernetes_secret.test-sa-token/token]"
+
+[sinks.output_default_lokistack_infrastructure.protocol.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35
+
+[sinks.output_default_lokistack_infrastructure.batch]
+max_bytes = 10000000
+
+[sinks.output_default_lokistack_infrastructure.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488

--- a/internal/generator/vector/output/lokistack/lokistack_test.go
+++ b/internal/generator/vector/output/lokistack/lokistack_test.go
@@ -3,6 +3,7 @@ package lokistack
 import (
 	_ "embed"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,6 +18,7 @@ import (
 
 	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var _ = Describe("Generate vector config", func() {
@@ -175,6 +177,18 @@ var _ = Describe("Generate vector config", func() {
 			}
 		}(), func(spec *obs.OutputSpec) {
 			spec.LokiStack.DataModel = obs.LokiStackDataModelOpenTelemetry
+		}),
+		Entry("with Otel datamodel and tuning", "lokistack_otel_tuning.toml", initOptions(), func(spec *obs.OutputSpec) {
+			spec.LokiStack.DataModel = obs.LokiStackDataModelOpenTelemetry
+			spec.LokiStack.Tuning = &obs.LokiTuningSpec{
+				BaseOutputTuningSpec: obs.BaseOutputTuningSpec{
+					DeliveryMode:     obs.DeliveryModeAtLeastOnce,
+					MaxWrite:         utils.GetPtr(resource.MustParse("10M")),
+					MaxRetryDuration: utils.GetPtr(time.Duration(35)),
+					MinRetryDuration: utils.GetPtr(time.Duration(20)),
+				},
+				Compression: "gzip",
+			}
 		}),
 		Entry("with ViaQ datamodel with receiver", "lokistack_viaq_receiver.toml", initReceiverOptions(), func(spec *obs.OutputSpec) {}),
 	)

--- a/internal/generator/vector/output/otlp/otlp_test.go
+++ b/internal/generator/vector/output/otlp/otlp_test.go
@@ -121,6 +121,33 @@ var _ = Describe("Generate vector config", func() {
 			},
 			"otlp_tuning.toml",
 		),
+		Entry("with tuning, compression and TLS",
+			map[string]*corev1.Secret{
+				"test-ca": {
+					Data: map[string][]byte{
+						constants.TrustedCABundleKey: []byte("test-ca-bundle"),
+					},
+				},
+			},
+			initOptions(),
+			true,
+			func(spec *obs.OutputSpec) {
+				spec.OTLP.URL = "https://localhost:4318/v1/logs"
+				spec.OTLP.Tuning = &obs.OTLPTuningSpec{
+					BaseOutputTuningSpec: *baseTune,
+					Compression:          "gzip",
+				}
+				spec.TLS = &obs.OutputTLSSpec{
+					TLSSpec: obs.TLSSpec{
+						CA: &obs.ValueReference{
+							Key:           constants.TrustedCABundleKey,
+							ConfigMapName: "test-ca",
+						},
+					},
+				}
+			},
+			"otlp_tuning_with_tls.toml",
+		),
 		Entry("with token auth from secret",
 			secrets,
 			initOptions(),

--- a/internal/generator/vector/output/otlp/otlp_tuning_with_tls.toml
+++ b/internal/generator/vector/output/otlp/otlp_tuning_with_tls.toml
@@ -1,0 +1,608 @@
+# Extract trace context from log messages
+[transforms.output_otel_collector_trace_context]
+type = "remap"
+inputs = ["pipeline_my_pipeline_viaq_0"]
+source = '''
+trace_context = {}
+# 1. Try to extract trace context from structured log fields
+if exists(._internal.structured) {
+	if exists(._internal.structured.trace_id) {
+		trace_context.trace_id = ._internal.structured.trace_id
+	}
+	if exists(._internal.structured.span_id) {
+		trace_context.span_id = ._internal.structured.span_id
+	}
+	if exists(._internal.structured.trace_flags) {
+		trace_context.trace_flags = ._internal.structured.trace_flags
+	}
+}
+
+# 2. If not structured, try parsing the message as JSON
+if !exists(._internal.structured) {
+	parsed, err = parse_json(._internal.message)
+	if err == null {
+		if exists(parsed.trace_id) {
+			trace_context.trace_id = parsed.trace_id
+		}
+		if exists(parsed.span_id) {
+			trace_context.span_id = parsed.span_id
+		}
+		if exists(parsed.trace_flags) {
+			trace_context.trace_flags = parsed.trace_flags
+		}
+	}
+}
+
+# 3. Fall back to regex for any fields still missing
+if trace_context.trace_id == null {
+	parsed, err = parse_regex(._internal.message, r'(?i)(trace_id|traceId|traceID|trace\-id|trace\.id)[=:]\s*["\']?(?<trace_id>[0-9a-f]{32})["\']?')
+	if err == null && exists(parsed.trace_id) {
+		trace_context.trace_id = parsed.trace_id
+	}
+}
+if trace_context.span_id == null {
+	parsed, err = parse_regex(._internal.message, r'(?i)(span_id|spanId|spanID|span\-id|span\.id)[=:]\s*["\']?(?<span_id>[0-9a-f]{16})["\']?')
+	if err == null && exists(parsed.span_id) {
+		trace_context.span_id = parsed.span_id
+	}
+}
+if trace_context.trace_flags == null {
+	parsed, err = parse_regex(._internal.message, r'(?i)(trace_flags|traceFlags|flags|trace\-flags|trace\.flags)[=:]\s*["\']?(?<trace_flags>[0-9a-f]{1,2})["\']?')
+	if err == null && exists(parsed.trace_flags) {
+		trace_context.trace_flags = parsed.trace_flags
+	}
+}
+
+# 4. Validate and set each trace context field
+if trace_context.trace_id != null {
+	trace_id_str = downcase(to_string!(trace_context.trace_id))
+	if match(trace_id_str, r'^[0-9a-f]{32}$') {
+		._internal.trace_id = trace_id_str
+	}
+}
+if trace_context.span_id != null {
+	span_id_str = downcase(to_string!(trace_context.span_id))
+	if match(span_id_str, r'^[0-9a-f]{16}$') {
+		._internal.span_id = span_id_str
+	}
+}
+if trace_context.trace_flags != null {
+	trace_flags_str = downcase(to_string!(trace_context.trace_flags))
+	if match(trace_flags_str, r'^0?[01]$') {
+		._internal.trace_flags = trace_flags_str
+	}
+}
+'''
+
+# Route logs separately by log_source
+[transforms.output_otel_collector_reroute]
+type = "route"
+inputs = ["output_otel_collector_trace_context"]
+route.auditd = '.log_source == "auditd"'
+route.container = '.log_source == "container"'
+route.kubeapi = '.log_source == "kubeAPI"'
+route.node = '.log_source == "node"'
+route.openshiftapi = '.log_source == "openshiftAPI"'
+route.ovn = '.log_source == "ovn"'
+
+[transforms.output_otel_collector_reroute_unmatched]
+inputs = ["output_otel_collector_reroute._unmatched"]
+type = "log_to_metric"
+
+[[transforms.output_otel_collector_reroute_unmatched.metrics]]
+field = "message"
+kind = "incremental"
+name = "component_event_unmatched_count"
+namespace = "logcollector"
+tags = {component_id = "output_otel_collector_reroute", log_source = "{{ log_source }}", log_type = "{{ log_type }}", output_type = "lokistack"}
+type = "counter"
+
+# Normalize container log records to OTLP semantic conventions
+[transforms.output_otel_collector_container]
+type = "remap"
+inputs = ["output_otel_collector_reroute.container"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+resource.attributes = append( resource.attributes,
+  [
+    {"key": "k8s.pod.name", "value": {"stringValue": .kubernetes.pod_name}},
+	{"key": "k8s.pod.uid", "value": {"stringValue": .kubernetes.pod_id}},
+    {"key": "k8s.container.name", "value": {"stringValue": .kubernetes.container_name}},
+    {"key": "k8s.namespace.name", "value": {"stringValue": .kubernetes.namespace_name}}
+  ]
+)
+if exists(.kubernetes.labels) {for_each(object!(.kubernetes.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "k8s.pod.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Append backward compatibility attributes for container logs
+resource.attributes = append( resource.attributes,
+	[{"key": "kubernetes.pod_name", "value": {"stringValue": .kubernetes.pod_name}},
+	{"key": "kubernetes.container_name", "value": {"stringValue": .kubernetes.container_name}},
+	{"key": "kubernetes.namespace_name", "value": {"stringValue": .kubernetes.namespace_name}}]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+r.severityText = .level
+# Create body from original message or structured
+value = .message
+if (value == null) { value = encode_json(.structured) }
+r.body = {"stringValue": string!(value)}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+r.attributes = append(r.attributes,
+  [
+	{"key": "log.iostream", "value": {"stringValue": .kubernetes.container_iostream}},
+	{"key": "level", "value": {"stringValue": .level}}
+  ]
+)
+  # Openshift and kubernetes objects for grouping containers (dropped before sending)
+  o = {
+      "log_type": .log_type,
+      "log_source": .log_source,
+      "cluster_id": .openshift.cluster_id
+  }
+  .kubernetes = {
+      "namespace_name": .kubernetes.namespace_name,
+      "pod_name": .kubernetes.pod_name,
+      "container_name": .kubernetes.container_name
+  }
+  . = {
+    "openshift": o,
+    "kubernetes": .kubernetes,
+    "resource": resource,
+    "logRecords": r
+  }
+'''
+
+# Merge container logs and group by namespace, pod and container
+[transforms.output_otel_collector_groupby_container]
+type = "reduce"
+inputs = ["output_otel_collector_container"]
+expire_after_ms = 15000
+max_events = 1
+group_by = [".openshift.cluster_id",".kubernetes.namespace_name",".kubernetes.pod_name",".kubernetes.container_name"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Normalize node log events to OTLP semantic conventions
+[transforms.output_otel_collector_node]
+type = "remap"
+inputs = ["output_otel_collector_reroute.node"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+resource.attributes = append(resource.attributes,
+  [
+	{"key": "process.command_line", "value": {"stringValue": .systemd.t.CMDLINE}},
+	{"key": "process.executable.name", "value": {"stringValue": .systemd.t.COMM}},
+	{"key": "process.executable.path", "value": {"stringValue": .systemd.t.EXE}},
+	{"key": "process.pid", "value": {"stringValue": .systemd.t.PID}},
+	{"key": "service.name", "value": {"stringValue": .systemd.t.SYSTEMD_UNIT}}
+  ]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+r.severityText = .level
+# Create body from original message or structured
+value = .message
+if (value == null) { value = encode_json(.structured) }
+r.body = {"stringValue": string!(value)}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+r.attributes = append(r.attributes, [{"key": "level", "value": {"stringValue": .level}}])
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": .openshift.cluster_id
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+'''
+
+# Normalize audit log record to OTLP semantic conventions
+[transforms.output_otel_collector_auditd]
+type = "remap"
+inputs = ["output_otel_collector_reroute.auditd"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+# Create body from internal message
+r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+# Fill up auditd logRecord object
+if exists(.level) { r.severityText = .level }
+kv = parse_key_value!(to_string!(get!(.,["_internal","message"])))
+if exists(kv.type) {
+    r.attributes = push(r.attributes, {"key": "auditd.type", "value": {"stringValue": kv.type }})
+}
+if exists(kv.msg) {
+    msg_str = ""
+    if is_array(kv.msg) {
+        msg_str = kv.msg[0]
+    } else {
+        msg_str = kv.msg
+    }
+    trimmed = slice!(msg_str, find!(msg_str, "(") + 1, -2)
+    parts = split!(trimmed, ":")
+    r.attributes = push(r.attributes, {"key": "log.sequence", "value": {"stringValue": parts[1] }})
+}
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": .openshift.cluster_id
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+'''
+
+# Normalize audit log kube record to OTLP semantic conventions
+[transforms.output_otel_collector_kubeapi]
+type = "remap"
+inputs = ["output_otel_collector_reroute.kubeapi"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+# Create body from internal message
+r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": .openshift.cluster_id
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+'''
+
+# Normalize audit openshiftAPI record to OTLP semantic conventions
+[transforms.output_otel_collector_openshiftapi]
+type = "remap"
+inputs = ["output_otel_collector_reroute.openshiftapi"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+# Create body from internal message
+r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": .openshift.cluster_id
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+'''
+
+# Normalize audit log ovn records to OTLP semantic conventions
+[transforms.output_otel_collector_ovn]
+type = "remap"
+inputs = ["output_otel_collector_reroute.ovn"]
+source = '''
+# Create base resource attributes
+resource.attributes = []
+resource.attributes = append(resource.attributes,
+  [
+    {"key": "openshift.cluster.uid", "value": {"stringValue": .openshift.cluster_id}},
+    {"key": "openshift.log.source", "value": {"stringValue": .log_source}},
+    {"key": "openshift.log.type", "value": {"stringValue": .log_type}},
+    {"key": "k8s.node.name", "value": {"stringValue": .hostname}}
+  ]
+)
+if exists(.openshift.labels) {for_each(object!(.openshift.labels)) -> |key,value| {
+    resource.attributes = append(resource.attributes,
+        [{"key": "openshift.label." + key, "value": {"stringValue": value}}]
+    )
+}}
+# Append backward compatibility attributes
+resource.attributes = append( resource.attributes,
+	[
+      {"key": "log_type", "value": {"stringValue": .log_type}},
+      {"key": "log_source", "value": {"stringValue": .log_source}},
+      {"key": "openshift.cluster_id", "value": {"stringValue": .openshift.cluster_id}},
+      {"key": "kubernetes.host", "value": {"stringValue": .hostname}}
+    ]
+)
+# Create logRecord object
+r = {"attributes": []}
+r.timeUnixNano = to_string(to_unix_timestamp(parse_timestamp!(.@timestamp, format:"%+"), unit:"nanoseconds"))
+r.observedTimeUnixNano = to_string(to_unix_timestamp(now(), unit:"nanoseconds"))
+# Create body from internal message
+r.body = {"stringValue": to_string!(get!(.,["_internal","message"]))}
+
+# Set trace context fields if any
+if exists(._internal.trace_id) {
+  r.traceId = ._internal.trace_id
+}
+if exists(._internal.span_id) {
+  r.spanId = ._internal.span_id
+}
+if exists(._internal.trace_flags) {
+  r.flags = ._internal.trace_flags
+}
+
+# Fill up OVN logRecord object
+if exists(.level) { r.severityText = .level }
+ovnTokens = split(to_string!(get!(.,["_internal","message"])),"|")
+if 0 < length(ovnTokens) { r.attributes = push(r.attributes, {"key": "log.sequence", "value": {"stringValue": ovnTokens[1] }})}
+if 1 < length(ovnTokens) { r.attributes = push(r.attributes, {"key": "k8s.ovn.component", "value": {"stringValue": ovnTokens[2] }})}
+# Openshift object for grouping (dropped before sending)
+o = {
+    "log_type": .log_type,
+    "log_source": .log_source,
+    "hostname": .hostname,
+    "cluster_id": .openshift.cluster_id
+}
+. = {
+  "openshift": o,
+  "resource": resource,
+  "logRecords": r
+}
+'''
+
+# Merge audit api and node logs and group by log_source
+[transforms.output_otel_collector_groupby_source]
+type = "reduce"
+inputs = ["output_otel_collector_kubeapi","output_otel_collector_openshiftapi","output_otel_collector_ovn"]
+expire_after_ms = 15000
+max_events = 1
+group_by = [".openshift.cluster_id",".openshift.log_type",".openshift.log_source"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Merge auditd host logs and group by hostname
+[transforms.output_otel_collector_groupby_host]
+type = "reduce"
+inputs = ["output_otel_collector_auditd","output_otel_collector_node"]
+expire_after_ms = 15000
+max_events = 1
+group_by = [".openshift.cluster_id",".openshift.hostname",".openshift.log_type",".openshift.log_source"]
+merge_strategies.resource = "retain"
+merge_strategies.logRecords = "array"
+
+# Create new resource object for OTLP JSON payload
+[transforms.output_otel_collector_resource_logs]
+type = "remap"
+inputs = ["output_otel_collector_groupby_container","output_otel_collector_groupby_host","output_otel_collector_groupby_source"]
+source = '''
+  . = {
+        "resource": {
+           "attributes": .resource.attributes,
+        },
+        "scopeLogs": [
+          {"logRecords": .logRecords}
+        ]
+      }
+'''
+
+[sinks.output_otel_collector]
+type = "opentelemetry"
+inputs = ["output_otel_collector_resource_logs"]
+
+[sinks.output_otel_collector.protocol]
+uri = "https://localhost:4318/v1/logs"
+type = "http"
+method = "post"
+payload_prefix = "{\"resourceLogs\":"
+payload_suffix = "}"
+compression = "gzip"
+
+[sinks.output_otel_collector.protocol.tls]
+ca_file = "/var/run/ocp-collector/config/test-ca/ca-bundle.crt"
+
+[sinks.output_otel_collector.protocol.encoding]
+codec = "json"
+except_fields = ["_internal"]
+
+[sinks.output_otel_collector.protocol.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35
+
+[sinks.output_otel_collector.batch]
+max_bytes = 10000000
+
+[sinks.output_otel_collector.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488


### PR DESCRIPTION
### Description
#### Root Cause
In `go-toml`, struct fields serialize in declaration order. The `TLS` field  was declared before `Compression`, causing compression to nest inside the TLS section.

#### Solution
Reorder `OpenTelemetryProtocol` fields: move `Compression` before `TLS`.
**Changes:**
  - Reorder struct fields in `opentelemetry_sink.go`
  - Add test case for LokiStack + Otel + tuning
  - Add test fixture `lokistack_otel_tuning.toml`
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9566
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry-based LokiStack output configuration that routes application, audit, and infrastructure logs and maps trace context into the generated OTLP payloads.
  * Introduced OTLP tuning enhancements including gzip-compressed JSON delivery, improved batching/retry behavior, and TLS with CA verification.

* **Tests**
  * Extended LokiStack and OTLP generation test suites to cover the new OpenTelemetry tuning scenarios, including TLS configuration and expected output validation.

* **Bug Fixes**
  * Corrected the ordering of OpenTelemetry sink configuration fields for consistent interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->