### PR TITLE
fix(syslog): guard facility/severity conversion against null values

### DIFF
--- a/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/rfc3164_with_defaults.toml
@@ -31,7 +31,7 @@ if exists(._syslog.proc_id) && is_empty(strip_whitespace(string!(._syslog.proc_i
 ._syslog.app_name = to_string!(._syslog.app_name || "")
 
 # try to convert syslog code to the facility, severity names (e.g. 4 -> "warning", "4" -> "warning"  )
-if exists(._syslog.facility) {
+if exists(._syslog.facility) && !is_null(._syslog.facility) {
   _, err = to_syslog_facility_code(._syslog.facility)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)
@@ -50,7 +50,7 @@ if exists(._syslog.facility) {
   # else: already a valid name, leave it as-is
 }
 
-if exists(._syslog.severity) {
+if exists(._syslog.severity) && !is_null(._syslog.severity) {
   _, err = to_syslog_severity(._syslog.severity)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)

--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -76,7 +76,7 @@ if err != null {
 
 	facilitySeverityConversionVRL = `
 # try to convert syslog code to the facility, severity names (e.g. 4 -> "warning", "4" -> "warning"  )
-if exists(._syslog.facility) {
+if exists(._syslog.facility) && !is_null(._syslog.facility) {
   _, err = to_syslog_facility_code(._syslog.facility)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)
@@ -95,7 +95,7 @@ if exists(._syslog.facility) {
   # else: already a valid name, leave it as-is
 }
 
-if exists(._syslog.severity) {
+if exists(._syslog.severity) && !is_null(._syslog.severity) {
   _, err = to_syslog_severity(._syslog.severity)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)

--- a/internal/generator/vector/output/syslog/tcp_with_defaults.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_defaults.toml
@@ -27,7 +27,7 @@ if .log_type == "audit" {
 }
 
 # try to convert syslog code to the facility, severity names (e.g. 4 -> "warning", "4" -> "warning"  )
-if exists(._syslog.facility) {
+if exists(._syslog.facility) && !is_null(._syslog.facility) {
   _, err = to_syslog_facility_code(._syslog.facility)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)
@@ -46,7 +46,7 @@ if exists(._syslog.facility) {
   # else: already a valid name, leave it as-is
 }
 
-if exists(._syslog.severity) {
+if exists(._syslog.severity) && !is_null(._syslog.severity) {
   _, err = to_syslog_severity(._syslog.severity)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)

--- a/internal/generator/vector/output/syslog/tcp_with_kubernetes_minimal_enrichment.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_kubernetes_minimal_enrichment.toml
@@ -27,7 +27,7 @@ if .log_type == "audit" {
 }
 
 # try to convert syslog code to the facility, severity names (e.g. 4 -> "warning", "4" -> "warning"  )
-if exists(._syslog.facility) {
+if exists(._syslog.facility) && !is_null(._syslog.facility) {
   _, err = to_syslog_facility_code(._syslog.facility)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)
@@ -46,7 +46,7 @@ if exists(._syslog.facility) {
   # else: already a valid name, leave it as-is
 }
 
-if exists(._syslog.severity) {
+if exists(._syslog.severity) && !is_null(._syslog.severity) {
   _, err = to_syslog_severity(._syslog.severity)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)

--- a/internal/generator/vector/output/syslog/tcp_with_tuning.toml
+++ b/internal/generator/vector/output/syslog/tcp_with_tuning.toml
@@ -28,7 +28,7 @@ if .log_type == "audit" {
 }
 
 # try to convert syslog code to the facility, severity names (e.g. 4 -> "warning", "4" -> "warning"  )
-if exists(._syslog.facility) {
+if exists(._syslog.facility) && !is_null(._syslog.facility) {
   _, err = to_syslog_facility_code(._syslog.facility)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)
@@ -47,7 +47,7 @@ if exists(._syslog.facility) {
   # else: already a valid name, leave it as-is
 }
 
-if exists(._syslog.severity) {
+if exists(._syslog.severity) && !is_null(._syslog.severity) {
   _, err = to_syslog_severity(._syslog.severity)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)

--- a/internal/generator/vector/output/syslog/tls_with_field_references.toml
+++ b/internal/generator/vector/output/syslog/tls_with_field_references.toml
@@ -11,7 +11,7 @@ source = '''
 ._syslog.msg_id = to_string!(._internal.structured.msg_id||"none")
 
 # try to convert syslog code to the facility, severity names (e.g. 4 -> "warning", "4" -> "warning"  )
-if exists(._syslog.facility) {
+if exists(._syslog.facility) && !is_null(._syslog.facility) {
   _, err = to_syslog_facility_code(._syslog.facility)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)
@@ -30,7 +30,7 @@ if exists(._syslog.facility) {
   # else: already a valid name, leave it as-is
 }
 
-if exists(._syslog.severity) {
+if exists(._syslog.severity) && !is_null(._syslog.severity) {
   _, err = to_syslog_severity(._syslog.severity)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)

--- a/internal/generator/vector/output/syslog/udp_with_every_setting.toml
+++ b/internal/generator/vector/output/syslog/udp_with_every_setting.toml
@@ -10,7 +10,7 @@ source = '''
 ._syslog.app_name = "appName"
 
 # try to convert syslog code to the facility, severity names (e.g. 4 -> "warning", "4" -> "warning"  )
-if exists(._syslog.facility) {
+if exists(._syslog.facility) && !is_null(._syslog.facility) {
   _, err = to_syslog_facility_code(._syslog.facility)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)
@@ -29,7 +29,7 @@ if exists(._syslog.facility) {
   # else: already a valid name, leave it as-is
 }
 
-if exists(._syslog.severity) {
+if exists(._syslog.severity) && !is_null(._syslog.severity) {
   _, err = to_syslog_severity(._syslog.severity)
   if err != null {
     # Field is not a valid name — try treating it as a code (int or string int)


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
Add `!is_null()` guard to both facility and severity conversion checks so null values skip conversion entirely, letting the syslog encoder use its default (`Informational`).

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: NO-JIRA
- Enhancement proposal:
