### PR TITLE
fix(syslog): restore KubernetesMinimal enrichment format by removing quotes around

### DIFF
--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -152,11 +152,11 @@ if payload_key != null && payload_key != "" {
 namespace = to_string(.kubernetes.namespace_name) ?? ""
 container = to_string(.kubernetes.container_name) ?? ""
 pod = to_string(.kubernetes.pod_name) ?? ""
-msg_value = encode_json(.message)
+msg_value = to_string(.message) ?? encode_json(.message)
 
-.message = "namespace_name=\"" + namespace + "\"" +
-           ", container_name=\"" + container + "\"" +
-           ", pod_name=\"" + pod + "\"" +
+.message = "namespace_name=" + namespace +
+           ", container_name=" + container +
+           ", pod_name=" + pod +
            ", message=" + msg_value`
 )
 

--- a/internal/generator/vector/output/syslog/tcp_with_kubernetes_minimal_enrichment.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_kubernetes_minimal_enrichment.toml
@@ -80,11 +80,11 @@ for_each(excluded_fields) -> |_index, field| {
 namespace = to_string(.kubernetes.namespace_name) ?? ""
 container = to_string(.kubernetes.container_name) ?? ""
 pod = to_string(.kubernetes.pod_name) ?? ""
-msg_value = encode_json(.message)
+msg_value = to_string(.message) ?? encode_json(.message)
 
-.message = "namespace_name=\"" + namespace + "\"" +
-           ", container_name=\"" + container + "\"" +
-           ", pod_name=\"" + pod + "\"" +
+.message = "namespace_name=" + namespace +
+           ", container_name=" + container +
+           ", pod_name=" + pod +
            ", message=" + msg_value
 '''
 

--- a/test/functional/outputs/syslog/rfc3164_test.go
+++ b/test/functional/outputs/syslog/rfc3164_test.go
@@ -1,7 +1,6 @@
 package syslog
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -80,10 +79,10 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 		Expect(logLine).To(MatchRegexp(`functionalcollector:`))
 
 		if enrichment == obs.EnrichmentTypeKubernetesMinimal {
-			Expect(logLine).To(MatchRegexp(`namespace_name="[^"]+"`))
-			Expect(logLine).To(ContainSubstring(`container_name="collector"`))
-			Expect(logLine).To(ContainSubstring(`pod_name="functional"`))
-			Expect(logLine).To(ContainSubstring(fmt.Sprintf("message=%q", payload)))
+			Expect(logLine).To(MatchRegexp(`namespace_name=[^,]+`))
+			Expect(logLine).To(ContainSubstring(`container_name=collector`))
+			Expect(logLine).To(ContainSubstring(`pod_name=functional`))
+			Expect(logLine).To(ContainSubstring("message=" + payload))
 		} else {
 			Expect(logLine).To(ContainSubstring(payload))
 		}


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9561
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syslog message formatting for Kubernetes metadata, reducing unnecessary quoting and escaping in the output.
  * Message content now preserves plain text when possible, with a fallback for structured values.
  * Updated Kubernetes fields in syslog output to appear in a cleaner, more readable format.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->