### PR TITLE
Log 9591 Do not overwrite ConfigMaps owned by other resources

### DIFF
--- a/internal/collector/trust_bundle.go
+++ b/internal/collector/trust_bundle.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/constants"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -23,10 +24,14 @@ var (
 // ReconcileTrustedCABundleConfigMap creates or returns an existing Trusted CA Bundle ConfigMap.
 // By setting label "config.openshift.io/inject-trusted-cabundle: true", the cert is automatically filled/updated.
 func ReconcileTrustedCABundleConfigMap(k8sClient client.Client, namespace, name string, owner metav1.OwnerReference) error {
+	desiredOwners := []metav1.OwnerReference{owner}
 	cm := runtime.NewConfigMap(namespace, name, nil)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8sClient, cm, func() error {
+		if err := utils.EnsureCanUpdateOwnedResource(cm, desiredOwners); err != nil {
+			return err
+		}
 		cm.Labels = map[string]string{constants.InjectTrustedCABundleLabel: "true"}
-		cm.OwnerReferences = []metav1.OwnerReference{owner}
+		cm.OwnerReferences = desiredOwners
 		return nil
 	})
 

--- a/internal/collector/trust_bundle.go
+++ b/internal/collector/trust_bundle.go
@@ -24,14 +24,13 @@ var (
 // ReconcileTrustedCABundleConfigMap creates or returns an existing Trusted CA Bundle ConfigMap.
 // By setting label "config.openshift.io/inject-trusted-cabundle: true", the cert is automatically filled/updated.
 func ReconcileTrustedCABundleConfigMap(k8sClient client.Client, namespace, name string, owner metav1.OwnerReference) error {
-	desiredOwners := []metav1.OwnerReference{owner}
 	cm := runtime.NewConfigMap(namespace, name, nil)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8sClient, cm, func() error {
-		if err := utils.EnsureCanUpdateOwnedResource(cm, desiredOwners); err != nil {
+		if err := utils.EnsureCanUpdateOwnedResource(cm, owner); err != nil {
 			return err
 		}
 		cm.Labels = map[string]string{constants.InjectTrustedCABundleLabel: "true"}
-		cm.OwnerReferences = desiredOwners
+		cm.OwnerReferences = []metav1.OwnerReference{owner}
 		return nil
 	})
 

--- a/internal/reconcile/configmaps.go
+++ b/internal/reconcile/configmaps.go
@@ -27,7 +27,7 @@ func Configmap(k8Client client.Client, reader client.Reader, configMap *corev1.C
 			return fmt.Errorf("failed to get %v configmap: %v", key, err)
 		}
 
-		if err := utils.EnsureCanUpdateOwnedResource(current, configMap.OwnerReferences); err != nil {
+		if err := utils.EnsureCanUpdateOwnedResource(current, configMap.OwnerReferences...); err != nil {
 			return err
 		}
 

--- a/internal/reconcile/configmaps.go
+++ b/internal/reconcile/configmaps.go
@@ -13,10 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Configmap creates or updates a ConfigMap owned by the ClusterLogForwarder.
+// Configmap creates or updates a ConfigMap owned by the desired ownerReferences.
 // If a ConfigMap with the same name already exists and is not owned by the desired
-// owner (for example, a LokiStack ConfigMap), it is left unchanged and an error is
-// returned so the operator does not overwrite foreign resources (LOG-9591).
+// owners, it is left unchanged and an error is returned (LOG-9591).
 func Configmap(k8Client client.Client, reader client.Reader, configMap *corev1.ConfigMap, opts ...comparators.ComparisonOption) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		current := &corev1.ConfigMap{}
@@ -28,11 +27,8 @@ func Configmap(k8Client client.Client, reader client.Reader, configMap *corev1.C
 			return fmt.Errorf("failed to get %v configmap: %v", key, err)
 		}
 
-		if !utils.HasSameOwner(current.OwnerReferences, configMap.OwnerReferences) {
-			return fmt.Errorf(
-				"configmap %s/%s already exists and is not owned by this ClusterLogForwarder; refusing to overwrite",
-				key.Namespace, key.Name,
-			)
+		if err := utils.EnsureCanUpdateOwnedResource(current, configMap.OwnerReferences); err != nil {
+			return err
 		}
 
 		if configmaps.AreSame(current, configMap, opts...) {

--- a/internal/reconcile/configmaps.go
+++ b/internal/reconcile/configmaps.go
@@ -13,6 +13,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// Configmap creates or updates a ConfigMap owned by the ClusterLogForwarder.
+// If a ConfigMap with the same name already exists and is not owned by the desired
+// owner (for example, a LokiStack ConfigMap), it is left unchanged and an error is
+// returned so the operator does not overwrite foreign resources (LOG-9591).
 func Configmap(k8Client client.Client, reader client.Reader, configMap *corev1.ConfigMap, opts ...comparators.ComparisonOption) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		current := &corev1.ConfigMap{}
@@ -23,14 +27,22 @@ func Configmap(k8Client client.Client, reader client.Reader, configMap *corev1.C
 			}
 			return fmt.Errorf("failed to get %v configmap: %v", key, err)
 		}
-		if configmaps.AreSame(current, configMap, opts...) && utils.HasSameOwner(current.OwnerReferences, configMap.OwnerReferences) {
-			return nil
-		} else {
-			current.Data = configMap.Data
-			current.Labels = configMap.Labels
-			current.Annotations = configMap.Annotations
-			current.OwnerReferences = configMap.OwnerReferences
+
+		if !utils.HasSameOwner(current.OwnerReferences, configMap.OwnerReferences) {
+			return fmt.Errorf(
+				"configmap %s/%s already exists and is not owned by this ClusterLogForwarder; refusing to overwrite",
+				key.Namespace, key.Name,
+			)
 		}
+
+		if configmaps.AreSame(current, configMap, opts...) {
+			return nil
+		}
+
+		current.Data = configMap.Data
+		current.Labels = configMap.Labels
+		current.Annotations = configMap.Annotations
+		current.OwnerReferences = configMap.OwnerReferences
 		return k8Client.Update(context.TODO(), current)
 	})
 }

--- a/internal/reconcile/configmaps_test.go
+++ b/internal/reconcile/configmaps_test.go
@@ -105,6 +105,18 @@ var _ = Describe("reconciling ConfigMap", func() {
 		Expect(result.OwnerReferences).To(Equal([]metav1.OwnerReference{lokiOwner}))
 	})
 
+	It("should refuse an identical ConfigMap owned by another resource", func() {
+		existing := runtime.NewConfigMap(namespace, name, map[string]string{
+			"vector.toml": "data_dir = \"/var/lib/vector\"",
+		})
+		utils.AddOwnerRefToObject(existing, lokiOwner)
+		k8sClient := newClient(existing)
+
+		err := reconcile.Configmap(k8sClient, k8sClient, desiredCollectorCM(), comparators.CompareLabels)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("refusing to overwrite"))
+	})
+
 	It("should refuse to take ownership of an existing ConfigMap with no owner", func() {
 		existing := runtime.NewConfigMap(namespace, name, map[string]string{
 			"config.yaml": "auth_enabled: false",
@@ -119,5 +131,23 @@ var _ = Describe("reconciling ConfigMap", func() {
 		result := getConfigMap(k8sClient)
 		Expect(result.Data).To(HaveKey("config.yaml"))
 		Expect(result.OwnerReferences).To(BeEmpty())
+	})
+
+	It("should allow update when the desired owner UID is present among additional owners", func() {
+		existing := runtime.NewConfigMap(namespace, name, map[string]string{
+			"vector.toml": "old",
+		})
+		utils.AddOwnerRefToObject(existing, clfOwner)
+		utils.AddOwnerRefToObject(existing, metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "extra",
+			UID:        "extra-uid",
+		})
+		k8sClient := newClient(existing)
+
+		Expect(reconcile.Configmap(k8sClient, k8sClient, desiredCollectorCM(), comparators.CompareLabels)).To(Succeed())
+		result := getConfigMap(k8sClient)
+		Expect(result.Data["vector.toml"]).To(Equal("data_dir = \"/var/lib/vector\""))
 	})
 })

--- a/internal/reconcile/configmaps_test.go
+++ b/internal/reconcile/configmaps_test.go
@@ -1,0 +1,123 @@
+package reconcile_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/reconcile"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	"github.com/openshift/cluster-logging-operator/internal/utils/comparators"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("reconciling ConfigMap", func() {
+
+	const (
+		namespace = "openshift-logging"
+		name      = "lokistack-config"
+	)
+
+	var (
+		clfOwner = metav1.OwnerReference{
+			APIVersion: "observability.openshift.io/v1",
+			Kind:       "ClusterLogForwarder",
+			Name:       "lokistack",
+			UID:        "clf-uid",
+			Controller: utils.GetPtr(true),
+		}
+		lokiOwner = metav1.OwnerReference{
+			APIVersion: "loki.grafana.com/v1",
+			Kind:       "LokiStack",
+			Name:       "lokistack",
+			UID:        "loki-uid",
+			Controller: utils.GetPtr(true),
+		}
+	)
+
+	newClient := func(objs ...client.Object) client.Client {
+		globalScheme := k8sruntime.NewScheme()
+		Expect(scheme.AddToScheme(globalScheme)).To(Succeed())
+		return fake.NewClientBuilder().WithScheme(globalScheme).WithObjects(objs...).Build()
+	}
+
+	getConfigMap := func(k8sClient client.Client) *corev1.ConfigMap {
+		result := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, result)).To(Succeed())
+		return result
+	}
+
+	desiredCollectorCM := func() *corev1.ConfigMap {
+		cm := runtime.NewConfigMap(namespace, name, map[string]string{
+			"vector.toml": "data_dir = \"/var/lib/vector\"",
+		})
+		utils.AddOwnerRefToObject(cm, clfOwner)
+		return cm
+	}
+
+	It("should create the ConfigMap when it does not exist", func() {
+		k8sClient := newClient()
+		desired := desiredCollectorCM()
+
+		Expect(reconcile.Configmap(k8sClient, k8sClient, desired, comparators.CompareLabels)).To(Succeed())
+
+		result := getConfigMap(k8sClient)
+		Expect(result.Data).To(HaveKey("vector.toml"))
+		Expect(result.OwnerReferences).To(Equal([]metav1.OwnerReference{clfOwner}))
+	})
+
+	It("should update the ConfigMap when owned by the ClusterLogForwarder", func() {
+		existing := runtime.NewConfigMap(namespace, name, map[string]string{
+			"vector.toml": "old",
+		})
+		utils.AddOwnerRefToObject(existing, clfOwner)
+		k8sClient := newClient(existing)
+
+		desired := desiredCollectorCM()
+		Expect(reconcile.Configmap(k8sClient, k8sClient, desired, comparators.CompareLabels)).To(Succeed())
+
+		result := getConfigMap(k8sClient)
+		Expect(result.Data["vector.toml"]).To(Equal("data_dir = \"/var/lib/vector\""))
+		Expect(result.OwnerReferences).To(Equal([]metav1.OwnerReference{clfOwner}))
+	})
+
+	It("should refuse to overwrite a ConfigMap owned by another resource", func() {
+		existing := runtime.NewConfigMap(namespace, name, map[string]string{
+			"config.yaml": "auth_enabled: false",
+		})
+		utils.AddOwnerRefToObject(existing, lokiOwner)
+		k8sClient := newClient(existing)
+
+		desired := desiredCollectorCM()
+		err := reconcile.Configmap(k8sClient, k8sClient, desired, comparators.CompareLabels)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("refusing to overwrite"))
+
+		result := getConfigMap(k8sClient)
+		Expect(result.Data).To(HaveKey("config.yaml"))
+		Expect(result.Data).NotTo(HaveKey("vector.toml"))
+		Expect(result.OwnerReferences).To(Equal([]metav1.OwnerReference{lokiOwner}))
+	})
+
+	It("should refuse to take ownership of an existing ConfigMap with no owner", func() {
+		existing := runtime.NewConfigMap(namespace, name, map[string]string{
+			"config.yaml": "auth_enabled: false",
+		})
+		k8sClient := newClient(existing)
+
+		desired := desiredCollectorCM()
+		err := reconcile.Configmap(k8sClient, k8sClient, desired, comparators.CompareLabels)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("refusing to overwrite"))
+
+		result := getConfigMap(k8sClient)
+		Expect(result.Data).To(HaveKey("config.yaml"))
+		Expect(result.OwnerReferences).To(BeEmpty())
+	})
+})

--- a/internal/reconcile/configmaps_test.go
+++ b/internal/reconcile/configmaps_test.go
@@ -132,22 +132,4 @@ var _ = Describe("reconciling ConfigMap", func() {
 		Expect(result.Data).To(HaveKey("config.yaml"))
 		Expect(result.OwnerReferences).To(BeEmpty())
 	})
-
-	It("should allow update when the desired owner UID is present among additional owners", func() {
-		existing := runtime.NewConfigMap(namespace, name, map[string]string{
-			"vector.toml": "old",
-		})
-		utils.AddOwnerRefToObject(existing, clfOwner)
-		utils.AddOwnerRefToObject(existing, metav1.OwnerReference{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-			Name:       "extra",
-			UID:        "extra-uid",
-		})
-		k8sClient := newClient(existing)
-
-		Expect(reconcile.Configmap(k8sClient, k8sClient, desiredCollectorCM(), comparators.CompareLabels)).To(Succeed())
-		result := getConfigMap(k8sClient)
-		Expect(result.Data["vector.toml"]).To(Equal("data_dir = \"/var/lib/vector\""))
-	})
 })

--- a/internal/reconcile/daemon_sets.go
+++ b/internal/reconcile/daemon_sets.go
@@ -17,7 +17,7 @@ import (
 func DaemonSet(k8Client client.Client, desired *apps.DaemonSet) error {
 	ds := runtime.NewDaemonSet(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, ds, func() error {
-		if err := utils.EnsureCanUpdateOwnedResource(ds, desired.OwnerReferences); err != nil {
+		if err := utils.EnsureCanUpdateOwnedResource(ds, desired.OwnerReferences...); err != nil {
 			return err
 		}
 		ds.Labels = desired.Labels

--- a/internal/reconcile/daemon_sets.go
+++ b/internal/reconcile/daemon_sets.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	apps "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,7 +17,9 @@ import (
 func DaemonSet(k8Client client.Client, desired *apps.DaemonSet) error {
 	ds := runtime.NewDaemonSet(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, ds, func() error {
-		// Update the daemonset with our desired state
+		if err := utils.EnsureCanUpdateOwnedResource(ds, desired.OwnerReferences); err != nil {
+			return err
+		}
 		ds.Labels = desired.Labels
 		ds.Spec = desired.Spec
 		ds.OwnerReferences = desired.OwnerReferences

--- a/internal/reconcile/daemonset_ownership_test.go
+++ b/internal/reconcile/daemonset_ownership_test.go
@@ -1,0 +1,73 @@
+package reconcile_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/reconcile"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("reconciling DaemonSet ownership", func() {
+	const (
+		namespace = "openshift-logging"
+		name      = "lokistack"
+	)
+
+	var (
+		clfOwner = metav1.OwnerReference{
+			APIVersion: "observability.openshift.io/v1",
+			Kind:       "ClusterLogForwarder",
+			Name:       "lokistack",
+			UID:        "clf-uid",
+			Controller: utils.GetPtr(true),
+		}
+		lokiOwner = metav1.OwnerReference{
+			APIVersion: "loki.grafana.com/v1",
+			Kind:       "LokiStack",
+			Name:       "lokistack",
+			UID:        "loki-uid",
+			Controller: utils.GetPtr(true),
+		}
+	)
+
+	newClient := func(objs ...client.Object) client.Client {
+		globalScheme := k8sruntime.NewScheme()
+		Expect(scheme.AddToScheme(globalScheme)).To(Succeed())
+		Expect(appsv1.AddToScheme(globalScheme)).To(Succeed())
+		return fake.NewClientBuilder().WithScheme(globalScheme).WithObjects(objs...).Build()
+	}
+
+	desiredDS := func() *appsv1.DaemonSet {
+		ds := runtime.NewDaemonSet(namespace, name)
+		ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"app": "collector"}}
+		ds.Spec.Template.Labels = map[string]string{"app": "collector"}
+		utils.AddOwnerRefToObject(ds, clfOwner)
+		return ds
+	}
+
+	It("should refuse to overwrite a DaemonSet owned by another resource", func() {
+		existing := runtime.NewDaemonSet(namespace, name)
+		existing.Spec.Selector = &metav1.LabelSelector{MatchLabels: map[string]string{"app": "loki"}}
+		existing.Spec.Template.Labels = map[string]string{"app": "loki"}
+		utils.AddOwnerRefToObject(existing, lokiOwner)
+		k8sClient := newClient(existing)
+
+		err := reconcile.DaemonSet(k8sClient, desiredDS())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("refusing to overwrite"))
+
+		got := &appsv1.DaemonSet{}
+		Expect(k8sClient.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, got)).To(Succeed())
+		Expect(got.Spec.Selector.MatchLabels["app"]).To(Equal("loki"))
+		Expect(got.OwnerReferences).To(Equal([]metav1.OwnerReference{lokiOwner}))
+	})
+})

--- a/internal/reconcile/deployment.go
+++ b/internal/reconcile/deployment.go
@@ -17,7 +17,7 @@ import (
 func Deployment(k8Client client.Client, desired *apps.Deployment) error {
 	dpl := runtime.NewDeployment(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, dpl, func() error {
-		if err := utils.EnsureCanUpdateOwnedResource(dpl, desired.OwnerReferences); err != nil {
+		if err := utils.EnsureCanUpdateOwnedResource(dpl, desired.OwnerReferences...); err != nil {
 			return err
 		}
 		dpl.Labels = desired.Labels

--- a/internal/reconcile/deployment.go
+++ b/internal/reconcile/deployment.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	apps "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,7 +17,9 @@ import (
 func Deployment(k8Client client.Client, desired *apps.Deployment) error {
 	dpl := runtime.NewDeployment(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, dpl, func() error {
-		// Update the deployment with our desired state
+		if err := utils.EnsureCanUpdateOwnedResource(dpl, desired.OwnerReferences); err != nil {
+			return err
+		}
 		dpl.Labels = desired.Labels
 		dpl.Spec = desired.Spec
 		dpl.OwnerReferences = desired.OwnerReferences

--- a/internal/reconcile/networkpolicy.go
+++ b/internal/reconcile/networkpolicy.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	networkingv1 "k8s.io/api/networking/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,6 +17,9 @@ import (
 func NetworkPolicy(k8Client client.Client, desired *networkingv1.NetworkPolicy) error {
 	np := runtime.NewNetworkPolicy(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, np, func() error {
+		if err := utils.EnsureCanUpdateOwnedResource(np, desired.OwnerReferences); err != nil {
+			return err
+		}
 		np.Labels = desired.Labels
 		np.Spec = desired.Spec
 		np.OwnerReferences = desired.OwnerReferences

--- a/internal/reconcile/networkpolicy.go
+++ b/internal/reconcile/networkpolicy.go
@@ -17,7 +17,7 @@ import (
 func NetworkPolicy(k8Client client.Client, desired *networkingv1.NetworkPolicy) error {
 	np := runtime.NewNetworkPolicy(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, np, func() error {
-		if err := utils.EnsureCanUpdateOwnedResource(np, desired.OwnerReferences); err != nil {
+		if err := utils.EnsureCanUpdateOwnedResource(np, desired.OwnerReferences...); err != nil {
 			return err
 		}
 		np.Labels = desired.Labels

--- a/internal/reconcile/rbac.go
+++ b/internal/reconcile/rbac.go
@@ -16,7 +16,7 @@ import (
 func Role(k8Client client.Client, desired *rbacv1.Role) error {
 	role := runtime.NewRole(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, role, func() error {
-		if err := utils.EnsureCanUpdateOwnedResource(role, desired.OwnerReferences); err != nil {
+		if err := utils.EnsureCanUpdateOwnedResource(role, desired.OwnerReferences...); err != nil {
 			return err
 		}
 		role.Rules = desired.Rules
@@ -41,7 +41,7 @@ func RoleBinding(k8Client client.Client, desired *rbacv1.RoleBinding) error {
 		return err
 	}
 
-	if err := utils.EnsureCanUpdateOwnedResource(existing, desired.OwnerReferences); err != nil {
+	if err := utils.EnsureCanUpdateOwnedResource(existing, desired.OwnerReferences...); err != nil {
 		return err
 	}
 
@@ -72,7 +72,7 @@ func ClusterRoleBinding(k8sClient client.Client, name string, generator func() *
 		return err
 	}
 
-	if err := utils.EnsureCanUpdateOwnedResource(existing, desired.OwnerReferences); err != nil {
+	if err := utils.EnsureCanUpdateOwnedResource(existing, desired.OwnerReferences...); err != nil {
 		return err
 	}
 

--- a/internal/reconcile/rbac.go
+++ b/internal/reconcile/rbac.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -15,7 +16,9 @@ import (
 func Role(k8Client client.Client, desired *rbacv1.Role) error {
 	role := runtime.NewRole(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, role, func() error {
-		// Update the role with our desired state
+		if err := utils.EnsureCanUpdateOwnedResource(role, desired.OwnerReferences); err != nil {
+			return err
+		}
 		role.Rules = desired.Rules
 		role.OwnerReferences = desired.OwnerReferences
 		return nil
@@ -35,6 +38,10 @@ func RoleBinding(k8Client client.Client, desired *rbacv1.RoleBinding) error {
 		return k8Client.Create(context.TODO(), desired)
 	}
 	if err != nil {
+		return err
+	}
+
+	if err := utils.EnsureCanUpdateOwnedResource(existing, desired.OwnerReferences); err != nil {
 		return err
 	}
 
@@ -65,6 +72,10 @@ func ClusterRoleBinding(k8sClient client.Client, name string, generator func() *
 		return err
 	}
 
+	if err := utils.EnsureCanUpdateOwnedResource(existing, desired.OwnerReferences); err != nil {
+		return err
+	}
+
 	if existing.RoleRef != desired.RoleRef {
 		log.V(3).Info("Deleting clusterRoleBinding due to roleRef change", "name", name)
 		if err := k8sClient.Delete(context.TODO(), existing); err != nil {
@@ -75,6 +86,7 @@ func ClusterRoleBinding(k8sClient client.Client, name string, generator func() *
 	}
 
 	existing.Subjects = desired.Subjects
+	existing.OwnerReferences = desired.OwnerReferences
 	log.V(3).Info("Updating clusterRoleBinding", "name", name)
 	return k8sClient.Update(context.TODO(), existing)
 }

--- a/internal/reconcile/rbac_test.go
+++ b/internal/reconcile/rbac_test.go
@@ -55,6 +55,7 @@ var _ = Describe("reconciling RoleBinding", func() {
 	It("should update Subjects and OwnerReferences when roleRef is unchanged", func() {
 		existing := runtime.NewRoleBinding(namespace, name, newRef,
 			rbacv1.Subject{Kind: "ServiceAccount", Name: "old-sa", Namespace: namespace})
+		existing.OwnerReferences = []metav1.OwnerReference{ownerRef}
 		k8sClient := newClient(existing)
 
 		desired := runtime.NewRoleBinding(namespace, name, newRef, subject)
@@ -71,6 +72,7 @@ var _ = Describe("reconciling RoleBinding", func() {
 	It("should delete and recreate the RoleBinding when roleRef changes", func() {
 		existing := runtime.NewRoleBinding(namespace, name, oldRef,
 			rbacv1.Subject{Kind: "ServiceAccount", Name: "old-sa", Namespace: namespace})
+		existing.OwnerReferences = []metav1.OwnerReference{ownerRef}
 		k8sClient := newClient(existing)
 
 		desired := runtime.NewRoleBinding(namespace, name, newRef, subject)
@@ -82,5 +84,19 @@ var _ = Describe("reconciling RoleBinding", func() {
 		Expect(result.RoleRef).To(Equal(newRef))
 		Expect(result.Subjects).To(Equal([]rbacv1.Subject{subject}))
 		Expect(result.OwnerReferences).To(Equal([]metav1.OwnerReference{ownerRef}))
+	})
+
+	It("should refuse to overwrite a RoleBinding owned by another resource", func() {
+		foreignOwner := metav1.OwnerReference{APIVersion: "v1", Kind: "ConfigMap", Name: "other", UID: "other-uid"}
+		existing := runtime.NewRoleBinding(namespace, name, newRef, subject)
+		existing.OwnerReferences = []metav1.OwnerReference{foreignOwner}
+		k8sClient := newClient(existing)
+
+		desired := runtime.NewRoleBinding(namespace, name, newRef, subject)
+		desired.OwnerReferences = []metav1.OwnerReference{ownerRef}
+
+		err := reconcile.RoleBinding(k8sClient, desired)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("refusing to overwrite"))
 	})
 })

--- a/internal/reconcile/service.go
+++ b/internal/reconcile/service.go
@@ -17,7 +17,7 @@ import (
 func Service(k8Client client.Client, desired *corev1.Service) error {
 	sm := runtime.NewService(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, sm, func() error {
-		if err := utils.EnsureCanUpdateOwnedResource(sm, desired.OwnerReferences); err != nil {
+		if err := utils.EnsureCanUpdateOwnedResource(sm, desired.OwnerReferences...); err != nil {
 			return err
 		}
 

--- a/internal/reconcile/service.go
+++ b/internal/reconcile/service.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,6 +17,9 @@ import (
 func Service(k8Client client.Client, desired *corev1.Service) error {
 	sm := runtime.NewService(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, sm, func() error {
+		if err := utils.EnsureCanUpdateOwnedResource(sm, desired.OwnerReferences); err != nil {
+			return err
+		}
 
 		// Set annotations upon creation
 		if sm.CreationTimestamp.IsZero() {

--- a/internal/reconcile/service_account.go
+++ b/internal/reconcile/service_account.go
@@ -15,7 +15,7 @@ import (
 func ServiceAccount(k8Client client.Client, desired *v1.ServiceAccount) (*v1.ServiceAccount, error) {
 	sa := runtime.NewServiceAccount(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, sa, func() error {
-		if err := utils.EnsureCanUpdateOwnedResource(sa, desired.OwnerReferences); err != nil {
+		if err := utils.EnsureCanUpdateOwnedResource(sa, desired.OwnerReferences...); err != nil {
 			return err
 		}
 		sa.Annotations = desired.Annotations

--- a/internal/reconcile/service_account.go
+++ b/internal/reconcile/service_account.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -14,6 +15,9 @@ import (
 func ServiceAccount(k8Client client.Client, desired *v1.ServiceAccount) (*v1.ServiceAccount, error) {
 	sa := runtime.NewServiceAccount(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, sa, func() error {
+		if err := utils.EnsureCanUpdateOwnedResource(sa, desired.OwnerReferences); err != nil {
+			return err
+		}
 		sa.Annotations = desired.Annotations
 		sa.OwnerReferences = desired.OwnerReferences
 		sa.Finalizers = desired.Finalizers

--- a/internal/reconcile/service_monitor.go
+++ b/internal/reconcile/service_monitor.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,6 +17,9 @@ import (
 func ServiceMonitor(k8Client client.Client, desired *monitoringv1.ServiceMonitor) error {
 	sm := runtime.NewServiceMonitor(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, sm, func() error {
+		if err := utils.EnsureCanUpdateOwnedResource(sm, desired.OwnerReferences); err != nil {
+			return err
+		}
 		sm.Labels = desired.Labels
 		sm.Spec = desired.Spec
 		sm.Annotations = desired.Annotations

--- a/internal/reconcile/service_monitor.go
+++ b/internal/reconcile/service_monitor.go
@@ -17,7 +17,7 @@ import (
 func ServiceMonitor(k8Client client.Client, desired *monitoringv1.ServiceMonitor) error {
 	sm := runtime.NewServiceMonitor(desired.Namespace, desired.Name)
 	op, err := controllerutil.CreateOrUpdate(context.TODO(), k8Client, sm, func() error {
-		if err := utils.EnsureCanUpdateOwnedResource(sm, desired.OwnerReferences); err != nil {
+		if err := utils.EnsureCanUpdateOwnedResource(sm, desired.OwnerReferences...); err != nil {
 			return err
 		}
 		sm.Labels = desired.Labels

--- a/internal/utils/ownership.go
+++ b/internal/utils/ownership.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EnsureCanUpdateOwnedResource returns nil when the object has not been persisted yet
+// (create path) or when it is already owned by all of the desired owners.
+// If the object exists and is not owned by the desired owners (foreign-owned or
+// unowned), it returns an error and callers must not mutate the object.
+//
+// Ownership is matched by OwnerReference UID so additional ownerRefs on the
+// object do not cause false conflicts (LOG-9591).
+func EnsureCanUpdateOwnedResource(obj metav1.Object, desiredOwners []metav1.OwnerReference) error {
+	if obj.GetResourceVersion() == "" {
+		return nil
+	}
+	if IsOwnedByDesired(obj.GetOwnerReferences(), desiredOwners) {
+		return nil
+	}
+	return ResourceOwnershipConflictError(obj)
+}
+
+// IsOwnedByDesired reports whether every desired owner UID is present among current owners.
+// An empty desired owner list only matches when current owners are also empty.
+func IsOwnedByDesired(current, desired []metav1.OwnerReference) bool {
+	if len(desired) == 0 {
+		return len(current) == 0
+	}
+	currentUIDs := make(map[string]struct{}, len(current))
+	for _, ref := range current {
+		currentUIDs[string(ref.UID)] = struct{}{}
+	}
+	for _, want := range desired {
+		if _, ok := currentUIDs[string(want.UID)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// ResourceOwnershipConflictError builds a stable error for ownership conflicts.
+func ResourceOwnershipConflictError(obj metav1.Object) error {
+	if ns := obj.GetNamespace(); ns != "" {
+		return fmt.Errorf(
+			"resource %s/%s already exists and is not owned by the expected owner; refusing to overwrite",
+			ns, obj.GetName(),
+		)
+	}
+	return fmt.Errorf(
+		"resource %s already exists and is not owned by the expected owner; refusing to overwrite",
+		obj.GetName(),
+	)
+}

--- a/internal/utils/ownership.go
+++ b/internal/utils/ownership.go
@@ -4,41 +4,38 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // EnsureCanUpdateOwnedResource returns nil when the object has not been persisted yet
-// (create path) or when it is already owned by all of the desired owners.
-// If the object exists and is not owned by the desired owners (foreign-owned or
+// (create path) or when it is already owned by the expected owner.
+// If the object exists and is not owned by the expected owner (foreign-owned or
 // unowned), it returns an error and callers must not mutate the object.
 //
-// Ownership is matched by OwnerReference UID so additional ownerRefs on the
-// object do not cause false conflicts (LOG-9591).
-func EnsureCanUpdateOwnedResource(obj metav1.Object, desiredOwners []metav1.OwnerReference) error {
+// CLO-managed resources have a single controller ownerReference (the CLF), or no
+// owner at all (e.g. dashboard ConfigMaps). Ownership is matched by UID.
+func EnsureCanUpdateOwnedResource(obj metav1.Object, desiredOwners ...metav1.OwnerReference) error {
 	if obj.GetResourceVersion() == "" {
 		return nil
 	}
-	if IsOwnedByDesired(obj.GetOwnerReferences(), desiredOwners) {
+	if hasSameOwnerUIDs(obj.GetOwnerReferences(), desiredOwners) {
 		return nil
 	}
 	return ResourceOwnershipConflictError(obj)
 }
 
-// IsOwnedByDesired reports whether every desired owner UID is present among current owners.
+// hasSameOwnerUIDs reports whether current and desired have the same owner UIDs.
 // An empty desired owner list only matches when current owners are also empty.
-func IsOwnedByDesired(current, desired []metav1.OwnerReference) bool {
-	if len(desired) == 0 {
-		return len(current) == 0
+func hasSameOwnerUIDs(current, desired []metav1.OwnerReference) bool {
+	return ownerUIDSet(current).Equal(ownerUIDSet(desired))
+}
+
+func ownerUIDSet(refs []metav1.OwnerReference) sets.Set[string] {
+	uids := sets.New[string]()
+	for _, ref := range refs {
+		uids.Insert(string(ref.UID))
 	}
-	currentUIDs := make(map[string]struct{}, len(current))
-	for _, ref := range current {
-		currentUIDs[string(ref.UID)] = struct{}{}
-	}
-	for _, want := range desired {
-		if _, ok := currentUIDs[string(want.UID)]; !ok {
-			return false
-		}
-	}
-	return true
+	return uids
 }
 
 // ResourceOwnershipConflictError builds a stable error for ownership conflicts.

--- a/internal/utils/ownership_test.go
+++ b/internal/utils/ownership_test.go
@@ -28,21 +28,27 @@ var _ = Describe("EnsureCanUpdateOwnedResource", func() {
 
 	It("should allow create when the object is not persisted", func() {
 		cm := runtime.NewConfigMap("openshift-logging", "lokistack-config", nil)
-		Expect(utils.EnsureCanUpdateOwnedResource(cm, []metav1.OwnerReference{clfOwner})).To(Succeed())
+		Expect(utils.EnsureCanUpdateOwnedResource(cm, clfOwner)).To(Succeed())
 	})
 
 	It("should allow update when owned by the desired owner", func() {
 		cm := runtime.NewConfigMap("openshift-logging", "lokistack-config", nil)
 		cm.SetResourceVersion("1")
 		utils.AddOwnerRefToObject(cm, clfOwner)
-		Expect(utils.EnsureCanUpdateOwnedResource(cm, []metav1.OwnerReference{clfOwner})).To(Succeed())
+		Expect(utils.EnsureCanUpdateOwnedResource(cm, clfOwner)).To(Succeed())
+	})
+
+	It("should allow update when neither object has an owner", func() {
+		cm := runtime.NewConfigMap("openshift-config-managed", "grafana-dashboard-cluster-logging", nil)
+		cm.SetResourceVersion("1")
+		Expect(utils.EnsureCanUpdateOwnedResource(cm)).To(Succeed())
 	})
 
 	It("should refuse update when owned by another resource", func() {
 		cm := runtime.NewConfigMap("openshift-logging", "lokistack-config", nil)
 		cm.SetResourceVersion("1")
 		utils.AddOwnerRefToObject(cm, lokiOwner)
-		err := utils.EnsureCanUpdateOwnedResource(cm, []metav1.OwnerReference{clfOwner})
+		err := utils.EnsureCanUpdateOwnedResource(cm, clfOwner)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("refusing to overwrite"))
 	})
@@ -50,7 +56,7 @@ var _ = Describe("EnsureCanUpdateOwnedResource", func() {
 	It("should refuse update when the object has no owner", func() {
 		cm := runtime.NewConfigMap("openshift-logging", "lokistack-config", nil)
 		cm.SetResourceVersion("1")
-		err := utils.EnsureCanUpdateOwnedResource(cm, []metav1.OwnerReference{clfOwner})
+		err := utils.EnsureCanUpdateOwnedResource(cm, clfOwner)
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/internal/utils/ownership_test.go
+++ b/internal/utils/ownership_test.go
@@ -1,0 +1,56 @@
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/runtime"
+	"github.com/openshift/cluster-logging-operator/internal/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("EnsureCanUpdateOwnedResource", func() {
+	var (
+		clfOwner = metav1.OwnerReference{
+			APIVersion: "observability.openshift.io/v1",
+			Kind:       "ClusterLogForwarder",
+			Name:       "lokistack",
+			UID:        "clf-uid",
+			Controller: utils.GetPtr(true),
+		}
+		lokiOwner = metav1.OwnerReference{
+			APIVersion: "loki.grafana.com/v1",
+			Kind:       "LokiStack",
+			Name:       "lokistack",
+			UID:        "loki-uid",
+			Controller: utils.GetPtr(true),
+		}
+	)
+
+	It("should allow create when the object is not persisted", func() {
+		cm := runtime.NewConfigMap("openshift-logging", "lokistack-config", nil)
+		Expect(utils.EnsureCanUpdateOwnedResource(cm, []metav1.OwnerReference{clfOwner})).To(Succeed())
+	})
+
+	It("should allow update when owned by the desired owner", func() {
+		cm := runtime.NewConfigMap("openshift-logging", "lokistack-config", nil)
+		cm.SetResourceVersion("1")
+		utils.AddOwnerRefToObject(cm, clfOwner)
+		Expect(utils.EnsureCanUpdateOwnedResource(cm, []metav1.OwnerReference{clfOwner})).To(Succeed())
+	})
+
+	It("should refuse update when owned by another resource", func() {
+		cm := runtime.NewConfigMap("openshift-logging", "lokistack-config", nil)
+		cm.SetResourceVersion("1")
+		utils.AddOwnerRefToObject(cm, lokiOwner)
+		err := utils.EnsureCanUpdateOwnedResource(cm, []metav1.OwnerReference{clfOwner})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("refusing to overwrite"))
+	})
+
+	It("should refuse update when the object has no owner", func() {
+		cm := runtime.NewConfigMap("openshift-logging", "lokistack-config", nil)
+		cm.SetResourceVersion("1")
+		err := utils.EnsureCanUpdateOwnedResource(cm, []metav1.OwnerReference{clfOwner})
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## Summary
- Prevents Cluster Logging Operator from updating resources that already exist but are not owned by the desired owner (e.g. ClusterLogForwarder).
- Surfaces the conflict as a deployment error on the CLF (`Ready=False` / `DeploymentError`) so users can rename or clean up conflicting resources.
- Replaces the earlier ConfigMap rename approach (closed PR #3352) per review consensus with @jcantrill / @xperimental.


## Details

### Problem
When a `LokiStack` and a `ClusterLogForwarder` share the same `metadata.name`, CLO previously overwrote Loki’s ConfigMap `{name}-config` (and could also create/collide on other same-named objects such as DaemonSet/Service/ServiceMonitor). That could leave Loki CrashLoopBackOff and is a general name-collision hazard, not Loki-specific.
Ref: [LOG-9591](https://redhat.atlassian.net/browse/LOG-9591)
### Solution
- Add shared helper `internal/utils/ownership.go` (`EnsureCanUpdateOwnedResource`) that refuses update when existing `ownerReferences` do not match the desired owner (UID-based).
- Wire the check into reconcile paths for:
  ConfigMap, DaemonSet, Deployment, Service, ServiceAccount, ServiceMonitor, NetworkPolicy, Role/RoleBinding, ClusterRoleBinding, and trusted-CA ConfigMap (`trust_bundle.go`).
- Unit tests cover create/update of owned objects and refusal for foreign-owned / unowned objects.

### Notes
- Customers should still use different names for LokiStack and ClusterLogForwarder.
- Shared SCC handling is unchanged (different ownership model).
- Symmetric fix in the Loki Operator is tracked separately.
### Test plan
- [x] Unit tests (`go test ./internal/utils/ ./internal/reconcile/`)
- [x] LokiStack first → same-named CLF → Loki ConfigMap unchanged; CLF Ready=False with refuse-overwrite message
- [x] Different CLF name → collector resources created; CLF Ready=True
- [x] Owned collector resources still update normally on reconcile
### Links
JIRA: https://redhat.atlassian.net/browse/LOG-9591
Supersedes: https://github.com/openshift/cluster-logging-operator/pull/3352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented reconciliation from overwriting resources owned by a different controller, including ConfigMaps, Deployments, DaemonSets, NetworkPolicies, Services, ServiceAccounts, ServiceMonitors, and RBAC objects.
  * Resources with conflicting ownership now remain unchanged and return a clear error.
  * Continued updates when ownership matches, including valid shared-owner scenarios.
  * Ensured owner references stay synchronized when permitted.

* **Tests**
  * Expanded coverage for ownership conflicts, matching owners, shared ownership, and protected resource state across supported resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->