### PR TITLE
fix(collector): only declare hostPath volumes when needed (LOG-9713)

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -167,16 +167,39 @@ func (f *Factory) NewPodSpec(trustedCABundle *v1.ConfigMap, spec obs.ClusterLogF
 	}
 
 	if f.isDaemonset {
-		podSpec.Volumes = append(podSpec.Volumes,
-			v1.Volume{Name: sourcePodsName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourcePodsPath}}},
-			v1.Volume{Name: sourceJournalName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceJournalPath}}},
-			v1.Volume{Name: sourceAuditdName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceAuditdPath}}},
-			v1.Volume{Name: sourceAuditOVNName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOVNPath}}},
-			v1.Volume{Name: sourceOAuthServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOAuthServerPath}}},
-			v1.Volume{Name: sourceOAuthAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOAuthAPIServerPath}}},
-			v1.Volume{Name: sourceOpenshiftAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOpenshiftAPIServerPath}}},
-			v1.Volume{Name: sourceKubeAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceKubeAPIServerPath}}},
-		)
+		inputs := internalobs.Inputs(spec.Inputs)
+		if inputs.HasContainerSource() {
+			podSpec.Volumes = append(podSpec.Volumes,
+				v1.Volume{Name: sourcePodsName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourcePodsPath}}},
+			)
+		}
+		if inputs.HasJournalSource() {
+			podSpec.Volumes = append(podSpec.Volumes,
+				v1.Volume{Name: sourceJournalName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceJournalPath}}},
+			)
+		}
+		if inputs.HasAuditSource(obs.AuditSourceAuditd) {
+			podSpec.Volumes = append(podSpec.Volumes,
+				v1.Volume{Name: sourceAuditdName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceAuditdPath}}},
+			)
+		}
+		if inputs.HasAuditSource(obs.AuditSourceKube) {
+			podSpec.Volumes = append(podSpec.Volumes,
+				v1.Volume{Name: sourceKubeAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceKubeAPIServerPath}}},
+			)
+		}
+		if inputs.HasAuditSource(obs.AuditSourceOpenShift) {
+			podSpec.Volumes = append(podSpec.Volumes,
+				v1.Volume{Name: sourceOpenshiftAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOpenshiftAPIServerPath}}},
+				v1.Volume{Name: sourceOAuthServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOAuthServerPath}}},
+				v1.Volume{Name: sourceOAuthAPIServerName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOAuthAPIServerPath}}},
+			)
+		}
+		if inputs.HasAuditSource(obs.AuditSourceOVN) {
+			podSpec.Volumes = append(podSpec.Volumes,
+				v1.Volume{Name: sourceAuditOVNName, VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: sourceOVNPath}}},
+			)
+		}
 	}
 
 	secretVolumes := AddSecretVolumes(podSpec, f.Secrets)

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -77,6 +77,11 @@ var _ = Describe("Factory#Daemonset", func() {
 			PodLabelVisitor: vector.PodLogExcludeLabel,
 		}
 		podSpec = *factory.NewPodSpec(nil, obs.ClusterLogForwarderSpec{
+			Inputs: []obs.InputSpec{
+				{Name: "app", Type: obs.InputTypeApplication},
+				{Name: "infra", Type: obs.InputTypeInfrastructure, Infrastructure: &obs.Infrastructure{}},
+				{Name: "audit", Type: obs.InputTypeAudit, Audit: &obs.Audit{}},
+			},
 			Outputs: []obs.OutputSpec{
 				{
 					Name: "myloki",


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Only declare hostPath volumes when their input sources are configured.

The collector pod spec unconditionally declares `hostPath` volumes for `audit API`, `journal` and `OVN` logs even when those inputs are not enabled. 

This fix moves the volume declarations inside the same input-source conditions that control the `volumeMounts`, so app-only collectors don't declare unnecessary `hostPath` access.

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9713
- Enhancement proposal:
