### PR TITLE
fix(collector): check resource existence before deletion

### DIFF
--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,8 +1,10 @@
 package collector
 
 import (
+	"context"
 	"os"
 	"path"
+	"sync/atomic"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,12 +19,50 @@ import (
 	"github.com/openshift/cluster-logging-operator/internal/tls"
 	"github.com/openshift/cluster-logging-operator/internal/utils"
 	. "github.com/openshift/cluster-logging-operator/test/matchers"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+func newClientWithDeleteCounter(objs ...client.Object) (client.Client, *atomic.Int32) {
+	var deleteCount atomic.Int32
+	builder := fake.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleteCount.Add(1)
+				return c.Delete(ctx, obj, opts...)
+			},
+		})
+	for _, obj := range objs {
+		builder = builder.WithObjects(obj)
+	}
+	return builder.Build(), &deleteCount
+}
+
+// newClientWithDeleteReturningNotFound simulates a race where the resource
+// is deleted between Get and Delete by returning NotFound from Delete.
+func newClientWithDeleteReturningNotFound(objs ...client.Object) client.Client {
+	builder := fake.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				return apierrors.NewNotFound(
+					schema.GroupResource{Group: "", Resource: obj.GetObjectKind().GroupVersionKind().Kind},
+					obj.GetName(),
+				)
+			},
+		})
+	for _, obj := range objs {
+		builder = builder.WithObjects(obj)
+	}
+	return builder.Build()
+}
 
 var _ = Describe("Factory#MaxUnavailable", func() {
 	var (
@@ -492,6 +532,30 @@ var _ = Describe("Factory#Daemonset", func() {
 		})
 	})
 
+	Context("RemoveDaemonSet", func() {
+		It("should not issue a DELETE API call when no daemonset exists", func() {
+			fakeClient, deleteCount := newClientWithDeleteCounter()
+			err := RemoveDaemonset(fakeClient, "openshift-logging", "collector")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deleteCount.Load()).To(Equal(int32(0)), "expected no DELETE calls when daemonset does not exist")
+		})
+
+		It("should issue a DELETE API call when a daemonset exists", func() {
+			existing := runtime.NewDaemonSet("openshift-logging", "collector")
+			fakeClient, deleteCount := newClientWithDeleteCounter(existing)
+			err := RemoveDaemonset(fakeClient, "openshift-logging", "collector")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deleteCount.Load()).To(Equal(int32(1)), "expected exactly one DELETE call when daemonset exists")
+		})
+
+		It("should succeed when the daemonset is deleted between Get and Delete", func() {
+			existing := runtime.NewDaemonSet("openshift-logging", "collector")
+			fakeClient := newClientWithDeleteReturningNotFound(existing)
+			err := RemoveDaemonset(fakeClient, "openshift-logging", "collector")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 })
 
 var _ = Describe("Factory#Deployment", func() {
@@ -759,6 +823,30 @@ var _ = Describe("Factory#Deployment", func() {
 			Expect(actDpl.Spec.Template.Annotations).To(HaveKey(constants.AnnotationSecretHash))
 			Expect(actDpl.Spec.Template.Annotations).To(HaveKey(constants.AnnotationConfigMapHash))
 			Expect(actDpl.Spec.Template.Annotations).To(HaveKey(targetAnnotation))
+		})
+	})
+
+	Context("RemoveDeployment", func() {
+		It("should not issue a DELETE API call when no deployment exists", func() {
+			fakeClient, deleteCount := newClientWithDeleteCounter()
+			err := RemoveDeployment(fakeClient, "openshift-logging", "collector")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deleteCount.Load()).To(Equal(int32(0)), "expected no DELETE calls when deployment does not exist")
+		})
+
+		It("should issue a DELETE API call when a deployment exists", func() {
+			existing := runtime.NewDeployment("openshift-logging", "collector")
+			fakeClient, deleteCount := newClientWithDeleteCounter(existing)
+			err := RemoveDeployment(fakeClient, "openshift-logging", "collector")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deleteCount.Load()).To(Equal(int32(1)), "expected exactly one DELETE call when deployment exists")
+		})
+
+		It("should succeed when the deployment is deleted between Get and Delete", func() {
+			existing := runtime.NewDeployment("openshift-logging", "collector")
+			fakeClient := newClientWithDeleteReturningNotFound(existing)
+			err := RemoveDeployment(fakeClient, "openshift-logging", "collector")
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 

--- a/internal/collector/daemonset.go
+++ b/internal/collector/daemonset.go
@@ -24,9 +24,15 @@ func (f *Factory) ReconcileDaemonset(k8sClient client.Client, namespace string, 
 	return reconcile.DaemonSet(k8sClient, desired)
 }
 
-func Remove(k8sClient client.Client, namespace, name string) (err error) {
+func RemoveDaemonset(k8sClient client.Client, namespace, name string) (err error) {
 	log.V(3).Info("Removing collector", "namespace", namespace, "name", name)
 	ds := runtime.NewDaemonSet(namespace, name)
+	if err = k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(ds), ds); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failure checking daemonset %s/%s: %v", namespace, name, err)
+	}
 	if err = k8sClient.Delete(context.TODO(), ds); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("failure deleting daemonset %s/%s: %v", namespace, name, err)
 	}

--- a/internal/collector/deployment.go
+++ b/internal/collector/deployment.go
@@ -26,6 +26,12 @@ func (f *Factory) ReconcileDeployment(k8sClient client.Client, namespace string,
 func RemoveDeployment(k8sClient client.Client, namespace, name string) (err error) {
 	log.V(3).Info("Removing collector deployment", "namespace", namespace, "name", name)
 	ds := runtime.NewDeployment(namespace, name)
+	if err = k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(ds), ds); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failure checking deployment %s/%s: %v", namespace, name, err)
+	}
 	if err = k8sClient.Delete(context.TODO(), ds); err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("failure deleting deployment %s/%s: %v", namespace, name, err)
 	}

--- a/internal/controller/observability/clusterlogforwarder_controller.go
+++ b/internal/controller/observability/clusterlogforwarder_controller.go
@@ -109,7 +109,11 @@ func (r *ClusterLogForwarderReconciler) Reconcile(_ context.Context, req ctrl.Re
 		readyCond.Reason = obsv1.ReasonValidationFailure
 		readyCond.Message = "collector not ready"
 		if validations.MustUndeployCollector(cxt.Forwarder.Status.Conditions) {
-			if deleteErr := collector.Remove(cxt.Client, cxt.Forwarder.Namespace, cxt.Forwarder.Name); deleteErr != nil {
+			removeFunc := collector.RemoveDaemonset
+			if internalobs.DeployAsDeployment(*cxt.Forwarder) {
+				removeFunc = collector.RemoveDeployment
+			}
+			if deleteErr := removeFunc(cxt.Client, cxt.Forwarder.Namespace, cxt.Forwarder.Name); deleteErr != nil {
 				log.V(0).Error(deleteErr, "Unable to remove collector deployment")
 			}
 		}
@@ -140,7 +144,7 @@ func (r *ClusterLogForwarderReconciler) Reconcile(_ context.Context, req ctrl.Re
 func RemoveStaleWorkload(k8Client client.Client, forwarder *obsv1.ClusterLogForwarder) error {
 	remove := collector.RemoveDeployment
 	if internalobs.DeployAsDeployment(*forwarder) {
-		remove = collector.Remove
+		remove = collector.RemoveDaemonset
 	}
 	return remove(k8Client, forwarder.Namespace, forwarder.Name)
 }


### PR DESCRIPTION
### Description
Avoid issuing `DELETE` API calls against non-existent deployments and daemonsets during reconciliation. 

Previously, `Remove()` and `RemoveDeployment()` would blindly call `Delete`, causing the API server
to return `404`s every reconcile cycle and inflating audit log noise. Now check with Get first - return early if NotFound, only `Delete` if the resource actually exists.

/cc @vparfonov 
/assign @jcantrill 

### Links
- JIRA: https://redhat.atlassian.net/browse/LOG-9810


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of collector workloads when resources are absent or require removal.
  * Prevented unnecessary delete operations for missing DaemonSets and Deployments.
  * Added clearer error handling when workload lookup or deletion fails.
  * Ensured stale collector resources are removed using the appropriate workload type.
  * Improved reliability when resources disappear during cleanup, avoiding unnecessary failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->