### PR TITLE
feat(vector): always raise file descriptor soft limit

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -19,6 +19,9 @@ https?://\S+
 # Version strings
 v\d+\.\d+(\.\d+)?
 
+# AsciiDoc source/listing blocks (---- delimited)
+(?s)^----$.*?^----$
+
 # AsciiDoc directives and macros
 ^include::.*$
 ^ifdef::.*$

--- a/docs/features/raise_fd_limit.adoc
+++ b/docs/features/raise_fd_limit.adoc
@@ -1,0 +1,7 @@
+== Vector Collector: Raising File Descriptor Limits
+
+The operator always sets `VECTOR_RAISE_FD_LIMIT=true` on the collector container so Vector raises its file descriptor soft limit to the hard limit at startup. This prevents "Too many open files" errors when Vector monitors a large number of log files concurrently.
+
+Systems often default to restrictive file descriptor soft limits (e.g. 1024 on Linux), which can cause Vector to fail when processing many log sources simultaneously. Vector reads `VECTOR_RAISE_FD_LIMIT` natively and raises the soft limit without requiring manual sysadmin intervention. The hard limit remains the safety ceiling set by the OS/container runtime.
+
+This behavior is not configurable. A collector tuning option may be added in the future if needed.

--- a/docs/reference/operator/api_observability_v1.adoc
+++ b/docs/reference/operator/api_observability_v1.adoc
@@ -61,6 +61,7 @@ Type:: object
 |networkPolicy|object|  Define the Network Policy for the Collector
 |nodeSelector|object|  Define nodes for scheduling the pods.
 |resources|object|  The resource requirements for the collector
+|terminationGracePeriodSeconds|int|  TerminationGracePeriodSeconds defines the termination grace period for collector pods in seconds. If not specified, the default is 10 seconds.
 |tolerations|array|  Define the tolerations the collector pods will accept
 |======================
 
@@ -650,6 +651,10 @@ Type:: object
 === .spec.collector.resources.requests
 
 Type:: object
+
+=== .spec.collector.terminationGracePeriodSeconds
+
+Type:: int
 
 === .spec.collector.tolerations[]
 

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -239,6 +239,7 @@ func (f *Factory) NewCollectorContainer(inputs internalobs.Inputs, outputs inter
 		{Name: "OPENSHIFT_CLUSTER_ID", Value: clusterID},
 		{Name: "POD_IP", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIP"}}},
 		{Name: "POD_IPS", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "status.podIPs"}}},
+		{Name: "VECTOR_RAISE_FD_LIMIT", Value: "true"},
 	}
 	collector.Env = append(collector.Env, utils.GetProxyEnvVars()...)
 

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -143,6 +143,10 @@ var _ = Describe("Factory#Daemonset", func() {
 				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{Name: "VECTOR_LOG", Value: logLevelDebug}))
 			})
 
+			It("should set VECTOR_RAISE_FD_LIMIT to true", func() {
+				Expect(collector.Env).To(IncludeEnvVar(v1.EnvVar{Name: "VECTOR_RAISE_FD_LIMIT", Value: "true"}))
+			})
+
 			Context("the volume mounts", func() {
 				It("should mount all output configmaps", func() {
 					Expect(collector.VolumeMounts).To(IncludeVolumeMount(

--- a/test/framework/functional/vector/deploy.go
+++ b/test/framework/functional/vector/deploy.go
@@ -38,6 +38,7 @@ func (c *VectorCollector) DeployConfigMapForConfig(name, config, clfName, clfYam
 
 func (c *VectorCollector) BuildCollectorContainer(b *runtime.ContainerBuilder, nodeName string) *runtime.ContainerBuilder {
 	return b.AddEnvVar("VECTOR_LOG", common.AdaptLogLevel()).
+		AddEnvVar("VECTOR_RAISE_FD_LIMIT", "true").
 		AddEnvVarFromFieldRef("POD_IP", "status.podIP").
 		AddEnvVar("NODE_NAME", nodeName).
 		AddEnvVar("VECTOR_INTERNAL_LOG_RATE_LIMIT", "0").

--- a/test/functional/misc/raise_fd_limit_test.go
+++ b/test/functional/misc/raise_fd_limit_test.go
@@ -1,0 +1,34 @@
+package misc
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	obs "github.com/openshift/cluster-logging-operator/api/observability/v1"
+	"github.com/openshift/cluster-logging-operator/internal/constants"
+	"github.com/openshift/cluster-logging-operator/test/framework/functional"
+	testruntime "github.com/openshift/cluster-logging-operator/test/runtime/observability"
+)
+
+var _ = Describe("[Functional][Misc][RaiseFdLimit] Vector raise-fd-limit", func() {
+
+	var framework *functional.CollectorFunctionalFramework
+
+	BeforeEach(func() {
+		framework = functional.NewCollectorFunctionalFramework()
+		testruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+			FromInput(obs.InputTypeInfrastructure).
+			ToHttpOutput()
+	})
+
+	AfterEach(func() {
+		framework.Cleanup()
+	})
+
+	It("should start with VECTOR_RAISE_FD_LIMIT=true", func() {
+		Expect(framework.Deploy()).To(BeNil())
+
+		out, err := framework.RunCommand(constants.CollectorName, "sh", "-c", "echo $VECTOR_RAISE_FD_LIMIT")
+		Expect(err).To(BeNil())
+		Expect(out).To(ContainSubstring("true"))
+	})
+})

--- a/test/functional/outputs/syslog/rfc3164_test.go
+++ b/test/functional/outputs/syslog/rfc3164_test.go
@@ -84,14 +84,14 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC3164 tests", func() {
 	},
 		// facility "user" = 1, priority = 1*8 + severity_code
 		// full-form keywords (RFC 5424)
-		Entry("full-form: critical", "critical", "<10>"),         // 8 + 2
-		Entry("full-form: emergency", "emergency", "<8>"),        // 8 + 0
-		Entry("full-form: error", "error", "<11>"),               // 8 + 3
+		Entry("full-form: critical", "critical", "<10>"),           // 8 + 2
+		Entry("full-form: emergency", "emergency", "<8>"),          // 8 + 0
+		Entry("full-form: error", "error", "<11>"),                 // 8 + 3
 		Entry("full-form: informational", "informational", "<14>"), // 8 + 6
-		Entry("full-form: warning", "warning", "<12>"),           // 8 + 4
+		Entry("full-form: warning", "warning", "<12>"),             // 8 + 4
 		// capitalized keywords (as documented in oc explain)
-		Entry("capitalized: Critical", "Critical", "<10>"),         // 8 + 2
-		Entry("capitalized: Emergency", "Emergency", "<8>"),        // 8 + 0
+		Entry("capitalized: Critical", "Critical", "<10>"),           // 8 + 2
+		Entry("capitalized: Emergency", "Emergency", "<8>"),          // 8 + 0
 		Entry("capitalized: Informational", "Informational", "<14>"), // 8 + 6
 	)
 

--- a/test/functional/outputs/syslog/rfc5424_test.go
+++ b/test/functional/outputs/syslog/rfc5424_test.go
@@ -231,11 +231,11 @@ var _ = Describe("[Functional][Outputs][Syslog] RFC5424 tests", func() {
 		Entry("full-form: notice", "notice", "<13>1 "),               // 8 + 5
 		Entry("full-form: alert", "alert", "<9>1 "),                  // 8 + 1
 		// short-form keywords (VRL to_syslog_level output)
-		Entry("short-form: crit", "crit", "<10>1 "),    // 8 + 2
-		Entry("short-form: emerg", "emerg", "<8>1 "),    // 8 + 0
-		Entry("short-form: err", "err", "<11>1 "),       // 8 + 3
-		Entry("short-form: info", "info", "<14>1 "),     // 8 + 6
-		Entry("short-form: warn", "warn", "<12>1 "),     // 8 + 4
+		Entry("short-form: crit", "crit", "<10>1 "),  // 8 + 2
+		Entry("short-form: emerg", "emerg", "<8>1 "), // 8 + 0
+		Entry("short-form: err", "err", "<11>1 "),    // 8 + 3
+		Entry("short-form: info", "info", "<14>1 "),  // 8 + 6
+		Entry("short-form: warn", "warn", "<12>1 "),  // 8 + 4
 		// capitalized keywords (as documented in oc explain)
 		Entry("capitalized: Critical", "Critical", "<10>1 "),           // 8 + 2
 		Entry("capitalized: Emergency", "Emergency", "<8>1 "),          // 8 + 0

--- a/test/helpers/types/types.go
+++ b/test/helpers/types/types.go
@@ -165,7 +165,7 @@ type OpenshiftMeta struct {
 	//+optional
 	Labels map[string]string `json:"labels,omitempty"`
 
-	//Sequence is increasing id used in conjunction with the timestamp to estblish a linear timeline
+	//Sequence is increasing id used in conjunction with the timestamp to establish a linear timeline
 	//of log records.  This was added as a workaround for logstores that do not have nano-second precision.
 	Sequence OptionalInt `json:"sequence,omitempty"`
 }


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Always set `VECTOR_RAISE_FD_LIMIT=true` on the collector so Vector raises its soft limit to the hard limit at startup. This prevents "Too many open files" errors when monitoring large numbers of log files, without requiring user configuration.

Also fix typo and formatting

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s): https://github.com/ViaQ/vector/pull/277
- Backport: https://github.com/openshift/cluster-logging-operator/pull/3311
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9829
- Enhancement proposal:
