### PR TITLE
feat(Dockerfile): modify base to use ubi-micro to reduce attack vectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.12 AS builder
+FROM golang:1.26 AS builder
 
 ARG CACHE_DEPS="true"
 WORKDIR /opt/app-root/src
@@ -17,20 +17,26 @@ COPY ./must-gather ./must-gather
 USER 0
 RUN make build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi:latest AS packages
 
-RUN INSTALL_PKGS=" \
-      openssl \
+# Install ubi-micro runtime packages into a staging root directory using DNF
+RUN mkdir -p /mnt/rootfs && \
+    dnf install -y --installroot /mnt/rootfs \
+      --releasever 9 \
+      --setopt=install_weak_deps=false \
+      --nodocs \
+      openssl-libs \
+      ca-certificates \
       rsync \
       file \
-      xz \
-      " && \
-    microdnf install -y ${INSTALL_PKGS} && \
-    rpm -V ${INSTALL_PKGS} && \
-    microdnf clean all && \
-    mkdir /tmp/ocp-clo && \
-    chmod og+w /tmp/ocp-clo
+      xz && \
+    dnf --installroot /mnt/rootfs clean all && \
+    mkdir -p /mnt/rootfs/tmp/ocp-clo && \
+    chmod og+w /mnt/rootfs/tmp/ocp-clo
 
+FROM registry.access.redhat.com/ubi9/ubi-micro
+
+COPY --from=packages /mnt/rootfs/ /
 COPY --from=builder /opt/app-root/src/bin/cluster-logging-operator /usr/bin/
 COPY --from=builder /opt/app-root/src/bin/must-gather /usr/bin/
 
@@ -50,5 +56,3 @@ LABEL \
         name="openshift-logging/cluster-logging-rhel9-operator" \
         com.redhat.component="cluster-logging-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
-
-

--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,4 +1,4 @@
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.12.20260813.141452 AS builder
+FROM registry.redhat.io/openshift/golang-builder:golang-builder-v1.26-rhel9 AS builder
 
 ENV GOEXPERIMENT=strictfipsruntime
 ENV CGO_ENABLED=1
@@ -8,19 +8,24 @@ WORKDIR /opt/app-root/src
 
 RUN make build BUILD_OPTS="-tags strictfipsruntime"
 
-FROM registry.redhat.io/ubi9/ubi-minimal:9.7
-
-RUN INSTALL_PKGS=" \
+# Install ubi-micro runtime packages into a staging root directory using DNF
+RUN mkdir -p /mnt/rootfs && \
+    dnf install -y --installroot /mnt/rootfs \
+      --releasever 9 \
+      --setopt=install_weak_deps=false \
+      --nodocs \
+      openssl-libs \
+      ca-certificates \
       rsync \
       file \
-      xz \
-      " && \
-    microdnf install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    microdnf clean all && \
-    mkdir /tmp/ocp-clo && \
-    chmod og+w /tmp/ocp-clo
+      xz && \
+    dnf --installroot /mnt/rootfs clean all && \
+    mkdir -p /mnt/rootfs/tmp/ocp-clo && \
+    chmod og+w /mnt/rootfs/tmp/ocp-clo
 
+FROM registry.redhat.io/ubi9/ubi-micro:9.7
+
+COPY --from=builder /mnt/rootfs/ /
 COPY --from=builder /opt/app-root/src/bin/cluster-logging-operator /usr/bin/
 COPY --from=builder /opt/app-root/src/bin/must-gather /usr/bin/
 


### PR DESCRIPTION
### Description
This PR:

* Modifies the final base image to ubi-micro to reduce the exposure to CVEs that are not part of the dependencies of the product

Replaces #3432 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the build environment to Go 1.26.
  * Updated runtime images to a smaller UBI Micro base.
  * Added required runtime support for OpenSSL, certificates, synchronization, file inspection, and archive handling.
  * Ensured the application temporary directory is available with appropriate write permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->