### PR TITLE
fix(syslog): add functional test for short-form syslog severity keywords

### DIFF
--- a/test/functional/outputs/syslog/rfc5424_test.go
+++ b/test/functional/outputs/syslog/rfc5424_test.go
@@ -164,6 +164,34 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC5424 tests", func() {
 		})
 	})
 
+	DescribeTable("should correctly encode short-form severity keywords", func(severity string, expectedPriority string) {
+		obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+			FromInput(obs.InputTypeApplication).
+			ToSyslogOutput(obs.SyslogRFC5424, func(spec *obs.OutputSpec) {
+				spec.Syslog.Facility = "user"
+				spec.Syslog.Severity = severity
+			})
+		Expect(framework.Deploy()).To(BeNil())
+
+		crioMessage := functional.NewFullCRIOLogMessage(functional.CRIOTime(time.Now()), `{"index":1}`)
+		Expect(framework.WriteMessagesToApplicationLog(crioMessage, 1)).To(BeNil())
+
+		outputlogs, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeSyslog))
+		Expect(err).To(BeNil(), "Expected no errors reading the logs")
+		Expect(outputlogs).To(HaveLen(1), "Expected the receiver to receive the message")
+		Expect(outputlogs[0]).To(HavePrefix(expectedPriority), "Expected priority to match facility(user/1)*8 + severity")
+	},
+		// facility "user" = 1, priority = 1*8 + severity_code
+		Entry("crit", "crit", "<10>1 "),    // 8 + 2
+		Entry("emerg", "emerg", "<8>1 "),    // 8 + 0
+		Entry("err", "err", "<11>1 "),       // 8 + 3
+		Entry("info", "info", "<14>1 "),     // 8 + 6
+		Entry("warn", "warn", "<12>1 "),     // 8 + 4
+		Entry("debug", "debug", "<15>1 "),   // 8 + 7
+		Entry("notice", "notice", "<13>1 "), // 8 + 5
+		Entry("alert", "alert", "<9>1 "),    // 8 + 1
+	)
+
 	It("should be able to send a large payload", func() {
 		obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 			FromInput(obs.InputTypeApplication).


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Verify that short-form severity values (`crit, emerg, err, info, warn, debug, notice, alert`) produce correct syslog priority codes in RFC5424 output. This confirms the fix in the Vector syslog encoder that adds aliases for these keywords.

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s): https://github.com/ViaQ/vector/pull/279
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9563
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for syslog severity keywords to ensure they produce the expected RFC5424 priority format.
  * Improved validation of log output handling for common severity levels such as critical, error, warning, info, and debug.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->