### PR TITLE
Update version to 6.6.1

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -59,4 +59,4 @@ LABEL \
         url="https://catalog.redhat.com/en/software/containers/openshift-logging/cluster-logging-rhel9-operator/644799230dfd5adb35db6f60" \
         vendor="Red Hat, Inc." \
         version_minor="v6.6" \
-        version="6.6.0"
+        version="6.6.1"

--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -2,8 +2,8 @@ updates:
   - file: "manifests/cluster-logging.clusterserviceversion.yaml" # relative to this file
     update_list:
       - search: "olm.skipRange: '>=6.2.0-0 <6.6.0'"
-        replace: "olm.skipRange: '>=6.2.0-0 <6.6.0'"
+        replace: "olm.skipRange: '>=6.2.0-0 <6.6.1'"
       - search: "version: 6.6.0"
-        replace: "version: 6.6.0"
+        replace: "version: 6.6.1"
       - search: "name: cluster-logging.v6.6.0"
-        replace: "name: cluster-logging.v6.6.0"
+        replace: "name: cluster-logging.v6.6.1"

--- a/bundle/cluster-logging-operator.package.yaml
+++ b/bundle/cluster-logging-operator.package.yaml
@@ -2,4 +2,4 @@
 packageName: cluster-logging
 channels:
 - name: stable-6.6
-  currentCSV: cluster-logging-operator.v6.6.0
+  currentCSV: cluster-logging.v6.6.1


### PR DESCRIPTION
### Description

/cc @jcantrill 
/assign @xperimental 

### Links

- JIRA: [LOG-9650](https://redhat.atlassian.net/browse/LOG-9650)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Updated the Cluster Logging release version to 6.6.1.
  * Updated package metadata and upgrade instructions to reference the 6.6.1 release.
  * Expanded upgrade compatibility to include versions earlier than 6.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->