### PR TITLE
Update version to 6.7.0

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -58,5 +58,5 @@ LABEL \
         summary="Operator for log collection and forwarding agents of Red Hat Openshift Logging" \
         url="https://catalog.redhat.com/en/software/containers/openshift-logging/cluster-logging-rhel9-operator/644799230dfd5adb35db6f60" \
         vendor="Red Hat, Inc." \
-        version_minor="v6.6" \
-        version="6.6.0"
+        version_minor="v6.7" \
+        version="6.7.0"

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ export OPERATOR_NAME=cluster-logging-operator
 export CURRENT_BRANCH=$(or $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null),no-branch)
 export IMAGE_TAG?=127.0.0.1:5000/openshift/origin-$(OPERATOR_NAME):$(CURRENT_BRANCH)
 
-OPENSHIFT_VERSIONS?="v4.20-v4.23"
-export LOGGING_VERSION?=6.6
+OPENSHIFT_VERSIONS?="v4.21-v5.0"
+export LOGGING_VERSION?=6.7
 export VERSION=$(LOGGING_VERSION).0
 export NAMESPACE?=openshift-logging
 export LOKI_OPERATOR_CHANNEL?=stable-6.4

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,8 +5,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=cluster-logging
-LABEL operators.operatorframework.io.bundle.channels.v1=stable-6.6
-LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-6.6
+LABEL operators.operatorframework.io.bundle.channels.v1=stable-6.7
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable-6.7
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-unknown
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
@@ -16,11 +16,11 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.20-v4.23"
+LABEL com.redhat.openshift.versions="v4.21-v5.0"
 
 LABEL \
     com.redhat.component="cluster-logging-operator" \
-    version="v6.6" \
+    version="v6.7" \
     name="cluster-logging-operator" \
     License="Apache-2.0" \
     io.k8s.display-name="cluster-logging-operator bundle" \

--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -1,9 +1,9 @@
 updates:
   - file: "manifests/cluster-logging.clusterserviceversion.yaml" # relative to this file
     update_list:
-      - search: "olm.skipRange: '>=6.2.0-0 <6.6.0'"
-        replace: "olm.skipRange: '>=6.2.0-0 <6.6.0'"
-      - search: "version: 6.6.0"
-        replace: "version: 6.6.0"
-      - search: "name: cluster-logging.v6.6.0"
-        replace: "name: cluster-logging.v6.6.0"
+      - search: "olm.skipRange: '>=6.5.0-0 <6.7.0'"
+        replace: "olm.skipRange: '>=6.5.0-0 <6.7.0'"
+      - search: "version: 6.7.0"
+        replace: "version: 6.7.0"
+      - search: "name: cluster-logging.v6.7.0"
+        replace: "name: cluster-logging.v6.7.0"

--- a/bundle/cluster-logging-operator.package.yaml
+++ b/bundle/cluster-logging-operator.package.yaml
@@ -1,5 +1,5 @@
 ---
 packageName: cluster-logging
 channels:
-- name: stable-6.6
-  currentCSV: cluster-logging-operator.v6.6.0
+- name: stable-6.7
+  currentCSV: cluster-logging.v6.7.0

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2026-07-07T19:26:30Z"
+    createdAt: "2026-07-15T11:39:59Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -95,7 +95,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=6.2.0-0 <6.6.0'
+    olm.skipRange: '>=6.5.0-0 <6.7.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |
       {
@@ -119,7 +119,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: cluster-logging.v6.6.0
+  name: cluster-logging.v6.7.0
   namespace: openshift-logging
 spec:
   apiservicedefinitions: {}
@@ -2720,4 +2720,4 @@ spec:
     name: vector
   - image: quay.io/openshift-logging/log-file-metric-exporter:latest
     name: log-file-metric-exporter
-  version: 6.6.0
+  version: 6.7.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,8 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: cluster-logging
-  operators.operatorframework.io.bundle.channels.v1: stable-6.6
-  operators.operatorframework.io.bundle.channel.default.v1: stable-6.6
+  operators.operatorframework.io.bundle.channels.v1: stable-6.7
+  operators.operatorframework.io.bundle.channel.default.v1: stable-6.7
   operators.operatorframework.io.metrics.builder: operator-sdk-unknown
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4

--- a/bundle/metadata/properties.yaml
+++ b/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: "4.23"
+    value: "5.0"

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=6.2.0-0 <6.6.0'
+    olm.skipRange: '>=6.5.0-0 <6.7.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/initialization-resource: |
       {
@@ -2431,4 +2431,4 @@ spec:
   minKubeVersion: 1.18.3
   provider:
     name: Red Hat
-  version: 6.6.0
+  version: 6.7.0

--- a/olm_deploy/operatorregistry/cluster-logging.package.yaml
+++ b/olm_deploy/operatorregistry/cluster-logging.package.yaml
@@ -1,5 +1,5 @@
 packageName: cluster-logging
-defaultChannel: "stable-6.6"
+defaultChannel: "stable-6.7"
 channels:
-  - name: "stable-6.6"
-    currentCSV: cluster-logging.v6.6.0
+  - name: "stable-6.7"
+    currentCSV: cluster-logging.v6.7.0

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "6.6.0"
+var Version = "6.7.0"


### PR DESCRIPTION
### Description

This PR updates the version attributes and the OpenShift configuration for the next Logging release.

/cc @jcantrill @vparfonov
/assign @xperimental 

### Links

- JIRA: [LOG-9669](https://redhat.atlassian.net/browse/LOG-9669)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the 6.7.0 release of the logging operator.
  * Added support for OpenShift 4.21 through 5.0 (including updated compatibility constraints).
  * Updated the default logging channel to **stable-6.7**.
* **Bug Fixes**
  * Updated upgrade/compatibility metadata, including version skip ranges and ClusterServiceVersion/related image versions, to align with 6.7.0.
* **Chores**
  * Refreshed bundle and image label version/channel information to **6.7.0** and **stable-6.7**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->