### PR TITLE
test(buffer): verify deeply nested JSON events do not corrupt disk buffer (LOG-9386)

### DIFF
--- a/test/functional/outputs/http/forward_to_http_test.go
+++ b/test/functional/outputs/http/forward_to_http_test.go
@@ -173,6 +173,64 @@ var _ = Describe("[Functional][Outputs][Http] Functional tests", func() {
 			Entry("should pass with no compression", "none"))
 	})
 
+	// LOG-9386: Verify that deeply nested JSON events (>32 protobuf nesting levels)
+	// don't crash Vector when disk buffering is enabled (AtLeastOnce delivery mode).
+	// Requires JSON parse filter so the nested JSON becomes a nested object in Vector.
+	Context("with deeply nested JSON and disk buffering", func() {
+		It("should drop over-nested events gracefully without crashing (LOG-9386)", func() {
+			f := functional.NewCollectorFunctionalFramework()
+			defer f.Cleanup()
+			obstestruntime.NewClusterLogForwarderBuilder(f.Forwarder).
+				FromInput(obs.InputTypeApplication).
+				WithParseJson().
+				ToHttpOutput(func(output *obs.OutputSpec) {
+					output.HTTP.Tuning = &obs.HTTPTuningSpec{
+						BaseOutputTuningSpec: obs.BaseOutputTuningSpec{
+							DeliveryMode: obs.DeliveryModeAtLeastOnce,
+						},
+					}
+				})
+
+			Expect(f.DeployWithVisitors([]runtime.PodBuilderVisitor{
+				func(b *runtime.PodBuilder) error {
+					return f.AddVectorHttpOutput(b, f.Forwarder.Spec.Outputs[0])
+				},
+			})).To(BeNil())
+
+			// Generate 40-level deep nested JSON (protobuf decode limit is 32)
+			nested := `{"msg":"deep"}`
+			for i := 0; i < 40; i++ {
+				nested = fmt.Sprintf(`{"l%d":%s}`, i, nested)
+			}
+			deepMsg := functional.CreateAppLogFromJson(nested)
+			Expect(f.WriteMessagesToApplicationLog(deepMsg, 1)).To(BeNil())
+
+			// Write a normal message to confirm the pipeline still works after dropping the nested one
+			marker := fmt.Sprintf("normal-log-%d", time.Now().UnixNano())
+			normalMsg := functional.NewCRIOLogMessage(functional.CRIOTime(time.Now()), fmt.Sprintf(`{"msg":"%s"}`, marker), false)
+			Expect(f.WriteMessagesToApplicationLog(normalMsg, 1)).To(BeNil())
+
+			raw, err := f.ReadRawApplicationLogsFrom(string(obs.OutputTypeHTTP))
+			Expect(err).To(BeNil(), "Expected no errors reading the logs")
+			output := strings.Join(raw, "\n")
+			Expect(output).To(ContainSubstring(marker),
+				"Expected the normal message to be delivered")
+			Expect(output).ToNot(ContainSubstring("l39"),
+				"Expected the deeply nested event to be dropped, not delivered")
+
+			collectorLogs, err := f.ReadCollectorLogs()
+			Expect(err).To(BeNil())
+			Expect(collectorLogs).ToNot(ContainSubstring("InvalidProtobufPayload"),
+				"Vector should not crash with InvalidProtobufPayload on deeply nested events")
+			Expect(collectorLogs).ToNot(ContainSubstring("failed to decoded record"),
+				"Vector should not fail to decode buffered records")
+			Expect(collectorLogs).To(ContainSubstring("Events dropped"),
+				"Expected over-nested event to be reported as dropped")
+			Expect(collectorLogs).To(ContainSubstring("Event nesting cost exceeds maximum"),
+				"Expected nesting cost warning for the over-nested event")
+		})
+	})
+
 	Context("timestamp in audit logs", func() {
 		DescribeTable("audit log should have a valid timestamp",
 			func(writeLog func() error, logSource obs.AuditSource) {


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Verify that deeply nested JSON events (>32 protobuf nesting levels) don't crash Vector when disk buffering if enabled (AtLeastOnce delivery mode) and JSON parse filter.

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s): https://github.com/ViaQ/vector/pull/286
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9386
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added functional coverage for deeply nested JSON events when using HTTP delivery with JSON parsing and disk buffering.
  * Verified overly nested events are safely dropped without interrupting delivery of valid messages.
  * Confirmed collector behavior avoids protobuf decoding failures and reports nesting cost warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->