### PR TITLE
chore(tests): use vector devel image for vector receivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ export NAMESPACE?=openshift-logging
 export LOKI_OPERATOR_CHANNEL?=stable-6.4
 
 IMAGE_LOGGING_VECTOR?=quay.io/openshift-logging/vector:v0.54.0
+IMAGE_VECTOR_RECEIVER?=quay.io/openshift-logging/vector:v0.54.0-devel
 IMAGE_LOGFILEMETRICEXPORTER?=quay.io/openshift-logging/log-file-metric-exporter:latest
 IMAGE_LOGGING_EVENTROUTER?=quay.io/openshift-logging/eventrouter:v0.5.0
 IMAGE_TLS_SCANNER?=quay.io/openshift/tls-scanner:latest
@@ -236,12 +237,14 @@ deploy-catalog:
 test-env: ## Echo test environment, useful for running tests outside of the Makefile.
 	@echo \
 	RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) \
+	IMAGE_VECTOR_RECEIVER=$(IMAGE_VECTOR_RECEIVER) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	IMAGE_TLS_SCANNER=$(IMAGE_TLS_SCANNER) \
 
 .PHONY: test-functional
 test-functional: test-functional-benchmarker-vector
 	RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) \
+	IMAGE_VECTOR_RECEIVER=$(IMAGE_VECTOR_RECEIVER) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	go test -race \
 		./test/functional/... \
@@ -259,11 +262,12 @@ test-forwarder-generator: bin/forwarder-generator
 
 test-functional-benchmarker-vector: bin/functional-benchmarker
 	@rm -rf /tmp/benchmark-test-vector
-	@out=$$(RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) bin/functional-benchmarker --image=$(IMAGE_LOGGING_VECTOR) --artifact-dir=/tmp/benchmark-test-vector 2>&1); if [ "$$?" != "0" ] ; then echo "$$out"; exit 1; fi
+	@out=$$(RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) IMAGE_VECTOR_RECEIVER=$(IMAGE_VECTOR_RECEIVER) bin/functional-benchmarker --image=$(IMAGE_LOGGING_VECTOR) --artifact-dir=/tmp/benchmark-test-vector 2>&1); if [ "$$?" != "0" ] ; then echo "$$out"; exit 1; fi
 
 .PHONY: test-unit
 test-unit: test-forwarder-generator test-unit-api
 	RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) \
+	IMAGE_VECTOR_RECEIVER=$(IMAGE_VECTOR_RECEIVER) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	go test -coverprofile=test.cov -race ./api/... ./internal/... `go list ./test/... | grep -Ev 'test/(e2e|functional|framework|client|helpers)'`
 
@@ -325,6 +329,7 @@ apply: namespace $(OPERATOR_SDK) ## Install kustomized resources directly to the
 .PHONY: test-upgrade
 test-upgrade: $(JUNITREPORT)
 	RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) \
+	IMAGE_VECTOR_RECEIVER=$(IMAGE_VECTOR_RECEIVER) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	IMAGE_LOGGING_EVENTROUTER=$(IMAGE_LOGGING_EVENTROUTER) \
 	exit 0
@@ -332,6 +337,7 @@ test-upgrade: $(JUNITREPORT)
 .PHONY: test-e2e-from-ci-bundle
 test-e2e-from-ci-bundle: $(JUNITREPORT)
 	RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) \
+	IMAGE_VECTOR_RECEIVER=$(IMAGE_VECTOR_RECEIVER) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	IMAGE_LOGGING_EVENTROUTER=$(IMAGE_LOGGING_EVENTROUTER) \
 	IMAGE_TLS_SCANNER=$(IMAGE_TLS_SCANNER) \
@@ -340,6 +346,7 @@ test-e2e-from-ci-bundle: $(JUNITREPORT)
 .PHONY: test-e2e
 test-e2e: $(JUNITREPORT)
 	RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) \
+	IMAGE_VECTOR_RECEIVER=$(IMAGE_VECTOR_RECEIVER) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	IMAGE_LOGGING_EVENTROUTER=$(IMAGE_LOGGING_EVENTROUTER) \
 	IMAGE_TLS_SCANNER=$(IMAGE_TLS_SCANNER) \
@@ -350,6 +357,7 @@ test-e2e-local: $(JUNITREPORT) deploy-image
 	LOG_LEVEL=3 \
 	LOKI_OPERATOR_CHANNEL=$(LOKI_OPERATOR_CHANNEL) \
 	RELATED_IMAGE_VECTOR=$(IMAGE_LOGGING_VECTOR) \
+	IMAGE_VECTOR_RECEIVER=$(IMAGE_VECTOR_RECEIVER) \
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	IMAGE_LOGGING_EVENTROUTER=$(IMAGE_LOGGING_EVENTROUTER) \
 	IMAGE_TLS_SCANNER=$(IMAGE_TLS_SCANNER) \

--- a/internal/cmd/functional-benchmarker/runners/cluster/cluster_runner.go
+++ b/internal/cmd/functional-benchmarker/runners/cluster/cluster_runner.go
@@ -117,7 +117,7 @@ func (r *ClusterRunner) Deploy() {
 				})
 			}
 			collectorBuilder.Update()
-			return r.framework.AddBenchmarkForwardOutput(b, r.framework.Forwarder.Spec.Outputs[0], utils.GetComponentImage(constants.VectorName))
+			return r.framework.AddBenchmarkForwardOutput(b, r.framework.Forwarder.Spec.Outputs[0], utils.GetComponentImage(constants.VectorReceiverName))
 		},
 	})
 	if err != nil {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -44,6 +44,7 @@ const (
 	TrustedCABundleMountDir           = "/etc/pki/ca-trust/extracted/pem/"
 	ElasticsearchName                 = "elasticsearch"
 	VectorName                        = "vector"
+	VectorReceiverName                = "vector-receiver"
 	KibanaName                        = "kibana"
 	LogfilesmetricexporterName        = "logfilesmetricexporter"
 	LogfilesmetricexporterPort        = int32(2112)
@@ -64,6 +65,7 @@ const (
 	CollectorTrustedCAName      = "collector-trusted-ca-bundle"
 
 	VectorImageEnvVar         = "RELATED_IMAGE_VECTOR"
+	VectorReceiverImageEnvVar = "IMAGE_VECTOR_RECEIVER"
 	LogfilesmetricImageEnvVar = "RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER"
 
 	ContainerLogDir = "/var/log/containers"

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -31,6 +31,7 @@ var (
 // COMPONENT_IMAGES are keys based on the "container name" + "-{image,version}"
 var COMPONENT_IMAGES = map[string]string{
 	constants.VectorName:                 constants.VectorImageEnvVar,
+	constants.VectorReceiverName:         constants.VectorReceiverImageEnvVar,
 	constants.LogfilesmetricexporterName: constants.LogfilesmetricImageEnvVar,
 }
 

--- a/test/framework/e2e/http_vector.go
+++ b/test/framework/e2e/http_vector.go
@@ -79,7 +79,7 @@ func (tc *E2ETestFramework) DeployHttpReceiver(ns string) (deployment *VectorHtt
 	}
 	container := corev1.Container{
 		Name:  HttpReceiver,
-		Image: utils.GetComponentImage(constants.VectorName),
+		Image: utils.GetComponentImage(constants.VectorReceiverName),
 		Ports: []corev1.ContainerPort{
 			{Name: "http", ContainerPort: 8090},
 		},

--- a/test/framework/functional/output_http.go
+++ b/test/framework/functional/output_http.go
@@ -206,7 +206,7 @@ func (f *CollectorFunctionalFramework) AddVectorHttpOutputWithConfig(b *runtime.
 	}
 
 	log.V(2).Info("Adding vector container", "name", name)
-	containerBuilder := b.AddContainer(name, utils.GetComponentImage(constants.VectorName)).
+	containerBuilder := b.AddContainer(name, utils.GetComponentImage(constants.VectorReceiverName)).
 		AddVolumeMount(config.Name, "/tmp/config", "", false).
 		AddEnvVar("VECTOR_LOG", common.AdaptLogLevel()).
 		AddEnvVar("VECTOR_INTERNAL_LOG_RATE_LIMIT", "0").


### PR DESCRIPTION
ref: LOG-9706

### Description
This PR:
* uses a devel image of vector when it is deployed as a receiver

### Links
* https://redhat.atlassian.net/browse/LOG-9760

cc @vparfonov @Clee2691 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable image selection for Vector receiver deployments.
  - Added a default Vector receiver image for test and benchmark environments.

- **Bug Fixes**
  - Updated HTTP receiver, functional output, benchmark, upgrade, unit, and end-to-end test setups to use the dedicated Vector receiver image.
  - Improved consistency when deploying and validating Vector receiver components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->