### PR TITLE
fix(spelling): fix workflow checkout failure and improve spell checking coverage

### DIFF
--- a/.github/actions/spelling/_typos.toml
+++ b/.github/actions/spelling/_typos.toml
@@ -1,46 +1,18 @@
 [files]
 extend-exclude = [
-    "vendor/",
-    ".bingo/",
-    ".github/actions/spelling/",
-    "bundle/",
-    "*.go",
-    "*.yaml",
-    "*.yml",
-    "*.json",
-    "*.sh",
-    "*.bash",
-    "*.toml",
-    "*.sum",
-    "*.mod",
+    # Directories: too noisy for spell checking (encoded data, UUIDs, base64)
+    "test/",
+
+    # Files: binary or generated, never useful to spell-check
     "*.png",
     "*.jpg",
-    "*.svg",
-    "*.ico",
-    "*.pb.go",
-    "*.pb",
-    "*.proto",
-    "*.csv",
-    "*.log",
-    "*.lock",
-    "*.cfg",
-    "*.conf",
-    "*.ini",
-    "*.xml",
-    "Makefile",
-    "Dockerfile*",
-    "LICENSE",
+    "*.sum",
+    "*.mod",
     "go.sum",
     "go.mod",
-    ".cache/",
-    "tmp/",
-    "config/",
-    "hack/",
-    "test/",
-    "internal/",
-    "api/",
-    "cmd/",
-    "must-gather/collection-scripts/",
+
+    # Source code: too many false positives from encoded data
+    "*.json",
 ]
 
 [default]

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,13 +1,9 @@
 name: Spell checking
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "**"
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 permissions:
   contents: read
@@ -15,9 +11,6 @@ permissions:
 jobs:
   spelling:
     name: Spell checking
-    permissions:
-      contents: read
-      pull-requests: read
     runs-on: ubuntu-latest
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
@@ -26,9 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Spell Check
-        uses: crate-ci/typos@v1.33.1
+        uses: crate-ci/typos@v1.48.0
         continue-on-error: true
         with:
           config: .github/actions/spelling/_typos.toml

--- a/internal/cmd/functional-benchmarker/main.go
+++ b/internal/cmd/functional-benchmarker/main.go
@@ -121,7 +121,7 @@ func gatherStatistics(runner runners.Runner, sample bool, msgSize int, startTime
 		return &stats.Statistics{}
 	}
 	log.V(4).Info("Parsed logs", "parsed", logs)
-	return stats.NewStatisics(logs, msgSize, endTime.Sub(startTime))
+	return stats.NewStatistics(logs, msgSize, endTime.Sub(startTime))
 }
 
 func createArtifactDir(artifactDir string) string {

--- a/internal/cmd/functional-benchmarker/stats/statistics.go
+++ b/internal/cmd/functional-benchmarker/stats/statistics.go
@@ -13,7 +13,7 @@ type Statistics struct {
 	Losses    LossStats
 }
 
-func NewStatisics(logs PerfLogs, msgSize int, elapsed time.Duration) *Statistics {
+func NewStatistics(logs PerfLogs, msgSize int, elapsed time.Duration) *Statistics {
 	return &Statistics{
 		logs,
 		msgSize,

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var _ = Describe("Factory#MaxUnavalable", func() {
+var _ = Describe("Factory#MaxUnavailable", func() {
 	var (
 		factory Factory
 	)

--- a/internal/generator/vector/output/azure/azuremonitor/azuremonitor_test.go
+++ b/internal/generator/vector/output/azure/azuremonitor/azuremonitor_test.go
@@ -21,7 +21,7 @@ import (
 var _ = Describe("Generating vector config for Azure Monitor Logs output:", func() {
 
 	const (
-		sharedKeyValue = "z9ndQSFH1RLDnS6WR35m84u326p3"
+		sharedKeyValue = "z9zdQSFH1RLDnS6WR35m84u326p3"
 		azureId        = "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/otherResourceGroup/providers/Microsoft.Storage/storageAccounts/examplestorage"
 		hostCN         = "ods.opinsights.azure.cn"
 		customerId     = "6vzw6sHc-0bba-6sHc-4b6c-8bz7sr5eggRt"

--- a/internal/generator/vector/output/otlp/transform.go
+++ b/internal/generator/vector/output/otlp/transform.go
@@ -161,7 +161,7 @@ o = {
   "logRecords": r
 }
 `
-	// The (M)inimum (V)iable (P)roduct Labels (MVP)
+	// The Minimum Viable Product (MVP) labels
 	BackwardCompatBaseResourceAttributes = `
 # Append backward compatibility attributes
 resource.attributes = append( resource.attributes,

--- a/internal/utils/resources.go
+++ b/internal/utils/resources.go
@@ -10,7 +10,7 @@ func AreResourcesSame(current, desired *v1.ResourceRequirements) bool {
 		return true
 	}
 	if (current != nil && desired == nil) || (current == nil && desired != nil) {
-		log.V(3).Info("Resources are not the same missing ResoureRequirement", "current", current, "desired", desired)
+		log.V(3).Info("Resources are not the same missing ResourceRequirement", "current", current, "desired", desired)
 		return false
 	}
 	// Check CPU limits

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -279,35 +279,35 @@ func EnvValueEqual(env1, env2 []v1.EnvVar) bool {
 	return true
 }
 
-func EnvVarSourceEqual(esource1, esource2 v1.EnvVarSource) bool {
-	if (esource1.FieldRef != nil && esource2.FieldRef == nil) ||
-		(esource1.FieldRef == nil && esource2.FieldRef != nil) ||
-		(esource1.ResourceFieldRef != nil && esource2.ResourceFieldRef == nil) ||
-		(esource1.ResourceFieldRef == nil && esource2.ResourceFieldRef != nil) ||
-		(esource1.ConfigMapKeyRef != nil && esource2.ConfigMapKeyRef == nil) ||
-		(esource1.ConfigMapKeyRef == nil && esource2.ConfigMapKeyRef != nil) ||
-		(esource1.SecretKeyRef != nil && esource2.SecretKeyRef == nil) ||
-		(esource1.SecretKeyRef == nil && esource2.SecretKeyRef != nil) {
+func EnvVarSourceEqual(envVarSource1, envVarSource2 v1.EnvVarSource) bool {
+	if (envVarSource1.FieldRef != nil && envVarSource2.FieldRef == nil) ||
+		(envVarSource1.FieldRef == nil && envVarSource2.FieldRef != nil) ||
+		(envVarSource1.ResourceFieldRef != nil && envVarSource2.ResourceFieldRef == nil) ||
+		(envVarSource1.ResourceFieldRef == nil && envVarSource2.ResourceFieldRef != nil) ||
+		(envVarSource1.ConfigMapKeyRef != nil && envVarSource2.ConfigMapKeyRef == nil) ||
+		(envVarSource1.ConfigMapKeyRef == nil && envVarSource2.ConfigMapKeyRef != nil) ||
+		(envVarSource1.SecretKeyRef != nil && envVarSource2.SecretKeyRef == nil) ||
+		(envVarSource1.SecretKeyRef == nil && envVarSource2.SecretKeyRef != nil) {
 		return false
 	}
 	var rval bool
-	if esource1.FieldRef != nil {
-		if rval = reflect.DeepEqual(*esource1.FieldRef, *esource2.FieldRef); !rval {
+	if envVarSource1.FieldRef != nil {
+		if rval = reflect.DeepEqual(*envVarSource1.FieldRef, *envVarSource2.FieldRef); !rval {
 			return rval
 		}
 	}
-	if esource1.ResourceFieldRef != nil {
-		if rval = EnvVarResourceFieldSelectorEqual(*esource1.ResourceFieldRef, *esource2.ResourceFieldRef); !rval {
+	if envVarSource1.ResourceFieldRef != nil {
+		if rval = EnvVarResourceFieldSelectorEqual(*envVarSource1.ResourceFieldRef, *envVarSource2.ResourceFieldRef); !rval {
 			return rval
 		}
 	}
-	if esource1.ConfigMapKeyRef != nil {
-		if rval = reflect.DeepEqual(*esource1.ConfigMapKeyRef, *esource2.ConfigMapKeyRef); !rval {
+	if envVarSource1.ConfigMapKeyRef != nil {
+		if rval = reflect.DeepEqual(*envVarSource1.ConfigMapKeyRef, *envVarSource2.ConfigMapKeyRef); !rval {
 			return rval
 		}
 	}
-	if esource1.SecretKeyRef != nil {
-		if rval = reflect.DeepEqual(*esource1.SecretKeyRef, *esource2.SecretKeyRef); !rval {
+	if envVarSource1.SecretKeyRef != nil {
+		if rval = reflect.DeepEqual(*envVarSource1.SecretKeyRef, *envVarSource2.SecretKeyRef); !rval {
 			return rval
 		}
 	}

--- a/test/functional/outputs/syslog/rfc3164_test.go
+++ b/test/functional/outputs/syslog/rfc3164_test.go
@@ -84,14 +84,14 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 	},
 		// facility "user" = 1, priority = 1*8 + severity_code
 		// full-form keywords (RFC 5424)
-		Entry("full-form: critical", "critical", "<10>"),         // 8 + 2
-		Entry("full-form: emergency", "emergency", "<8>"),        // 8 + 0
-		Entry("full-form: error", "error", "<11>"),               // 8 + 3
+		Entry("full-form: critical", "critical", "<10>"),           // 8 + 2
+		Entry("full-form: emergency", "emergency", "<8>"),          // 8 + 0
+		Entry("full-form: error", "error", "<11>"),                 // 8 + 3
 		Entry("full-form: informational", "informational", "<14>"), // 8 + 6
-		Entry("full-form: warning", "warning", "<12>"),           // 8 + 4
+		Entry("full-form: warning", "warning", "<12>"),             // 8 + 4
 		// capitalized keywords (as documented in oc explain)
-		Entry("capitalized: Critical", "Critical", "<10>"),         // 8 + 2
-		Entry("capitalized: Emergency", "Emergency", "<8>"),        // 8 + 0
+		Entry("capitalized: Critical", "Critical", "<10>"),           // 8 + 2
+		Entry("capitalized: Emergency", "Emergency", "<8>"),          // 8 + 0
 		Entry("capitalized: Informational", "Informational", "<14>"), // 8 + 6
 	)
 

--- a/test/functional/outputs/syslog/rfc5424_test.go
+++ b/test/functional/outputs/syslog/rfc5424_test.go
@@ -231,11 +231,11 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC5424 tests", func() {
 		Entry("full-form: notice", "notice", "<13>1 "),               // 8 + 5
 		Entry("full-form: alert", "alert", "<9>1 "),                  // 8 + 1
 		// short-form keywords (VRL to_syslog_level output)
-		Entry("short-form: crit", "crit", "<10>1 "),    // 8 + 2
-		Entry("short-form: emerg", "emerg", "<8>1 "),    // 8 + 0
-		Entry("short-form: err", "err", "<11>1 "),       // 8 + 3
-		Entry("short-form: info", "info", "<14>1 "),     // 8 + 6
-		Entry("short-form: warn", "warn", "<12>1 "),     // 8 + 4
+		Entry("short-form: crit", "crit", "<10>1 "),  // 8 + 2
+		Entry("short-form: emerg", "emerg", "<8>1 "), // 8 + 0
+		Entry("short-form: err", "err", "<11>1 "),    // 8 + 3
+		Entry("short-form: info", "info", "<14>1 "),  // 8 + 6
+		Entry("short-form: warn", "warn", "<12>1 "),  // 8 + 4
 		// capitalized keywords (as documented in oc explain)
 		Entry("capitalized: Critical", "Critical", "<10>1 "),           // 8 + 2
 		Entry("capitalized: Emergency", "Emergency", "<8>1 "),          // 8 + 0

--- a/test/helpers/oc/adm_top.go
+++ b/test/helpers/oc/adm_top.go
@@ -6,14 +6,14 @@ import (
 )
 
 // Execer is interface for collecting arguments for Exec command
-type AdmTopComman interface {
+type AdmTopCommand interface {
 	Command
 
 	//ForContainers to retrieve `oc adm top` of containers
-	ForContainers() AdmTopComman
+	ForContainers() AdmTopCommand
 
 	//NoHeaders to not include noHeaders
-	NoHeaders() AdmTopComman
+	NoHeaders() AdmTopCommand
 }
 
 type admTop struct {
@@ -25,7 +25,7 @@ type admTop struct {
 }
 
 // AdmTop creates an 'oc adm top' command
-func AdmTop(namespace, name string) AdmTopComman {
+func AdmTop(namespace, name string) AdmTopCommand {
 	e := &admTop{
 		runner:    &runner{},
 		namespace: namespace,
@@ -35,12 +35,12 @@ func AdmTop(namespace, name string) AdmTopComman {
 	return e
 }
 
-func (e *admTop) ForContainers() AdmTopComman {
+func (e *admTop) ForContainers() AdmTopCommand {
 	e.containers = true
 	return e
 }
 
-func (e *admTop) NoHeaders() AdmTopComman {
+func (e *admTop) NoHeaders() AdmTopCommand {
 	e.noHeaders = true
 	return e
 }

--- a/test/helpers/types/type_eventrouter.go
+++ b/test/helpers/types/type_eventrouter.go
@@ -4,7 +4,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// EventRouterLog is a Viaq wrappered log from the eventrouter of
+// EventRouterLog is a Viaq wrapped log from the eventrouter of
 // kubernetes core events
 type EventRouterLog struct {
 	ViaQCommon `json:",inline,omitempty"`

--- a/test/matchers/errors.go
+++ b/test/matchers/errors.go
@@ -7,7 +7,7 @@ import (
 
 // ExpectOK is shorthand for these annoyingly long ginkgo forms:
 //
-//	Expect(err).NotTo(HaveOccured()
+//	Expect(err).NotTo(HaveOccurred ()
 //	Expect(err).To(Succeed())
 //
 // It also does a WrapError to show stderr for *exec.ExitError.


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

- Switch from `pull_request_target` to `pull_request` trigger to fix `actions/checkout` error
- Bump `crate-ci/typos` to `v1.48.0`
- Remove redundant exclusions to expand spell checking coverage
- Fix typos found across the codebase
- Fix formatting of functional tests

/cc @Clee2691 @xperimental <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Renamed misspelled constructor and related helper/test identifiers to restore expected naming consistency.
  * Corrected the nil resource-mismatch log message to match the intended wording.
  * Updated syslog RFC3164/RFC5424 test cases formatting without changing expected severity-to-priority mappings.

* **Chores**
  * Refined typo-checking exclusions to reduce false positives and clarify ignored paths/file types.
  * Hardened the spelling workflow by switching to pull request events, tightening permissions, and updating the typos action version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->