### PR TITLE
fix(test): add functional test for Java exceptions with non-nested continuation lines

### DIFF
--- a/test/functional/filters/multilineexception/multiline_exception_test.go
+++ b/test/functional/filters/multilineexception/multiline_exception_test.go
@@ -24,6 +24,12 @@ var _ = Describe("[Functional][Filters][MultilineException] Multi-line exception
        at testjava.Main.printMe(Main.java:19)
        at testjava.Main.main(Main.java:10)`
 
+		javaExceptionWithNonNestedLines = `java.sql.SQLException: Listener refused the connection with the following error:
+ORA-12521, TNS:listener does not currently know of instance requested in connect descriptor
+  (CONNECTION_ID=r6n2ZPL0TqS/BLDhIydj+A==)
+    at oracle.jdbc.driver.T4CConnection.handleLogonNetException(T4CConnection.java:893)
+    at oracle.jdbc.driver.T4CConnection.logon(T4CConnection.java:698)`
+
 		jsClientSideException = `Error
 				at bls (<anonymous>:3:9)
 				at <anonymous>:6:4
@@ -107,6 +113,7 @@ created by main.main
 		}
 	},
 		Entry("of Java services to stderr stream", constants.STDERR, javaException, nil),
+		Entry("of Java services with non-nested continuation lines to stderr stream", constants.STDERR, javaExceptionWithNonNestedLines, nil),
 		Entry("of JS client side exception to stdout stream", constants.STDOUT, jsClientSideException, nil),
 		Entry("of V8 errors stack trace to stdout stream", constants.STDOUT, jsV8Exception, nil),
 		Entry("of NodeJS services to stdout stream", constants.STDOUT, nodeJSException, nil),


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Adds a test case for Java exceptions where multi-line error messages have non-indented lines between the exception header and the stack trace

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s): https://github.com/ViaQ/vector/pull/282
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9565
- Enhancement proposal:
