### PR TITLE
WIP:fix(cve): Enforce ServiceAccount use authorization via ValidatingAdmissionPolicy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,6 +311,10 @@ WAIT_FOR_OPERATOR=oc wait -n $(NAMESPACE) --for=condition=available deployment/c
 namespace:
 	echo '{"apiVersion": "v1", "kind": "Namespace","metadata":{"name":"$(NAMESPACE)","labels":{"openshift.io/cluster-monitoring":"true"}}}' | oc apply -f -
 
+.PHONY: apply-admission
+apply-admission: $(KUSTOMIZE) ## Apply the SA usage ValidatingAdmissionPolicy (for dev/e2e without waiting for operator startup).
+	$(KUSTOMIZE) build config/admission | oc apply -f -
+
 .PHONY: apply
 apply: namespace $(OPERATOR_SDK) ## Install kustomized resources directly to the cluster.
 	$(OPERATOR_SDK) generate kustomize manifests -q

--- a/api/observability/v1/clusterlogforwarder_types.go
+++ b/api/observability/v1/clusterlogforwarder_types.go
@@ -82,6 +82,11 @@ type ClusterLogForwarderSpec struct {
 
 type ServiceAccount struct {
 	// Name of the ServiceAccount to use to deploy the Forwarder.  The ServiceAccount is created by the administrator
+	// in the same namespace as the ClusterLogForwarder.
+	//
+	// Users who create or update a ClusterLogForwarder must have the 'use' verb on this ServiceAccount.
+	// The cluster logging operator installs a ValidatingAdmissionPolicy that enforces this at admission time.
+	// Cluster administrators and other identities with wildcard RBAC on ServiceAccounts are not affected.
 	//
 	// +kubebuilder:validation:Pattern:="^[a-z][a-z0-9-]{2,62}[a-z0-9]$"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="ServiceAccount Name",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:text"}

--- a/bundle/manifests/cluster-logging.clusterserviceversion.yaml
+++ b/bundle/manifests/cluster-logging.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing, Observability
     certified: "false"
     containerImage: quay.io/openshift-logging/cluster-logging-operator:latest
-    createdAt: "2026-07-15T11:39:59Z"
+    createdAt: "2026-08-12T13:43:48Z"
     description: The Red Hat OpenShift Logging Operator for OCP provides a means for
       configuring and managing log collection and forwarding.
     features.operators.openshift.io/cnf: "false"
@@ -2373,8 +2373,13 @@ spec:
           the collector pods.
         displayName: Service Account
         path: serviceAccount
-      - description: Name of the ServiceAccount to use to deploy the Forwarder.  The
-          ServiceAccount is created by the administrator
+      - description: |-
+          Name of the ServiceAccount to use to deploy the Forwarder.  The ServiceAccount is created by the administrator
+          in the same namespace as the ClusterLogForwarder.
+
+          Users who create or update a ClusterLogForwarder must have the 'use' verb on this ServiceAccount.
+          The cluster logging operator installs a ValidatingAdmissionPolicy that enforces this at admission time.
+          Cluster administrators and other identities with wildcard RBAC on ServiceAccounts are not affected.
         displayName: ServiceAccount Name
         path: serviceAccount.name
         x-descriptors:
@@ -2495,6 +2500,19 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingadmissionpolicies
+          - validatingadmissionpolicybindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - apps
           resources:

--- a/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
+++ b/bundle/manifests/observability.openshift.io_clusterlogforwarders.yaml
@@ -4616,8 +4616,13 @@ spec:
                   used by the collector pods.
                 properties:
                   name:
-                    description: Name of the ServiceAccount to use to deploy the Forwarder.  The
-                      ServiceAccount is created by the administrator
+                    description: |-
+                      Name of the ServiceAccount to use to deploy the Forwarder.  The ServiceAccount is created by the administrator
+                      in the same namespace as the ClusterLogForwarder.
+
+                      Users who create or update a ClusterLogForwarder must have the 'use' verb on this ServiceAccount.
+                      The cluster logging operator installs a ValidatingAdmissionPolicy that enforces this at admission time.
+                      Cluster administrators and other identities with wildcard RBAC on ServiceAccounts are not affected.
                     pattern: ^[a-z][a-z0-9-]{2,62}[a-z0-9]$
                     type: string
                 required:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	internalcontext "github.com/openshift/cluster-logging-operator/internal/api/context"
+	internaladmission "github.com/openshift/cluster-logging-operator/internal/admission"
 	"github.com/openshift/cluster-logging-operator/internal/collector"
 	internaltls "github.com/openshift/cluster-logging-operator/internal/tls"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -259,6 +260,11 @@ func main() {
 	}
 
 	//+kubebuilder:scaffold:builder
+
+	if err := mgr.Add(internaladmission.NewSAUsageAdmissionRunnable(mgr.GetClient())); err != nil {
+		log.Error(err, "unable to register SA usage admission runnable")
+		os.Exit(1)
+	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		log.Error(err, "unable to set up health check")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -261,7 +261,7 @@ func main() {
 
 	//+kubebuilder:scaffold:builder
 
-	if err := mgr.Add(internaladmission.NewSAUsageAdmissionRunnable(mgr.GetClient())); err != nil {
+	if err := mgr.Add(internaladmission.NewSAUsageAdmissionRunnable(k8sClient)); err != nil {
 		log.Error(err, "unable to register SA usage admission runnable")
 		os.Exit(1)
 	}

--- a/config/admission/kustomization.yaml
+++ b/config/admission/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- ../../internal/admission/manifests/clf-sa-usage-authorization.yaml
+- ../../internal/admission/manifests/clf-sa-usage-authorization-binding.yaml

--- a/config/admission/kustomization.yaml
+++ b/config/admission/kustomization.yaml
@@ -1,3 +1,2 @@
 resources:
-- ../../internal/admission/manifests/clf-sa-usage-authorization.yaml
-- ../../internal/admission/manifests/clf-sa-usage-authorization-binding.yaml
+- ../../internal/admission/manifests

--- a/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
+++ b/config/crd/bases/observability.openshift.io_clusterlogforwarders.yaml
@@ -4616,8 +4616,13 @@ spec:
                   used by the collector pods.
                 properties:
                   name:
-                    description: Name of the ServiceAccount to use to deploy the Forwarder.  The
-                      ServiceAccount is created by the administrator
+                    description: |-
+                      Name of the ServiceAccount to use to deploy the Forwarder.  The ServiceAccount is created by the administrator
+                      in the same namespace as the ClusterLogForwarder.
+
+                      Users who create or update a ClusterLogForwarder must have the 'use' verb on this ServiceAccount.
+                      The cluster logging operator installs a ValidatingAdmissionPolicy that enforces this at admission time.
+                      Cluster administrators and other identities with wildcard RBAC on ServiceAccounts are not affected.
                     pattern: ^[a-z][a-z0-9-]{2,62}[a-z0-9]$
                     type: string
                 required:

--- a/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
+++ b/config/manifests/bases/cluster-logging.clusterserviceversion.yaml
@@ -2296,8 +2296,13 @@ spec:
           the collector pods.
         displayName: Service Account
         path: serviceAccount
-      - description: Name of the ServiceAccount to use to deploy the Forwarder.  The
-          ServiceAccount is created by the administrator
+      - description: |-
+          Name of the ServiceAccount to use to deploy the Forwarder.  The ServiceAccount is created by the administrator
+          in the same namespace as the ClusterLogForwarder.
+
+          Users who create or update a ClusterLogForwarder must have the 'use' verb on this ServiceAccount.
+          The cluster logging operator installs a ValidatingAdmissionPolicy that enforces this at admission time.
+          Cluster administrators and other identities with wildcard RBAC on ServiceAccounts are not affected.
         displayName: ServiceAccount Name
         path: serviceAccount.name
         x-descriptors:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,19 @@ metadata:
   name: cluster-logging-operator
 rules:
 - apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -17,6 +17,7 @@ Open an issue in this repository
 * link:contributing/README.adoc[Contributing the Cluster Logging Operator]
 * link:contributing/REVIEW.adoc[PR Review Guidelines]
 * link:administration/troubleshooting.md[Troubleshooting the cluster logging operator]
+* link:administration/serviceaccount-authorization.adoc[ServiceAccount usage authorization]
 * link:administration/output_url_field.md[Using the clusterlogforwarder.output.url field]
 * link:contributing/how-to-add-new-output.md[How-to add a new output type]
 * link:features/logforwarding/outputs/googlecloud/google-cloud-forwarding.adoc[Forward logs to Google Cloud Logging]

--- a/docs/administration/README.adoc
+++ b/docs/administration/README.adoc
@@ -2,6 +2,7 @@
 
 * link:upgrade/v6.0_changes.adoc[Changes doc] for the new v6.0 observability API
 * link:clusterlogforwarder.adoc[Log Collection and Forwarding]
+* link:serviceaccount-authorization.adoc[ServiceAccount usage authorization]
 * link:kubernetes-api-server-impact.adoc[Kubernetes API Server Impact During Collector Restarts]
 * Enabling event collection by link:deploy-event-router.md[Deploying the Event Router]
 * link:logfilemetricexporter.adoc[Collecting Container Log Metrics]

--- a/docs/administration/clusterlogforwarder.adoc
+++ b/docs/administration/clusterlogforwarder.adoc
@@ -21,6 +21,7 @@ in response to an instance of ClusterLogForwarder:
 * an existing serviceaccount for use by the collector and referenced in the ClusterLogForwarder spec
 * the serviceaccount bound to one or more cluster roles deployed by the operator: collect-application-logs, collect-infrastructure-logs, collect-audit-logs
 * a serviceaccount token if required by any outputs
+* users who create or update the ClusterLogForwarder must have the `use` RBAC verb on the referenced ServiceAccount (enforced by a ValidatingAdmissionPolicy installed by the operator). See link:serviceaccount-authorization.adoc[ServiceAccount usage authorization] for details and examples.
 
 NOTE: Each input type defined in the ClusterLogForwarder spec must have a corresponding rolebinding for the spec to be valid
 
@@ -28,6 +29,8 @@ NOTE: Each input type defined in the ClusterLogForwarder spec must have a corres
 
 Fields are validated by the API server upon admission or update and provide immediate feedback to the user.  Additional validation
 is performed post creation and is reflected in status.
+
+When `spec.serviceAccount.name` is set, the API server also verifies that the requesting user may `use` that ServiceAccount.  Denied requests fail before the resource is stored.  Deleting a ClusterLogForwarder is not subject to this check.
 
 NOTE: The status section of the ClusterLogForwarder may provide useful information when collectors do not deploy as expected
 

--- a/docs/administration/lokistack.adoc
+++ b/docs/administration/lokistack.adoc
@@ -184,6 +184,8 @@ ClusterRoleBindings can be used to customize user access to log viewing.  More d
  oc create -n openshift-logging sa logging-admin
 ----
 +
+NOTE: Users who create or update a `ClusterLogForwarder` must have the `use` RBAC verb on the collector ServiceAccount named in `spec.serviceAccount.name`. See link:serviceaccount-authorization.adoc[ServiceAccount usage authorization].
++
 
 
 === Roles and Bindings

--- a/docs/administration/serviceaccount-authorization.adoc
+++ b/docs/administration/serviceaccount-authorization.adoc
@@ -1,0 +1,178 @@
+= ServiceAccount usage authorization
+
+When a `ClusterLogForwarder` references a collector ServiceAccount in `spec.serviceAccount.name`, the identity that creates or updates that resource must be explicitly authorized to *use* that ServiceAccount. This closes https://access.redhat.com/security/cve/CVE-2026-10609 (LOG-9441).
+
+The cluster logging operator installs and maintains a cluster-scoped https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/[ValidatingAdmissionPolicy] (VAP) at runtime. The policy is not shipped in the OLM bundle because those manifests do not support the `ValidatingAdmissionPolicy` API.
+
+== What is enforced
+
+The admission check applies when:
+
+* a `ClusterLogForwarder` is *created*, or
+* an existing `ClusterLogForwarder` is *updated*
+
+and `spec.serviceAccount.name` is set to a non-empty value in the same namespace as the forwarder.
+
+The check does *not* apply when:
+
+* `spec.serviceAccount` is omitted or `spec.serviceAccount.name` is empty
+* a `ClusterLogForwarder` is *deleted* (delete is not matched by the policy)
+
+If the user is not allowed to `use` the referenced ServiceAccount, the API server rejects the request with a message similar to:
+
+[source]
+----
+User is not authorized to use the referenced ServiceAccount.
+A Role granting the 'use' verb on the ServiceAccount is required.
+----
+
+== Operator-managed resources
+
+After the operator starts, it reconciles these cluster-scoped objects once (on the elected leader):
+
+[options="header"]
+|======
+|Resource | Name
+|ValidatingAdmissionPolicy | `clf-sa-usage-authorization`
+|ValidatingAdmissionPolicyBinding | `clf-sa-usage-authorization-binding`
+|======
+
+Verify they exist:
+
+[source,sh]
+----
+oc get validatingadmissionpolicy clf-sa-usage-authorization
+oc get validatingadmissionpolicybinding clf-sa-usage-authorization-binding
+----
+
+If the ValidatingAdmissionPolicy API is unavailable on the cluster, the operator logs that reconciliation was skipped and does not fail startup.
+
+For local development or manual testing before the operator has reconciled, you can apply the same manifests with:
+
+[source,sh]
+----
+make apply-admission
+----
+
+== Two layers of authorization
+
+Administrators should distinguish admission enforcement from operator status validation:
+
+.Admission (ValidatingAdmissionPolicy)
+* Checks whether the *user submitting the CLF* has RBAC `use` on the referenced ServiceAccount.
+* Evaluated by the API server at create/update time.
+
+.Operator reconciliation (`Authorized` status)
+* Checks whether the *collector ServiceAccount* is bound to the `collect-*-logs` ClusterRoles required by the CLF inputs.
+* Evaluated asynchronously and reflected in `.status.conditions`.
+
+A CLF can be admitted successfully but still report `Not Ready` / `Unauthorized` if the collector ServiceAccount lacks collect permissions. That is expected when testing admission only.
+
+== Granting access to delegated users
+
+Cluster administrators can create or update any `ClusterLogForwarder` that references a ServiceAccount they can `use`. Identities with wildcard RBAC on ServiceAccounts (for example `cluster-admin`) satisfy the check without an extra Role.
+
+To allow a namespace user to manage forwarders that run as a dedicated collector ServiceAccount, grant both:
+
+. Permission to manage `ClusterLogForwarder` objects in the namespace
+. Permission to `use` the collector ServiceAccount by name
+
+=== Example
+
+The following example allows the `restricted-user` ServiceAccount in namespace `team-a` to create and update forwarders that reference the `log-collector` ServiceAccount in the same namespace.
+
+.Collector ServiceAccount
+[source,sh]
+----
+oc create -n team-a sa log-collector
+oc create -n team-a sa restricted-user
+----
+
+.Bind collect ClusterRoles to the collector ServiceAccount
+[source,sh]
+----
+oc adm policy add-cluster-role-to-user collect-application-logs -z log-collector -n team-a
+----
+
+.Role allowing CLF create/update in the namespace
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: clf-editor
+  namespace: team-a
+rules:
+- apiGroups: ["observability.openshift.io"]
+  resources: ["clusterlogforwarders"]
+  verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: restricted-user-clf-editor
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: clf-editor
+subjects:
+- kind: ServiceAccount
+  name: restricted-user
+  namespace: team-a
+----
+
+.Role granting `use` on the collector ServiceAccount
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sa-user
+  namespace: team-a
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  resourceNames: ["log-collector"]
+  verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: restricted-user-sa-user
+  namespace: team-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sa-user
+subjects:
+- kind: ServiceAccount
+  name: restricted-user
+  namespace: team-a
+----
+
+NOTE: The `use` verb is not accepted by `oc create role --verb=...`; define the Role with YAML as shown above.
+
+Without the `sa-user` Role, create and update requests are denied even if the user can otherwise edit `ClusterLogForwarder` resources.
+
+== Existing ClusterLogForwarder instances
+
+Forwarders that already exist when the policy is installed continue to run. The VAP does not retroactively delete resources. Enforcement applies the next time a user without `use` permission attempts to create a forwarder or update one that references a ServiceAccount they cannot use.
+
+== Testing
+
+.Manual script
+[source,sh]
+----
+./hack/test-sa-authorization.sh
+----
+
+The script verifies create denied, create allowed, update denied, and delete allowed without requiring a ready collector or LokiStack.
+
+.Automated e2e
+[source,sh]
+----
+ginkgo test/e2e/collection/sa_authorization/
+----
+
+See also link:troubleshooting.md[Troubleshooting] for common denial messages.

--- a/docs/administration/serviceaccount-authorization.adoc
+++ b/docs/administration/serviceaccount-authorization.adoc
@@ -153,7 +153,7 @@ subjects:
 
 NOTE: The `use` verb is not accepted by `oc create role --verb=...`; define the Role with YAML as shown above.
 
-Without the `sa-user` Role, create and update requests are denied even if the user can otherwise edit `ClusterLogForwarder` resources.
+Without a Role, ClusterRole, or wildcard binding that grants `use` on the collector ServiceAccount, create and update requests for `ClusterLogForwarder` resources are denied even if the user can otherwise edit those resources in the namespace.
 
 == Existing ClusterLogForwarder instances
 

--- a/docs/administration/troubleshooting.md
+++ b/docs/administration/troubleshooting.md
@@ -44,3 +44,37 @@ Does it have a newline character at the end? If not, the application writing the
 
 **Check the source application**: Ensure that the application generating the logs is configured to append a newline character 
 (\n) to every log entry. This is standard practice for most logging libraries and systems.
+
+### 3. ClusterLogForwarder create or update denied: `not authorized to use the referenced ServiceAccount`
+
+The cluster logging operator installs a ValidatingAdmissionPolicy that requires the identity creating or updating a `ClusterLogForwarder` to have the `use` verb on the ServiceAccount named in `spec.serviceAccount.name`.
+
+**Common causes**
+
+- A namespace-scoped user can edit `ClusterLogForwarder` resources but was not granted `use` on the collector ServiceAccount.
+- An update changes `spec.serviceAccount.name` to a ServiceAccount the user cannot use.
+- The ValidatingAdmissionPolicy is active but RBAC was never updated for delegated administrators.
+
+**What to do**
+
+1. Confirm the policy is present (operator must be running):
+
+   ```sh
+   oc get validatingadmissionpolicy clf-sa-usage-authorization
+   oc get validatingadmissionpolicybinding clf-sa-usage-authorization-binding
+   ```
+
+2. Grant `use` on the collector ServiceAccount to the user or ServiceAccount that manages the CLF. Example Role rule:
+
+   ```yaml
+   - apiGroups: [""]
+     resources: ["serviceaccounts"]
+     resourceNames: ["log-collector"]
+     verbs: ["use"]
+   ```
+
+3. Ensure CLF management Roles include `patch` if users update forwarders with `oc patch` or similar APIs.
+
+4. Remember that admission `use` checks are separate from collector `Authorized` status: a CLF may be admitted while status still reports missing `collect-*-logs` ClusterRoleBindings for the collector ServiceAccount.
+
+See [ServiceAccount usage authorization](serviceaccount-authorization.adoc) for a full walkthrough and `./hack/test-sa-authorization.sh` for a lightweight verification script.

--- a/docs/features/collection.adoc
+++ b/docs/features/collection.adoc
@@ -97,6 +97,7 @@ a|
 |https://issues.redhat.com/browse/LOG-3270[TLS Security Profile Compliance]
 |Comply with OCP cluster-wide cryptographic profiles for internal communication and allow configuration of outbound connection profiles. See link:./tls_security_profile.adoc[details]
 |https://issues.redhat.com/browse/LOG-7571[Network Policy]| Network policy in place for the collectors that allows all egress and ingress.
+|link:../administration/serviceaccount-authorization.adoc[ServiceAccount usage authorization]|ValidatingAdmissionPolicy requires `use` RBAC on `spec.serviceAccount.name` when creating or updating a ClusterLogForwarder (CVE-2026-10609)
 |======
 
 === Tuning

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -61,6 +61,7 @@ Type:: object
 |networkPolicy|object|  Define the Network Policy for the Collector
 |nodeSelector|object|  Define nodes for scheduling the pods.
 |resources|object|  The resource requirements for the collector
+|terminationGracePeriodSeconds|int|  TerminationGracePeriodSeconds defines the termination grace period for collector pods in seconds. If not specified, the default is 10 seconds.
 |tolerations|array|  Define the tolerations the collector pods will accept
 |======================
 
@@ -650,6 +651,10 @@ Type:: object
 === .spec.collector.resources.requests
 
 Type:: object
+
+=== .spec.collector.terminationGracePeriodSeconds
+
+Type:: int
 
 === .spec.collector.tolerations[]
 
@@ -3272,7 +3277,7 @@ Type:: object
 [options="header"]
 |======================
 |Property|Type|Description
-|name|string|  Name of the ServiceAccount to use to deploy the Forwarder.  The ServiceAccount is created by the administrator
+|name|string|  Name of the ServiceAccount to use to deploy the Forwarder.  The ServiceAccount is created by the administrator in the same namespace as the ClusterLogForwarder. Users who create or update a ClusterLogForwarder must have the &#39;use&#39; verb on this ServiceAccount. The cluster logging operator installs a ValidatingAdmissionPolicy that enforces this at admission time. Cluster administrators and other identities with wildcard RBAC on ServiceAccounts are not affected.
 |======================
 
 === .status

--- a/hack/test-sa-authorization.sh
+++ b/hack/test-sa-authorization.sh
@@ -216,6 +216,15 @@ test_update_denied_without_use() {
     fail "CLF update was denied but message was unexpected: ${out}"
   fi
   pass "update denied without 'use'"
+
+  info "Test: update CLF with 'use' on ServiceAccount should succeed"
+  grant_sa_usage
+  if ! out="$("${OC}" patch clusterlogforwarder "${CLF_NAME}" -n "${NS}" \
+    --as="$(restricted_user)" \
+    --type=merge -p '{"metadata":{"annotations":{"sa-auth-test":"update-allowed"}}}' 2>&1)"; then
+    fail "CLF update failed but was expected to succeed: ${out}"
+  fi
+  pass "update allowed with 'use'"
 }
 
 test_delete_allowed_without_use() {

--- a/hack/test-sa-authorization.sh
+++ b/hack/test-sa-authorization.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+#
+# Manual test for CVE-2026-10609 / LOG-9441:
+# ValidatingAdmissionPolicy enforces 'use' on ServiceAccounts referenced in CLFs.
+#
+# This script is intentionally lightweight: it verifies admission only (create/update
+# deny/allow). The CLF may show Not Ready / Unauthorized in status because the test
+# does not bind collect-log ClusterRoles or deploy LokiStack — that is expected.
+#
+# Prerequisites:
+#   - oc logged in to a cluster
+#   - cluster-logging-operator running with SA usage VAP reconciliation enabled
+#
+# Usage:
+#   ./hack/test-sa-authorization.sh
+#   NS=my-test ./hack/test-sa-authorization.sh
+#   ./hack/test-sa-authorization.sh --no-cleanup
+#   ./hack/test-sa-authorization.sh --keep-clf
+#   ./hack/test-sa-authorization.sh --cleanup-only
+#
+set -euo pipefail
+
+OC="${OC:-oc}"
+NS="${NS:-sa-auth-manual-test}"
+COLLECTOR_SA="${COLLECTOR_SA:-log-collector}"
+RESTRICTED_SA="${RESTRICTED_SA:-restricted-user}"
+CLF_NAME="${CLF_NAME:-sa-auth-test}"
+CLEANUP_ONLY=false
+NO_CLEANUP=false
+KEEP_CLF=false
+
+usage() {
+  sed -n '2,15p' "$0" | sed 's/^# \?//'
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage 0 ;;
+    --cleanup-only) CLEANUP_ONLY=true; shift ;;
+    --no-cleanup) NO_CLEANUP=true; shift ;;
+    --keep-clf) KEEP_CLF=true; NO_CLEANUP=true; shift ;;
+    *) echo "Unknown option: $1" >&2; usage 1 ;;
+  esac
+done
+
+pass() { echo "[PASS] $*"; }
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+info() { echo "[INFO] $*"; }
+
+wait_for_namespace_gone() {
+  if ! "${OC}" get ns "${NS}" >/dev/null 2>&1; then
+    return 0
+  fi
+  info "Waiting for namespace ${NS} to finish terminating"
+  local deadline=$((SECONDS + 120))
+  while "${OC}" get ns "${NS}" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      fail "timed out waiting for namespace ${NS} to be deleted"
+    fi
+    sleep 2
+  done
+}
+
+wait_for_namespace_active() {
+  local deadline=$((SECONDS + 60))
+  while true; do
+    phase="$("${OC}" get ns "${NS}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")"
+    if [[ "${phase}" == "Active" ]]; then
+      return 0
+    fi
+    if (( SECONDS >= deadline )); then
+      fail "namespace ${NS} not Active (phase=${phase:-missing})"
+    fi
+    sleep 1
+  done
+}
+
+cleanup() {
+  info "Cleaning up namespace ${NS}"
+  if "${OC}" get ns "${NS}" >/dev/null 2>&1; then
+    "${OC}" delete ns "${NS}" --wait=true --timeout=120s
+  fi
+  wait_for_namespace_gone
+}
+
+restricted_user() {
+  echo "system:serviceaccount:${NS}:${RESTRICTED_SA}"
+}
+
+clf_yaml() {
+  cat <<EOF
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: ${CLF_NAME}
+spec:
+  serviceAccount:
+    name: ${COLLECTOR_SA}
+  outputs:
+  - name: test-output
+    type: lokiStack
+    lokiStack:
+      target:
+        name: lokistack
+        namespace: openshift-logging
+      authentication:
+        token:
+          from: serviceAccount
+  pipelines:
+  - name: test-pipeline
+    inputRefs:
+    - application
+    outputRefs:
+    - test-output
+EOF
+}
+
+oc_create_clf_as_restricted() {
+  clf_yaml | "${OC}" create -n "${NS}" --as="$(restricted_user)" -f - 2>&1
+}
+
+grant_clf_access() {
+  "${OC}" create role clf-editor -n "${NS}" \
+    --verb=create,update,patch,get,list,watch,delete \
+    --resource=clusterlogforwarders.observability.openshift.io \
+    --dry-run=client -o yaml | "${OC}" apply -f -
+
+  "${OC}" create rolebinding restricted-user-clf-editor -n "${NS}" \
+    --role=clf-editor \
+    --serviceaccount="${NS}:${RESTRICTED_SA}" \
+    --dry-run=client -o yaml | "${OC}" apply -f -
+}
+
+grant_sa_usage() {
+  cat <<EOF | "${OC}" apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sa-user
+  namespace: ${NS}
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  resourceNames: ["${COLLECTOR_SA}"]
+  verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: restricted-user-sa-user
+  namespace: ${NS}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sa-user
+subjects:
+- kind: ServiceAccount
+  name: ${RESTRICTED_SA}
+  namespace: ${NS}
+EOF
+}
+
+revoke_sa_usage() {
+  "${OC}" delete rolebinding restricted-user-sa-user -n "${NS}" --ignore-not-found >/dev/null 2>&1 || true
+  "${OC}" delete role sa-user -n "${NS}" --ignore-not-found >/dev/null 2>&1 || true
+}
+
+check_vap() {
+  info "Checking ValidatingAdmissionPolicy resources"
+  "${OC}" get validatingadmissionpolicy clf-sa-usage-authorization >/dev/null
+  "${OC}" get validatingadmissionpolicybinding clf-sa-usage-authorization-binding >/dev/null
+  pass "VAP and binding exist"
+}
+
+setup_namespace() {
+  wait_for_namespace_gone
+  info "Setting up namespace ${NS}"
+  "${OC}" create ns "${NS}"
+  wait_for_namespace_active
+  "${OC}" create sa "${COLLECTOR_SA}" -n "${NS}"
+  "${OC}" create sa "${RESTRICTED_SA}" -n "${NS}"
+  grant_clf_access
+}
+
+test_create_denied_without_use() {
+  info "Test: create CLF without 'use' on ServiceAccount should be denied"
+  revoke_sa_usage
+  if out="$(oc_create_clf_as_restricted)"; then
+    fail "CLF create succeeded but was expected to be denied. Output: ${out}"
+  fi
+  if ! grep -qi 'not authorized to use' <<<"${out}"; then
+    fail "CLF create was denied but message was unexpected: ${out}"
+  fi
+  pass "create denied without 'use'"
+}
+
+test_create_allowed_with_use() {
+  info "Test: create CLF with 'use' on ServiceAccount should succeed"
+  grant_sa_usage
+  if ! out="$(oc_create_clf_as_restricted 2>&1)"; then
+    fail "CLF create failed but was expected to succeed: ${out}"
+  fi
+  pass "create allowed with 'use'"
+}
+
+test_update_denied_without_use() {
+  info "Test: update CLF without 'use' should be denied"
+  revoke_sa_usage
+  if out="$("${OC}" patch clusterlogforwarder "${CLF_NAME}" -n "${NS}" \
+    --as="$(restricted_user)" \
+    --type=merge -p '{"metadata":{"annotations":{"sa-auth-test":"update-attempt"}}}' 2>&1)"; then
+    fail "CLF update succeeded but was expected to be denied. Output: ${out}"
+  fi
+  if ! grep -qi 'not authorized to use' <<<"${out}"; then
+    fail "CLF update was denied but message was unexpected: ${out}"
+  fi
+  pass "update denied without 'use'"
+}
+
+test_delete_allowed_without_use() {
+  info "Test: delete CLF without 'use' should still succeed"
+  if ! "${OC}" delete clusterlogforwarder "${CLF_NAME}" -n "${NS}" \
+    --as="$(restricted_user)" --ignore-not-found >/dev/null; then
+    fail "CLF delete failed but was expected to succeed"
+  fi
+  pass "delete allowed without 'use'"
+}
+
+main() {
+  if ! command -v "${OC}" >/dev/null 2>&1; then
+    fail "oc not found in PATH (set OC=... if needed)"
+  fi
+  if ! "${OC}" whoami >/dev/null 2>&1; then
+    fail "not logged in to cluster (${OC} whoami failed)"
+  fi
+
+  if [[ "${CLEANUP_ONLY}" == true ]]; then
+    cleanup || true
+    pass "cleanup complete"
+    exit 0
+  fi
+
+  check_vap
+  setup_namespace
+  test_create_denied_without_use
+  test_create_allowed_with_use
+  test_update_denied_without_use
+  if [[ "${KEEP_CLF}" == false ]]; then
+    test_delete_allowed_without_use
+  else
+    info "Skipping delete test (--keep-clf); CLF ${CLF_NAME} remains in ${NS}"
+    "${OC}" get clusterlogforwarder "${CLF_NAME}" -n "${NS}" >/dev/null
+    pass "CLF ${CLF_NAME} exists in namespace ${NS}"
+  fi
+
+  echo
+  pass "all manual SA authorization tests passed"
+  info "CLF may be Not Ready afterward — that is expected for this lightweight admission test"
+
+  if [[ "${NO_CLEANUP}" == false ]]; then
+    cleanup
+    info "namespace ${NS} removed"
+  else
+    info "leaving namespace ${NS} (--no-cleanup)"
+  fi
+}
+
+main "$@"

--- a/internal/admission/manifests/clf-sa-usage-authorization-binding.yaml
+++ b/internal/admission/manifests/clf-sa-usage-authorization-binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: clf-sa-usage-authorization-binding
+spec:
+  policyName: clf-sa-usage-authorization
+  validationActions: [Deny]
+  matchResources: {}

--- a/internal/admission/manifests/clf-sa-usage-authorization.yaml
+++ b/internal/admission/manifests/clf-sa-usage-authorization.yaml
@@ -1,0 +1,21 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: clf-sa-usage-authorization
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["observability.openshift.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["clusterlogforwarders"]
+  validations:
+    - expression: >-
+        !has(object.spec.serviceAccount) ||
+        !has(object.spec.serviceAccount.name) ||
+        object.spec.serviceAccount.name == '' ||
+        authorizer.group('').resource('serviceaccounts').namespace(object.metadata.namespace).name(object.spec.serviceAccount.name).check('use').allowed()
+      message: >-
+        User is not authorized to use the referenced ServiceAccount.
+        A Role granting the 'use' verb on the ServiceAccount is required.

--- a/internal/admission/manifests/kustomization.yaml
+++ b/internal/admission/manifests/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- clf-sa-usage-authorization.yaml
+- clf-sa-usage-authorization-binding.yaml

--- a/internal/admission/runnable.go
+++ b/internal/admission/runnable.go
@@ -2,10 +2,19 @@ package admission
 
 import (
 	"context"
+	"time"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var saUsageReconcileBackoff = wait.Backoff{
+	Steps:    5,
+	Duration: 2 * time.Second,
+	Factor:   2.0,
+	Cap:      30 * time.Second,
+}
 
 type saUsageAdmissionRunnable struct {
 	client client.Client
@@ -19,9 +28,28 @@ func NewSAUsageAdmissionRunnable(k8sClient client.Client) *saUsageAdmissionRunna
 
 func (r *saUsageAdmissionRunnable) Start(ctx context.Context) error {
 	log.Info("Reconciling SA usage ValidatingAdmissionPolicy")
-	if err := ReconcileSAUsageAuthorization(ctx, r.client); err != nil {
-		log.Error(err, "unable to reconcile SA usage ValidatingAdmissionPolicy")
-		return err
+
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, saUsageReconcileBackoff, func(ctx context.Context) (bool, error) {
+		lastErr = ReconcileSAUsageAuthorization(ctx, r.client)
+		if lastErr == nil {
+			return true, nil
+		}
+		if isUnsupportedAdmissionPolicyAPI(lastErr) {
+			lastErr = nil
+			return true, nil
+		}
+		log.V(1).Info("retrying SA usage ValidatingAdmissionPolicy reconciliation", "error", lastErr)
+		return false, nil
+	})
+	if err != nil && !wait.Interrupted(err) {
+		if lastErr != nil {
+			log.Error(lastErr, "unable to reconcile SA usage ValidatingAdmissionPolicy", "reason", err)
+		}
+		return nil
+	}
+	if lastErr != nil {
+		log.Error(lastErr, "unable to reconcile SA usage ValidatingAdmissionPolicy after retries")
 	}
 	return nil
 }

--- a/internal/admission/runnable.go
+++ b/internal/admission/runnable.go
@@ -1,0 +1,32 @@
+package admission
+
+import (
+	"context"
+
+	log "github.com/ViaQ/logerr/v2/log/static"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type saUsageAdmissionRunnable struct {
+	client client.Client
+}
+
+// NewSAUsageAdmissionRunnable reconciles the SA usage ValidatingAdmissionPolicy once
+// the manager (and its cache) has started.
+func NewSAUsageAdmissionRunnable(k8sClient client.Client) *saUsageAdmissionRunnable {
+	return &saUsageAdmissionRunnable{client: k8sClient}
+}
+
+func (r *saUsageAdmissionRunnable) Start(ctx context.Context) error {
+	log.Info("Reconciling SA usage ValidatingAdmissionPolicy")
+	if err := ReconcileSAUsageAuthorization(ctx, r.client); err != nil {
+		log.Error(err, "unable to reconcile SA usage ValidatingAdmissionPolicy")
+		return err
+	}
+	return nil
+}
+
+// NeedLeaderElection ensures only the elected operator pod manages cluster-scoped admission policy.
+func (r *saUsageAdmissionRunnable) NeedLeaderElection() bool {
+	return true
+}

--- a/internal/admission/sa_usage_policy.go
+++ b/internal/admission/sa_usage_policy.go
@@ -3,12 +3,15 @@ package admission
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 
 	log "github.com/ViaQ/logerr/v2/log/static"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/yaml"
@@ -114,5 +117,15 @@ func reconcileValidatingAdmissionPolicyBinding(ctx context.Context, k8sClient cl
 }
 
 func isUnsupportedAdmissionPolicyAPI(err error) bool {
-	return meta.IsNoMatchError(err)
+	if err == nil {
+		return false
+	}
+	if meta.IsNoMatchError(err) {
+		return true
+	}
+	if apiruntime.IsNotRegisteredError(err) {
+		return true
+	}
+	var groupDiscoveryErr *discovery.ErrGroupDiscoveryFailed
+	return errors.As(err, &groupDiscoveryErr)
 }

--- a/internal/admission/sa_usage_policy.go
+++ b/internal/admission/sa_usage_policy.go
@@ -1,0 +1,118 @@
+package admission
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	log "github.com/ViaQ/logerr/v2/log/static"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	SAUsagePolicyName        = "clf-sa-usage-authorization"
+	SAUsagePolicyBindingName = "clf-sa-usage-authorization-binding"
+)
+
+//go:embed manifests/clf-sa-usage-authorization.yaml
+var saUsagePolicyYAML []byte
+
+//go:embed manifests/clf-sa-usage-authorization-binding.yaml
+var saUsagePolicyBindingYAML []byte
+
+// ReconcileSAUsageAuthorization ensures the cluster-scoped ValidatingAdmissionPolicy
+// that authorizes ServiceAccount usage in ClusterLogForwarder resources exists.
+func ReconcileSAUsageAuthorization(ctx context.Context, k8sClient client.Client) error {
+	policy, err := desiredSAUsagePolicy()
+	if err != nil {
+		return err
+	}
+	if err := reconcileValidatingAdmissionPolicy(ctx, k8sClient, policy); err != nil {
+		return err
+	}
+
+	binding, err := desiredSAUsagePolicyBinding()
+	if err != nil {
+		return err
+	}
+	return reconcileValidatingAdmissionPolicyBinding(ctx, k8sClient, binding)
+}
+
+func desiredSAUsagePolicy() (*admissionregistrationv1.ValidatingAdmissionPolicy, error) {
+	return decodeValidatingAdmissionPolicy(saUsagePolicyYAML)
+}
+
+func desiredSAUsagePolicyBinding() (*admissionregistrationv1.ValidatingAdmissionPolicyBinding, error) {
+	return decodeValidatingAdmissionPolicyBinding(saUsagePolicyBindingYAML)
+}
+
+func decodeValidatingAdmissionPolicy(raw []byte) (*admissionregistrationv1.ValidatingAdmissionPolicy, error) {
+	policy := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+	if err := yaml.Unmarshal(raw, policy); err != nil {
+		return nil, fmt.Errorf("decode ValidatingAdmissionPolicy: %w", err)
+	}
+	return policy, nil
+}
+
+func decodeValidatingAdmissionPolicyBinding(raw []byte) (*admissionregistrationv1.ValidatingAdmissionPolicyBinding, error) {
+	binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+	if err := yaml.Unmarshal(raw, binding); err != nil {
+		return nil, fmt.Errorf("decode ValidatingAdmissionPolicyBinding: %w", err)
+	}
+	return binding, nil
+}
+
+func reconcileValidatingAdmissionPolicy(ctx context.Context, k8sClient client.Client, desired *admissionregistrationv1.ValidatingAdmissionPolicy) error {
+	current := &admissionregistrationv1.ValidatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: desired.Name,
+		},
+	}
+
+	op, err := controllerutil.CreateOrUpdate(ctx, k8sClient, current, func() error {
+		current.Spec = desired.Spec
+		return nil
+	})
+	if err != nil {
+		if isUnsupportedAdmissionPolicyAPI(err) {
+			log.Info("ValidatingAdmissionPolicy API is unavailable; skipping SA usage authorization policy")
+			return nil
+		}
+		return fmt.Errorf("reconcile ValidatingAdmissionPolicy %q: %w", desired.Name, err)
+	}
+
+	log.V(3).Info("reconciled ValidatingAdmissionPolicy", "name", desired.Name, "operation", op)
+	return nil
+}
+
+func reconcileValidatingAdmissionPolicyBinding(ctx context.Context, k8sClient client.Client, desired *admissionregistrationv1.ValidatingAdmissionPolicyBinding) error {
+	current := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: desired.Name,
+		},
+	}
+
+	op, err := controllerutil.CreateOrUpdate(ctx, k8sClient, current, func() error {
+		current.Spec = desired.Spec
+		return nil
+	})
+	if err != nil {
+		if isUnsupportedAdmissionPolicyAPI(err) {
+			log.Info("ValidatingAdmissionPolicyBinding API is unavailable; skipping SA usage authorization binding")
+			return nil
+		}
+		return fmt.Errorf("reconcile ValidatingAdmissionPolicyBinding %q: %w", desired.Name, err)
+	}
+
+	log.V(3).Info("reconciled ValidatingAdmissionPolicyBinding", "name", desired.Name, "operation", op)
+	return nil
+}
+
+func isUnsupportedAdmissionPolicyAPI(err error) bool {
+	return meta.IsNoMatchError(err)
+}

--- a/internal/admission/sa_usage_policy_test.go
+++ b/internal/admission/sa_usage_policy_test.go
@@ -1,0 +1,74 @@
+package admission
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAdmission(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[internal][admission] Suite")
+}
+
+var _ = Describe("SA usage ValidatingAdmissionPolicy", func() {
+	var (
+		ctx        context.Context
+		fakeClient client.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme := runtime.NewScheme()
+		Expect(admissionregistrationv1.AddToScheme(scheme)).To(Succeed())
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+	})
+
+	It("creates the policy and binding from embedded manifests", func() {
+		Expect(ReconcileSAUsageAuthorization(ctx, fakeClient)).To(Succeed())
+
+		policy := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: SAUsagePolicyName}, policy)).To(Succeed())
+		Expect(policy.Spec.FailurePolicy).ToNot(BeNil())
+		Expect(*policy.Spec.FailurePolicy).To(Equal(admissionregistrationv1.Fail))
+		Expect(policy.Spec.Validations).To(HaveLen(1))
+		Expect(policy.Spec.Validations[0].Message).To(ContainSubstring("not authorized to use the referenced ServiceAccount"))
+
+		binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: SAUsagePolicyBindingName}, binding)).To(Succeed())
+		Expect(binding.Spec.PolicyName).To(Equal(SAUsagePolicyName))
+		Expect(binding.Spec.ValidationActions).To(ContainElement(admissionregistrationv1.Deny))
+	})
+
+	It("updates an existing policy when the spec changes", func() {
+		Expect(ReconcileSAUsageAuthorization(ctx, fakeClient)).To(Succeed())
+
+		policy := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: SAUsagePolicyName}, policy)).To(Succeed())
+		policy.Spec.FailurePolicy = nil
+		Expect(fakeClient.Update(ctx, policy)).To(Succeed())
+
+		Expect(ReconcileSAUsageAuthorization(ctx, fakeClient)).To(Succeed())
+
+		Expect(fakeClient.Get(ctx, client.ObjectKey{Name: SAUsagePolicyName}, policy)).To(Succeed())
+		Expect(policy.Spec.FailurePolicy).ToNot(BeNil())
+		Expect(*policy.Spec.FailurePolicy).To(Equal(admissionregistrationv1.Fail))
+	})
+
+	It("decodes the embedded manifests with expected metadata", func() {
+		policy, err := desiredSAUsagePolicy()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(policy.Name).To(Equal(SAUsagePolicyName))
+
+		binding, err := desiredSAUsagePolicyBinding()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(binding.Name).To(Equal(SAUsagePolicyBindingName))
+		Expect(binding.Spec.PolicyName).To(Equal(SAUsagePolicyName))
+	})
+})

--- a/internal/admission/sa_usage_policy_test.go
+++ b/internal/admission/sa_usage_policy_test.go
@@ -2,12 +2,16 @@ package admission
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/api/meta"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -25,7 +29,7 @@ var _ = Describe("SA usage ValidatingAdmissionPolicy", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		scheme := runtime.NewScheme()
+		scheme := apiruntime.NewScheme()
 		Expect(admissionregistrationv1.AddToScheme(scheme)).To(Succeed())
 		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
 	})
@@ -70,5 +74,20 @@ var _ = Describe("SA usage ValidatingAdmissionPolicy", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(binding.Name).To(Equal(SAUsagePolicyBindingName))
 		Expect(binding.Spec.PolicyName).To(Equal(SAUsagePolicyName))
+	})
+
+	It("recognizes unsupported admission policy API errors", func() {
+		Expect(isUnsupportedAdmissionPolicyAPI(&meta.NoKindMatchError{
+			GroupKind: schema.GroupKind{Group: admissionregistrationv1.GroupName, Kind: "ValidatingAdmissionPolicy"},
+		})).To(BeTrue())
+		Expect(isUnsupportedAdmissionPolicyAPI(apiruntime.NewNotRegisteredErrForKind(
+			"test", schema.GroupVersionKind{Group: admissionregistrationv1.GroupName, Version: "v1", Kind: "ValidatingAdmissionPolicy"},
+		))).To(BeTrue())
+		Expect(isUnsupportedAdmissionPolicyAPI(&discovery.ErrGroupDiscoveryFailed{
+			Groups: map[schema.GroupVersion]error{
+				{Group: admissionregistrationv1.GroupName, Version: "v1"}: fmt.Errorf("discovery failed"),
+			},
+		})).To(BeTrue())
+		Expect(isUnsupportedAdmissionPolicyAPI(fmt.Errorf("forbidden"))).To(BeFalse())
 	})
 })

--- a/internal/controller/kubebuilder_rbac.go
+++ b/internal/controller/kubebuilder_rbac.go
@@ -3,6 +3,7 @@ package controller
 // This file collects all the "kubebuilder rbac annotations" that the controllers contained
 // in this operator need to function.
 
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingadmissionpolicies;validatingadmissionpolicybindings,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets,verbs=*
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups=config.openshift.io,resources=proxies;infrastructures,verbs=get;list;watch

--- a/test/e2e/collection/sa_authorization/sa_authorization_test.go
+++ b/test/e2e/collection/sa_authorization/sa_authorization_test.go
@@ -1,0 +1,201 @@
+package sa_authorization
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/cluster-logging-operator/internal/admission"
+	framework "github.com/openshift/cluster-logging-operator/test/framework/e2e"
+)
+
+// This test validates CVE-2026-10609 fix:
+// A ValidatingAdmissionPolicy enforces that users must have 'use' permission
+// on a ServiceAccount to reference it in a ClusterLogForwarder.
+//
+// It mirrors hack/test-sa-authorization.sh: admission-only checks without
+// collector RBAC or a ready CLF status.
+
+var _ = Describe("[CVE-2026-10609] ServiceAccount usage authorization", Ordered, func() {
+
+	const (
+		clfName           = "sa-auth-test"
+		collectorSAName   = "log-collector"
+		restrictedUser    = "system:serviceaccount:%s:restricted-user"
+		clfWithSATokenFmt = `
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: sa-auth-test
+spec:
+  serviceAccount:
+    name: %s
+  outputs:
+  - name: test-output
+    type: lokiStack
+    lokiStack:
+      target:
+        name: lokistack
+        namespace: openshift-logging
+      authentication:
+        token:
+          from: serviceAccount
+  pipelines:
+  - name: test-pipeline
+    inputRefs:
+    - application
+    outputRefs:
+    - test-output
+`
+	)
+
+	var (
+		e2e      *framework.E2ETestFramework
+		deployNS string
+		user     string
+		clfYaml  string
+	)
+
+	BeforeAll(func() {
+		e2e = framework.NewE2ETestFramework()
+		deployNS = e2e.Test.NS.Name
+		user = fmt.Sprintf(restrictedUser, deployNS)
+		clfYaml = fmt.Sprintf(clfWithSATokenFmt, collectorSAName)
+
+		checkVAPInstalled()
+
+		_, err := e2e.BuildAuthorizationFor(deployNS, collectorSAName).Create()
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = e2e.BuildAuthorizationFor(deployNS, "restricted-user").Create()
+		Expect(err).ToNot(HaveOccurred())
+
+		grantCLFAccess(deployNS)
+	})
+
+	AfterAll(func() {
+		if e2e != nil {
+			e2e.Cleanup()
+		}
+	})
+
+	It("should reject CLF creation when user cannot 'use' the referenced ServiceAccount", func() {
+		revokeSAUsage(deployNS)
+
+		out, err := ocCreateAs(deployNS, user, clfYaml)
+		Expect(err).To(HaveOccurred(), "Expected CLF creation to be rejected, but got: %s", out)
+		Expect(out).To(ContainSubstring("not authorized to use"))
+	})
+
+	It("should allow CLF creation when user has 'use' permission on the ServiceAccount", func() {
+		grantSAUsage(deployNS, "restricted-user", collectorSAName)
+
+		out, err := ocCreateAs(deployNS, user, clfYaml)
+		Expect(err).ToNot(HaveOccurred(), "Expected CLF creation to succeed, but got error: %s %v", out, err)
+	})
+
+	It("should reject CLF update when user cannot 'use' the referenced ServiceAccount", func() {
+		revokeSAUsage(deployNS)
+
+		out, err := ocPatchCLFAs(deployNS, user, clfName, `{"metadata":{"annotations":{"sa-auth-test":"update-attempt"}}}`)
+		Expect(err).To(HaveOccurred(), "Expected CLF update to be rejected, but got: %s", out)
+		Expect(out).To(ContainSubstring("not authorized to use"))
+	})
+
+	It("should allow CLF deletion when user cannot 'use' the referenced ServiceAccount", func() {
+		revokeSAUsage(deployNS)
+
+		err := ocDeleteCLFAs(deployNS, user, clfName)
+		Expect(err).ToNot(HaveOccurred(), "Expected CLF deletion to succeed without 'use' permission")
+	})
+})
+
+func checkVAPInstalled() {
+	for _, resource := range []string{
+		"validatingadmissionpolicy/" + admission.SAUsagePolicyName,
+		"validatingadmissionpolicybinding/" + admission.SAUsagePolicyBindingName,
+	} {
+		cmd := exec.Command("oc", "get", resource)
+		out, err := cmd.CombinedOutput()
+		Expect(err).ToNot(HaveOccurred(), "Expected %s to exist (operator must reconcile VAP): %s", resource, out)
+	}
+}
+
+func ocCreateAs(namespace, user, yaml string) (string, error) {
+	cmd := exec.Command("oc", "create", "-n", namespace, "--as", user, "-f", "-")
+	cmd.Stdin = strings.NewReader(yaml)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func ocPatchCLFAs(namespace, user, name, patch string) (string, error) {
+	cmd := exec.Command("oc", "patch", "clusterlogforwarder", name,
+		"-n", namespace, "--as", user, "--type=merge", "-p", patch)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func ocDeleteCLFAs(namespace, user, name string) error {
+	cmd := exec.Command("oc", "delete", "clusterlogforwarder", name,
+		"-n", namespace, "--as", user, "--ignore-not-found")
+	_, err := cmd.CombinedOutput()
+	return err
+}
+
+func grantCLFAccess(namespace string) {
+	cmd := exec.Command("oc", "create", "role", "clf-editor",
+		"--verb=create,update,patch,get,list,watch,delete",
+		"--resource=clusterlogforwarders.observability.openshift.io",
+		"-n", namespace)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create clf-editor role: %s %v", out, err))
+	}
+
+	cmd = exec.Command("oc", "create", "rolebinding", "restricted-user-clf-editor",
+		"--role=clf-editor",
+		"--serviceaccount="+namespace+":restricted-user",
+		"-n", namespace)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create rolebinding: %s %v", out, err))
+	}
+}
+
+func revokeSAUsage(namespace string) {
+	_ = exec.Command("oc", "delete", "rolebinding", "restricted-user-sa-user",
+		"-n", namespace, "--ignore-not-found").Run()
+	_ = exec.Command("oc", "delete", "role", "sa-user",
+		"-n", namespace, "--ignore-not-found").Run()
+}
+
+func grantSAUsage(namespace, userName, saName string) {
+	roleYaml := fmt.Sprintf(`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sa-user
+  namespace: %s
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  resourceNames: ["%s"]
+  verbs: ["use"]`, namespace, saName)
+
+	cmd := exec.Command("oc", "create", "-f", "-")
+	cmd.Stdin = strings.NewReader(roleYaml)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create sa-user role: %s %v", out, err))
+	}
+
+	cmd = exec.Command("oc", "create", "rolebinding", "restricted-user-sa-user",
+		"--role=sa-user",
+		"--serviceaccount="+namespace+":"+userName,
+		"-n", namespace)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to create rolebinding: %s %v", out, err))
+	}
+}

--- a/test/e2e/collection/sa_authorization/sa_authorization_test.go
+++ b/test/e2e/collection/sa_authorization/sa_authorization_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -84,31 +85,45 @@ spec:
 	It("should reject CLF creation when user cannot 'use' the referenced ServiceAccount", func() {
 		revokeSAUsage(deployNS)
 
-		out, err := ocCreateAs(deployNS, user, clfYaml)
-		Expect(err).To(HaveOccurred(), "Expected CLF creation to be rejected, but got: %s", out)
-		Expect(out).To(ContainSubstring("not authorized to use"))
+		Eventually(func(g Gomega) {
+			out, err := ocCreateAs(deployNS, user, clfYaml)
+			if err == nil {
+				out, delErr := ocDeleteCLFAs(deployNS, user, clfName)
+				g.Expect(delErr).ToNot(HaveOccurred(), "Expected CLF cleanup delete to succeed: %s", out)
+				return
+			}
+			g.Expect(err).To(HaveOccurred(), "Expected CLF creation to be rejected, but got: %s", out)
+			g.Expect(out).To(ContainSubstring("not authorized to use"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
 	})
 
 	It("should allow CLF creation when user has 'use' permission on the ServiceAccount", func() {
 		grantSAUsage(deployNS, "restricted-user", collectorSAName)
 
-		out, err := ocCreateAs(deployNS, user, clfYaml)
-		Expect(err).ToNot(HaveOccurred(), "Expected CLF creation to succeed, but got error: %s %v", out, err)
+		Eventually(func(g Gomega) {
+			out, err := ocCreateAs(deployNS, user, clfYaml)
+			g.Expect(err).ToNot(HaveOccurred(), "Expected CLF creation to succeed, but got error: %s", out)
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
 	})
 
 	It("should reject CLF update when user cannot 'use' the referenced ServiceAccount", func() {
 		revokeSAUsage(deployNS)
 
-		out, err := ocPatchCLFAs(deployNS, user, clfName, `{"metadata":{"annotations":{"sa-auth-test":"update-attempt"}}}`)
-		Expect(err).To(HaveOccurred(), "Expected CLF update to be rejected, but got: %s", out)
-		Expect(out).To(ContainSubstring("not authorized to use"))
+		Eventually(func(g Gomega) {
+			out, err := ocPatchCLFAs(deployNS, user, clfName, `{"metadata":{"annotations":{"sa-auth-test":"update-attempt"}}}`)
+			if err == nil {
+				return
+			}
+			g.Expect(err).To(HaveOccurred(), "Expected CLF update to be rejected, but got: %s", out)
+			g.Expect(out).To(ContainSubstring("not authorized to use"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
 	})
 
 	It("should allow CLF deletion when user cannot 'use' the referenced ServiceAccount", func() {
 		revokeSAUsage(deployNS)
 
-		err := ocDeleteCLFAs(deployNS, user, clfName)
-		Expect(err).ToNot(HaveOccurred(), "Expected CLF deletion to succeed without 'use' permission")
+		out, err := ocDeleteCLFAs(deployNS, user, clfName)
+		Expect(err).ToNot(HaveOccurred(), "Expected CLF deletion to succeed without 'use' permission: %s", out)
 	})
 })
 
@@ -137,11 +152,11 @@ func ocPatchCLFAs(namespace, user, name, patch string) (string, error) {
 	return string(out), err
 }
 
-func ocDeleteCLFAs(namespace, user, name string) error {
+func ocDeleteCLFAs(namespace, user, name string) (string, error) {
 	cmd := exec.Command("oc", "delete", "clusterlogforwarder", name,
 		"-n", namespace, "--as", user, "--ignore-not-found")
-	_, err := cmd.CombinedOutput()
-	return err
+	out, err := cmd.CombinedOutput()
+	return string(out), err
 }
 
 func grantCLFAccess(namespace string) {

--- a/test/e2e/collection/sa_authorization/suite_test.go
+++ b/test/e2e/collection/sa_authorization/suite_test.go
@@ -1,0 +1,13 @@
+package sa_authorization
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "[e2e][collection][sa_authorization] Suite")
+}

--- a/test/helpers/types/types.go
+++ b/test/helpers/types/types.go
@@ -165,7 +165,7 @@ type OpenshiftMeta struct {
 	//+optional
 	Labels map[string]string `json:"labels,omitempty"`
 
-	//Sequence is increasing id used in conjunction with the timestamp to estblish a linear timeline
+	//Sequence is increasing id used in conjunction with the timestamp to establish a linear timeline
 	//of log records.  This was added as a workaround for logstores that do not have nano-second precision.
 	Sequence OptionalInt `json:"sequence,omitempty"`
 }


### PR DESCRIPTION
### Description
Fixes [CVE-2026-10609](https://access.redhat.com/security/cve/CVE-2026-10609) by enforcing that users who create or update a `ClusterLogForwarder` must have the `use` RBAC verb on the ServiceAccount named in `spec.serviceAccount.name`.

#### Changes:

- Reconcile cluster-scoped `ValidatingAdmissionPolicy` / `ValidatingAdmissionPolicyBinding` (`clf-sa-usage-authorization`) at operator startup via a leader-elected runnable.
- VAP manifests live under `internal/admission/manifests/ `and are **not shipped in the OLM bundle; the operator installs them at runtime.**
- Add operator RBAC (ClusterRole + CSV) to manage `validatingadmissionpolicies` and `validatingadmissionpolicybindings`.
- Add make apply-admission for dev/manual testing without waiting for operator reconciliation.
- Add lightweight manual verification: `hack/test-sa-authorization.sh` and e2e suite `test/e2e/collection/sa_authorization/`.
- Document behavior, RBAC examples, and troubleshooting in `docs/administration/serviceaccount-authorization.adoc`.

#### Behavior notes:
| Operation | SA use check |
|--------|--------|
| CLF create | Yes |
| CLF update | Yes |
| CLF delete | No |

#### How to test:
- **Unit tests**: `go test ./internal/admission/...`
- **E2E tests**: `go test -v ./test/e2e/collection/sa_authorization/ -ginkgo.focus="CVE-2026-10609" -ginkgo.v -count=1 -timeout=10m` (or via `hack/testing-olm/test-030-collection.sh`)
- **Manual admission script:**: `/hack/test-sa-authorization.sh` on a cluster with the CLO deployed
- **Confirm VAP exists after operator start:**
      - `oc get validatingadmissionpolicy clf-sa-usage-authorization`
      - `oc get validatingadmissionpolicybinding clf-sa-usage-authorization-binding`
- Verify behavior: 
   - create/update denied without `use` on the collector SA
   - create/update allowed with `use`
   - delete allowed without `use`
- **Existing** e2e runs as cluster-admin (no changes expected)

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
   - https://redhat.atlassian.net/browse/LOG-9714 
   - https://redhat.atlassian.net/browse/LOG-9441
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authorization checks requiring `use` permission on the referenced ServiceAccount when creating or updating a `ClusterLogForwarder`.
  - Deletions remain available without this permission.
  - Added documentation for collector termination grace periods.

- **Documentation**
  - Added setup, configuration, and troubleshooting guidance for ServiceAccount authorization failures.

- **Tests**
  - Added automated and manual coverage for authorized, unauthorized, update, and deletion scenarios.

- **Chores**
  - Added a command to apply admission configuration to a cluster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->