### PR TITLE
fix(security): CVE-2026-10609 verify CLF creator authorization for SA token usage (LOG-9441)

### DIFF
--- a/bundle/manifests/cluster-logging-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/cluster-logging-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
+  creationTimestamp: null
+  name: cluster-logging-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    name: cluster-logging-operator
+status:
+  loadBalancer: {}

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2026-02-19T21:00:21Z"
+    createdAt: "2026-08-04T17:40:36Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -2392,6 +2392,10 @@ spec:
                 image: quay.io/openshift-logging/cluster-logging-operator:latest
                 imagePullPolicy: IfNotPresent
                 name: cluster-logging-operator
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
                 resources: {}
                 securityContext:
                   allowPrivilegeEscalation: false
@@ -2401,11 +2405,20 @@ spec:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
               nodeSelector:
                 kubernetes.io/os: linux
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: cluster-logging-operator
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: webhook-server-cert
     strategy: deployment
   installModes:
   - supported: true
@@ -2438,3 +2451,24 @@ spec:
   - image: quay.io/openshift-logging/log-file-metric-exporter:latest
     name: log-file-metric-exporter
   version: 6.5.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: cluster-logging-operator
+    failurePolicy: Fail
+    generateName: vclusterlogforwarder.observability.openshift.io
+    rules:
+    - apiGroups:
+      - observability.openshift.io
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - clusterlogforwarders
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-observability-openshift-io-v1-clusterlogforwarder

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/cluster-logging-operator/api/logging/v1alpha1"
 	observabilityv1 "github.com/openshift/cluster-logging-operator/api/observability/v1"
 	observabilitycontroller "github.com/openshift/cluster-logging-operator/internal/controller/observability"
+	clfwebhook "github.com/openshift/cluster-logging-operator/internal/webhook"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 
@@ -146,7 +147,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "b430cc2e.openshift.io",
-		Cache:                  cacheOptions,
+		Cache: cacheOptions,
 	})
 	if err != nil {
 		log.Error(err, "unable to start manager")
@@ -209,6 +210,11 @@ func main() {
 		},
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create controller", "controller", "observability.ClusterLogForwarder")
+		os.Exit(1)
+	}
+
+	if err = clfwebhook.SetupWebhookWithManager(mgr); err != nil {
+		log.Error(err, "unable to create webhook", "webhook", "ClusterLogForwarder")
 		os.Exit(1)
 	}
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -17,9 +17,8 @@ resources:
 - ../rbac
 - ../manager
 #- ../scheduling
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
-# crd/kustomization.yaml
-#- ../webhook
+# [WEBHOOK]
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'. 
@@ -40,9 +39,11 @@ resources:
 #  target:
 #    kind: Deployment
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
-# crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+patches:
+# [WEBHOOK]
+- path: manager_webhook_patch.yaml
+  target:
+    kind: Deployment
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-logging-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: cluster-logging-operator
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- manifests.yaml
+- service.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: cluster-logging-operator-validating-webhook
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: cluster-logging-operator-webhook-service
+      namespace: system
+      path: /validate-observability-openshift-io-v1-clusterlogforwarder
+  failurePolicy: Fail
+  name: vclusterlogforwarder.observability.openshift.io
+  rules:
+  - apiGroups:
+    - observability.openshift.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterlogforwarders
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-logging-operator-webhook-service
+  namespace: system
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    name: cluster-logging-operator

--- a/hack/run-linter
+++ b/hack/run-linter
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/internal/api/observability/configmap_test.go
+++ b/internal/api/observability/configmap_test.go
@@ -11,39 +11,39 @@ import (
 var _ = Describe("ConfigMaps ", func() {
 
 	It("should return different hashes when configmap content changes", func() {
-			original := internalobs.ConfigMaps{
-				"ca-test": &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Name: "ca-test"},
-					Data:       map[string]string{"service-ca.crt": "-----BEGIN CERTIFICATE-----\nORIGINAL\n-----END CERTIFICATE-----"},
-				},
-			}
-			modified := internalobs.ConfigMaps{
-				"ca-test": &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Name: "ca-test"},
-					Data:       map[string]string{"service-ca.crt": "-----BEGIN CERTIFICATE-----\nUPDATED\n-----END CERTIFICATE-----"},
-				},
-			}
-			Expect(original.Hash64a()).ToNot(Equal(modified.Hash64a()))
-		})
+		original := internalobs.ConfigMaps{
+			"ca-test": &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "ca-test"},
+				Data:       map[string]string{"service-ca.crt": "-----BEGIN CERTIFICATE-----\nORIGINAL\n-----END CERTIFICATE-----"},
+			},
+		}
+		modified := internalobs.ConfigMaps{
+			"ca-test": &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "ca-test"},
+				Data:       map[string]string{"service-ca.crt": "-----BEGIN CERTIFICATE-----\nUPDATED\n-----END CERTIFICATE-----"},
+			},
+		}
+		Expect(original.Hash64a()).ToNot(Equal(modified.Hash64a()))
+	})
 
-		It("should return the same hash for identical content", func() {
-			cm1 := internalobs.ConfigMaps{
-				"ca-test": &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Name: "ca-test"},
-					Data:       map[string]string{"service-ca.crt": "same-content"},
-				},
-			}
-			cm2 := internalobs.ConfigMaps{
-				"ca-test": &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Name: "ca-test"},
-					Data:       map[string]string{"service-ca.crt": "same-content"},
-				},
-			}
-			Expect(cm1.Hash64a()).To(Equal(cm2.Hash64a()))
-		})
+	It("should return the same hash for identical content", func() {
+		cm1 := internalobs.ConfigMaps{
+			"ca-test": &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "ca-test"},
+				Data:       map[string]string{"service-ca.crt": "same-content"},
+			},
+		}
+		cm2 := internalobs.ConfigMaps{
+			"ca-test": &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "ca-test"},
+				Data:       map[string]string{"service-ca.crt": "same-content"},
+			},
+		}
+		Expect(cm1.Hash64a()).To(Equal(cm2.Hash64a()))
+	})
 
-		It("should return a consistent hash for empty configmaps", func() {
-			empty := internalobs.ConfigMaps{}
-			Expect(empty.Hash64a()).ToNot(BeEmpty())
+	It("should return a consistent hash for empty configmaps", func() {
+		empty := internalobs.ConfigMaps{}
+		Expect(empty.Hash64a()).ToNot(BeEmpty())
 	})
 })

--- a/internal/generator/vector/output/aws/s3/s3.go
+++ b/internal/generator/vector/output/aws/s3/s3.go
@@ -118,5 +118,3 @@ func endpointConfig(s3 *obs.S3) framework.Element {
 		URL: s3.URL,
 	}
 }
-
-

--- a/internal/generator/vector/output/aws/s3/s3_test.go
+++ b/internal/generator/vector/output/aws/s3/s3_test.go
@@ -159,12 +159,12 @@ var _ = Describe("Generating vector config for s3 output", func() {
 				spec.S3.KeyPrefix = "app-{.log_type||\"missing\"}"
 				spec.S3.URL = "http://mylogreceiver"
 				spec.S3.Tuning = &obs.S3TuningSpec{Compression: "none"}
-			} ,true,  framework.NoOptions, "files/s3_with_none_compession.toml"),
+			}, true, framework.NoOptions, "files/s3_with_none_compession.toml"),
 			Entry("should pass with 'gzip' compression", func(spec *obs.OutputSpec) {
 				spec.S3.KeyPrefix = "app-{.log_type||\"missing\"}"
 				spec.S3.URL = "http://mylogreceiver"
 				spec.S3.Tuning = &obs.S3TuningSpec{Compression: "gzip"}
-			} ,true,  framework.NoOptions, "files/s3_with_gzip_compession.toml"),
+			}, true, framework.NoOptions, "files/s3_with_gzip_compession.toml"),
 		)
 	})
 

--- a/internal/webhook/clusterlogforwarder_webhook.go
+++ b/internal/webhook/clusterlogforwarder_webhook.go
@@ -1,0 +1,86 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	authorizationapi "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:path=/validate-observability-openshift-io-v1-clusterlogforwarder,mutating=false,failurePolicy=fail,sideEffects=None,groups=observability.openshift.io,resources=clusterlogforwarders,verbs=create;update,versions=v1,name=vclusterlogforwarder.observability.openshift.io,admissionReviewVersions=v1
+
+type ClusterLogForwarderValidator struct {
+	Client client.Client
+}
+
+var _ webhook.CustomValidator = &ClusterLogForwarderValidator{}
+
+func SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&obs.ClusterLogForwarder{}).
+		WithValidator(&ClusterLogForwarderValidator{Client: mgr.GetClient()}).
+		Complete()
+}
+
+func (v *ClusterLogForwarderValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return v.validateSAUsage(ctx, obj)
+}
+
+func (v *ClusterLogForwarderValidator) ValidateUpdate(ctx context.Context, _ runtime.Object, newObj runtime.Object) (admission.Warnings, error) {
+	return v.validateSAUsage(ctx, newObj)
+}
+
+func (v *ClusterLogForwarderValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validateSAUsage verifies the requesting user has permission to use the referenced ServiceAccount.
+// This check is unconditional — any SA can be granted SCC permissions and mounted to workloads,
+// so we validate usage regardless of whether outputs forward the SA token.
+func (v *ClusterLogForwarderValidator) validateSAUsage(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	clf, ok := obj.(*obs.ClusterLogForwarder)
+	if !ok {
+		return nil, fmt.Errorf("expected ClusterLogForwarder, got %T", obj)
+	}
+
+	saName := clf.Spec.ServiceAccount.Name
+	if saName == "" {
+		return nil, nil
+	}
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get admission request from context: %w", err)
+	}
+
+	sar := &authorizationapi.SubjectAccessReview{
+		Spec: authorizationapi.SubjectAccessReviewSpec{
+			User:   req.UserInfo.Username,
+			Groups: req.UserInfo.Groups,
+			UID:    req.UserInfo.UID,
+			ResourceAttributes: &authorizationapi.ResourceAttributes{
+				Group:     "",
+				Verb:      "use",
+				Resource:  "serviceaccounts",
+				Name:      saName,
+				Namespace: clf.Namespace,
+			},
+		},
+	}
+
+	if err := v.Client.Create(ctx, sar); err != nil {
+		return nil, fmt.Errorf("failed to check service account usage permission: %w", err)
+	}
+
+	if !sar.Status.Allowed {
+		return nil, fmt.Errorf("user %q is not authorized to use service account %q in namespace %q", req.UserInfo.Username, saName, clf.Namespace)
+	}
+
+	return nil, nil
+}

--- a/internal/webhook/clusterlogforwarder_webhook_test.go
+++ b/internal/webhook/clusterlogforwarder_webhook_test.go
@@ -1,0 +1,146 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationapi "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][webhook] Suite")
+}
+
+func contextWithUserInfo(info authenticationv1.UserInfo) context.Context {
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UserInfo: info,
+		},
+	}
+	return admission.NewContextWithRequest(context.TODO(), req)
+}
+
+var _ = Describe("ClusterLogForwarder Webhook", func() {
+
+	Context("ValidatingWebhook (Validator)", func() {
+		var (
+			validator *ClusterLogForwarderValidator
+			clf       *obs.ClusterLogForwarder
+			mockSAR   *mockSARClient
+		)
+
+		BeforeEach(func() {
+			mockSAR = &mockSARClient{Client: fake.NewFakeClient(), allowed: true}
+			validator = &ClusterLogForwarderValidator{Client: mockSAR}
+			clf = &obs.ClusterLogForwarder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-clf",
+					Namespace: "openshift-logging",
+				},
+				Spec: obs.ClusterLogForwarderSpec{
+					ServiceAccount: obs.ServiceAccount{
+						Name: "log-collector",
+					},
+				},
+			}
+		})
+
+		It("should allow CLF when user has permission to use the SA", func() {
+			ctx := contextWithUserInfo(authenticationv1.UserInfo{Username: "admin-user"})
+			warnings, err := validator.ValidateCreate(ctx, clf)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(warnings).To(BeNil())
+		})
+
+		It("should reject CLF when user does not have permission to use the SA", func() {
+			mockSAR.allowed = false
+			ctx := contextWithUserInfo(authenticationv1.UserInfo{Username: "attacker"})
+			warnings, err := validator.ValidateCreate(ctx, clf)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not authorized to use service account"))
+			Expect(warnings).To(BeNil())
+		})
+
+		It("should allow CLF without a service account name", func() {
+			clf.Spec.ServiceAccount.Name = ""
+			ctx := contextWithUserInfo(authenticationv1.UserInfo{Username: "bob"})
+			warnings, err := validator.ValidateCreate(ctx, clf)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(warnings).To(BeNil())
+		})
+
+		It("should allow delete without checks", func() {
+			ctx := contextWithUserInfo(authenticationv1.UserInfo{Username: "bob"})
+			warnings, err := validator.ValidateDelete(ctx, clf)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(warnings).To(BeNil())
+		})
+
+		It("should validate on update the same as create", func() {
+			mockSAR.allowed = false
+			ctx := contextWithUserInfo(authenticationv1.UserInfo{Username: "attacker"})
+			oldClf := clf.DeepCopy()
+			warnings, err := validator.ValidateUpdate(ctx, oldClf, clf)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not authorized to use service account"))
+			Expect(warnings).To(BeNil())
+		})
+
+		It("should pass user groups and UID in the SAR", func() {
+			ctx := contextWithUserInfo(authenticationv1.UserInfo{
+				Username: "bob",
+				Groups:   []string{"system:authenticated", "developers"},
+				UID:      "uid-456",
+			})
+			warnings, err := validator.ValidateCreate(ctx, clf)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(warnings).To(BeNil())
+			Expect(mockSAR.lastSAR.Spec.User).To(Equal("bob"))
+			Expect(mockSAR.lastSAR.Spec.Groups).To(Equal([]string{"system:authenticated", "developers"}))
+			Expect(mockSAR.lastSAR.Spec.UID).To(Equal("uid-456"))
+		})
+
+		It("should return error when SAR creation fails", func() {
+			mockSAR.err = fmt.Errorf("API server unavailable")
+			ctx := contextWithUserInfo(authenticationv1.UserInfo{Username: "bob"})
+			warnings, err := validator.ValidateCreate(ctx, clf)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to check service account usage permission"))
+			Expect(warnings).To(BeNil())
+		})
+	})
+})
+
+type mockSARClient struct {
+	client.Client
+	allowed bool
+	err     error
+	lastSAR *authorizationapi.SubjectAccessReview
+}
+
+func (c *mockSARClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	sar, ok := obj.(*authorizationapi.SubjectAccessReview)
+	if !ok {
+		return fmt.Errorf("unexpected object type: %T", obj)
+	}
+	Expect(sar.Spec.ResourceAttributes).ToNot(BeNil())
+	Expect(sar.Spec.ResourceAttributes.Resource).To(Equal("serviceaccounts"))
+	Expect(sar.Spec.ResourceAttributes.Verb).To(Equal("use"))
+	c.lastSAR = sar
+	if c.err != nil {
+		return c.err
+	}
+	sar.Status.Allowed = c.allowed
+	return nil
+}

--- a/test/e2e/collection/sa_authorization/sa_authorization_test.go
+++ b/test/e2e/collection/sa_authorization/sa_authorization_test.go
@@ -1,0 +1,158 @@
+package sa_authorization
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
+)
+
+// This test validates CVE-2026-10609 fix:
+// Users must have 'use' permission on a ServiceAccount to reference it in a CLF
+// that forwards the SA token to outputs.
+
+var _ = Describe("[CVE-2026-10609] ServiceAccount usage authorization", func() {
+
+	const (
+		collectorSAName   = "log-collector"
+		restrictedUser    = "system:serviceaccount:%s:restricted-user"
+		clfWithSATokenFmt = `
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: sa-auth-test
+spec:
+  serviceAccount:
+    name: %s
+  outputs:
+  - name: test-output
+    type: lokiStack
+    lokiStack:
+      target:
+        name: lokistack
+        namespace: openshift-logging
+      authentication:
+        token:
+          from: serviceAccount
+  pipelines:
+  - name: test-pipeline
+    inputRefs:
+    - application
+    outputRefs:
+    - test-output
+`
+	)
+
+	var (
+		e2e      *framework.E2ETestFramework
+		deployNS string
+	)
+
+	BeforeEach(func() {
+		e2e = framework.NewE2ETestFramework()
+		deployNS = e2e.Test.NS.Name
+
+		// Create the collector SA with collect permissions
+		_, err := e2e.BuildAuthorizationFor(deployNS, collectorSAName).
+			AllowClusterRole(framework.ClusterRoleCollectApplicationLogs).
+			AllowClusterRole(framework.ClusterRoleCollectInfrastructureLogs).
+			Create()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Create a restricted user SA (used for impersonation)
+		_, err = e2e.BuildAuthorizationFor(deployNS, "restricted-user").Create()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Grant restricted-user permission to create CLFs in the namespace
+		grantCLFAccess(deployNS)
+	})
+
+	AfterEach(func() {
+		if e2e != nil {
+			e2e.Cleanup()
+		}
+	})
+
+	It("should reject CLF creation when user cannot 'use' the referenced ServiceAccount", func() {
+		user := fmt.Sprintf(restrictedUser, deployNS)
+		clfYaml := fmt.Sprintf(clfWithSATokenFmt, collectorSAName)
+
+		// Create CLF as restricted-user who does NOT have 'use' permission on the collector SA
+		out, err := ocCreateAs(deployNS, user, clfYaml)
+		Expect(err).To(HaveOccurred(), "Expected CLF creation to be rejected, but got: %s", out)
+		Expect(out).To(ContainSubstring("not authorized to use service account"))
+	})
+
+	It("should allow CLF creation when user has 'use' permission on the ServiceAccount", func() {
+		user := fmt.Sprintf(restrictedUser, deployNS)
+		clfYaml := fmt.Sprintf(clfWithSATokenFmt, collectorSAName)
+
+		// Grant 'use' permission on the collector SA to restricted-user
+		grantSAUsage(deployNS, "restricted-user", collectorSAName)
+
+		// Create CLF as restricted-user who now HAS 'use' permission
+		out, err := ocCreateAs(deployNS, user, clfYaml)
+		Expect(err).ToNot(HaveOccurred(), "Expected CLF creation to succeed, but got error: %s %v", out, err)
+	})
+})
+
+func ocCreateAs(namespace, user, yaml string) (string, error) {
+	cmd := exec.Command("oc", "create", "-n", namespace, "--as", user, "-f", "-")
+	cmd.Stdin = strings.NewReader(yaml)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func grantCLFAccess(namespace string) {
+	cmd := exec.Command("oc", "create", "role", "clf-editor",
+		"--verb=create,update,get,list,watch,delete",
+		"--resource=clusterlogforwarders.observability.openshift.io",
+		"-n", namespace)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create clf-editor role: %s %v", out, err))
+	}
+
+	cmd = exec.Command("oc", "create", "rolebinding", "restricted-user-clf-editor",
+		"--role=clf-editor",
+		"--serviceaccount="+namespace+":restricted-user",
+		"-n", namespace)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create rolebinding: %s %v", out, err))
+	}
+}
+
+func grantSAUsage(namespace, userName, saName string) {
+	// 'use' is not a standard Kubernetes verb, so 'oc create role' rejects it.
+	// Create the Role via YAML instead.
+	roleYaml := fmt.Sprintf(`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sa-user
+  namespace: %s
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  resourceNames: ["%s"]
+  verbs: ["use"]`, namespace, saName)
+
+	cmd := exec.Command("oc", "create", "-f", "-")
+	cmd.Stdin = strings.NewReader(roleYaml)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create sa-user role: %s %v", out, err))
+	}
+
+	cmd = exec.Command("oc", "create", "rolebinding", "restricted-user-sa-user",
+		"--role=sa-user",
+		"--serviceaccount="+namespace+":"+userName,
+		"-n", namespace)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create rolebinding: %s %v", out, err))
+	}
+}

--- a/test/e2e/collection/sa_authorization/suite_test.go
+++ b/test/e2e/collection/sa_authorization/suite_test.go
@@ -1,0 +1,13 @@
+package sa_authorization
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[e2e][collection][sa_authorization] Suite")
+}


### PR DESCRIPTION
## [CVE-2026-10609](https://access.redhat.com/security/cve/cve-2026-10609): Authorize ServiceAccount usage in ClusterLogForwarder

### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

This PR addresses CVE-2026-10609, a privilege escalation vulnerability where users could reference any `ServiceAccount` in a `ClusterLogForwarder (CLF)` and forward its token to external log outputs without having explicit permission to use that `ServiceAccount`.

#### Root Cause
The operator did not validate whether a user had permission to use the `ServiceAccount` specified in a CLF. This allowed privilege escalation if a cluster admin had granted a user's pod SCC permissions but not SA usage rights the user could then create a CLF to steal that SA's token.

#### Solution

- **Added a ValidatingAdmissionWebhook**: Intercepts all `CREATE` and `UPDATE` operations for `ClusterLogForwarder` resources.
- **SubjectAccessReview (SAR) Enforcement**: Performs an unconditional SAR check using the requesting user's full identity (Username, UID, and Groups) to verify they possess the use verb on the referenced `ServiceAccount`.
- **Zero-Downtime Upgrades**: Because the check is performed purely at the admission webhook level, existing CLFs already in `etcd` will continue to run without interruption upon operator upgrade.

#### Additionally
- fix a few formatting issue
- update `hack/run-linter` script shebangs to `#!/usr/bin/env bash` for better portability

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9441
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admission validation for ClusterLogForwarder resources that use ServiceAccount tokens.
  * Requests now verify authorization to use referenced ServiceAccounts.
  * Added automatic tracking of the requesting identity for auditing and validation.
  * Enabled mutating and validating webhooks for ClusterLogForwarder creation and updates.

* **Bug Fixes**
  * Preserved compatibility for resources without modifier metadata.
  * Improved permission handling for infrastructure and audit log inputs.

* **Tests**
  * Added unit and end-to-end coverage for authorized, denied, and legacy ServiceAccount usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->