### PR TITLE
test(multilineexception): add functional test for incorrectly concatenates independent JSON log records.

### DIFF
--- a/test/functional/filters/multilineexception/multiline_exception_test.go
+++ b/test/functional/filters/multilineexception/multiline_exception_test.go
@@ -134,4 +134,42 @@ created by main.main
 		}),
 	)
 
+	// LOG-9963: Independent log records where the first line contains an exception
+	// keyword must NOT cause subsequent unrelated lines to be merged.
+	// Reproduces the production scenario: a container emits single-line JSON logs;
+	// one log has an exception-related term (e.g. SecretConfigException) in its
+	// message field, and subsequent normal logs are greedily consumed by the
+	// catch-all continuation rule.
+	It("should not merge independent log records when first line contains an exception keyword", func() {
+		testruntime.NewClusterLogForwarderBuilder(framework.Forwarder).
+			FromInput(obs.InputTypeApplication).
+			WithMultilineErrorDetectionFilter().
+			ToHttpOutput()
+
+		Expect(framework.Deploy()).To(BeNil())
+
+		// Line 1 triggers exception detection (contains "Exception:");
+		// lines 2 and 3 are regular logs that must NOT be merged with line 1.
+		messages := []string{
+			"SecretConfigException: config not found for key db.password",
+			"Request completed in 235ms",
+			"Processing batch 42 records",
+		}
+
+		var buffer []string
+		for _, msg := range messages {
+			crioLine := functional.NewCRIOLogMessageWithStream(timestamp, constants.STDOUT, msg, false)
+			buffer = append(buffer, crioLine)
+		}
+		appNamespace = framework.Pod.Namespace
+		Expect(framework.WriteMessagesToNamespace(strings.Join(buffer, "\n"), appNamespace, 1)).To(Succeed())
+
+		logs, err := framework.ReadApplicationLogsFrom(string(obs.OutputTypeHTTP))
+		Expect(err).To(BeNil(), "Expected no errors reading the logs")
+		Expect(len(logs)).To(Equal(len(messages)), "Expected each independent message to be a separate log event, got %d instead of %d", len(logs), len(messages))
+		for i, msg := range messages {
+			Expect(logs[i].Message).To(Equal(msg), "Log event %d should match the original message", i)
+		}
+	})
+
 })


### PR DESCRIPTION
### Description
<!-- MANDATORY: Summarize the intent of the change in the title. Provide a text description about the issue the PR is addressing that ensures the reader understands the context, the rationale behind and catches a 1000-feet perspective of the implementation.  Enrich the description with screenshots, code blocks. Use formatting to ensure a good readability for all public audience! -->

Add test verifying that independent log records are NOT merged when the first line contains an exception keyword.
This reproduces the production scenario where a container emits single-line JSON logs, one log has a exception-related term (e.g. SecretConfigException) in its message field, and subsequent normal logs are greedily consumed by the catch-all continuation rule.
    
The test sends 3 independent messages:
1. `"SecretConfigException: ..."` - triggers exception detection
2. `"Request completed in 235ms"` - regular log
3. `"Processing batch 42 records"` - regular log
    
Expected: 3 separate log events in the output
Buggy behavior: all 3 merged into 1 event
    

/cc @Clee2691 <!-- MANDATORY: Assign at least one reviewer from top-level OWNERS file -->
/assign @jcantrill <!-- MANDATORY: Assign at least one approver from top-level OWNERS file -->

<!-- OPTIONAL: Declare release name for the next release branch to get this PR cherry-picked by the bot. Example: /cherrypick release-x.y  -->

### Links
<!-- Provide links to dependent PRs, related JIRA issues or enhancement proposals related to this PR -->
- Depending on PR(s): https://github.com/ViaQ/vector/pull/305
- GitHub issue:
- JIRA: https://redhat.atlassian.net/browse/LOG-9998
- Enhancement proposal:
