### PR TITLE
fix(syslog): eliminate VRL compilation warnings for facility/severity conversion

### DIFF
--- a/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
@@ -41,10 +41,10 @@ if exists(._syslog.facility) && !is_null(._syslog.facility) {
       if err3 == null {
         ._syslog.facility = facility
       } else {
-        log("Invalid syslog facility code: " + to_string!(._syslog.facility) , level: "warn")
+        log("Invalid syslog facility code", level: "warn")
       }
     } else {
-      log("Invalid syslog facility value: " + to_string!(._syslog.facility), level: "warn")
+      log("Invalid syslog facility value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is
@@ -60,10 +60,10 @@ if exists(._syslog.severity) && !is_null(._syslog.severity) {
       if err3 == null {
         ._syslog.severity = severity
       } else {
-        log("Invalid syslog severity code: " + to_string!(._syslog.severity), level: "warn")
+        log("Invalid syslog severity code", level: "warn")
       }
     } else {
-      log("Invalid syslog severity value: " + to_string!(._syslog.severity), level: "warn")
+      log("Invalid syslog severity value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -86,10 +86,10 @@ if exists(._syslog.facility) && !is_null(._syslog.facility) {
       if err3 == null {
         ._syslog.facility = facility
       } else {
-        log("Invalid syslog facility code: " + to_string!(._syslog.facility) , level: "warn")
+        log("Invalid syslog facility code", level: "warn")
       }
     } else {
-      log("Invalid syslog facility value: " + to_string!(._syslog.facility), level: "warn")
+      log("Invalid syslog facility value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is
@@ -105,10 +105,10 @@ if exists(._syslog.severity) && !is_null(._syslog.severity) {
       if err3 == null {
         ._syslog.severity = severity
       } else {
-        log("Invalid syslog severity code: " + to_string!(._syslog.severity), level: "warn")
+        log("Invalid syslog severity code", level: "warn")
       }
     } else {
-      log("Invalid syslog severity value: " + to_string!(._syslog.severity), level: "warn")
+      log("Invalid syslog severity value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is

--- a/internal/generator/vector/output/syslog/tcp_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_defaults.toml
@@ -37,10 +37,10 @@ if exists(._syslog.facility) && !is_null(._syslog.facility) {
       if err3 == null {
         ._syslog.facility = facility
       } else {
-        log("Invalid syslog facility code: " + to_string!(._syslog.facility) , level: "warn")
+        log("Invalid syslog facility code", level: "warn")
       }
     } else {
-      log("Invalid syslog facility value: " + to_string!(._syslog.facility), level: "warn")
+      log("Invalid syslog facility value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is
@@ -56,10 +56,10 @@ if exists(._syslog.severity) && !is_null(._syslog.severity) {
       if err3 == null {
         ._syslog.severity = severity
       } else {
-        log("Invalid syslog severity code: " + to_string!(._syslog.severity), level: "warn")
+        log("Invalid syslog severity code", level: "warn")
       }
     } else {
-      log("Invalid syslog severity value: " + to_string!(._syslog.severity), level: "warn")
+      log("Invalid syslog severity value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is

--- a/internal/generator/vector/output/syslog/tcp_with_kubernetes_minimal_enrichment.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_kubernetes_minimal_enrichment.toml
@@ -37,10 +37,10 @@ if exists(._syslog.facility) && !is_null(._syslog.facility) {
       if err3 == null {
         ._syslog.facility = facility
       } else {
-        log("Invalid syslog facility code: " + to_string!(._syslog.facility) , level: "warn")
+        log("Invalid syslog facility code", level: "warn")
       }
     } else {
-      log("Invalid syslog facility value: " + to_string!(._syslog.facility), level: "warn")
+      log("Invalid syslog facility value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is
@@ -56,10 +56,10 @@ if exists(._syslog.severity) && !is_null(._syslog.severity) {
       if err3 == null {
         ._syslog.severity = severity
       } else {
-        log("Invalid syslog severity code: " + to_string!(._syslog.severity), level: "warn")
+        log("Invalid syslog severity code", level: "warn")
       }
     } else {
-      log("Invalid syslog severity value: " + to_string!(._syslog.severity), level: "warn")
+      log("Invalid syslog severity value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is

--- a/internal/generator/vector/output/syslog/tcp_with_tuning.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_tuning.toml
@@ -38,10 +38,10 @@ if exists(._syslog.facility) && !is_null(._syslog.facility) {
       if err3 == null {
         ._syslog.facility = facility
       } else {
-        log("Invalid syslog facility code: " + to_string!(._syslog.facility) , level: "warn")
+        log("Invalid syslog facility code", level: "warn")
       }
     } else {
-      log("Invalid syslog facility value: " + to_string!(._syslog.facility), level: "warn")
+      log("Invalid syslog facility value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is
@@ -57,10 +57,10 @@ if exists(._syslog.severity) && !is_null(._syslog.severity) {
       if err3 == null {
         ._syslog.severity = severity
       } else {
-        log("Invalid syslog severity code: " + to_string!(._syslog.severity), level: "warn")
+        log("Invalid syslog severity code", level: "warn")
       }
     } else {
-      log("Invalid syslog severity value: " + to_string!(._syslog.severity), level: "warn")
+      log("Invalid syslog severity value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is

--- a/internal/generator/vector/output/syslog/tls_with_field_references.toml
+++ b/internal/generator/vector/output/syslog/tls_with_field_references.toml
@@ -21,10 +21,10 @@ if exists(._syslog.facility) && !is_null(._syslog.facility) {
       if err3 == null {
         ._syslog.facility = facility
       } else {
-        log("Invalid syslog facility code: " + to_string!(._syslog.facility) , level: "warn")
+        log("Invalid syslog facility code", level: "warn")
       }
     } else {
-      log("Invalid syslog facility value: " + to_string!(._syslog.facility), level: "warn")
+      log("Invalid syslog facility value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is
@@ -40,10 +40,10 @@ if exists(._syslog.severity) && !is_null(._syslog.severity) {
       if err3 == null {
         ._syslog.severity = severity
       } else {
-        log("Invalid syslog severity code: " + to_string!(._syslog.severity), level: "warn")
+        log("Invalid syslog severity code", level: "warn")
       }
     } else {
-      log("Invalid syslog severity value: " + to_string!(._syslog.severity), level: "warn")
+      log("Invalid syslog severity value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is

--- a/internal/generator/vector/output/syslog/udp_with_every_setting.toml
+++ b/internal/generator/vector/output/syslog/udp_with_every_setting.toml
@@ -20,10 +20,10 @@ if exists(._syslog.facility) && !is_null(._syslog.facility) {
       if err3 == null {
         ._syslog.facility = facility
       } else {
-        log("Invalid syslog facility code: " + to_string!(._syslog.facility) , level: "warn")
+        log("Invalid syslog facility code", level: "warn")
       }
     } else {
-      log("Invalid syslog facility value: " + to_string!(._syslog.facility), level: "warn")
+      log("Invalid syslog facility value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is
@@ -39,10 +39,10 @@ if exists(._syslog.severity) && !is_null(._syslog.severity) {
       if err3 == null {
         ._syslog.severity = severity
       } else {
-        log("Invalid syslog severity code: " + to_string!(._syslog.severity), level: "warn")
+        log("Invalid syslog severity code", level: "warn")
       }
     } else {
-      log("Invalid syslog severity value: " + to_string!(._syslog.severity), level: "warn")
+      log("Invalid syslog severity value", level: "warn")
     }
   }
   # else: already a valid name, leave it as-is


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
Remove `to_string!()` calls from facility/severity warning log messages. VRL flags these as `"can't abort infallible function"` when the value type is statically known. No infallible alternative exists that works for all source types, so drop the value from warning messages.

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill  <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9564
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syslog facility and severity conversion warnings across syslog outputs.
  * Updated warning messages to be consistent and reliable when facility/severity codes or values are invalid.
  * Warnings no longer attempt to include the malformed input value, avoiding cases where log generation could fail and making messages easier to scan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->