### PR TITLE
fix(vector/api): explicitly bind api and disable playground

### DIFF
--- a/internal/generator/vector/api/api.go
+++ b/internal/generator/vector/api/api.go
@@ -2,5 +2,7 @@ package api
 
 // Api is the API vector configurations
 type Api struct {
-	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+	Enabled    bool   `json:"enabled,omitempty" yaml:"enabled,omitempty" toml:"enabled,omitempty"`
+	Address    string `json:"address,omitempty" yaml:"address,omitempty" toml:"address,omitempty"`
+	Playground bool   `json:"playground" yaml:"playground" toml:"playground"`
 }

--- a/internal/generator/vector/api/config_test.go
+++ b/internal/generator/vector/api/config_test.go
@@ -15,6 +15,7 @@ data_dir = "/var/lib/vector/openshift-logging/collector"
 
 [api]
 enabled = true
+address = "127.0.0.1:8686"
 
 [log_schema]
 host_key = "hostname"
@@ -43,7 +44,9 @@ expire_metrics_secs: 60
 data_dir: "/var/lib/vector/openshift-logging/collector"
 api:
   enabled: true
-log_schema: 
+  address: "127.0.0.1:8686"
+  playground: false
+log_schema:
   host_key: "hostname"
 secret:
   kubernetes_secret:

--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -3,6 +3,7 @@ data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
 
 [api]
 enabled = true
+address = "127.0.0.1:8686"
 
 [log_schema]
 host_key = "hostname"

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -3,6 +3,7 @@ data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
 
 [api]
 enabled = true
+address = "127.0.0.1:8686"
 
 [log_schema]
 host_key = "hostname"

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -3,6 +3,7 @@ data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
 
 [api]
 enabled = true
+address = "127.0.0.1:8686"
 
 [log_schema]
 host_key = "hostname"

--- a/internal/generator/vector/conf/global.go
+++ b/internal/generator/vector/conf/global.go
@@ -12,7 +12,7 @@ func Global(c *api.Config, namespace, forwarderName string) *api.Config {
 	if dataDir == vector.DefaultDataPath {
 		dataDir = ""
 	}
-	c.Api = &api.Api{Enabled: true}
+	c.Api = &api.Api{Enabled: true, Address: "127.0.0.1:8686", Playground: false}
 	c.LogSchema = &api.LogSchema{HostKey: "hostname"}
 	c.Global = api.Global{
 		ExpireMetricsSec: 60,

--- a/internal/generator/vector/conf/global_test.go
+++ b/internal/generator/vector/conf/global_test.go
@@ -19,6 +19,7 @@ data_dir = "/var/lib/vector/openshift-logging/my-forwarder"
 
 [api]
 enabled = true
+address = "127.0.0.1:8686"
 
 [log_schema]
 host_key = "hostname"
@@ -37,10 +38,11 @@ path = "/var/run/ocp-collector/secrets"
 
 	[api]
 	enabled = true
+	address = "127.0.0.1:8686"
 
     [log_schema]
     host_key = "hostname"
-	
+
 	[secret.kubernetes_secret]
 	type = "directory"
 	path = "/var/run/ocp-collector/secrets"


### PR DESCRIPTION
ref: LOG-9711

### Description
This PR:
* explicitly binds the API endpoint to its default
* explicitly disables the API playground

### Links
https://redhat.atlassian.net/browse/LOG-9711

/cherrypick release-6.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for the API listening address and Playground availability.
  * API configurations now support explicitly binding to `127.0.0.1:8686`.
  * Playground access is disabled by default in generated configurations.

* **Bug Fixes**
  * Updated configuration handling and validation to preserve the new API settings across supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->