### PR TITLE
fix(test): attempt to fix HTTP audit functional test flake and artifact log writer bug

### DIFF
--- a/test/framework/common/log/buffered_log_writer.go
+++ b/test/framework/common/log/buffered_log_writer.go
@@ -37,31 +37,38 @@ func NewBufferedLogWriter() *BufferedLogWriter {
 }
 
 func (w *BufferedLogWriter) FlushToArtifactsDir(name string) {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
 	if dir := os.Getenv("ARTIFACT_DIR"); dir != "" {
 		if parts := strings.SplitAfter(name, "/test/"); len(parts) == 2 {
 			name = strings.ReplaceAll(parts[1], "/", "_")
 			fullPath := path.Join(dir, name)
 			if file, err := os.Create(fullPath); err != nil {
-				w.out = os.Stdout
 				w.log.Error(err, fmt.Sprintf("Unable to flush logs to file: %s", fullPath))
 			} else {
 				w.out = file
-				defer errors.LogIfError(file.Close())
+				w.flushLocked()
+				errors.LogIfError(file.Close())
+				w.out = os.Stdout
+				return
 			}
 		}
-
 	}
-	w.Flush()
+	w.flushLocked()
+}
+
+func (w *BufferedLogWriter) flushLocked() {
+	if _, err := w.out.Write(w.buffer); err != nil {
+		w.log.Error(err, "error flushing log messages")
+	}
+	w.buffer = []byte{}
 }
 
 // Flush the contents of the sink
 func (w *BufferedLogWriter) Flush() {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
-	if _, err := w.out.Write(w.buffer); err != nil {
-		w.log.Error(err, "error flushing log messages")
-	}
-	w.buffer = []byte{}
+	w.flushLocked()
 }
 
 func (w *BufferedLogWriter) Write(p []byte) (n int, err error) {

--- a/test/functional/outputs/http/forward_to_http_test.go
+++ b/test/functional/outputs/http/forward_to_http_test.go
@@ -176,6 +176,7 @@ var _ = Describe("[Functional][Outputs][Http] Functional tests", func() {
 	Context("timestamp in audit logs", func() {
 		DescribeTable("audit log should have a valid timestamp",
 			func(writeLog func() error, logSource obs.AuditSource) {
+				framework = functional.NewCollectorFunctionalFramework()
 				obstestruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
 					FromInput(obs.InputTypeAudit).
 					ToHttpOutput()


### PR DESCRIPTION
### Description
- Fix intermittent context deadline exceeded failure in the HTTP audit log timestamp functional test by giving it a fresh framework instead of reusing one pre-configured for application logs
- Fix a Go defer argument evaluation bug in `BufferedLogWriter.FlushToArtifactsDir` that silently prevented test failure artifact logs from being written

NO-JIRA

/cc @vparfonov 
/assign @jcantrill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffered log flushing so logs are written to artifact files more reliably and closed/flushed promptly when artifact output is successfully created.
  * Refined flush behavior to consistently restore the active output stream when artifact flushing is not used.
* **Tests**
  * Updated the HTTP audit-log timestamp functional test to initialize a fresh functional framework instance within each table-driven test case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->