### PR TITLE
[release-6.5]fix(kubernetes_log source): fix VRL crashing on null (not exist) namespace_name when pod metadata annotation fails

### DIFF
--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -342,10 +342,20 @@ inputs = ["input_infrastructure_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
 
     # If namespace is infra, label log_type as infra
-    if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+    if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
         ._internal.log_type = "infrastructure"
     } else {
         ._internal.log_type = "application"
@@ -557,10 +567,20 @@ inputs = ["input_mytestapp_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
 
     # If namespace is infra, label log_type as infra
-    if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+    if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
         ._internal.log_type = "infrastructure"
     } else {
         ._internal.log_type = "application"

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -339,10 +339,20 @@ inputs = ["input_infrastructure_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
 
     # If namespace is infra, label log_type as infra
-    if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+    if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
         ._internal.log_type = "infrastructure"
     } else {
         ._internal.log_type = "application"
@@ -595,10 +605,20 @@ inputs = ["input_mytestapp_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
 
     # If namespace is infra, label log_type as infra
-    if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+    if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
         ._internal.log_type = "infrastructure"
     } else {
         ._internal.log_type = "application"

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -35,10 +35,20 @@ inputs = ["input_myinfra_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
 
     # If namespace is infra, label log_type as infra
-    if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+    if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
         ._internal.log_type = "infrastructure"
     } else {
         ._internal.log_type = "application"
@@ -168,10 +178,20 @@ inputs = ["input_mytestapp_container"]
 source = '''
 . = {"_internal": .}
 if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
 ._internal.log_source = "container"
 
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application.toml
+++ b/internal/generator/vector/input/application.toml
@@ -20,9 +20,19 @@ inputs = ["input_application_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application_exclude_container_from_infra.toml
+++ b/internal/generator/vector/input/application_exclude_container_from_infra.toml
@@ -21,9 +21,19 @@ inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application_excludes_container.toml
+++ b/internal/generator/vector/input/application_excludes_container.toml
@@ -20,9 +20,19 @@ inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application_includes_container.toml
+++ b/internal/generator/vector/input/application_includes_container.toml
@@ -21,9 +21,19 @@ inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application_with_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_includes_excludes.toml
@@ -21,9 +21,19 @@ inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application_with_infra_includes_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_excludes.toml
@@ -21,9 +21,19 @@ inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_infra_includes_infra_excludes.toml
@@ -21,9 +21,19 @@ inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application_with_matchLabels.toml
+++ b/internal/generator/vector/input/application_with_matchLabels.toml
@@ -21,9 +21,19 @@ inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application_with_max_merge_line_size.toml
+++ b/internal/generator/vector/input/application_with_max_merge_line_size.toml
@@ -21,9 +21,19 @@ inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
+++ b/internal/generator/vector/input/application_with_specific_infra_includes_infra_excludes.toml
@@ -21,9 +21,19 @@ inputs = ["input_my_app_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/application_with_throttle.toml
+++ b/internal/generator/vector/input/application_with_throttle.toml
@@ -20,9 +20,19 @@ inputs = ["input_application_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/infrastructure.toml
+++ b/internal/generator/vector/input/infrastructure.toml
@@ -21,10 +21,20 @@ inputs = ["input_infrastructure_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
 
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/infrastructure_container.toml
+++ b/internal/generator/vector/input/infrastructure_container.toml
@@ -21,9 +21,19 @@ inputs = ["input_myinfra_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/infrastructure_container_with_max_merge_line_size.toml
+++ b/internal/generator/vector/input/infrastructure_container_with_max_merge_line_size.toml
@@ -22,9 +22,19 @@ inputs = ["input_myinfra_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/infrastructure_container_with_throttle.toml
+++ b/internal/generator/vector/input/infrastructure_container_with_throttle.toml
@@ -21,9 +21,19 @@ inputs = ["input_myinfra_container"]
 source = '''
   . = {"_internal": .}
   if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}
+
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
   ._internal.log_source = "container"
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"

--- a/internal/generator/vector/input/internal.go
+++ b/internal/generator/vector/input/internal.go
@@ -19,7 +19,7 @@ const (
 	fmtLogType       = `._internal.log_type = %q`
 	logTypeContainer = `
   # If namespace is infra, label log_type as infra
-  if match_any(string!(._internal.kubernetes.namespace_name), [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
+  if match_any(string(._internal.kubernetes.namespace_name) ?? "", [r'^default$', r'^openshift(-.+)?$', r'^kube(-.+)?$']) {
       ._internal.log_type = "infrastructure"
   } else {
       ._internal.log_type = "application"
@@ -36,6 +36,21 @@ const (
 	setKubernetesContainerIOStream = `if exists(._internal.stream) {._internal.kubernetes.container_iostream = ._internal.stream}`
 	setEnvelopeToStructured        = `. = {"_internal": {"structured": .}}`
 	setHostName                    = `._internal.hostname = get_env_var("VECTOR_SELF_NODE_NAME") ?? ""`
+
+	// Fallback: when Vector fails to annotate pod metadata (e.g. pod already deleted),
+	// extract kubernetes metadata from the log file path which is always available.
+	// Path format: /var/log/pods/<namespace>_<podname>_<pod-uid>/<container>/<n>.log
+	recoverMetadataFromFilePath = `
+if exists(._internal.file) && !exists(._internal.kubernetes.namespace_name) {
+  parsed_path, err = parse_regex(string!(._internal.file), r'^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>.+)_(?P<uid>[a-f0-9-]{36})/(?P<container>[^/]+)/\d+\.log$')
+  if err == null {
+    ._internal.kubernetes.namespace_name = parsed_path.namespace
+    ._internal.kubernetes.pod_name = parsed_path.pod
+    ._internal.kubernetes.pod_id = parsed_path.uid
+    ._internal.kubernetes.container_name = parsed_path.container
+  }
+}
+`
 )
 
 // NewAuditInternalNormalization returns configuration elements to normalize audit log entries to an internal, common data model
@@ -66,8 +81,10 @@ func NewInternalNormalization(id string, logSource, logType interface{}, inputs 
 
 	if logSource == obs.InfrastructureSourceContainer {
 		logTypeVRL = logTypeContainer
-		// Add kubernetes container iostream for all container sources
-		vrls = append(vrls, setKubernetesContainerIOStream)
+		vrls = append(vrls,
+			setKubernetesContainerIOStream,
+			recoverMetadataFromFilePath,
+		)
 	}
 	vrls = append(vrls, fmt.Sprintf(fmtLogSource, logSource),
 		logTypeVRL,

--- a/test/functional/normalization/container_metadata_fallback_test.go
+++ b/test/functional/normalization/container_metadata_fallback_test.go
@@ -1,0 +1,73 @@
+package normalization
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	testruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
+)
+
+const (
+	deletedPodNamespace = "deleted-ns"
+	deletedPodName      = "deleted-pod"
+	deletedPodUID       = "aabbccdd-1234-5678-abcd-ef0123456789"
+	deletedContainer    = "deleted-container"
+)
+
+var deletedPodLogPath = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s/0.log",
+	deletedPodNamespace, deletedPodName, deletedPodUID, deletedContainer)
+
+var fakeContainerSource = fmt.Sprintf(`
+[sources.input_application_container]
+type = "file"
+include = ["%s"]
+host_key = "hostname"
+glob_minimum_cooldown_ms = 15000
+
+`, deletedPodLogPath)
+
+var _ = Describe("[Functional][Normalization] container metadata fallback from file path (LOG-9584)", func() {
+
+	var (
+		framework *functional.CollectorFunctionalFramework
+	)
+
+	BeforeEach(func() {
+		framework = functional.NewCollectorFunctionalFramework()
+		testruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+			FromInput(obs.InputTypeApplication).
+			ToElasticSearchOutput()
+
+		framework.VisitConfig = func(conf string) string {
+			// Match the entire kubernetes_logs source block including sub-tables
+			// (pod_annotation_fields, namespace_annotation_fields)
+			re := regexp.MustCompile(`(?ms)\[sources\.input_application_container\]\n.*?(\n\[(?:transforms|sources\.internal))`)
+			return string(re.ReplaceAll([]byte(conf), []byte(fakeContainerSource+"$1")))
+		}
+		Expect(framework.Deploy()).To(BeNil())
+	})
+	AfterEach(func() {
+		framework.Cleanup()
+	})
+
+	It("should extract kubernetes metadata from file path when pod metadata annotation is missing", func() {
+		msg := functional.NewCRIOLogMessage(functional.CRIOTime(time.Now()), "log from deleted pod", false)
+		Expect(framework.WriteMessagesToLog(msg, 1, deletedPodLogPath)).To(BeNil())
+
+		logs, err := framework.ReadApplicationLogsFrom(string(obs.OutputTypeElasticsearch))
+		Expect(err).To(BeNil(), "Expected no errors reading the logs")
+		Expect(logs).ToNot(BeEmpty())
+
+		log := logs[0]
+		Expect(log.Kubernetes.NamespaceName).To(Equal(deletedPodNamespace))
+		Expect(log.Kubernetes.PodName).To(Equal(deletedPodName))
+		Expect(log.Kubernetes.PodID).To(Equal(deletedPodUID))
+		Expect(log.Kubernetes.ContainerName).To(Equal(deletedContainer))
+		Expect(log.LogType).To(Equal("application"))
+	})
+})


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

When Vector's kubernetes_logs source fails to annotate an event with pod metadata (e.g. pod already deleted), the kubernetes.namespace_name field is null, causing string!() to abort the remap transform.

Add fallback VRL logic that extracts kubernetes metadata (namespace, pod name, pod UID, container name) from the log file path, which is always available even when the Kubernetes API lookup fails. The file path format `/var/log/pods/<ns>_<pod>_<uid>/<container>/<n>.log` is parsed via regex.

Also use fallible `string()` with null coalescing in the `match_any` call as defense-in-depth in case the file path parsing also fails.

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9584
- Enhancement proposal:
