### PR TITLE
add check on "VRL compilation warning"

### DIFF
--- a/test/framework/functional/framework.go
+++ b/test/framework/functional/framework.go
@@ -32,6 +32,7 @@ import (
 	yaml "sigs.k8s.io/yaml"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
+	"github.com/onsi/gomega"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	"github.com/openshift/cluster-logging-operator/test/client"
@@ -129,20 +130,36 @@ func (f *CollectorFunctionalFramework) AddSecret(secret *corev1.Secret) *Collect
 }
 
 func (f *CollectorFunctionalFramework) Cleanup() {
-	if g, ok := test.GinkgoCurrentTest(); ok && g.Failed() {
-		for _, container := range f.Pod.Spec.Containers {
-			log.Info("Dumping logs for container", "container", container.Name)
-			logs, err := oc.Logs().WithNamespace(f.Namespace).WithPod(f.Pod.Name).WithContainer(container.Name).Run()
-			if err != nil {
-				log.Error(err, "Unable to retrieve logs", "container", container.Name)
+	defer f.closeClient()
+
+	if g, ok := test.GinkgoCurrentTest(); ok {
+		if g.Failed() {
+			for _, container := range f.Pod.Spec.Containers {
+				log.Info("Dumping logs for container", "container", container.Name)
+				logs, err := oc.Logs().WithNamespace(f.Namespace).WithPod(f.Pod.Name).WithContainer(container.Name).Run()
+				if err != nil {
+					log.Error(err, "Unable to retrieve logs", "container", container.Name)
+				}
+				if _, err = fmt.Fprintln(f.delayedWriter, logs); err != nil {
+					log.Error(err, "Error writing", "container", container.Name)
+				}
 			}
-			if _, err = fmt.Fprintln(f.delayedWriter, logs); err != nil {
-				log.Error(err, "Error writing", "container", container.Name)
+			f.delayedWriter.FlushToArtifactsDir(fmt.Sprintf("%s_%d.log", g.FileName(), g.LineNumber()))
+		}
+
+		if !g.Failed() {
+			if collectorLogs, err := f.ReadCollectorLogs(); err != nil {
+				log.Error(err, "Unable to read collector logs for VRL warning check")
+			} else if strings.Contains(collectorLogs, "VRL compilation warning") {
+				log.Info("VRL compilation warning detected in collector logs")
+				if _, err := fmt.Fprintln(f.delayedWriter, collectorLogs); err != nil {
+					log.Error(err, "Error writing collector logs")
+				}
+				f.delayedWriter.FlushToArtifactsDir(fmt.Sprintf("%s_%d.log", g.FileName(), g.LineNumber()))
+				gomega.Expect(collectorLogs).ToNot(gomega.ContainSubstring("VRL compilation warning"))
 			}
 		}
-		f.delayedWriter.FlushToArtifactsDir(fmt.Sprintf("%s_%d.log", g.FileName(), g.LineNumber()))
 	}
-	f.closeClient()
 }
 
 func (f *CollectorFunctionalFramework) GetMaxReadDuration() time.Duration {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
This PR add checking what VRL code has no warnings  

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved functional test cleanup and diagnostics.
  * Collector logs are now checked for VRL compilation warnings during successful tests.
  * Test artifacts and container logs continue to be preserved when tests fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->