### PR TITLE
fix(test): `--slow-spec-threshold` has been deprecated, replace it with `--poll-progress-after` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,13 +248,13 @@ test-functional: test-functional-benchmarker-vector
 	RELATED_IMAGE_LOG_FILE_METRIC_EXPORTER=$(IMAGE_LOGFILEMETRICEXPORTER) \
 	go test -race \
 		./test/functional/... \
-		-ginkgo.no-color -timeout=40m -ginkgo.slow-spec-threshold='45.0s'
+		-ginkgo.no-color -timeout=40m -ginkgo.poll-progress-after='45s'
 
 .PHONY: test-helpers
 test-helpers:
 	go test -race \
 		./test/helpers/... \
-		-ginkgo.no-color -timeout=40m -ginkgo.slow-spec-threshold='45.0s'
+		-ginkgo.no-color -timeout=40m -ginkgo.poll-progress-after='45s'
 
 .PHONY: test-forwarder-generator
 test-forwarder-generator: bin/forwarder-generator


### PR DESCRIPTION
### Description
`--ginkgo.slow-spec-threshold` is deprecated  and will be removed in a future version of Ginkgo.  This PR replace it with `--poll-progress-after`

<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA: NO-JIRA
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test progress reporting to display polling progress after 45 seconds.
  * Preserved existing test duration and configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->