### PR TITLE
fix(lfme): explicitly set -secureMetrics=true on exporter daemonset

### DIFF
--- a/internal/metrics/logfilemetricexporter/daemonset_test.go
+++ b/internal/metrics/logfilemetricexporter/daemonset_test.go
@@ -63,6 +63,21 @@ var _ = Describe("Reconcile LogFileMetricExporter Daemonset", func() {
 		Expect(dsInstance.Spec.Template.Spec.Containers[0].Resources.Requests).To(BeNil())
 	})
 
+	It("should pass -secureMetrics=true so the metrics endpoint requires authentication", func() {
+
+		// Reconcile the exporter daemonset
+		Expect(ReconcileDaemonset(*lfmeInstance,
+			reqClient,
+			constants.OpenshiftNS,
+			constants.LogfilesmetricexporterName, dsOwner)).To(Succeed())
+
+		// Get and check the daemonset
+		Expect(reqClient.Get(context.TODO(), dsKey, dsInstance)).Should(Succeed())
+		Expect(dsInstance.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(dsInstance.Spec.Template.Spec.Containers[0].Args).
+			To(ContainElement(ContainSubstring("-secureMetrics=true")))
+	})
+
 	It("should reconcile successfully a daemonset with specified resources.requests", func() {
 		lfmeInstance.Spec = loggingv1alpha1.LogFileMetricExporterSpec{
 			Resources: &corev1.ResourceRequirements{

--- a/internal/metrics/logfilemetricexporter/factory.go
+++ b/internal/metrics/logfilemetricexporter/factory.go
@@ -116,7 +116,7 @@ func newLogMetricsExporterContainer(exporter loggingv1a1.LogFileMetricExporter, 
 	// TODO: When openshift/api is updated with the Groups field in TLSProfileSpec,
 	// pass groups from the profile spec instead of nil.
 	exporterContainer.Args = []string{"-c",
-		"/usr/local/bin/log-file-metric-exporter -verbosity=2 -dir=/var/log/pods -http=:2112 -keyFile=/etc/logfilemetricexporter/metrics/tls.key -crtFile=/etc/logfilemetricexporter/metrics/tls.crt -secureMetrics -tlsMinVersion=" +
+		"/usr/local/bin/log-file-metric-exporter -verbosity=2 -dir=/var/log/pods -http=:2112 -keyFile=/etc/logfilemetricexporter/metrics/tls.key -crtFile=/etc/logfilemetricexporter/metrics/tls.crt -secureMetrics=true -tlsMinVersion=" +
 			tls.MinTLSVersion(tlsProfileSpec) + " -cipherSuites=" + strings.Join(tls.TLSCiphers(tlsProfileSpec), ",")}
 
 	exporterContainer.VolumeMounts = []v1.VolumeMount{


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

This PR explicitly sets `-secureMetrics=true` on the exporter daemonset.

/cc @vparfonov 
/assign @jcantrill 

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
- JIRA: https://redhat.atlassian.net/browse/LOG-9875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Metrics endpoints now require authentication by default for the log-file metrics exporter.
* **Tests**
  * Added coverage verifying that deployed exporter instances use secure metrics settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->