### PR TITLE
Use equals form for dnf installroot flags in Dockerfile.art

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -10,8 +10,8 @@ RUN make build BUILD_OPTS="-tags strictfipsruntime"
 
 # Install ubi-micro runtime packages into a staging root directory using DNF
 RUN mkdir -p /mnt/rootfs && \
-    dnf install -y --installroot /mnt/rootfs \
-      --releasever 9 \
+    dnf install -y --installroot=/mnt/rootfs \
+      --releasever=9 \
       --setopt=install_weak_deps=false \
       --nodocs \
       openssl-libs \
@@ -19,7 +19,7 @@ RUN mkdir -p /mnt/rootfs && \
       rsync \
       file \
       xz && \
-    dnf --installroot /mnt/rootfs clean all && \
+    dnf --installroot=/mnt/rootfs clean all && \
     mkdir -p /mnt/rootfs/tmp/ocp-clo && \
     chmod og+w /mnt/rootfs/tmp/ocp-clo
 


### PR DESCRIPTION
## Summary

Use `--installroot=` and `--releasever=` in `Dockerfile.art` instead of spaced forms (`--installroot /mnt/rootfs`, `--releasever 9`).

rpm-lockfile-prototype currently treats spaced dnf option values as package names when scanning Containerfiles for hermetic RPM lockfile generation. That breaks Konflux hermetic builds until upstream argument parsing is fixed. The `=` form is equivalent for dnf and avoids the parser bug.

## Test plan

- [ ] Konflux/hermetic build for cluster-logging-operator resolves the correct installroot packages into `rpms.lock.yaml`
- [ ] Image build still succeeds with the updated `dnf` flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build configuration to use explicit installation-root and release-version settings.
  * Package installation, cleanup, and staging behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->