### PR TITLE
fix(rbac): handle immutable roleRef in RoleBinding reconciliation

### DIFF
--- a/internal/reconcile/rbac.go
+++ b/internal/reconcile/rbac.go
@@ -28,19 +28,29 @@ func Role(k8Client client.Client, desired *rbacv1.Role) error {
 }
 
 func RoleBinding(k8Client client.Client, desired *rbacv1.RoleBinding) error {
-	roleBinding := runtime.NewRoleBinding(desired.Namespace, desired.Name, desired.RoleRef)
-	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, roleBinding, func() error {
-		// Update the rolebinding with our desired state
-		roleBinding.RoleRef = desired.RoleRef
-		roleBinding.Subjects = desired.Subjects
-		roleBinding.OwnerReferences = desired.OwnerReferences
-		return nil
-	})
-
-	if err == nil {
-		log.V(3).Info(fmt.Sprintf("reconciled roleBinding - operation: %s", op))
+	existing := runtime.NewRoleBinding(desired.Namespace, desired.Name, rbacv1.RoleRef{})
+	err := k8Client.Get(context.TODO(), client.ObjectKeyFromObject(existing), existing)
+	if apierrors.IsNotFound(err) {
+		log.V(3).Info("Creating roleBinding", "name", desired.Name, "namespace", desired.Namespace)
+		return k8Client.Create(context.TODO(), desired)
 	}
-	return err
+	if err != nil {
+		return err
+	}
+
+	if existing.RoleRef != desired.RoleRef {
+		log.V(3).Info("Deleting roleBinding due to roleRef change", "name", desired.Name, "namespace", desired.Namespace)
+		if err := k8Client.Delete(context.TODO(), existing); err != nil {
+			return err
+		}
+		log.V(3).Info("Recreating roleBinding", "name", desired.Name, "namespace", desired.Namespace)
+		return k8Client.Create(context.TODO(), desired)
+	}
+
+	existing.Subjects = desired.Subjects
+	existing.OwnerReferences = desired.OwnerReferences
+	log.V(3).Info("Updating roleBinding", "name", desired.Name, "namespace", desired.Namespace)
+	return k8Client.Update(context.TODO(), existing)
 }
 
 func ClusterRoleBinding(k8sClient client.Client, name string, generator func() *rbacv1.ClusterRoleBinding) error {

--- a/internal/reconcile/rbac_test.go
+++ b/internal/reconcile/rbac_test.go
@@ -1,0 +1,86 @@
+package reconcile_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/reconcile"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("reconciling RoleBinding", func() {
+
+	var (
+		namespace = "test-namespace"
+		name      = "test-rolebinding"
+		oldRef    = rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "old-role"}
+		newRef    = rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "new-role"}
+		subject   = rbacv1.Subject{Kind: "ServiceAccount", Name: "test-sa", Namespace: namespace}
+		ownerRef  = metav1.OwnerReference{APIVersion: "v1", Kind: "ConfigMap", Name: "owner", UID: "12345"}
+	)
+
+	newClient := func(objs ...client.Object) client.Client {
+		globalScheme := k8sruntime.NewScheme()
+		Expect(scheme.AddToScheme(globalScheme)).To(Succeed())
+		return fake.NewClientBuilder().WithScheme(globalScheme).WithObjects(objs...).Build()
+	}
+
+	getRoleBinding := func(k8sClient client.Client) *rbacv1.RoleBinding {
+		result := &rbacv1.RoleBinding{}
+		key := client.ObjectKey{Namespace: namespace, Name: name}
+		Expect(k8sClient.Get(context.TODO(), key, result)).To(Succeed())
+		return result
+	}
+
+	It("should create the RoleBinding when it does not exist", func() {
+		k8sClient := newClient()
+		desired := runtime.NewRoleBinding(namespace, name, newRef, subject)
+		desired.OwnerReferences = []metav1.OwnerReference{ownerRef}
+
+		Expect(reconcile.RoleBinding(k8sClient, desired)).To(Succeed())
+
+		result := getRoleBinding(k8sClient)
+		Expect(result.RoleRef).To(Equal(newRef))
+		Expect(result.Subjects).To(Equal([]rbacv1.Subject{subject}))
+		Expect(result.OwnerReferences).To(Equal([]metav1.OwnerReference{ownerRef}))
+	})
+
+	It("should update Subjects and OwnerReferences when roleRef is unchanged", func() {
+		existing := runtime.NewRoleBinding(namespace, name, newRef,
+			rbacv1.Subject{Kind: "ServiceAccount", Name: "old-sa", Namespace: namespace})
+		k8sClient := newClient(existing)
+
+		desired := runtime.NewRoleBinding(namespace, name, newRef, subject)
+		desired.OwnerReferences = []metav1.OwnerReference{ownerRef}
+
+		Expect(reconcile.RoleBinding(k8sClient, desired)).To(Succeed())
+
+		result := getRoleBinding(k8sClient)
+		Expect(result.RoleRef).To(Equal(newRef))
+		Expect(result.Subjects).To(Equal([]rbacv1.Subject{subject}))
+		Expect(result.OwnerReferences).To(Equal([]metav1.OwnerReference{ownerRef}))
+	})
+
+	It("should delete and recreate the RoleBinding when roleRef changes", func() {
+		existing := runtime.NewRoleBinding(namespace, name, oldRef,
+			rbacv1.Subject{Kind: "ServiceAccount", Name: "old-sa", Namespace: namespace})
+		k8sClient := newClient(existing)
+
+		desired := runtime.NewRoleBinding(namespace, name, newRef, subject)
+		desired.OwnerReferences = []metav1.OwnerReference{ownerRef}
+
+		Expect(reconcile.RoleBinding(k8sClient, desired)).To(Succeed())
+
+		result := getRoleBinding(k8sClient)
+		Expect(result.RoleRef).To(Equal(newRef))
+		Expect(result.Subjects).To(Equal([]rbacv1.Subject{subject}))
+		Expect(result.OwnerReferences).To(Equal([]metav1.OwnerReference{ownerRef}))
+	})
+})


### PR DESCRIPTION
### Description
`RoleBinding.roleRef` is immutable in Kubernetes. When the referenced `Role` name changes (e.g. during upgrade from v6.5 to v6.6), delete and recreate the `RoleBinding` instead of attempting to update.

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9542
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RoleBinding reconciliation to handle permission changes more reliably.
  * Existing bindings are now updated when only subjects or ownership change, while bindings with changed role references are recreated to ensure the correct access is applied.
* **Tests**
  * Added coverage for creating, updating, and recreating RoleBindings during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->