### PR TITLE
fix(syslog): quote payloadKey path to prevent VRL evaluation as expression

### DIFF
--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -125,16 +125,14 @@ for_each(excluded_fields) -> |_index, field| {
 
 	payloadKeyConfiguredVRL = `
 # Payload key configured, going to use the payload key for .message field
-payload_key = %s
-if payload_key != null && payload_key != "" {
-  payload_key = string!(payload_key)
-  path = split!(payload_key, ".")
-  value, err = get(., path)
-  if err == null && value != null {
-    .message = value
-  } else {
-    log("payload_key not found in event, skipping", level: "warn")
-  }
+payload_key = "%s"
+if starts_with(payload_key, ".") {
+  payload_key = slice!(payload_key, 1)
+}
+path = split!(payload_key, ".")
+value, err = get(., path)
+if err == null && value != null {
+  .message = value
 } else {
   excluded_fields = ["_internal", "_syslog"]
   temp = .
@@ -239,7 +237,7 @@ func parseEncoding(inputs []string, o *obs.Syslog) types.Transform {
 	vrls = append(vrls, facilitySeverityConversionVRL)
 
 	if key := PayloadKey(o.PayloadKey); key != "" {
-		vrls = append(vrls, fmt.Sprintf(payloadKeyConfiguredVRL, key))
+		vrls = append(vrls, fmt.Sprintf(payloadKeyConfiguredVRL, strings.ReplaceAll(key, `"`, `\"`)))
 	} else {
 		vrls = append(vrls, payloadKeyDefaultVRL)
 	}

--- a/internal/generator/vector/output/syslog/tls_with_field_references.toml
+++ b/internal/generator/vector/output/syslog/tls_with_field_references.toml
@@ -50,16 +50,14 @@ if exists(._syslog.severity) && !is_null(._syslog.severity) {
 }
 
 # Payload key configured, going to use the payload key for .message field
-payload_key = .payload_key
-if payload_key != null && payload_key != "" {
-  payload_key = string!(payload_key)
-  path = split!(payload_key, ".")
-  value, err = get(., path)
-  if err == null && value != null {
-    .message = value
-  } else {
-    log("payload_key not found in event, skipping", level: "warn")
-  }
+payload_key = ".payload_key"
+if starts_with(payload_key, ".") {
+  payload_key = slice!(payload_key, 1)
+}
+path = split!(payload_key, ".")
+value, err = get(., path)
+if err == null && value != null {
+  .message = value
 } else {
   excluded_fields = ["_internal", "_syslog"]
   temp = .

--- a/internal/generator/vector/output/syslog/udp_with_every_setting.toml
+++ b/internal/generator/vector/output/syslog/udp_with_every_setting.toml
@@ -49,16 +49,14 @@ if exists(._syslog.severity) && !is_null(._syslog.severity) {
 }
 
 # Payload key configured, going to use the payload key for .message field
-payload_key = .plKey
-if payload_key != null && payload_key != "" {
-  payload_key = string!(payload_key)
-  path = split!(payload_key, ".")
-  value, err = get(., path)
-  if err == null && value != null {
-    .message = value
-  } else {
-    log("payload_key not found in event, skipping", level: "warn")
-  }
+payload_key = ".plKey"
+if starts_with(payload_key, ".") {
+  payload_key = slice!(payload_key, 1)
+}
+path = split!(payload_key, ".")
+value, err = get(., path)
+if err == null && value != null {
+  .message = value
 } else {
   excluded_fields = ["_internal", "_syslog"]
   temp = .

--- a/test/functional/outputs/syslog/rfc5424_test.go
+++ b/test/functional/outputs/syslog/rfc5424_test.go
@@ -115,6 +115,35 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC5424 tests", func() {
 		Entry("should include the message when payloadkey is not found", `{.structured.appname_key||"none"}`, `{.structured.msgid_key||"none"}`, `{.structured.procid_key||"none"}`, "{.key_not_available}"),
 	)
 
+	It("should set message to the value of the specified payload key field", func() {
+		obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+			FromInput(obs.InputTypeApplication).
+			WithParseJson().
+			ToSyslogOutput(obs.SyslogRFC5424, func(output *obs.OutputSpec) {
+				output.Syslog.Facility = "user"
+				output.Syslog.Severity = "debug"
+				output.Syslog.PayloadKey = "{.structured.msgcontent}"
+			})
+		Expect(framework.Deploy()).To(BeNil())
+
+		record := `{"msgcontent":"My life is my message","appname_key":"rec_appname"}`
+		crioMessage := functional.NewFullCRIOLogMessage(functional.CRIOTime(time.Now()), record)
+		Expect(framework.WriteMessagesToApplicationLog(crioMessage, 1)).To(BeNil())
+
+		outputlogs, err := framework.ReadRawApplicationLogsFrom(string(obs.OutputTypeSyslog))
+		Expect(err).To(BeNil(), "Expected no errors reading the logs")
+		Expect(outputlogs).To(HaveLen(1), "Expected the receiver to receive the message")
+
+		fields := strings.Split(outputlogs[0], " - ")
+		payload := strings.TrimSpace(fields[1])
+		Expect(payload).To(Equal("My life is my message"),
+			fmt.Sprintf("Expected payload to be the value of the specified payloadKey field, got: %q", payload))
+
+		collectorLogs, err := framework.ReadCollectorLogs()
+		Expect(err).To(BeNil())
+		Expect(collectorLogs).ToNot(ContainSubstring("payload_key not found in event"))
+	})
+
 	Describe("configured with values for facility,severity", func() {
 		It("should use values from the record", func() {
 			obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
#### Root Cause:
The payloadKey path (e.g., .message) was injected unquoted into the VRL template:
`payload_key = .message    # evaluates as VRL expression, reads the VALUE of .message`

This resolved `.message` to its runtime value (e.g., "Hello World"), which was then treated as a field path looking for a field literally named "Hello World", which doesn't exist.

For payloadKey: `"{.message}"` this only produced noisy warnings (since `.message` was left unchanged). For any other field (e.g., `{.kubernetes.namespace_name}`), it silently failed to set `.message` to the intended value.

#### Fix:
Quote the path as a string literal and strip the leading dot before splitting:
```
payload_key = ".message"   # string literal, stays as a path
  if starts_with(payload_key, ".") {
    payload_key = slice!(payload_key, 1)
  }
  path = split!(payload_key, ".")
  value, err = get(., path)
```

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9562
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved syslog message extraction when using a configured payload key.
  * Enhanced handling for payload keys coming from structured JSON content (RFC5424).
* **Bug Fixes**
  * Removed inconsistent skip-and-warning behavior when the configured payload field is missing or empty.
  * When lookup fails, syslog now reliably falls back to a cleaned-up message derived from the event.
* **Tests**
  * Added functional coverage for RFC5424 payload key behavior with structured input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->