### PR TITLE
[release-6.2] fix(lfme): set -secureMetrics=false on exporter daemonset

### DIFF
--- a/internal/metrics/logfilemetricexporter/factory.go
+++ b/internal/metrics/logfilemetricexporter/factory.go
@@ -111,7 +111,7 @@ func newLogMetricsExporterContainer(exporter loggingv1a1.LogFileMetricExporter, 
 	}
 	exporterContainer.Command = []string{"/bin/bash"}
 	exporterContainer.Args = []string{"-c",
-		"/usr/local/bin/log-file-metric-exporter -verbosity=2 -dir=/var/log/pods -http=:2112 -keyFile=/etc/logfilemetricexporter/metrics/tls.key -crtFile=/etc/logfilemetricexporter/metrics/tls.crt -tlsMinVersion=" +
+		"/usr/local/bin/log-file-metric-exporter -verbosity=2 -dir=/var/log/pods -http=:2112 -keyFile=/etc/logfilemetricexporter/metrics/tls.key -crtFile=/etc/logfilemetricexporter/metrics/tls.crt -secureMetrics=false -tlsMinVersion=" +
 			tls.MinTLSVersion(tlsProfileSpec) + " -cipherSuites=" + strings.Join(tls.TLSCiphers(tlsProfileSpec), ",")}
 
 	exporterContainer.VolumeMounts = []v1.VolumeMount{

--- a/internal/metrics/logfilemetricexporter/factory_test.go
+++ b/internal/metrics/logfilemetricexporter/factory_test.go
@@ -3,6 +3,7 @@ package logfilemetricexporter
 import (
 	"context"
 	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
@@ -86,6 +87,8 @@ var _ = Describe("Reconcile LogFileMetricExporter", func() {
 		// Get and check the daemonset
 		Expect(reqClient.Get(context.TODO(), dsKey, dsInstance)).Should(Succeed())
 		Expect(dsInstance.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(dsInstance.Spec.Template.Spec.Containers[0].Args).To(HaveLen(2))
+		Expect(dsInstance.Spec.Template.Spec.Containers[0].Args[1]).To(ContainSubstring("-secureMetrics=false"))
 		Expect(dsInstance.Spec.Template.Spec.Containers[0].Resources.Requests).To(Not(BeNil()))
 		Expect(dsInstance.Spec.Template.Spec.Containers[0].Resources.Limits).To(Not(BeNil()))
 


### PR DESCRIPTION
### Description

This PR sets the `-secureMetrics` arg on the `LogFileMetricExporter` container to `false`.

/cc @vparfonov 
/assign @jcantrill 

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- JIRA: https://redhat.atlassian.net/browse/LOG-9873
