### PR TITLE
fix(spelling): fix workflow checkout failure on fork PRs

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,13 +1,9 @@
 name: Spell checking
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "**"
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 permissions:
   contents: read
@@ -15,9 +11,6 @@ permissions:
 jobs:
   spelling:
     name: Spell checking
-    permissions:
-      contents: read
-      pull-requests: read
     runs-on: ubuntu-latest
     concurrency:
       group: spelling-${{ github.event.pull_request.number || github.ref }}
@@ -26,9 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Spell Check
-        uses: crate-ci/typos@v1.33.1
+        uses: crate-ci/typos@v1.48.0
         continue-on-error: true
         with:
           config: .github/actions/spelling/_typos.toml


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->
Switch from `pull_request_target` to `pull_request trigger` to fix actions/checkout refusing to check out fork PR code. 
Bump `crate-ci/typos` to `v1.48.0`.
/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:
