### PR TITLE
fix(elasticsearch): add compression to Elasticsearch output generation

### DIFF
--- a/internal/generator/vector/output/elasticsearch/elasticsearch.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch.go
@@ -38,6 +38,7 @@ if exists(.kubernetes.event.metadata.uid) {
 		}
 		s.ApiVersion = apiVersionFrom(o.Elasticsearch.Version)
 		s.Encoding = common.NewApiEncoding("")
+		s.Compression = sinks.CompressionType(o.GetTuning().Compression)
 		s.Batch = common.NewApiBatch(o)
 		s.Buffer = common.NewApiBuffer(o)
 		s.Request = common.NewApiRequest(o)

--- a/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
+++ b/internal/generator/vector/output/elasticsearch/elasticsearch_test.go
@@ -147,6 +147,13 @@ var _ = Describe("Generate Vector config", func() {
 				BaseOutputTuningSpec: *baseTune,
 			}
 		}, true, framework.NoOptions, "es_with_tune.toml"),
+		Entry("with tuning and compression", func(spec *obs.OutputSpec) {
+			spec.TLS = tlsSpec
+			spec.Elasticsearch.Tuning = &obs.ElasticsearchTuningSpec{
+				BaseOutputTuningSpec: *baseTune,
+				Compression:          "gzip",
+			}
+		}, true, framework.NoOptions, "es_with_tune_and_compression.toml"),
 		Entry("with headers", func(spec *obs.OutputSpec) {
 			spec.Elasticsearch.Headers = map[string]string{
 				"Key": "Value",

--- a/internal/generator/vector/output/elasticsearch/es_with_tune_and_compression.toml
+++ b/internal/generator/vector/output/elasticsearch/es_with_tune_and_compression.toml
@@ -1,0 +1,42 @@
+[transforms.es_1_index]
+type = "remap"
+inputs = ["application"]
+source = '''
+._internal.es_1_index = to_string!(._internal.log_type||"none")
+'''
+
+[sinks.es_1]
+type = "elasticsearch"
+inputs = ["es_1_index"]
+endpoints = ["https://es.svc.infra.cluster:9200"]
+api_version = "v8"
+compression = "gzip"
+
+[sinks.es_1.bulk]
+index = "{{ _internal.es_1_index }}"
+action = "create"
+
+[sinks.es_1.auth]
+strategy = "basic"
+user = "SECRET[kubernetes_secret.es-1/username]"
+password = "SECRET[kubernetes_secret.es-1/password]"
+
+[sinks.es_1.encoding]
+except_fields = ["_internal"]
+
+[sinks.es_1.batch]
+max_bytes = 10000000
+
+[sinks.es_1.buffer]
+type = "disk"
+when_full = "block"
+max_size = 268435488
+
+[sinks.es_1.request]
+retry_initial_backoff_secs = 20
+retry_max_duration_secs = 35
+
+[sinks.es_1.tls]
+key_file = "/var/run/ocp-collector/secrets/es-1/tls.key"
+crt_file = "/var/run/ocp-collector/secrets/es-1/tls.crt"
+ca_file = "/var/run/ocp-collector/secrets/es-1/ca-bundle.crt"


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9634
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Elasticsearch output now respects compression settings, including gzip, when generating sink configuration.
  * Added support for generated Elasticsearch configuration with tuning plus compression enabled.

* **Tests**
  * Expanded coverage for Elasticsearch output generation to verify the new compression-enabled configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->