### PR TITLE
fix(validation): allow empty sources for audit and infrastructure inputs

### DIFF
--- a/internal/api/observability/input_types.go
+++ b/internal/api/observability/input_types.go
@@ -17,6 +17,7 @@ var (
 	)
 	ReservedApplicationSources    = sets.NewString(obs.ApplicationSourceContainer.String())
 	ReservedInfrastructureSources = sets.NewString(obs.InfrastructureSourceContainer.String(), obs.InfrastructureSourceNode.String())
+	ReservedAuditSources          = sets.NewString(obs.AuditSourceKube.String(), obs.AuditSourceOpenShift.String(), obs.AuditSourceAuditd.String(), obs.AuditSourceOVN.String())
 
 	InfraNSRegex = regexp.MustCompile(`^(?P<default>default)|(?P<openshift>openshift.*)|(?P<kube>kube.*)$`)
 )
@@ -90,9 +91,17 @@ func (inputs Inputs) InputSources(inputType obs.InputType) []string {
 			case obs.InputTypeApplication:
 				types.Insert(ReservedApplicationSources.List()...)
 			case obs.InputTypeInfrastructure:
-				types.Insert(InfrastructureSources(i.Infrastructure.Sources).AsStrings()...)
+				if i.Infrastructure == nil || len(i.Infrastructure.Sources) == 0 {
+					types.Insert(ReservedInfrastructureSources.List()...)
+				} else {
+					types.Insert(InfrastructureSources(i.Infrastructure.Sources).AsStrings()...)
+				}
 			case obs.InputTypeAudit:
-				types.Insert(AuditSources(i.Audit.Sources).AsStrings()...)
+				if i.Audit == nil || len(i.Audit.Sources) == 0 {
+					types.Insert(ReservedAuditSources.List()...)
+				} else {
+					types.Insert(AuditSources(i.Audit.Sources).AsStrings()...)
+				}
 			}
 		}
 	}

--- a/internal/api/observability/input_types_test.go
+++ b/internal/api/observability/input_types_test.go
@@ -1,0 +1,64 @@
+package observability_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	. "github.com/openshift/cluster-logging-operator/internal/api/observability"
+)
+
+var _ = Describe("#InputSources", func() {
+
+	Context("for audit input type", func() {
+		It("should return all audit sources when Sources is empty", func() {
+			inputs := Inputs{
+				{Name: "audit", Type: obs.InputTypeAudit, Audit: &obs.Audit{Sources: []obs.AuditSource{}}},
+			}
+			Expect(inputs.InputSources(obs.InputTypeAudit)).To(Equal(ReservedAuditSources.List()))
+		})
+
+		It("should return all audit sources when Sources is nil", func() {
+			inputs := Inputs{
+				{Name: "audit", Type: obs.InputTypeAudit, Audit: &obs.Audit{}},
+			}
+			Expect(inputs.InputSources(obs.InputTypeAudit)).To(Equal(ReservedAuditSources.List()))
+		})
+
+		It("should return all audit sources when Audit is nil", func() {
+			inputs := Inputs{
+				{Name: "audit", Type: obs.InputTypeAudit},
+			}
+			Expect(inputs.InputSources(obs.InputTypeAudit)).To(Equal(ReservedAuditSources.List()))
+		})
+
+		It("should return only specified sources when Sources is explicit", func() {
+			inputs := Inputs{
+				{Name: "audit", Type: obs.InputTypeAudit, Audit: &obs.Audit{Sources: []obs.AuditSource{obs.AuditSourceKube}}},
+			}
+			Expect(inputs.InputSources(obs.InputTypeAudit)).To(Equal([]string{obs.AuditSourceKube.String()}))
+		})
+	})
+
+	Context("for infrastructure input type", func() {
+		It("should return all infra sources when Sources is empty", func() {
+			inputs := Inputs{
+				{Name: "infra", Type: obs.InputTypeInfrastructure, Infrastructure: &obs.Infrastructure{Sources: []obs.InfrastructureSource{}}},
+			}
+			Expect(inputs.InputSources(obs.InputTypeInfrastructure)).To(Equal(ReservedInfrastructureSources.List()))
+		})
+
+		It("should return all infra sources when Infrastructure is nil", func() {
+			inputs := Inputs{
+				{Name: "infra", Type: obs.InputTypeInfrastructure},
+			}
+			Expect(inputs.InputSources(obs.InputTypeInfrastructure)).To(Equal(ReservedInfrastructureSources.List()))
+		})
+
+		It("should return only specified sources when Sources is explicit", func() {
+			inputs := Inputs{
+				{Name: "infra", Type: obs.InputTypeInfrastructure, Infrastructure: &obs.Infrastructure{Sources: []obs.InfrastructureSource{obs.InfrastructureSourceNode}}},
+			}
+			Expect(inputs.InputSources(obs.InputTypeInfrastructure)).To(Equal([]string{obs.InfrastructureSourceNode.String()}))
+		})
+	})
+})

--- a/internal/generator/vector/output/lokistack/lokistack.go
+++ b/internal/generator/vector/output/lokistack/lokistack.go
@@ -116,13 +116,7 @@ func generateSinkForTenant(id, routeID, inputType string, o obs.OutputSpec, inpu
 
 func getInputSources(inputSpecs []obs.InputSpec, inputType obs.InputType) []string {
 	inputSources := observability.Inputs(inputSpecs).InputSources(inputType)
-
-	if len(inputSources) == 0 && inputType == obs.InputTypeInfrastructure {
-		inputSources = append(inputSources, observability.ReservedInfrastructureSources.List()...)
-	}
-
 	addReceiverSources(&inputSources, inputSpecs, inputType)
-
 	return inputSources
 }
 

--- a/internal/generator/vector/output/lokistack/lokistack_test.go
+++ b/internal/generator/vector/output/lokistack/lokistack_test.go
@@ -153,6 +153,29 @@ var _ = Describe("Generate vector config", func() {
 		Entry("with Otel datamodel", "lokistack_otel.toml", initOptions(), func(spec *obs.OutputSpec) {
 			spec.LokiStack.DataModel = obs.LokiStackDataModelOpenTelemetry
 		}),
+		Entry("with Otel datamodel and empty audit sources", "lokistack_otel.toml", func() utils.Options {
+			output := initOutput()
+			return utils.Options{
+				framework.OptionServiceAccountTokenSecretName: saTokenSecretName,
+				helpers.CLFSpec: observability.ClusterLogForwarderSpec(obs.ClusterLogForwarderSpec{
+					Outputs: []obs.OutputSpec{output},
+					Pipelines: []obs.PipelineSpec{
+						{
+							Name:       "lokistack",
+							InputRefs:  []string{obs.InputTypeApplication.String(), obs.InputTypeInfrastructure.String(), obs.InputTypeAudit.String()},
+							OutputRefs: []string{output.Name},
+						},
+					},
+					Inputs: []obs.InputSpec{
+						{Name: obs.InputTypeApplication.String(), Type: obs.InputTypeApplication},
+						{Name: obs.InputTypeInfrastructure.String(), Type: obs.InputTypeInfrastructure, Infrastructure: &obs.Infrastructure{Sources: obs.InfrastructureSources}},
+						{Name: obs.InputTypeAudit.String(), Type: obs.InputTypeAudit, Audit: &obs.Audit{}},
+					},
+				}),
+			}
+		}(), func(spec *obs.OutputSpec) {
+			spec.LokiStack.DataModel = obs.LokiStackDataModelOpenTelemetry
+		}),
 		Entry("with ViaQ datamodel with receiver", "lokistack_viaq_receiver.toml", initReceiverOptions(), func(spec *obs.OutputSpec) {}),
 	)
 })

--- a/internal/validations/observability/inputs/audit.go
+++ b/internal/validations/observability/inputs/audit.go
@@ -18,11 +18,6 @@ func ValidateAudit(spec obs.InputSpec) []metav1.Condition {
 			internalobs.NewConditionFromPrefix(obs.ConditionTypeValidInputPrefix, spec.Name, false, obs.ReasonMissingSpec, fmt.Sprintf("%s has nil audit spec", spec.Name)),
 		}
 	}
-	if len(spec.Audit.Sources) == 0 {
-		return []metav1.Condition{
-			internalobs.NewConditionFromPrefix(obs.ConditionTypeValidInputPrefix, spec.Name, false, obs.ReasonValidationFailure, fmt.Sprintf("%s must define at least one valid source", spec.Name)),
-		}
-	}
 	return []metav1.Condition{
 		internalobs.NewConditionFromPrefix(obs.ConditionTypeValidInputPrefix, spec.Name, true, obs.ReasonValidationSuccess, fmt.Sprintf("input %q is valid", spec.Name)),
 	}

--- a/internal/validations/observability/inputs/audit_test.go
+++ b/internal/validations/observability/inputs/audit_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
 )
 
-var _ = Describe("#ValidateInfrastructure", func() {
+var _ = Describe("#ValidateAudit", func() {
 
 	var (
 		input              obs.InputSpec
@@ -36,8 +36,12 @@ var _ = Describe("#ValidateInfrastructure", func() {
 		conds := ValidateAudit(input)
 		Expect(conds).To(HaveCondition(expConditionTypeRE, true, obs.ReasonValidationSuccess, `input.*is valid`))
 	})
-	It("should fail when no sources are defined", func() {
+	It("should pass when sources is empty", func() {
 		input.Audit.Sources = []obs.AuditSource{}
-		Expect(ValidateAudit(input)).To(HaveCondition(expConditionTypeRE, false, obs.ReasonValidationFailure, "must define at least one valid source"))
+		Expect(ValidateAudit(input)).To(HaveCondition(expConditionTypeRE, true, obs.ReasonValidationSuccess, `input.*is valid`))
+	})
+	It("should pass when sources is nil", func() {
+		input.Audit.Sources = nil
+		Expect(ValidateAudit(input)).To(HaveCondition(expConditionTypeRE, true, obs.ReasonValidationSuccess, `input.*is valid`))
 	})
 })

--- a/internal/validations/observability/inputs/infrastructure.go
+++ b/internal/validations/observability/inputs/infrastructure.go
@@ -20,12 +20,7 @@ func ValidateInfrastructure(spec obs.InputSpec) []metav1.Condition {
 			internalobs.NewConditionFromPrefix(obs.ConditionTypeValidInputPrefix, spec.Name, false, obs.ReasonMissingSpec, fmt.Sprintf("%s has nil infrastructure spec", spec.Name)),
 		}
 	}
-	if len(spec.Infrastructure.Sources) == 0 {
-		return []metav1.Condition{
-			internalobs.NewConditionFromPrefix(obs.ConditionTypeValidInputPrefix, spec.Name, false, obs.ReasonValidationFailure, fmt.Sprintf("%s must define at least one valid source", spec.Name)),
-		}
-	}
-	if !set.New(spec.Infrastructure.Sources...).Has(obs.InfrastructureSourceContainer) && spec.Infrastructure.Tuning != nil &&
+	if len(spec.Infrastructure.Sources) > 0 && !set.New(spec.Infrastructure.Sources...).Has(obs.InfrastructureSourceContainer) && spec.Infrastructure.Tuning != nil &&
 		spec.Infrastructure.Tuning.Container != nil && spec.Infrastructure.Tuning.Container.MaxMessageSize != nil {
 		sources := make([]string, len(spec.Infrastructure.Sources))
 		for i, s := range spec.Infrastructure.Sources {

--- a/internal/validations/observability/inputs/infrastructure_test.go
+++ b/internal/validations/observability/inputs/infrastructure_test.go
@@ -39,9 +39,24 @@ var _ = Describe("#ValidateInfrastructure", func() {
 		Expect(conds).To(HaveCondition(expConditionTypeRE, true, obs.ReasonValidationSuccess, `input.*is valid`))
 
 	})
-	It("should fail when no sources are defined", func() {
+	It("should pass when sources is empty", func() {
 		input.Infrastructure.Sources = []obs.InfrastructureSource{}
-		Expect(ValidateInfrastructure(input)).To(HaveCondition(expConditionTypeRE, false, obs.ReasonValidationFailure, "must define at least one valid source"))
+		Expect(ValidateInfrastructure(input)).To(HaveCondition(expConditionTypeRE, true, obs.ReasonValidationSuccess, `input.*is valid`))
+	})
+	It("should pass when sources is nil", func() {
+		input.Infrastructure.Sources = nil
+		Expect(ValidateInfrastructure(input)).To(HaveCondition(expConditionTypeRE, true, obs.ReasonValidationSuccess, `input.*is valid`))
+	})
+	It("should pass with empty sources and container tuning", func() {
+		input.Infrastructure = &obs.Infrastructure{
+			Sources: []obs.InfrastructureSource{},
+			Tuning: &obs.InfrastructureInputTuningSpec{
+				Container: &obs.ContainerInputTuningSpec{
+					MaxMessageSize: utils.GetPtr(resource.MustParse("1Mi")),
+				},
+			},
+		}
+		Expect(ValidateInfrastructure(input)).To(HaveCondition(expConditionTypeRE, true, obs.ReasonValidationSuccess, `input.*is valid`))
 	})
 	It("should pass for valid infrastructure input with container source and MaxMessageSize", func() {
 		input.Infrastructure = &obs.Infrastructure{
@@ -54,7 +69,7 @@ var _ = Describe("#ValidateInfrastructure", func() {
 		}
 		Expect(ValidateInfrastructure(input)).To(HaveCondition(expConditionTypeRE, true, obs.ReasonValidationSuccess, `input.*is valid`))
 	})
-	It("should fail for valid infrastructure input with node source and MaxMessageSiz", func() {
+	It("should fail for valid infrastructure input with node source and MaxMessageSize", func() {
 		input.Infrastructure = &obs.Infrastructure{
 			Sources: []obs.InfrastructureSource{obs.InfrastructureSourceNode},
 			Tuning: &obs.InfrastructureInputTuningSpec{


### PR DESCRIPTION
### Description
- Remove validation that required at least one source for audit and infrastructure inputs — empty sources now means "all sources"
- Guard the infrastructure container-tuning check so it only fires when sources are explicitly specified
- Fix test Describe label in audit tests and typo in infrastructure test name

/cc @vparfonov 
/assign @jcantrill

### Links
- JIRA: https://redhat.atlassian.net/browse/LOG-9541


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audit and infrastructure inputs now validate successfully even when no sources are explicitly provided.
  * Default reserved sources are applied automatically in those cases, improving out-of-the-box behavior.
  * Loki output generation now handles empty audit source configurations more reliably.
  * Updated related test coverage to reflect the new validation and source-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->