### PR TITLE
fix(vector): fix internal_metrics typo and set sane 30s scrape interval

### DIFF
--- a/internal/generator/vector/api/config_test.go
+++ b/internal/generator/vector/api/config_test.go
@@ -26,8 +26,8 @@ type = "file"
 path = "/var/run/ocp-collector/secrets"
 
 [sources.internal_metrics]
+scrape_interval_secs = 30
 type = "internal_metrics"
-scrape_interval_seconds = 2
 
 [transforms.bar]
 inputs = ["internal_metrics"]
@@ -54,8 +54,8 @@ secret:
     path: "/var/run/ocp-collector/secrets"
 sources:
   internal_metrics:
+    scrape_interval_secs: 30
     type: "internal_metrics"
-    scrape_interval_seconds: 2
 transforms:
   bar:
     inputs: ["internal_metrics"]

--- a/internal/generator/vector/api/sources/internal_metrics.go
+++ b/internal/generator/vector/api/sources/internal_metrics.go
@@ -5,8 +5,8 @@ import (
 )
 
 type InternalMetrics struct {
-	Type                 types.SourceType `json:"type" yaml:"type" toml:"type"`
-	ScrapIntervalSeconds uint             `json:"scrape_interval_seconds,omitempty" yaml:"scrape_interval_seconds,omitempty" toml:"scrape_interval_seconds,omitempty"`
+	Type                  types.SourceType `json:"type" yaml:"type" toml:"type"`
+	ScrapeIntervalSeconds uint             `json:"scrape_interval_secs,omitempty" yaml:"scrape_interval_secs,omitempty" toml:"scrape_interval_secs,omitempty"`
 }
 
 func (i *InternalMetrics) SourceType() types.SourceType {
@@ -15,6 +15,7 @@ func (i *InternalMetrics) SourceType() types.SourceType {
 
 func NewInternalMetrics() types.Source {
 	return &InternalMetrics{
-		Type: types.SourceTypeInternalMetrics,
+		Type:                  types.SourceTypeInternalMetrics,
+		ScrapeIntervalSeconds: 30,
 	}
 }

--- a/internal/generator/vector/conf/complex.toml
+++ b/internal/generator/vector/conf/complex.toml
@@ -13,6 +13,7 @@ type = "directory"
 path = "/var/run/ocp-collector/secrets"
 
 [sources.internal_metrics]
+scrape_interval_secs = 30
 type = "internal_metrics"
 
 [sources.input_audit_host]

--- a/internal/generator/vector/conf/complex_http_receiver.toml
+++ b/internal/generator/vector/conf/complex_http_receiver.toml
@@ -13,6 +13,7 @@ type = "directory"
 path = "/var/run/ocp-collector/secrets"
 
 [sources.internal_metrics]
+scrape_interval_secs = 30
 type = "internal_metrics"
 
 [sources.input_audit_host]

--- a/internal/generator/vector/conf/container.toml
+++ b/internal/generator/vector/conf/container.toml
@@ -14,6 +14,7 @@ type = "directory"
 path = "/var/run/ocp-collector/secrets"
 
 [sources.internal_metrics]
+scrape_interval_secs = 30
 type = "internal_metrics"
 
 [sources.input_myinfra_container]


### PR DESCRIPTION
### Description

The Vector collector DaemonSet consistently consumes 4–6 GiB of RAM per node (and up to 10 GiB) on our cluster. By looking at the prometheus metrics, the source of the memory consumption is the component internal_metrics which generates upward of 3Mib/s (compared to 0.2 MiB/s forthe application logs).

This is because the generated `vector.toml` completely omits `scrape_interval_secs`, forcing Vector to poll its entire registry on its internal 1-second default

This PR corrects the typo in the key name (ScrapeIntervalSeconds instead of ScrapIntervalSeconds) and in the serialization tags (secs instead of seconds) and sets a sane, explicit default of 30 seconds inside the generator.

/cc jcantrill
/assign alanconway

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s):
- GitHub issue:
- JIRA:
- Enhancement proposal:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the internal metrics scrape interval setting name.
  * Internal metrics now scrape every 30 seconds by default across generated configurations.
  * Prometheus output authentication explicitly uses the GET HTTP method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->