### PR TITLE
feat(Dockerfile): modify base to use ubi-micro to reduce attack vectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ COPY ./must-gather ./must-gather
 USER 0
 RUN make build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-micro
 
 RUN INSTALL_PKGS=" \
-      openssl \
+      openssl-libs \
+      ca-certificates \
       rsync \
       file \
       xz \

--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -8,9 +8,11 @@ WORKDIR /opt/app-root/src
 
 RUN make build BUILD_OPTS="-tags strictfipsruntime"
 
-FROM registry.redhat.io/ubi9/ubi-minimal:9.7
+FROM registry.redhat.io/ubi9/ubi-micro:9.7
 
 RUN INSTALL_PKGS=" \
+      openssl-libs \
+      ca-certificates \
       rsync \
       file \
       xz \


### PR DESCRIPTION
### Description
This PR:

* Modifies the final base image to ubi-micro to reduce the exposure to CVEs that are not part of the dependencies of the product


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime container images for a smaller, streamlined footprint.
  * Added trusted certificate support and refined OpenSSL runtime libraries.
  * Applied the same runtime improvements across standard and ART container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->