### PR TITLE
[release-6.6]fix(syslog): remove abort operator from infallible split() in payload

### DIFF
--- a/internal/generator/vector/output/syslog/syslog.go
+++ b/internal/generator/vector/output/syslog/syslog.go
@@ -129,7 +129,7 @@ payload_key = "%s"
 if starts_with(payload_key, ".") {
   payload_key = slice!(payload_key, 1)
 }
-path = split!(payload_key, ".")
+path = split(payload_key, ".")
 value, err = get(., path)
 if err == null && value != null {
   .message = value

--- a/internal/generator/vector/output/syslog/tls_with_field_references.toml
+++ b/internal/generator/vector/output/syslog/tls_with_field_references.toml
@@ -54,7 +54,7 @@ payload_key = ".payload_key"
 if starts_with(payload_key, ".") {
   payload_key = slice!(payload_key, 1)
 }
-path = split!(payload_key, ".")
+path = split(payload_key, ".")
 value, err = get(., path)
 if err == null && value != null {
   .message = value

--- a/internal/generator/vector/output/syslog/udp_with_every_setting.toml
+++ b/internal/generator/vector/output/syslog/udp_with_every_setting.toml
@@ -53,7 +53,7 @@ payload_key = ".plKey"
 if starts_with(payload_key, ".") {
   payload_key = slice!(payload_key, 1)
 }
-path = split!(payload_key, ".")
+path = split(payload_key, ".")
 value, err = get(., path)
 if err == null && value != null {
   .message = value

--- a/test/functional/outputs/otlp/journal_test.go
+++ b/test/functional/outputs/otlp/journal_test.go
@@ -100,6 +100,10 @@ var _ = Describe("[Functional][Outputs][OTLP] Functional tests", func() {
 			// (Deprecated) compatibility attribute
 			Expect(logAttributeNames).To(ContainElement(otlp.Level), "Expect logRecord attributes to contain level")
 			Expect(logRecord.Attribute(otlp.Level).String()).To(Equal("err"))
+
+			collectorLogs, err := framework.ReadCollectorLogs()
+			Expect(err).To(BeNil())
+			Expect(collectorLogs).ToNot(ContainSubstring("VRL compilation warning"))
 		})
 	})
 })

--- a/test/functional/outputs/syslog/rfc5424_test.go
+++ b/test/functional/outputs/syslog/rfc5424_test.go
@@ -142,6 +142,7 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC5424 tests", func() {
 		collectorLogs, err := framework.ReadCollectorLogs()
 		Expect(err).To(BeNil())
 		Expect(collectorLogs).ToNot(ContainSubstring("payload_key not found in event"))
+		Expect(collectorLogs).ToNot(ContainSubstring("VRL compilation warning"))
 	})
 
 	Describe("configured with values for facility,severity", func() {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- Back-port: https://github.com/openshift/cluster-logging-operator/pull/3344
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9675
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syslog payload path handling to avoid VRL compilation warnings when using configured payload keys.
  * Preserved correct message extraction for nested payload fields.

* **Tests**
  * Added coverage confirming collectors produce no VRL compilation warnings during OTLP journal and syslog processing.
  * Continued validating payload extraction and message-field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->